### PR TITLE
[ENG-308] Add command to open DG settings

### DIFF
--- a/apps/obsidian/src/utils/registerCommands.ts
+++ b/apps/obsidian/src/utils/registerCommands.ts
@@ -1,5 +1,4 @@
-import { Editor, MarkdownView, MarkdownFileInfo } from "obsidian";
-import { SampleModal } from "~/components/SampleModal";
+import { Editor } from "obsidian";
 import type DiscourseGraphPlugin from "~/index";
 import { NodeTypeModal } from "~/components/NodeTypeModal";
 
@@ -18,6 +17,17 @@ export const registerCommands = (plugin: DiscourseGraphPlugin) => {
     name: "Toggle Discourse Context",
     callback: () => {
       plugin.toggleDiscourseContextView();
+    },
+  });
+
+  plugin.addCommand({
+    id: "open-discourse-graph-settings",
+    name: "Open Discourse Graph Settings",
+    callback: () => {
+      // This is another unofficial API, but it works
+      const setting = (plugin.app as any).setting;
+      setting.open();
+      setting.openTabById(plugin.manifest.id);
     },
   });
 };

--- a/apps/obsidian/src/utils/registerCommands.ts
+++ b/apps/obsidian/src/utils/registerCommands.ts
@@ -24,7 +24,7 @@ export const registerCommands = (plugin: DiscourseGraphPlugin) => {
     id: "open-discourse-graph-settings",
     name: "Open Discourse Graph Settings",
     callback: () => {
-      // This is another unofficial API, but it works
+      // plugin.app.setting is an unofficial API
       const setting = (plugin.app as any).setting;
       setting.open();
       setting.openTabById(plugin.manifest.id);


### PR DESCRIPTION
# Context
- A polish feature for Obsidian beta launch to test users

# Tests
<img width="1288" alt="Screenshot 2025-05-14 at 14 44 19" src="https://github.com/user-attachments/assets/ad895192-9eb5-424a-ae2d-6f3e5ff82753" />
<img width="1629" alt="Screenshot 2025-05-14 at 14 44 29" src="https://github.com/user-attachments/assets/0ddde04a-a071-40b9-a528-7a746e9f5d28" />

## Note
This is an unofficial API for Obsidian. I couldn't find any official documentation to open the specific plugin's setting page. But found[ this community post](https://forum.obsidian.md/t/open-settings-for-my-plugin-community-plugin-settings-deeplink/61563/2) with a workaround