### PR TITLE
Add Personal Node Menu Trigger, style Node Menu

### DIFF
--- a/apps/roam/src/components/DiscourseNodeMenu.tsx
+++ b/apps/roam/src/components/DiscourseNodeMenu.tsx
@@ -154,4 +154,100 @@ export const render = (props: Props) => {
   );
 };
 
+// node_modules\@blueprintjs\core\lib\esm\components\hotkeys\hotkeyParser.js
+const isMac = () => {
+  const platform =
+    typeof navigator !== "undefined" ? navigator.platform : undefined;
+  return platform == null ? false : /Mac|iPod|iPhone|iPad/.test(platform);
+};
+const MODIFIER_BIT_MASKS = {
+  alt: 1,
+  ctrl: 2,
+  meta: 4,
+  shift: 8,
+};
+const ALIASES: { [key: string]: string } = {
+  cmd: "meta",
+  command: "meta",
+  escape: "esc",
+  minus: "-",
+  mod: isMac() ? "meta" : "ctrl",
+  option: "alt",
+  plus: "+",
+  return: "enter",
+  win: "meta",
+};
+const normalizeKeyCombo = (combo: string) => {
+  const keys = combo.replace(/\s/g, "").split("+");
+  return keys.map(function (key) {
+    const keyName = ALIASES[key] != null ? ALIASES[key] : key;
+    return keyName === "meta" ? (isMac() ? "cmd" : "win") : keyName;
+  });
+};
+
+export const getModifiersFromCombo = (comboKey: IKeyCombo) => {
+  if (!comboKey) return [];
+  return [
+    comboKey.modifiers & MODIFIER_BIT_MASKS.alt && "alt",
+    comboKey.modifiers & MODIFIER_BIT_MASKS.ctrl && "ctrl",
+    comboKey.modifiers & MODIFIER_BIT_MASKS.shift && "shift",
+    comboKey.modifiers & MODIFIER_BIT_MASKS.meta && "meta",
+  ].filter(Boolean);
+};
+
+export const NodeMenuTriggerComponent = (
+  extensionAPI: OnloadArgs["extensionAPI"],
+) => {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [isActive, setIsActive] = useState(false);
+  const [comboKey, setComboKey] = useState<IKeyCombo>(
+    () =>
+      (extensionAPI.settings.get(
+        "personal-node-menu-trigger",
+      ) as IKeyCombo) || { modifiers: 0, key: "" },
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      e.stopPropagation();
+      e.preventDefault();
+      const comboObj = getKeyCombo(e.nativeEvent);
+      if (!comboObj.key) return;
+
+      setComboKey({ key: comboObj.key, modifiers: comboObj.modifiers });
+      extensionAPI.settings.set("personal-node-menu-trigger", comboObj);
+    },
+    [extensionAPI],
+  );
+
+  const shortcut = useMemo(() => {
+    if (!comboKey.key) return "";
+
+    const modifiers = getModifiersFromCombo(comboKey);
+    const comboString = [...modifiers, comboKey.key].join("+");
+    return normalizeKeyCombo(comboString).join("+");
+  }, [comboKey]);
+
+  return (
+    <InputGroup
+      inputRef={inputRef}
+      placeholder={isActive ? "Press keys ..." : "Click to set trigger"}
+      value={shortcut}
+      onKeyDown={handleKeyDown}
+      onFocus={() => setIsActive(true)}
+      onBlur={() => setIsActive(false)}
+      rightElement={
+        <Button
+          hidden={!comboKey.key}
+          icon={"remove"}
+          onClick={() => {
+            setComboKey({ modifiers: 0, key: "" });
+            extensionAPI.settings.set("personal-node-menu-trigger", "");
+          }}
+          minimal
+        />
+      }
+    />
+  );
+};
 export default NodeMenu;

--- a/apps/roam/src/components/DiscourseNodeMenu.tsx
+++ b/apps/roam/src/components/DiscourseNodeMenu.tsx
@@ -1,4 +1,13 @@
-import { Menu, MenuItem, Popover, Position } from "@blueprintjs/core";
+import {
+  Menu,
+  MenuItem,
+  Popover,
+  Position,
+  Button,
+  InputGroup,
+  getKeyCombo,
+  IKeyCombo,
+} from "@blueprintjs/core";
 import React, {
   useCallback,
   useEffect,
@@ -14,6 +23,8 @@ import { getCoordsFromTextarea } from "roamjs-components/components/CursorMenu";
 import getDiscourseNodes from "../utils/getDiscourseNodes";
 import createDiscourseNode from "../utils/createDiscourseNode";
 import { getNewDiscourseNodeText } from "../utils/formatUtils";
+import { OnloadArgs } from "roamjs-components/types";
+import { formatHexColor } from "./settings/DiscourseNodeCanvasSettings";
 
 type Props = {
   textarea: HTMLTextAreaElement;
@@ -118,14 +129,28 @@ const NodeMenu = ({ onClose, textarea }: { onClose: () => void } & Props) => {
       content={
         <Menu ulRef={menuRef} data-active-index={activeIndex}>
           {discourseNodes.map((item, i) => {
+            const nodeColor =
+              formatHexColor(item?.canvasSettings?.color) || "#000";
             return (
               <MenuItem
                 key={item.text}
                 data-node={item.type}
-                text={`${item.text} - (${item.shortcut})`}
+                text={item.text}
                 active={i === activeIndex}
                 onMouseEnter={() => setActiveIndex(i)}
                 onClick={() => onSelect(i)}
+                className="flex items-center"
+                icon={
+                  <div
+                    className="mr-2 h-4 w-4 select-none rounded-full"
+                    style={{
+                      backgroundColor: nodeColor,
+                    }}
+                  />
+                }
+                labelElement={
+                  <span className="font-mono">{item.shortcut}</span>
+                }
               />
             );
           })}

--- a/apps/roam/src/settings/settingsPanel.ts
+++ b/apps/roam/src/settings/settingsPanel.ts
@@ -1,4 +1,5 @@
 import { OnloadArgs } from "roamjs-components/types";
+import { NodeMenuTriggerComponent } from "~/components/DiscourseNodeMenu";
 import { SettingsPanel } from "~/components/settings/Settings";
 
 export const createSettingsPanel = (onloadArgs: OnloadArgs) => {
@@ -14,6 +15,17 @@ export const createSettingsPanel = (onloadArgs: OnloadArgs) => {
           type: "reactComponent",
           component: () => SettingsPanel({ onloadArgs }),
         },
+      },
+      {
+        id: "discourse-node-menu-trigger",
+        name: "Personal Node Menu Trigger",
+        action: {
+          type: "reactComponent",
+          component: () => NodeMenuTriggerComponent(extensionAPI),
+        },
+
+        description:
+          "Override the global trigger for the Discourse Node Menu. Must refresh after editing.",
       },
     ],
   });


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/6d4a9302-475c-4dee-bad3-fe59d06c39f1)

![image](https://github.com/user-attachments/assets/45e43f44-8c17-43c0-8545-4b76a52f43bb)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced customizable keyboard shortcuts for the Discourse Node Menu.
	- Added a new setting for users to define their personal Node Menu trigger.
	- Enhanced visual representation of menu items with color indicators.

- **Bug Fixes**
	- Improved handling of keyboard events to prioritize personal triggers over global triggers.

- **Documentation**
	- Updated descriptions for new settings to clarify functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->