### PR TITLE
Eng 286 show when GitHub sync is disabled globally

### DIFF
--- a/apps/roam/src/components/settings/GeneralSettings.tsx
+++ b/apps/roam/src/components/settings/GeneralSettings.tsx
@@ -40,7 +40,13 @@ const DiscourseGraphHome = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
         uid={settings.githubSync.uid}
         value={settings.githubSync.value}
         options={{
-          onChange: (checked) => toggleGitHubSync(checked, onloadArgs),
+          onChange: async (checked) => {
+            await toggleGitHubSync(checked, onloadArgs);
+            setTimeout(() => {
+              // Wait for the GitHub Sync flag block to be updated
+              refreshConfigTree();
+            }, 250);
+          },
         }}
       />
     </div>

--- a/apps/roam/src/components/settings/Settings.tsx
+++ b/apps/roam/src/components/settings/Settings.tsx
@@ -155,7 +155,13 @@ export const SettingsDialog = ({
               id={n.type}
               title={n.text}
               className="overflow-y-auto"
-              panel={<NodeConfig node={n} onloadArgs={onloadArgs} />}
+              panel={
+                <NodeConfig
+                  node={n}
+                  onloadArgs={onloadArgs}
+                  setMainTab={setSelectedTabId}
+                />
+              }
             />
           ))}
           <Tabs.Expander />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added navigation from node settings to global settings when GitHub Sync is disabled globally.
  - GitHub Sync UI in node settings is now conditionally displayed based on global enablement.

- **Improvements**
  - Ensured consistent availability of discourse node context for GitHub Sync comment operations.
  - Improved refresh timing of configuration after toggling the GitHub Sync flag.

- **User Interface**
  - Updated settings panels to reflect global GitHub Sync status and provide clearer navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->