### PR TITLE
Roam: Add feedback toggle

### DIFF
--- a/apps/roam/src/components/BirdEatsBugs.tsx
+++ b/apps/roam/src/components/BirdEatsBugs.tsx
@@ -1,4 +1,5 @@
 import getCurrentUserEmail from "roamjs-components/queries/getCurrentUserEmail";
+import { OnloadArgs } from "roamjs-components/types";
 
 type FeedbackWidget = {
   initialize?: boolean;
@@ -40,7 +41,45 @@ declare global {
   }
 }
 
-export const initFeedbackWidget = (): void => {
+const addFeedbackButtonHidingStyles = () => {
+  const styleId = "feedback-button-hiding-styles";
+
+  if (document.getElementById(styleId)) {
+    return;
+  }
+
+  const styleElement = document.createElement("style");
+  styleElement.id = styleId;
+  styleElement.textContent = `
+    #birdeatsbug-sdk,
+    #birdeatsbug-default-button {
+      display: none !important;
+    }
+  `;
+
+  document.head.appendChild(styleElement);
+};
+
+const removeFeedbackButtonHidingStyles = () => {
+  const styleElement = document.getElementById("feedback-button-hiding-styles");
+  if (styleElement) {
+    styleElement.remove();
+  }
+};
+
+export const initFeedbackWidget = (
+  extensionAPI?: OnloadArgs["extensionAPI"],
+): void => {
+  if (
+    extensionAPI &&
+    (extensionAPI.settings.get("hide-feedback-button") as boolean)
+  ) {
+    addFeedbackButtonHidingStyles();
+    return;
+  } else if (extensionAPI) {
+    removeFeedbackButtonHidingStyles();
+  }
+
   const birdeatsbug = (window.birdeatsbug =
     window.birdeatsbug || []) as FeedbackWidget;
 
@@ -175,3 +214,6 @@ export const initFeedbackWidget = (): void => {
     });
   }
 };
+
+export const hideFeedbackButton = addFeedbackButtonHidingStyles;
+export const showFeedbackButton = removeFeedbackButtonHidingStyles;

--- a/apps/roam/src/components/BirdEatsBugs.tsx
+++ b/apps/roam/src/components/BirdEatsBugs.tsx
@@ -41,15 +41,15 @@ declare global {
   }
 }
 
-const addFeedbackButtonHidingStyles = () => {
-  const styleId = "feedback-button-hiding-styles";
+const STYLE_ID = "feedback-button-hiding-styles";
 
-  if (document.getElementById(styleId)) {
+const addFeedbackButtonHidingStyles = () => {
+  if (document.getElementById(STYLE_ID)) {
     return;
   }
 
   const styleElement = document.createElement("style");
-  styleElement.id = styleId;
+  styleElement.id = STYLE_ID;
   styleElement.textContent = `
     #birdeatsbug-sdk,
     #birdeatsbug-default-button {
@@ -61,24 +61,21 @@ const addFeedbackButtonHidingStyles = () => {
 };
 
 const removeFeedbackButtonHidingStyles = () => {
-  const styleElement = document.getElementById("feedback-button-hiding-styles");
+  const styleElement = document.getElementById(STYLE_ID);
   if (styleElement) {
     styleElement.remove();
   }
 };
 
 export const initFeedbackWidget = (
-  extensionAPI?: OnloadArgs["extensionAPI"],
+  extensionAPI: OnloadArgs["extensionAPI"],
 ): void => {
-  if (
-    extensionAPI &&
-    (extensionAPI.settings.get("hide-feedback-button") as boolean)
-  ) {
+  if (extensionAPI.settings.get("hide-feedback-button") as boolean) {
     addFeedbackButtonHidingStyles();
     return;
-  } else if (extensionAPI) {
-    removeFeedbackButtonHidingStyles();
   }
+
+  removeFeedbackButtonHidingStyles();
 
   const birdeatsbug = (window.birdeatsbug =
     window.birdeatsbug || []) as FeedbackWidget;

--- a/apps/roam/src/components/settings/HomePersonalSettings.tsx
+++ b/apps/roam/src/components/settings/HomePersonalSettings.tsx
@@ -8,6 +8,7 @@ import {
   onPageRefObserverChange,
   previewPageRefHandler,
 } from "~/utils/pageRefObserverHandlers";
+import { hideFeedbackButton, showFeedbackButton } from "../BirdEatsBugs";
 
 const HomePersonalSettings = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
   const extensionAPI = onloadArgs.extensionAPI;
@@ -80,6 +81,40 @@ const HomePersonalSettings = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
             <Description
               description={
                 "Whether or not to display page previews when hovering over page refs"
+              }
+            />
+          </>
+        }
+      />
+      <Checkbox
+        defaultChecked={
+          extensionAPI.settings.get("hide-feedback-button") as boolean
+        }
+        onChange={(e) => {
+          const target = e.target as HTMLInputElement;
+          extensionAPI.settings.set("hide-feedback-button", target.checked);
+
+          if (target.checked) {
+            hideFeedbackButton();
+          } else {
+            showFeedbackButton();
+          }
+
+          if (
+            !document.getElementById("birdeatsbug-default-button") &&
+            !document.getElementById("feedback-button-hiding-styles")
+          ) {
+            alert(
+              "Please refresh the page for this change to take full effect.",
+            );
+          }
+        }}
+        labelElement={
+          <>
+            Hide Feedback Button
+            <Description
+              description={
+                "Hide the 'Send feedback' button at the bottom right of the screen. Changes take full effect after page refresh."
               }
             />
           </>

--- a/apps/roam/src/components/settings/HomePersonalSettings.tsx
+++ b/apps/roam/src/components/settings/HomePersonalSettings.tsx
@@ -2,14 +2,16 @@ import React from "react";
 import { OnloadArgs } from "roamjs-components/types";
 import { Label, Checkbox } from "@blueprintjs/core";
 import Description from "roamjs-components/components/Description";
-import { NodeMenuTriggerComponent } from "../DiscourseNodeMenu";
+import { NodeMenuTriggerComponent } from "~/components/DiscourseNodeMenu";
 import {
   getOverlayHandler,
   onPageRefObserverChange,
   previewPageRefHandler,
 } from "~/utils/pageRefObserverHandlers";
-import { hideFeedbackButton, showFeedbackButton } from "../BirdEatsBugs";
-import renderToast from "roamjs-components/components/Toast";
+import {
+  hideFeedbackButton,
+  showFeedbackButton,
+} from "~/components/BirdEatsBugs";
 
 const HomePersonalSettings = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
   const extensionAPI = onloadArgs.extensionAPI;

--- a/apps/roam/src/components/settings/HomePersonalSettings.tsx
+++ b/apps/roam/src/components/settings/HomePersonalSettings.tsx
@@ -9,6 +9,7 @@ import {
   previewPageRefHandler,
 } from "~/utils/pageRefObserverHandlers";
 import { hideFeedbackButton, showFeedbackButton } from "../BirdEatsBugs";
+import renderToast from "roamjs-components/components/Toast";
 
 const HomePersonalSettings = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
   const extensionAPI = onloadArgs.extensionAPI;
@@ -99,22 +100,13 @@ const HomePersonalSettings = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
           } else {
             showFeedbackButton();
           }
-
-          if (
-            !document.getElementById("birdeatsbug-default-button") &&
-            !document.getElementById("feedback-button-hiding-styles")
-          ) {
-            alert(
-              "Please refresh the page for this change to take full effect.",
-            );
-          }
         }}
         labelElement={
           <>
             Hide Feedback Button
             <Description
               description={
-                "Hide the 'Send feedback' button at the bottom right of the screen. Changes take full effect after page refresh."
+                "Hide the 'Send feedback' button at the bottom right of the screen."
               }
             />
           </>

--- a/apps/roam/src/index.ts
+++ b/apps/roam/src/index.ts
@@ -60,7 +60,7 @@ export default runExtension(async (onloadArgs) => {
     });
   }
 
-  initFeedbackWidget();
+  initFeedbackWidget(onloadArgs.extensionAPI);
 
   if (window?.roamjs?.loaded?.has("query-builder")) {
     renderToast({


### PR DESCRIPTION
add settings to hide or show button, also works when disabled or enabled midway

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced dynamic control of the feedback widget, allowing users to toggle the visibility of the feedback button via a new settings checkbox.
  - Enhanced the initialization process to apply user preferences for feedback button display.
  - Enabled external control for showing or hiding the feedback button.
  - Added a prompt to refresh the page when visibility elements are not detected for the changes to take full effect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->