### PR TITLE
Roam: add getDiscourseNodes to window obj

### DIFF
--- a/apps/roam/src/index.ts
+++ b/apps/roam/src/index.ts
@@ -20,6 +20,7 @@ import styles from "./styles/styles.css";
 import settingsStyles from "./styles/settingsStyles.css";
 import discourseGraphStyles from "./styles/discourseGraphStyles.css";
 import posthog from "posthog-js";
+import getDiscourseNodes from "./utils/getDiscourseNodes";
 
 const initPostHog = () => {
   posthog.init("phc_SNMmBqwNfcEpNduQ41dBUjtGNEUEKAy6jTn63Fzsrax", {
@@ -103,6 +104,8 @@ export default runExtension(async (onloadArgs) => {
     },
     listActiveQueries: () => listActiveQueries(extensionAPI),
     isDiscourseNode: isDiscourseNode,
+    // @ts-ignore - we are still using roamjs-components global definition
+    getDiscourseNodes: getDiscourseNodes,
   };
 
   return {


### PR DESCRIPTION
@sid597 `window.roamjs.extension.queryBuilder.getDiscourseNodes()` will return all of the info for defined nodes.

![image](https://github.com/user-attachments/assets/f7c3bad7-f6ef-4bac-b06e-3099f6bcf39b)
