### PR TITLE
Roam: Bug fix - Insert Discourse Node after creation

### DIFF
--- a/apps/roam/src/components/DiscourseNodeMenu.tsx
+++ b/apps/roam/src/components/DiscourseNodeMenu.tsx
@@ -111,9 +111,11 @@ const NodeMenu = ({
           menuRef.current?.getAttribute("data-active-index"),
         );
         onSelect(index);
+        // Remove focus from the block to ensure updateBlock works properly
         document.body.click();
       } else if (shortcuts.has(e.key.toUpperCase())) {
         onSelect(indexBySC[e.key.toUpperCase()]);
+        // Remove focus from the block to ensure updateBlock works properly
         document.body.click();
       } else {
         return;

--- a/apps/roam/src/components/DiscourseNodeMenu.tsx
+++ b/apps/roam/src/components/DiscourseNodeMenu.tsx
@@ -111,8 +111,10 @@ const NodeMenu = ({
           menuRef.current?.getAttribute("data-active-index"),
         );
         onSelect(index);
+        document.body.click();
       } else if (shortcuts.has(e.key.toUpperCase())) {
         onSelect(indexBySC[e.key.toUpperCase()]);
+        document.body.click();
       } else {
         return;
       }


### PR DESCRIPTION
When user hit's `Enter` to select an item in the node menu, the block is still in edit mode.
This makes `updateBlock` have no effect.
This PR removes focus after menu select via `Enter` to allow `updateBlock` to work.

Example of the bug
https://www.loom.com/share/34b5b715224a4ad19b28a9af90aa673a?sid=f7ca36bd-0c16-4cf9-8560-7d3b81442760

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved menu behavior when selecting items with the keyboard, ensuring the menu closes properly after selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->