### PR TITLE
[ENG-310] Preload nodes and relations in setting

### DIFF
--- a/apps/obsidian/src/constants.ts
+++ b/apps/obsidian/src/constants.ts
@@ -1,7 +1,7 @@
-import { DiscourseNode, DiscourseRelationType, Settings } from "./types";
-import generateUid from "./utils/generateUid";
+import { DiscourseNode, DiscourseRelationType, Settings } from "~/types";
+import generateUid from "~/utils/generateUid";
 
-export const defaultNodeTypes: Record<string, DiscourseNode> = {
+export const DEFAULT_NODE_TYPES: Record<string, DiscourseNode> = {
   Question: {
     id: generateUid("node"),
     name: "Question",
@@ -18,7 +18,7 @@ export const defaultNodeTypes: Record<string, DiscourseNode> = {
     format: "EVD - {content}",
   },
 };
-export const defaultRelationTypes: Record<string, DiscourseRelationType> = {
+export const DEFAULT_RELATION_TYPES: Record<string, DiscourseRelationType> = {
   supports: {
     id: generateUid("relation"),
     label: "supports",
@@ -37,23 +37,23 @@ export const defaultRelationTypes: Record<string, DiscourseRelationType> = {
 };
 
 export const DEFAULT_SETTINGS: Settings = {
-  nodeTypes: Object.values(defaultNodeTypes),
-  relationTypes: Object.values(defaultRelationTypes),
+  nodeTypes: Object.values(DEFAULT_NODE_TYPES),
+  relationTypes: Object.values(DEFAULT_RELATION_TYPES),
   discourseRelations: [
     {
-      sourceId: defaultNodeTypes.Evidence!.id,
-      destinationId: defaultNodeTypes.Question!.id,
-      relationshipTypeId: defaultRelationTypes.informs!.id,
+      sourceId: DEFAULT_NODE_TYPES.Evidence!.id,
+      destinationId: DEFAULT_NODE_TYPES.Question!.id,
+      relationshipTypeId: DEFAULT_RELATION_TYPES.informs!.id,
     },
     {
-      sourceId: defaultNodeTypes.Evidence!.id,
-      destinationId: defaultNodeTypes.Claim!.id,
-      relationshipTypeId: defaultRelationTypes.supports!.id,
+      sourceId: DEFAULT_NODE_TYPES.Evidence!.id,
+      destinationId: DEFAULT_NODE_TYPES.Claim!.id,
+      relationshipTypeId: DEFAULT_RELATION_TYPES.supports!.id,
     },
     {
-      sourceId: defaultNodeTypes.Evidence!.id,
-      destinationId: defaultNodeTypes.Claim!.id,
-      relationshipTypeId: defaultRelationTypes.opposes!.id,
+      sourceId: DEFAULT_NODE_TYPES.Evidence!.id,
+      destinationId: DEFAULT_NODE_TYPES.Claim!.id,
+      relationshipTypeId: DEFAULT_RELATION_TYPES.opposes!.id,
     },
   ],
 };

--- a/apps/obsidian/src/constants.ts
+++ b/apps/obsidian/src/constants.ts
@@ -41,19 +41,19 @@ export const DEFAULT_SETTINGS: Settings = {
   relationTypes: Object.values(defaultRelationTypes),
   discourseRelations: [
     {
-      sourceId: defaultNodeTypes.Question!.id,
-      destinationId: defaultNodeTypes.Evidence!.id,
+      sourceId: defaultNodeTypes.Evidence!.id,
+      destinationId: defaultNodeTypes.Question!.id,
+      relationshipTypeId: defaultRelationTypes.informs!.id,
+    },
+    {
+      sourceId: defaultNodeTypes.Evidence!.id,
+      destinationId: defaultNodeTypes.Claim!.id,
       relationshipTypeId: defaultRelationTypes.supports!.id,
     },
     {
-      sourceId: defaultNodeTypes.Claim!.id,
-      destinationId: defaultNodeTypes.Evidence!.id,
+      sourceId: defaultNodeTypes.Evidence!.id,
+      destinationId: defaultNodeTypes.Claim!.id,
       relationshipTypeId: defaultRelationTypes.opposes!.id,
-    },
-    {
-      sourceId: defaultNodeTypes.Claim!.id,
-      destinationId: defaultNodeTypes.Evidence!.id,
-      relationshipTypeId: defaultRelationTypes.informs!.id,
     },
   ],
 };

--- a/apps/obsidian/src/constants.ts
+++ b/apps/obsidian/src/constants.ts
@@ -1,0 +1,59 @@
+import { DiscourseNode, DiscourseRelationType, Settings } from "./types";
+import generateUid from "./utils/generateUid";
+
+export const defaultNodeTypes: Record<string, DiscourseNode> = {
+  Question: {
+    id: generateUid("node"),
+    name: "Question",
+    format: "QUE - {content}",
+  },
+  Claim: {
+    id: generateUid("node"),
+    name: "Claim",
+    format: "CLM - {content}",
+  },
+  Evidence: {
+    id: generateUid("node"),
+    name: "Evidence",
+    format: "EVD - {content}",
+  },
+};
+export const defaultRelationTypes: Record<string, DiscourseRelationType> = {
+  supports: {
+    id: generateUid("relation"),
+    label: "supports",
+    complement: "is supported by",
+  },
+  opposes: {
+    id: generateUid("relation"),
+    label: "opposes",
+    complement: "is opposed by",
+  },
+  informs: {
+    id: generateUid("relation"),
+    label: "informs",
+    complement: "is informed by",
+  },
+};
+
+export const DEFAULT_SETTINGS: Settings = {
+  nodeTypes: Object.values(defaultNodeTypes),
+  relationTypes: Object.values(defaultRelationTypes),
+  discourseRelations: [
+    {
+      sourceId: defaultNodeTypes.Question!.id,
+      destinationId: defaultNodeTypes.Evidence!.id,
+      relationshipTypeId: defaultRelationTypes.supports!.id,
+    },
+    {
+      sourceId: defaultNodeTypes.Claim!.id,
+      destinationId: defaultNodeTypes.Evidence!.id,
+      relationshipTypeId: defaultRelationTypes.opposes!.id,
+    },
+    {
+      sourceId: defaultNodeTypes.Claim!.id,
+      destinationId: defaultNodeTypes.Evidence!.id,
+      relationshipTypeId: defaultRelationTypes.informs!.id,
+    },
+  ],
+};

--- a/apps/obsidian/src/index.ts
+++ b/apps/obsidian/src/index.ts
@@ -1,16 +1,11 @@
-import { Plugin, Editor, Menu, Notice, TFile } from "obsidian";
+import { Plugin, Editor, Menu } from "obsidian";
 import { SettingsTab } from "~/components/Settings";
 import { Settings } from "~/types";
 import { registerCommands } from "~/utils/registerCommands";
 import { DiscourseContextView } from "~/components/DiscourseContextView";
-import { VIEW_TYPE_DISCOURSE_CONTEXT, DiscourseNode } from "~/types";
+import { VIEW_TYPE_DISCOURSE_CONTEXT } from "~/types";
 import { processTextToDiscourseNode } from "./utils/createNodeFromSelectedText";
-
-const DEFAULT_SETTINGS: Settings = {
-  nodeTypes: [],
-  discourseRelations: [],
-  relationTypes: [],
-};
+import { DEFAULT_SETTINGS } from "./constants";
 
 export default class DiscourseGraphPlugin extends Plugin {
   settings: Settings = { ...DEFAULT_SETTINGS };

--- a/apps/obsidian/src/index.ts
+++ b/apps/obsidian/src/index.ts
@@ -87,7 +87,12 @@ export default class DiscourseGraphPlugin extends Plugin {
   }
 
   async loadSettings() {
-    this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
+    const loadedData = await this.loadData();
+    this.settings = Object.assign({}, DEFAULT_SETTINGS, loadedData);
+
+    if (!loadedData) {
+      await this.saveSettings();
+    }
   }
 
   async saveSettings() {


### PR DESCRIPTION
https://www.loom.com/share/91210e4a0c864615ab9364b66723834d?sid=84cc7718-ba22-433a-9a86-ca3b222d9fbb

# Context:
- We're preloading the plugin with node types, relation types, and discourse relations, as defined in the Linear ticket
- This feature is part of the preparation for Obsidian beta launch for test users.