### PR TITLE
check if query builder already loaded

### DIFF
--- a/apps/roam/src/components/toastMessages.tsx
+++ b/apps/roam/src/components/toastMessages.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+export const QueryBuilderLoadedToast = () => (
+  <div className="p-4">
+    <h3 className="text-center text-xl font-bold">
+      Discourse Graph Not Loaded
+    </h3>
+    <p>
+      The <strong>Query Builder</strong> extension is already loaded elsewhere.
+    </p>
+    <p>Having both loaded at the same time may cause issues.</p>
+    <p className="mt-4 w-fit rounded-md bg-white p-3 text-center font-medium text-gray-800">
+      Please disable Query Builder
+      <br />
+      then reload your graph.
+    </p>
+  </div>
+);

--- a/apps/roam/src/index.ts
+++ b/apps/roam/src/index.ts
@@ -30,9 +30,21 @@ import { isQueryPage } from "./utils/isQueryPage";
 import { listActiveQueries } from "./utils/listActiveQueries";
 import { registerSmartBlock } from "./utils/registerSmartBlock";
 
+import { QueryBuilderLoadedToast } from "./components/toastMessages";
+
 export const DEFAULT_CANVAS_PAGE_FORMAT = "Canvas/*";
 
 export default runExtension(async (onloadArgs) => {
+  if (window?.roamjs?.loaded?.has("query-builder")) {
+    renderToast({
+      timeout: 10000,
+      id: "query-builder-loaded",
+      content: QueryBuilderLoadedToast(),
+      intent: "danger",
+    });
+    return;
+  }
+
   if (process.env.NODE_ENV === "development") {
     renderToast({
       id: "discourse-graph-loaded",


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/f39159ba-0cb8-4c2b-b548-b14b35714665)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a toast notification to inform users when the "Discourse Graph" cannot be loaded due to the "Query Builder" extension being active.
	- Provides clear instructions for users to resolve the issue.

- **Bug Fixes**
	- Added a conditional check to ensure the toast notification displays appropriately when the "query-builder" feature is loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->