### PR TITLE
[ENG-301] Create node in right-click menu

### DIFF
--- a/apps/obsidian/src/components/NodeTypeModal.tsx
+++ b/apps/obsidian/src/components/NodeTypeModal.tsx
@@ -27,6 +27,10 @@ export class NodeTypeModal extends SuggestModal<DiscourseNode> {
   }
 
   async onChooseSuggestion(nodeType: DiscourseNode) {
-    await processTextToDiscourseNode(this.app, this.editor, nodeType);
+    await processTextToDiscourseNode({
+      app: this.app,
+      editor: this.editor,
+      nodeType,
+    });
   }
 }

--- a/apps/obsidian/src/components/NodeTypeModal.tsx
+++ b/apps/obsidian/src/components/NodeTypeModal.tsx
@@ -1,7 +1,6 @@
 import { App, Editor, SuggestModal, TFile, Notice } from "obsidian";
 import { DiscourseNode } from "~/types";
-import { getDiscourseNodeFormatExpression } from "~/utils/getDiscourseNodeFormatExpression";
-import { checkInvalidChars } from "~/utils/validateNodeType";
+import { processTextToDiscourseNode } from "~/utils/createNodeFromSelectedText";
 
 export class NodeTypeModal extends SuggestModal<DiscourseNode> {
   constructor(
@@ -27,58 +26,7 @@ export class NodeTypeModal extends SuggestModal<DiscourseNode> {
     el.createEl("div", { text: nodeType.name });
   }
 
-  async createDiscourseNode(
-    title: string,
-    nodeType: DiscourseNode,
-  ): Promise<TFile | null> {
-    try {
-      const instanceId = `${nodeType.id}-${Date.now()}`;
-      const filename = `${title}.md`;
-
-      await this.app.vault.create(filename, "");
-
-      const newFile = this.app.vault.getAbstractFileByPath(filename);
-      if (!(newFile instanceof TFile)) {
-        throw new Error("Failed to create new file");
-      }
-
-      await this.app.fileManager.processFrontMatter(newFile, (fm) => {
-        fm.nodeTypeId = nodeType.id;
-        fm.nodeInstanceId = instanceId;
-      });
-
-      new Notice(`Created discourse node: ${title}`);
-      return newFile;
-    } catch (error: unknown) {
-      const errorMessage =
-        error instanceof Error ? error.message : "Unknown error";
-      new Notice(`Error creating discourse node: ${errorMessage}`, 5000);
-      console.error("Failed to create discourse node:", error);
-      return null;
-    }
-  }
-
   async onChooseSuggestion(nodeType: DiscourseNode) {
-    const selectedText = this.editor.getSelection();
-    const regex = getDiscourseNodeFormatExpression(nodeType.format);
-
-    const nodeFormat = regex.source.match(/^\^(.*?)\(\.\*\?\)(.*?)\$$/);
-    if (!nodeFormat) return;
-
-    const formattedNodeName =
-      nodeFormat[1]?.replace(/\\/g, "") +
-      selectedText +
-      nodeFormat[2]?.replace(/\\/g, "");
-
-    const isFilenameValid = checkInvalidChars(formattedNodeName);
-    if (!isFilenameValid.isValid) {
-      new Notice(`${isFilenameValid.error}`, 5000);
-      return;
-    }
-
-    const newFile = await this.createDiscourseNode(formattedNodeName, nodeType);
-    if (newFile) {
-      this.editor.replaceSelection(`[[${formattedNodeName}]]`);
-    }
+    await processTextToDiscourseNode(this.app, this.editor, nodeType);
   }
 }

--- a/apps/obsidian/src/index.ts
+++ b/apps/obsidian/src/index.ts
@@ -47,7 +47,11 @@ export default class DiscourseGraphPlugin extends Plugin {
                 .setTitle(nodeType.name)
                 .setIcon("file-type")
                 .onClick(async () => {
-                  await processTextToDiscourseNode(this.app, editor, nodeType);
+                  await processTextToDiscourseNode({
+                    app: this.app,
+                    editor,
+                    nodeType,
+                  });
                 });
             });
           });

--- a/apps/obsidian/src/index.ts
+++ b/apps/obsidian/src/index.ts
@@ -4,8 +4,6 @@ import { Settings } from "~/types";
 import { registerCommands } from "~/utils/registerCommands";
 import { DiscourseContextView } from "~/components/DiscourseContextView";
 import { VIEW_TYPE_DISCOURSE_CONTEXT, DiscourseNode } from "~/types";
-import { getDiscourseNodeFormatExpression } from "~/utils/getDiscourseNodeFormatExpression";
-import { checkInvalidChars } from "~/utils/validateNodeType";
 import { processTextToDiscourseNode } from "./utils/createNodeFromSelectedText";
 
 const DEFAULT_SETTINGS: Settings = {

--- a/apps/obsidian/src/utils/createNodeFromSelectedText.ts
+++ b/apps/obsidian/src/utils/createNodeFromSelectedText.ts
@@ -50,7 +50,7 @@ export async function createDiscourseNodeFile(
   }
 }
 export async function processTextToDiscourseNode(
-  app: any,
+  app: App,
   editor: Editor,
   nodeType: DiscourseNode,
 ): Promise<TFile | null> {

--- a/apps/obsidian/src/utils/createNodeFromSelectedText.ts
+++ b/apps/obsidian/src/utils/createNodeFromSelectedText.ts
@@ -30,7 +30,7 @@ export async function createDiscourseNodeFile(
     );
     if (existingFile && existingFile instanceof TFile) {
       new Notice(`File ${formattedNodeName} already exists`, 3000);
-      return existingFile;
+      return null; 
     }
 
     const newFile = await app.vault.create(`${formattedNodeName}.md`, "");

--- a/apps/obsidian/src/utils/createNodeFromSelectedText.ts
+++ b/apps/obsidian/src/utils/createNodeFromSelectedText.ts
@@ -1,0 +1,79 @@
+import { App, Editor, Notice, TFile } from "obsidian";
+import { DiscourseNode } from "~/types";
+import { getDiscourseNodeFormatExpression } from "./getDiscourseNodeFormatExpression";
+import { checkInvalidChars } from "./validateNodeType";
+
+export function formatNodeName(
+  selectedText: string,
+  nodeType: DiscourseNode,
+): string | null {
+  const regex = getDiscourseNodeFormatExpression(nodeType.format);
+  const nodeFormat = regex.source.match(/^\^(.*?)\(\.\*\?\)(.*?)\$$/);
+
+  if (!nodeFormat) return null;
+
+  return (
+    nodeFormat[1]?.replace(/\\/g, "") +
+    selectedText +
+    nodeFormat[2]?.replace(/\\/g, "")
+  );
+}
+
+export async function createDiscourseNodeFile(
+  app: App,
+  formattedNodeName: string,
+  nodeType: DiscourseNode,
+): Promise<TFile | null> {
+  try {
+    const existingFile = app.vault.getAbstractFileByPath(
+      `${formattedNodeName}.md`,
+    );
+    if (existingFile && existingFile instanceof TFile) {
+      new Notice(`File ${formattedNodeName} already exists`, 3000);
+      return existingFile;
+    }
+
+    const newFile = await app.vault.create(`${formattedNodeName}.md`, "");
+    await app.fileManager.processFrontMatter(newFile, (fm) => {
+      fm.nodeTypeId = nodeType.id;
+    });
+
+    new Notice(`Created discourse node: ${formattedNodeName}`);
+    return newFile;
+  } catch (error) {
+    console.error("Error creating discourse node:", error);
+    new Notice(
+      `Error creating node: ${error instanceof Error ? error.message : String(error)}`,
+      5000,
+    );
+    return null;
+  }
+}
+export async function processTextToDiscourseNode(
+  app: any,
+  editor: Editor,
+  nodeType: DiscourseNode,
+): Promise<TFile | null> {
+  const selectedText = editor.getSelection();
+  if (!selectedText) return null;
+
+  const formattedNodeName = formatNodeName(selectedText, nodeType);
+  if (!formattedNodeName) return null;
+
+  const isFilenameValid = checkInvalidChars(formattedNodeName);
+  if (!isFilenameValid.isValid) {
+    new Notice(`${isFilenameValid.error}`, 5000);
+    return null;
+  }
+
+  const newFile = await createDiscourseNodeFile(
+    app,
+    formattedNodeName,
+    nodeType,
+  );
+  if (newFile) {
+    editor.replaceSelection(`[[${formattedNodeName}]]`);
+  }
+
+  return newFile;
+}


### PR DESCRIPTION
https://www.loom.com/share/69f8e429eac04c6e840504f7c4f02120
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to convert selected text in the editor into a discourse node via a right-click context menu, with options for different node types.
  - When converting, the selected text is replaced with a link to the newly created node file, which includes relevant frontmatter.

- **Improvements**
  - Streamlined the process of creating discourse nodes, providing user notifications for errors and successful actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->