### PR TITLE
Roam: Add zoom-path column view option

### DIFF
--- a/apps/roam/src/components/results-view/ResultsTable.tsx
+++ b/apps/roam/src/components/results-view/ResultsTable.tsx
@@ -176,11 +176,13 @@ export const CellEmbed = ({
     const el = contentRef.current;
     const open =
       viewValue === "open" ? true : viewValue === "closed" ? false : null;
+    const zoomPath = viewValue === "On" ? true : false; // temp
     if (el) {
       window.roamAlphaAPI.ui.components.renderBlock({
         uid,
         el,
         // "open?": open, // waiting for roamAlphaAPI to add a open/close to renderBlock
+        "zoom-path?": zoomPath, // TODO update roamjs-components
       });
     }
   }, [contentRef]);

--- a/apps/roam/src/components/results-view/ResultsView.tsx
+++ b/apps/roam/src/components/results-view/ResultsView.tsx
@@ -52,7 +52,7 @@ import { Inputs } from "./Inputs";
 const VIEWS: Record<string, { value: boolean }> = {
   link: { value: false },
   plain: { value: false },
-  embed: { value: false },
+  embed: { value: true },
   alias: { value: true },
 };
 
@@ -1040,11 +1040,32 @@ const ResultsView: ResultsViewComponent = ({
                                     <Icon
                                       icon="info-sign"
                                       iconSize={12}
-                                      className="opacity-80 ml-2 align-middle"
+                                      className="ml-2 align-middle opacity-80"
                                     />
                                   </Tooltip>
                                 </div>
                               )} */}
+                              {/* TEMP JUST FOR USER TESTING */}
+                              {/* view.value shape has to change */}
+                              {mode === "embed" && (
+                                <div className="flex items-center">
+                                  <MenuItemSelect
+                                    className="roamjs-view-select"
+                                    items={["Off", "On"]}
+                                    activeItem={!!value ? value : "Off"}
+                                    onItemSelect={(value) => {
+                                      onViewChange({ mode, column, value }, i);
+                                    }}
+                                  />
+                                  <Tooltip content="Include zoom-path">
+                                    <Icon
+                                      icon="info-sign"
+                                      iconSize={12}
+                                      className="ml-2 align-middle opacity-80"
+                                    />
+                                  </Tooltip>
+                                </div>
+                              )}
                             </td>
                           )}
                         </tr>


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/cee1e91d-715a-4a2f-976e-8e006cfa3277)


temp draft to allow users to view/test
`view.value` shape has to change to support multiple options