### PR TITLE
moved canvas setting to global setting

### DIFF
--- a/apps/roam/src/components/Export.tsx
+++ b/apps/roam/src/components/Export.tsx
@@ -153,7 +153,6 @@ const ExportDialog: ExportDialogComponent = ({
   const [selectedPageUid, setSelectedPageUid] = useState(currentPageUid);
   const isCanvasPage = checkIfCanvasPage({
     title: selectedPageTitle,
-    extensionAPI: getExtensionAPI(),
   });
   const [activeSendToDestination, setActiveSendToDestination] =
     useState<(typeof SEND_TO_DESTINATIONS)[number]>("page");

--- a/apps/roam/src/components/settings/GeneralSettings.tsx
+++ b/apps/roam/src/components/settings/GeneralSettings.tsx
@@ -19,6 +19,14 @@ const DiscourseGraphHome = () => {
         parentUid={settings.settingsUid}
         value={settings.trigger.value || ""}
       />
+      <TextPanel
+        title="Canvas Page Format"
+        description="The page format for canvas pages"
+        order={1}
+        uid={settings.canvasPageFormat.uid}
+        parentUid={settings.settingsUid}
+        value={settings.canvasPageFormat.value || ""}
+      />
     </div>
   );
 };

--- a/apps/roam/src/components/settings/GeneralSettings.tsx
+++ b/apps/roam/src/components/settings/GeneralSettings.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from "react";
 import TextPanel from "roamjs-components/components/ConfigPanels/TextPanel";
 import { getFormattedConfigTree } from "~/utils/discourseConfigRef";
 import refreshConfigTree from "~/utils/refreshConfigTree";
+import { DEFAULT_CANVAS_PAGE_FORMAT } from "~/index";
 
 const DiscourseGraphHome = () => {
   const settings = useMemo(() => {
@@ -17,7 +18,7 @@ const DiscourseGraphHome = () => {
         order={0}
         uid={settings.trigger.uid}
         parentUid={settings.settingsUid}
-        value={settings.trigger.value || ""}
+        value={settings.trigger.value}
       />
       <TextPanel
         title="Canvas Page Format"
@@ -25,7 +26,8 @@ const DiscourseGraphHome = () => {
         order={1}
         uid={settings.canvasPageFormat.uid}
         parentUid={settings.settingsUid}
-        value={settings.canvasPageFormat.value || ""}
+        value={settings.canvasPageFormat.value}
+        defaultValue={DEFAULT_CANVAS_PAGE_FORMAT}
       />
     </div>
   );

--- a/apps/roam/src/components/settings/HomePersonalSettings.tsx
+++ b/apps/roam/src/components/settings/HomePersonalSettings.tsx
@@ -29,14 +29,6 @@ const HomePersonalSettings = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
   return (
     <div className="flex flex-col gap-4 p-1">
       <Label>
-        Canvas Page Format
-        <Description description={"The page format for canvas pages"} />
-        <InputGroup
-          value={canvasPage}
-          onChange={(e) => handleSetCanvasPage(e.target.value)}
-        />
-      </Label>
-      <Label>
         Personal Node Menu Trigger
         <Description
           description={

--- a/apps/roam/src/components/settings/HomePersonalSettings.tsx
+++ b/apps/roam/src/components/settings/HomePersonalSettings.tsx
@@ -1,8 +1,7 @@
-import React, { useState, useMemo } from "react";
+import React from "react";
 import { OnloadArgs } from "roamjs-components/types";
-import { Label, InputGroup, Checkbox } from "@blueprintjs/core";
+import { Label, Checkbox } from "@blueprintjs/core";
 import Description from "roamjs-components/components/Description";
-import { DEFAULT_CANVAS_PAGE_FORMAT } from "~/index";
 import { NodeMenuTriggerComponent } from "../DiscourseNodeMenu";
 import {
   getOverlayHandler,
@@ -10,15 +9,8 @@ import {
   previewPageRefHandler,
 } from "~/utils/pageRefObserverHandlers";
 
-const CANVAS_PAGE_FORMAT_KEY = "canvas-page-format";
 const HomePersonalSettings = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
   const extensionAPI = onloadArgs.extensionAPI;
-  const getInitCanvasPage = () => {
-    const savedFormat = extensionAPI.settings.get(
-      CANVAS_PAGE_FORMAT_KEY,
-    ) as string;
-    return savedFormat || DEFAULT_CANVAS_PAGE_FORMAT;
-  };
   const overlayHandler = getOverlayHandler(onloadArgs);
 
   return (

--- a/apps/roam/src/components/settings/HomePersonalSettings.tsx
+++ b/apps/roam/src/components/settings/HomePersonalSettings.tsx
@@ -19,11 +19,6 @@ const HomePersonalSettings = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
     ) as string;
     return savedFormat || DEFAULT_CANVAS_PAGE_FORMAT;
   };
-  const [canvasPage, setCanvasPage] = useState(getInitCanvasPage);
-  const handleSetCanvasPage = (e: string) => {
-    extensionAPI.settings.set(CANVAS_PAGE_FORMAT_KEY, e);
-    setCanvasPage(e);
-  };
   const overlayHandler = getOverlayHandler(onloadArgs);
 
   return (

--- a/apps/roam/src/components/settings/Settings.tsx
+++ b/apps/roam/src/components/settings/Settings.tsx
@@ -15,6 +15,7 @@ import getDiscourseNodes, {
 import NodeConfig from "./NodeConfig";
 import sendErrorEmail from "~/utils/sendErrorEmail";
 import HomePersonalSettings from "./HomePersonalSettings";
+import refreshConfigTree from "~/utils/refreshConfigTree";
 
 type SectionHeaderProps = {
   children: React.ReactNode;
@@ -74,7 +75,10 @@ export const SettingsDialog = ({
   return (
     <Dialog
       isOpen={isOpen}
-      onClose={onClose}
+      onClose={() => {
+        refreshConfigTree();
+        onClose?.();
+      }}
       isCloseButtonShown={false}
       style={{ width: "80vw", height: "80vh" }}
       className="relative bg-white"

--- a/apps/roam/src/utils/configPageTabs.ts
+++ b/apps/roam/src/utils/configPageTabs.ts
@@ -27,13 +27,6 @@ export const configPageTabs = (args: OnloadArgs): ConfigTab[] => [
         // @ts-ignore
         Panel: TextPanel,
       },
-      {
-        title: "Canvas Page Format",
-        description: "The page format for canvas pages",
-        defaultValue: "Canvas/*",
-        // @ts-ignore
-        Panel: TextPanel,
-      },
     ],
   },
   {

--- a/apps/roam/src/utils/configPageTabs.ts
+++ b/apps/roam/src/utils/configPageTabs.ts
@@ -27,6 +27,13 @@ export const configPageTabs = (args: OnloadArgs): ConfigTab[] => [
         // @ts-ignore
         Panel: TextPanel,
       },
+      {
+        title: "Canvas Page Format",
+        description: "The page format for canvas pages",
+        defaultValue: "Canvas/*",
+        // @ts-ignore
+        Panel: TextPanel,
+      },
     ],
   },
   {

--- a/apps/roam/src/utils/discourseConfigRef.ts
+++ b/apps/roam/src/utils/discourseConfigRef.ts
@@ -20,6 +20,7 @@ type FormattedConfigTree = {
   nodesUid: string;
   trigger: StringSetting;
   export: ExportConfigWithUids;
+  canvasPageFormat: StringSetting;
 };
 
 export const getFormattedConfigTree = (): FormattedConfigTree => {
@@ -42,6 +43,10 @@ export const getFormattedConfigTree = (): FormattedConfigTree => {
       text: "trigger",
     }),
     export: getExportSettingsAndUids(),
+    canvasPageFormat: getUidAndStringSetting({
+      tree: configTreeRef.tree,
+      text: "Canvas Page Format",
+    }),
   };
 };
 export default configTreeRef;

--- a/apps/roam/src/utils/isCanvasPage.ts
+++ b/apps/roam/src/utils/isCanvasPage.ts
@@ -1,14 +1,19 @@
 import { OnloadArgs } from "roamjs-components/types";
 import { DEFAULT_CANVAS_PAGE_FORMAT } from "..";
+import type { RoamBasicNode } from "roamjs-components/types";
+import { getUidAndStringSetting } from "./getExportSettings";
 
-export const isCanvasPage = ({
-  title,
-  extensionAPI,
-}: {
-  title: string;
-  extensionAPI: OnloadArgs["extensionAPI"];
-}) => {
-  const formatInSettings = extensionAPI.settings.get("canvas-page-format");
+const configTreeRef: {
+  tree: RoamBasicNode[];
+  nodes: { [uid: string]: { text: string; children: RoamBasicNode[] } };
+} = { tree: [], nodes: {} };
+
+export const isCanvasPage = ({ title }: { title: string }) => {
+  const formatInSettings = getUidAndStringSetting({
+    tree: configTreeRef.tree,
+    text: "Canvas Page Format",
+  });
+  console.log("formatInSettings", formatInSettings);
   const format = formatInSettings || DEFAULT_CANVAS_PAGE_FORMAT;
   const canvasRegex = new RegExp(`^${format}$`.replace(/\*/g, ".+"));
   return canvasRegex.test(title);
@@ -17,12 +22,9 @@ export const isCanvasPage = ({
 export const isCurrentPageCanvas = ({
   title,
   h1,
-  onloadArgs,
 }: {
   title: string;
   h1: HTMLHeadingElement;
-  onloadArgs: OnloadArgs;
 }) => {
-  const { extensionAPI } = onloadArgs;
-  return isCanvasPage({ title, extensionAPI }) && !!h1.closest(".roam-article");
+  return isCanvasPage({ title }) && !!h1.closest(".roam-article");
 };

--- a/apps/roam/src/utils/isCanvasPage.ts
+++ b/apps/roam/src/utils/isCanvasPage.ts
@@ -1,20 +1,9 @@
-import { OnloadArgs } from "roamjs-components/types";
 import { DEFAULT_CANVAS_PAGE_FORMAT } from "..";
-import type { RoamBasicNode } from "roamjs-components/types";
-import { getUidAndStringSetting } from "./getExportSettings";
-
-const configTreeRef: {
-  tree: RoamBasicNode[];
-  nodes: { [uid: string]: { text: string; children: RoamBasicNode[] } };
-} = { tree: [], nodes: {} };
+import { getFormattedConfigTree } from "./discourseConfigRef";
 
 export const isCanvasPage = ({ title }: { title: string }) => {
-  const formatInSettings = getUidAndStringSetting({
-    tree: configTreeRef.tree,
-    text: "Canvas Page Format",
-  });
-  console.log("formatInSettings", formatInSettings);
-  const format = formatInSettings || DEFAULT_CANVAS_PAGE_FORMAT;
+  const { canvasPageFormat } = getFormattedConfigTree();
+  const format = canvasPageFormat.value || DEFAULT_CANVAS_PAGE_FORMAT;
   const canvasRegex = new RegExp(`^${format}$`.replace(/\*/g, ".+"));
   return canvasRegex.test(title);
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a "Canvas Page Format" configuration option, allowing users to specify the format for canvas pages with clear titles, descriptions, and default values.
  
- **Refactor**
  - Streamlined user settings by removing the previous "Canvas Page Format" controls from personal settings and consolidating the configuration in a dedicated panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->