### PR TITLE
Roam: temp fix for useSyncExternalStore error on direct load

### DIFF
--- a/apps/roam/src/components/canvas/Tldraw.tsx
+++ b/apps/roam/src/components/canvas/Tldraw.tsx
@@ -822,6 +822,16 @@ const TldrawCanvas = ({ title }: Props) => {
     };
   }, []);
 
+  // TEMP HACK for useSyncExternalStore error on direct load
+  const [isLoading, setIsLoading] = useState(true);
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setIsLoading(false);
+    }, 250);
+
+    return () => clearTimeout(timer);
+  }, []);
+
   return (
     <div
       className={`z-10 h-full w-full overflow-hidden rounded-md border border-gray-300 bg-white ${
@@ -861,88 +871,93 @@ const TldrawCanvas = ({ title }: Props) => {
         font-family: var(--rs-font-sans);
       }`}
       </style>
-      <TldrawEditor
-        baseUrl="https://samepage.network/assets/tldraw/"
-        instanceId={instanceId}
-        userId={userId}
-        config={customTldrawConfig}
-        store={store}
-        onMount={(app) => {
-          if (process.env.NODE_ENV !== "production") {
-            if (!window.tldrawApps) window.tldrawApps = {};
-            const { tldrawApps } = window;
-            tldrawApps[title] = app;
-          }
-          appRef.current = app;
-          posthog.capture("Canvas: Mounted", {
-            title: title,
-          });
-          // TODO - this should move to one of DiscourseNodeTool's children classes instead
-          app.on("event", (e) => {
-            discourseContext.lastAppEvent = e.name;
-
-            const validModifier = e.shiftKey || e.ctrlKey || e.metaKey;
-            if (!(e.name === "pointer_up" && e.shape && validModifier)) return;
-            if (app.selectedIds.length) return; // User is positioning selected shape
-
-            const shapeUid = e.shape?.props.uid;
-            if (!isLiveBlock(shapeUid)) {
-              if (!e.shape.props.title) return;
-              renderToast({
-                id: "tldraw-warning",
-                intent: "warning",
-                content: `Not a valid UID. Cannot Open.`,
-              });
+      {isLoading ? (
+        <></>
+      ) : (
+        <TldrawEditor
+          baseUrl="https://samepage.network/assets/tldraw/"
+          instanceId={instanceId}
+          userId={userId}
+          config={customTldrawConfig}
+          store={store}
+          onMount={(app) => {
+            if (process.env.NODE_ENV !== "production") {
+              if (!window.tldrawApps) window.tldrawApps = {};
+              const { tldrawApps } = window;
+              tldrawApps[title] = app;
             }
+            appRef.current = app;
+            posthog.capture("Canvas: Mounted", {
+              title: title,
+            });
+            // TODO - this should move to one of DiscourseNodeTool's children classes instead
+            app.on("event", (e) => {
+              discourseContext.lastAppEvent = e.name;
 
-            if (e.shiftKey) {
-              // TODO - do not openBlockInSidebar if user is using shift to select
-              openBlockInSidebar(e.shape.props.uid);
-            }
-            if (e.ctrlKey || e.metaKey) {
-              const isPage = !!getPageTitleByPageUid(shapeUid);
-              if (isPage) {
-                window.roamAlphaAPI.ui.mainWindow.openPage({
-                  page: { uid: shapeUid },
-                });
-              } else {
-                window.roamAlphaAPI.ui.mainWindow.openBlock({
-                  block: { uid: shapeUid },
+              const validModifier = e.shiftKey || e.ctrlKey || e.metaKey;
+              if (!(e.name === "pointer_up" && e.shape && validModifier))
+                return;
+              if (app.selectedIds.length) return; // User is positioning selected shape
+
+              const shapeUid = e.shape?.props.uid;
+              if (!isLiveBlock(shapeUid)) {
+                if (!e.shape.props.title) return;
+                renderToast({
+                  id: "tldraw-warning",
+                  intent: "warning",
+                  content: `Not a valid UID. Cannot Open.`,
                 });
               }
-            }
-          });
-          const oldOnBeforeDelete = app.store.onBeforeDelete;
-          app.store.onBeforeDelete = (record) => {
-            oldOnBeforeDelete?.(record);
-            if (record.typeName === "shape") {
-              const util = app.getShapeUtil(record);
-              if (util instanceof DiscourseNodeUtil) {
-                util.onBeforeDelete(record as DiscourseNodeShape);
+
+              if (e.shiftKey) {
+                // TODO - do not openBlockInSidebar if user is using shift to select
+                openBlockInSidebar(e.shape.props.uid);
               }
-            }
-          };
-          const oldOnAfterCreate = app.store.onAfterCreate;
-          app.store.onAfterCreate = (record) => {
-            oldOnAfterCreate?.(record);
-            if (record.typeName === "shape") {
-              const util = app.getShapeUtil(record);
-              if (util instanceof DiscourseNodeUtil) {
-                util.onAfterCreate(record as DiscourseNodeShape);
+              if (e.ctrlKey || e.metaKey) {
+                const isPage = !!getPageTitleByPageUid(shapeUid);
+                if (isPage) {
+                  window.roamAlphaAPI.ui.mainWindow.openPage({
+                    page: { uid: shapeUid },
+                  });
+                } else {
+                  window.roamAlphaAPI.ui.mainWindow.openBlock({
+                    block: { uid: shapeUid },
+                  });
+                }
               }
-            }
-          };
-        }}
-      >
-        <TldrawUi
-          assetBaseUrl="https://samepage.network/assets/tldraw/"
-          overrides={uiOverrides}
+            });
+            const oldOnBeforeDelete = app.store.onBeforeDelete;
+            app.store.onBeforeDelete = (record) => {
+              oldOnBeforeDelete?.(record);
+              if (record.typeName === "shape") {
+                const util = app.getShapeUtil(record);
+                if (util instanceof DiscourseNodeUtil) {
+                  util.onBeforeDelete(record as DiscourseNodeShape);
+                }
+              }
+            };
+            const oldOnAfterCreate = app.store.onAfterCreate;
+            app.store.onAfterCreate = (record) => {
+              oldOnAfterCreate?.(record);
+              if (record.typeName === "shape") {
+                const util = app.getShapeUtil(record);
+                if (util instanceof DiscourseNodeUtil) {
+                  util.onAfterCreate(record as DiscourseNodeShape);
+                }
+              }
+            };
+          }}
         >
-          <ContextMenu>
-            <Canvas />
-          </ContextMenu>
-        </TldrawUi>
-      </TldrawEditor>
+          <TldrawUi
+            assetBaseUrl="https://samepage.network/assets/tldraw/"
+            overrides={uiOverrides}
+          >
+            <ContextMenu>
+              <Canvas />
+            </ContextMenu>
+          </TldrawUi>
+        </TldrawEditor>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
https://www.loom.com/share/4e62f554c0f245bf879fbd3826165859
https://linear.app/discourse-graphs/issue/ENG-106/query-builder-tldraw-next-error

```javascript
TypeError: Cannot read properties of undefined (reading 'next')
    at Fh (https://roamresearch.com/js/compiled/main.js:317:391)
    at Object.useState (https://roamresearch.com/js/compiled/main.js:459:422)
    at c.useState (https://roamresearch.com/js/compiled/main.js:199:263)
    at Object.Bae [as useSyncExternalStore] (blob:https://roamresearch.com/57bd50f8-13ae-494f-b1e2-f45ff284411d:1:2253)
    at kf (blob:https://roamresearch.com/5c4ffe65-6f93-4e2a-a001-30ec4f2ca418:157:74826)
    at Object.apply (blob:https://roamresearch.com/5c4ffe65-6f93-4e2a-a001-30ec4f2ca418:157:74979)
    at qe (https://roamresearch.com/js/compiled/main.js:315:278)
    at Ue (https://roamresearch.com/js/compiled/main.js:334:440)
    at Fg (https://roamresearch.com/js/compiled/main.js:333:86)
    at ar (https://roamresearch.com/js/compiled/main.js:474:244)
```

Usually happens when loading roam directly on to a Canvas page.
the `useSyncExternalStore` call stems from the `signia-react` package


