### PR TITLE
Discourse Context Refactor

### DIFF
--- a/apps/roam/package.json
+++ b/apps/roam/package.json
@@ -32,7 +32,7 @@
     "react-draggable": "^4.4.5",
     "react-in-viewport": "^1.0.0-alpha.20",
     "react-vertical-timeline-component": "^3.5.2",
-    "roamjs-components": "^0.83.4",
+    "roamjs-components": "^0.84.0",
     "signia-react": "^0.1.1"
   },
   "overrides": {

--- a/apps/roam/src/components/DiscourseContext.tsx
+++ b/apps/roam/src/components/DiscourseContext.tsx
@@ -321,6 +321,7 @@ export const ContextContent = ({ uid, results }: Props) => {
     [rawQueryResults],
   );
   const [loading, setLoading] = useState(true);
+  const debouncedLoading = useDebounce(loading, 150);
 
   const onRefresh = useCallback(() => {
     setRawQueryResults({});
@@ -382,14 +383,14 @@ export const ContextContent = ({ uid, results }: Props) => {
             }
           />
         ))}
-        {loading && (
+        {debouncedLoading && (
           <div className="text-muted-foreground m-auto flex items-center gap-2 text-sm">
             <Spinner />
           </div>
         )}
       </Tabs>
     </>
-  ) : loading && !results ? (
+  ) : debouncedLoading && !results ? (
     <Tabs selectedTabId={0} onChange={() => {}} vertical>
       <Tab
         id={0}
@@ -436,6 +437,23 @@ const DiscourseContext = ({ uid }: Props) => {
       </div>
     </>
   );
+};
+
+// used here to prevent the loading spinner from flashing briefly when queries resolve quickly
+const useDebounce = <T,>(value: T, delay: number): T => {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
 };
 
 export default DiscourseContext;

--- a/apps/roam/src/components/DiscourseContext.tsx
+++ b/apps/roam/src/components/DiscourseContext.tsx
@@ -364,6 +364,7 @@ export const ContextContent = ({ uid, results }: Props) => {
         selectedTabId={tabId}
         onChange={(e) => setTabId(Number(e))}
         vertical
+        renderActiveTabPanelOnly
       >
         {queryResults.map((r, i) => (
           <Tab

--- a/apps/roam/src/components/settings/GeneralSettings.tsx
+++ b/apps/roam/src/components/settings/GeneralSettings.tsx
@@ -50,11 +50,13 @@ const DiscourseGraphHome = ({
         />
         <FlagPanel
           title="overlay"
-          description="Whether or not to overlay discourse context information over node references"
+          // description="Whether or not to overlay discourse context information over node references"
+          description="Currently disabled. Being reworked."
           order={3}
           uid={settings.overlay.uid}
           parentUid={settings.grammarUid}
           value={settings.overlay.value || false}
+          disabled={true}
         />
       </div>
       <TextPanel

--- a/apps/roam/src/discourseGraphsMode.ts
+++ b/apps/roam/src/discourseGraphsMode.ts
@@ -222,8 +222,10 @@ const initializeDiscourseGraphsMode = async (args: OnloadArgs) => {
             {
               title: "overlay",
               Panel: FlagPanel,
-              description:
-                "Whether to overlay discourse context information over node references",
+              // description:
+              //   "Whether to overlay discourse context information over node references",
+              description: "Currently disabled. Being reworked.",
+              disabled: true,
               options: {
                 onChange: (val) => {
                   onPageRefObserverChange(overlayPageRefHandler)(val);
@@ -473,9 +475,9 @@ const initializeDiscourseGraphsMode = async (args: OnloadArgs) => {
   });
 
   if (isFlagEnabled("preview")) pageRefObservers.add(previewPageRefHandler);
-  if (isFlagEnabled("grammar.overlay")) {
-    pageRefObservers.add(overlayPageRefHandler);
-  }
+  // if (isFlagEnabled("grammar.overlay")) {
+  //   pageRefObservers.add(overlayPageRefHandler);
+  // }
   if (pageRefObservers.size) enablePageRefObserver();
 
   const queryPages = args.extensionAPI.settings.get("query-pages");

--- a/apps/roam/src/utils/fireQuery.ts
+++ b/apps/roam/src/utils/fireQuery.ts
@@ -14,6 +14,7 @@ import predefinedSelections, {
 import { DEFAULT_RETURN_NODE } from "./parseQuery";
 import { DiscourseNode } from "./getDiscourseNodes";
 import { DiscourseRelation } from "./getDiscourseRelations";
+import nanoid from "nanoid";
 
 export type QueryArgs = {
   returnNode?: string;
@@ -323,10 +324,15 @@ const fireQuery: FireQuery = async (_args) => {
       }
     : getDatalogQuery(args);
   try {
-    if (getNodeEnv() === "development") {
-      console.log("Query to Roam:");
-      console.log(query);
+    const nodeEnv = getNodeEnv();
+    const queryId = nodeEnv === "development" ? nanoid(4) : "";
+
+    if (nodeEnv === "development") {
+      console.groupCollapsed(`🔍 Roam Query - ${queryId}`);
+      console.log("%c" + query, "color: #94a3b8; font-family: monospace;");
       if (inputs.length) console.log("Inputs:", ...inputs);
+      console.time(`Query - ${queryId}`);
+      console.groupEnd();
     }
 
     //@ts-ignore - todo add async q to roamjs-components
@@ -334,10 +340,17 @@ const fireQuery: FireQuery = async (_args) => {
       query,
       ...inputs,
     );
+
+    if (nodeEnv === "development") {
+      console.timeEnd(`Query - ${queryId}`);
+      console.groupEnd();
+    }
+
     return Promise.all(queryResults.map(formatResult));
   } catch (e) {
-    console.error("Error from Roam:");
+    console.group("🚨 Roam Query Error");
     console.error((e as Error).message);
+    console.groupEnd();
     return [];
   }
 };

--- a/apps/roam/src/utils/getDiscourseContextResults.ts
+++ b/apps/roam/src/utils/getDiscourseContextResults.ts
@@ -3,10 +3,136 @@ import { Result } from "roamjs-components/types/query-builder";
 import findDiscourseNode from "./findDiscourseNode";
 import fireQuery from "./fireQuery";
 import getDiscourseNodes from "./getDiscourseNodes";
-import getDiscourseRelations from "./getDiscourseRelations";
+import getDiscourseRelations, {
+  DiscourseRelation,
+} from "./getDiscourseRelations";
+import { Selection } from "./types";
 
 const resultCache: Record<string, Awaited<ReturnType<typeof fireQuery>>> = {};
 const CACHE_TIMEOUT = 1000 * 60 * 5;
+
+type BuildQueryConfig = {
+  args: {
+    ignoreCache?: true;
+  };
+  targetUid: string;
+  fireQueryContext: {
+    nodes: ReturnType<typeof getDiscourseNodes>;
+    relations: ReturnType<typeof getDiscourseRelations>;
+  };
+  nodeTextByType: Record<string, string>;
+  r: DiscourseRelation;
+  complement: boolean;
+};
+type QueryConfig = {
+  relation: {
+    id: string;
+    text: string;
+    target: string;
+    isComplement: boolean;
+  };
+  queryPromise: () => Promise<Result[]>;
+};
+
+type SelectionConfig = {
+  r: DiscourseRelation;
+  conditionUid?: string;
+};
+const buildSelections = ({
+  r,
+  conditionUid = window.roamAlphaAPI.util.generateUID(),
+}: SelectionConfig): Selection[] => {
+  const selections: Selection[] = [];
+
+  if (r.triples.some((t) => t.some((a) => /context/i.test(a)))) {
+    selections.push({
+      uid: window.roamAlphaAPI.util.generateUID(),
+      label: "context",
+      text: `node:${conditionUid}-Context`,
+    });
+  } else if (r.triples.some((t) => t.some((a) => /anchor/i.test(a)))) {
+    selections.push({
+      uid: window.roamAlphaAPI.util.generateUID(),
+      label: "anchor",
+      text: `node:${conditionUid}-Anchor`,
+    });
+  }
+
+  return selections;
+};
+
+const executeQueries = async (queryConfigs: QueryConfig[]) => {
+  const results = await Promise.all(
+    queryConfigs.map(async ({ relation, queryPromise }) => ({
+      relation,
+      results: await queryPromise(),
+    })),
+  );
+  return results;
+};
+
+const buildQueryConfig = ({
+  args,
+  targetUid,
+  fireQueryContext,
+  nodeTextByType,
+  r,
+  complement: isComplement,
+}: BuildQueryConfig): QueryConfig => {
+  const { ignoreCache } = args;
+  const target = isComplement ? r.source : r.destination;
+  const text = isComplement ? r.complement : r.label;
+  const cacheKey = `${targetUid}~${text}~${target}`;
+
+  const relation = {
+    id: r.id,
+    text,
+    target,
+    isComplement,
+  };
+
+  if (resultCache[cacheKey] && !ignoreCache) {
+    return {
+      relation,
+      queryPromise: () => Promise.resolve(resultCache[cacheKey]),
+    };
+  }
+
+  const returnNode = nodeTextByType[target];
+
+  const conditionUid = window.roamAlphaAPI.util.generateUID();
+  const selections = buildSelections({ r, conditionUid });
+  const { nodes, relations } = fireQueryContext;
+  return {
+    relation,
+    queryPromise: () =>
+      fireQuery({
+        returnNode,
+        conditions: [
+          {
+            source: returnNode,
+            // NOTE! This MUST be the OPPOSITE of `label`
+            relation: isComplement ? r.label : r.complement,
+            target: targetUid,
+            uid: conditionUid,
+            type: "clause",
+          },
+        ],
+        selections,
+        context: {
+          relationsInQuery: [relation],
+          customNodes: nodes,
+          customRelations: relations,
+        },
+      }).then((results) => {
+        resultCache[cacheKey] = results;
+        setTimeout(() => {
+          delete resultCache[cacheKey];
+        }, CACHE_TIMEOUT);
+        return results;
+      }),
+  };
+};
 
 const getDiscourseContextResults = async ({
   uid,
@@ -19,6 +145,8 @@ const getDiscourseContextResults = async ({
   relations?: ReturnType<typeof getDiscourseRelations>;
   ignoreCache?: true;
 }) => {
+  const args = { ignoreCache };
+
   const discourseNode = findDiscourseNode(uid);
   if (!discourseNode) return [];
   const nodeType = discourseNode?.type;
@@ -26,92 +154,48 @@ const getDiscourseContextResults = async ({
     nodes.map(({ type, text }) => [type, text]),
   );
   nodeTextByType["*"] = "Any";
-  const resultsWithRelation = await Promise.all(
-    relations
-      .flatMap((r) => {
-        const queries = [];
-        if (r.source === nodeType || r.source === "*") {
-          queries.push({
-            r,
-            complement: false,
-          });
-        }
-        if (r.destination === nodeType || r.destination === "*") {
-          queries.push({
-            r,
-            complement: true,
-          });
-        }
-        return queries;
-      })
-      .map(async ({ r, complement: isComplement }) => {
-        const target = isComplement ? r.source : r.destination;
-        const text = isComplement ? r.complement : r.label;
-        const returnNode = nodeTextByType[target];
-        const cacheKey = `${uid}~${text}~${target}`;
-        const conditionUid = window.roamAlphaAPI.util.generateUID();
-        const selections = [];
-        if (r.triples.some((t) => t.some((a) => /context/i.test(a)))) {
-          selections.push({
-            uid: window.roamAlphaAPI.util.generateUID(),
-            label: "context",
-            text: `node:${conditionUid}-Context`,
-          });
-        } else if (r.triples.some((t) => t.some((a) => /anchor/i.test(a)))) {
-          selections.push({
-            uid: window.roamAlphaAPI.util.generateUID(),
-            label: "anchor",
-            text: `node:${conditionUid}-Anchor`,
-          });
-        }
-        const relation = {
-          id: r.id,
-          text,
-          target,
-          isComplement,
-        };
-        const rawResults =
-          resultCache[cacheKey] && !ignoreCache
-            ? Promise.resolve(resultCache[cacheKey])
-            : fireQuery({
-                returnNode,
-                conditions: [
-                  {
-                    source: returnNode,
-                    // NOTE! This MUST be the OPPOSITE of `label`
-                    relation: isComplement ? r.label : r.complement,
-                    target: uid,
-                    uid: conditionUid,
-                    type: "clause",
-                  },
-                ],
-                selections,
-                context: {
-                  relationsInQuery: [relation],
-                  customNodes: nodes,
-                  customRelations: relations,
-                },
-              }).then((results) => {
-                resultCache[cacheKey] = results;
-                setTimeout(() => {
-                  delete resultCache[cacheKey];
-                }, CACHE_TIMEOUT);
-                return results;
-              });
-        return rawResults.then((results) => ({
-          relation: {
-            text,
-            isComplement,
-            target,
-            id: r.id,
-          },
-          results,
-        }));
-      }),
-  ).catch((e) => {
-    console.error(e);
-    return [] as const;
+
+  type RelationWithComplement = {
+    id: string;
+    r: DiscourseRelation;
+    complement: boolean;
+  };
+  const uniqueRelations = new Map<string, RelationWithComplement>();
+
+  relations.forEach((r) => {
+    if (r.source === nodeType || r.source === "*") {
+      uniqueRelations.set(`${r.id}-false`, {
+        id: r.id,
+        r,
+        complement: false,
+      });
+    }
+    if (r.destination === nodeType || r.destination === "*") {
+      uniqueRelations.set(`${r.id}-true`, {
+        id: r.id,
+        r,
+        complement: true,
+      });
+    }
   });
+
+  const relationsWithComplement = Array.from(uniqueRelations.values());
+
+  const context = { nodes, relations };
+  const queryConfigs = relationsWithComplement.map((relation) =>
+    buildQueryConfig({
+      args,
+      targetUid: uid,
+      nodeTextByType,
+      fireQueryContext: {
+        ...context,
+      },
+      r: relation.r,
+      complement: relation.complement,
+    }),
+  );
+
+  const resultsWithRelation = await executeQueries(queryConfigs);
   const groupedResults = Object.fromEntries(
     resultsWithRelation.map((r) => [
       r.relation.text,
@@ -121,6 +205,7 @@ const getDiscourseContextResults = async ({
       >,
     ]),
   );
+
   resultsWithRelation.forEach((r) =>
     r.results
       .filter((a) => a.uid !== uid)

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "react-draggable": "^4.4.5",
         "react-in-viewport": "^1.0.0-alpha.20",
         "react-vertical-timeline-component": "^3.5.2",
-        "roamjs-components": "^0.83.4",
+        "roamjs-components": "^0.84.0",
         "signia-react": "^0.1.1"
       },
       "devDependencies": {
@@ -5724,7 +5724,9 @@
       }
     },
     "apps/roam/node_modules/roamjs-components": {
-      "version": "0.83.4",
+      "version": "0.84.0",
+      "resolved": "https://registry.npmjs.org/roamjs-components/-/roamjs-components-0.84.0.tgz",
+      "integrity": "sha512-dsK2GAPszxAjkUZGPAhHnZbgU8T3IWXIH+l6bVry7oR5vJL7FxnXFNZF/n8iDNNiDM+o+9n3gQxCl5aL+N3rzg==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
- huge speed boost
  - [take advantage of `async.q`](https://github.com/DiscourseGraphs/discourse-graph/pull/24)
  - stream results in
  - [getFilteredRelations cache ](https://github.com/DiscourseGraphs/discourse-graph/commit/78ec88f2b21845719ced7631cab33a6a8ca43264)
  - [matchDiscourseNode early return for single "has title" clause](https://github.com/DiscourseGraphs/discourse-graph/commit/a5fd2a0147be39add45db58f16bfe5629eecac54)
- large refactor
- query time logging
- roamjs-components bump