### PR TITLE
[ENG-97] Use TailwindCSS in obsidian app

### DIFF
--- a/apps/obsidian/package.json
+++ b/apps/obsidian/package.json
@@ -12,7 +12,6 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "@repo/tailwind-config": "*",
     "@types/node": "^16.11.6",
     "@typescript-eslint/eslint-plugin": "5.29.0",
     "@typescript-eslint/parser": "5.29.0",

--- a/apps/obsidian/package.json
+++ b/apps/obsidian/package.json
@@ -12,6 +12,7 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
+    "@repo/tailwind-config": "*",
     "@types/node": "^16.11.6",
     "@typescript-eslint/eslint-plugin": "5.29.0",
     "@typescript-eslint/parser": "5.29.0",
@@ -20,7 +21,10 @@
     "obsidian": "^1.7.2",
     "tslib": "2.4.0",
     "tsx": "^4.19.2",
-    "typescript": "4.7.4"
+    "typescript": "4.7.4",
+    "tailwindcss": "^3.3.0",
+    "postcss": "^8.4.24",
+    "autoprefixer": "^10.4.14"
   },
   "dependencies": {
     "react": "^19.0.0",

--- a/apps/obsidian/postcss.config.js
+++ b/apps/obsidian/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/apps/obsidian/styles.css
+++ b/apps/obsidian/styles.css
@@ -1,3 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 .discourse-relations .relationship-visualization {
   transition: all 0.2s ease;
 }

--- a/apps/obsidian/tailwind.config.ts
+++ b/apps/obsidian/tailwind.config.ts
@@ -1,0 +1,7 @@
+import type { Config } from "tailwindcss";
+
+const config: Pick<Config, "content" | "presets"> = {
+  content: ["./src/**/*.{js,jsx,ts,tsx}"],
+};
+
+export default config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,9 +34,12 @@
         "@types/node": "^16.11.6",
         "@typescript-eslint/eslint-plugin": "5.29.0",
         "@typescript-eslint/parser": "5.29.0",
+        "autoprefixer": "^10.4.14",
         "builtin-modules": "3.3.0",
         "esbuild": "0.17.3",
         "obsidian": "^1.7.2",
+        "postcss": "^8.4.24",
+        "tailwindcss": "^3.3.0",
         "tslib": "2.4.0",
         "tsx": "^4.19.2",
         "typescript": "4.7.4"


### PR DESCRIPTION
Update Obsidian app to integrate Tailwind CSS with PostCSS and Autoprefixer support

- Added Tailwind CSS, PostCSS, and Autoprefixer to package dependencies
- Configured styles.css to include Tailwind directives
- Enhanced compile script to process styles using PostCSS with Tailwind and Autoprefixer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the styling workflow by integrating modern CSS tools to deliver a more consistent and refined visual experience. The system now intelligently processes primary styles together with additional styles, ensuring a seamless design.

- **Chores**
  - Updated internal styling dependencies and configurations to support improved CSS processing and maintain development efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->