### PR TITLE
Roam: When a user deletes a node also delete all the corresponding relations to the node - ENG-26

### DIFF
--- a/apps/roam/src/components/settings/DiscourseNodeConfigPanel.tsx
+++ b/apps/roam/src/components/settings/DiscourseNodeConfigPanel.tsx
@@ -193,7 +193,6 @@ const DiscourseNodeConfigPanel: React.FC<DiscourseNodeConfigPanelProps> = ({
                   />
                 </Tooltip>
                 <Button
-                  children="Confirm"
                   intent={Intent.DANGER}
                   onClick={() => {
                     handleDeleteNodeTypeWithConfirmation(n.type, n.text);
@@ -201,14 +200,17 @@ const DiscourseNodeConfigPanel: React.FC<DiscourseNodeConfigPanelProps> = ({
                   className={`mx-1 ${
                     deleteConfirmation !== n.type ? "opacity-0" : ""
                   }`}
-                />
+                >
+                  Confirm
+                </Button>
                 <Button
-                  children="Cancel"
                   onClick={() => setDeleteConfirmation(null)}
                   className={`mx-1 ${
                     deleteConfirmation !== n.type ? "opacity-0" : ""
                   }`}
-                />
+                >
+                  Cancel
+                </Button>
               </td>
             </tr>
           ))}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a confirmation dialog when deleting a discourse node type, allowing users to review and confirm the deletion.
  - If the node type has related discourse relations, the dialog lists them and warns that they will also be deleted.
  - Users can now cancel the deletion process from the dialog.
- **Improvements**
  - The node list and configuration tree update automatically after deletions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->