### PR TITLE
move pageRefObs from discourseGraphMode

### DIFF
--- a/apps/roam/src/utils/isCanvasPage.ts
+++ b/apps/roam/src/utils/isCanvasPage.ts
@@ -13,3 +13,16 @@ export const isCanvasPage = ({
   const canvasRegex = new RegExp(`^${format}$`.replace(/\*/g, ".+"));
   return canvasRegex.test(title);
 };
+
+export const isCurrentPageCanvas = ({
+  title,
+  h1,
+  onloadArgs,
+}: {
+  title: string;
+  h1: HTMLHeadingElement;
+  onloadArgs: OnloadArgs;
+}) => {
+  const { extensionAPI } = onloadArgs;
+  return isCanvasPage({ title, extensionAPI }) && !!h1.closest(".roam-article");
+};

--- a/apps/roam/src/utils/isDiscourseNodeConfigPage.ts
+++ b/apps/roam/src/utils/isDiscourseNodeConfigPage.ts
@@ -1,0 +1,4 @@
+import { NODE_CONFIG_PAGE_TITLE } from "~/settings/configPages";
+
+export const isDiscourseNodeConfigPage = (title: string) =>
+  title.startsWith(NODE_CONFIG_PAGE_TITLE);

--- a/apps/roam/src/utils/pageRefObserverHandlers.ts
+++ b/apps/roam/src/utils/pageRefObserverHandlers.ts
@@ -1,0 +1,101 @@
+import { createHTMLObserver } from "roamjs-components/dom";
+import { render as previewRender } from "../components/LivePreview";
+import isDiscourseNode from "./isDiscourseNode";
+import getPageUidByPageTitle from "roamjs-components/queries/getPageUidByPageTitle";
+import { render as discourseOverlayRender } from "../components/DiscourseContextOverlay";
+import { OnloadArgs } from "roamjs-components/types";
+
+const pageRefObservers = new Set<(s: HTMLSpanElement) => void>();
+const pageRefObserverRef: { current?: MutationObserver } = {
+  current: undefined,
+};
+
+export const overlayPageRefHandler = (s: HTMLSpanElement, args: OnloadArgs) => {
+  if (s.parentElement && !s.parentElement.closest(".rm-page-ref")) {
+    const tag =
+      s.getAttribute("data-tag") ||
+      s.parentElement.getAttribute("data-link-title");
+    if (
+      tag &&
+      !s.getAttribute("data-roamjs-discourse-overlay") &&
+      isDiscourseNode(getPageUidByPageTitle(tag))
+    ) {
+      s.setAttribute("data-roamjs-discourse-overlay", "true");
+      const parent = document.createElement("span");
+      discourseOverlayRender({
+        parent,
+        tag: tag.replace(/\\"/g, '"'),
+        onloadArgs: args,
+      });
+      if (s.hasAttribute("data-tag")) {
+        s.appendChild(parent);
+      } else {
+        s.parentElement.appendChild(parent);
+      }
+    }
+  }
+};
+
+export const previewPageRefHandler = (s: HTMLSpanElement) => {
+  const tag =
+    s.getAttribute("data-tag") ||
+    s.parentElement?.getAttribute("data-link-title");
+  if (tag && !s.getAttribute("data-roamjs-discourse-augment-tag")) {
+    s.setAttribute("data-roamjs-discourse-augment-tag", "true");
+    const parent = document.createElement("span");
+    previewRender({
+      parent,
+      tag,
+      registerMouseEvents: ({ open, close }) => {
+        s.addEventListener("mouseenter", (e) => open(e.ctrlKey));
+        s.addEventListener("mouseleave", close);
+      },
+    });
+    s.appendChild(parent);
+  }
+};
+
+export const enablePageRefObserver = () =>
+  (pageRefObserverRef.current = createHTMLObserver({
+    useBody: true,
+    tag: "SPAN",
+    className: "rm-page-ref",
+    callback: (s: HTMLSpanElement) => {
+      pageRefObservers.forEach((f) => f(s));
+    },
+  }));
+
+const disablePageRefObserver = () => {
+  pageRefObserverRef.current?.disconnect();
+  pageRefObserverRef.current = undefined;
+};
+
+export const onPageRefObserverChange =
+  (handler: (s: HTMLSpanElement) => void) => (b: boolean) => {
+    if (b) {
+      if (!pageRefObservers.size) enablePageRefObserver();
+      pageRefObservers.add(handler);
+    } else {
+      pageRefObservers.delete(handler);
+      if (!pageRefObservers.size) disablePageRefObserver();
+    }
+  };
+
+export const addPageRefObserver = (handler: (s: HTMLSpanElement) => void) => {
+  pageRefObservers.add(handler);
+  if (pageRefObservers.size === 1) enablePageRefObserver();
+};
+
+export const removePageRefObserver = (
+  handler: (s: HTMLSpanElement) => void,
+) => {
+  pageRefObservers.delete(handler);
+  if (pageRefObservers.size === 0) disablePageRefObserver();
+};
+
+export const clearPageRefObservers = () => {
+  disablePageRefObserver();
+  pageRefObservers.clear();
+};
+
+export const getPageRefObserversSize = () => pageRefObservers.size;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new functions for managing page reference observers, enhancing the dynamic observation and interaction with page reference elements.
	- Added new utility functions for determining page types, including checks for canvas pages and discourse node configuration pages.

- **Bug Fixes**
	- Streamlined logic for handling page types and observers, improving overall functionality and performance.

- **Documentation**
	- Updated method signatures and documentation to reflect new utility functions and their usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->