### PR TITLE
[ENG-299] Trigger for DG summoning menu

### DIFF
--- a/apps/roam/src/components/DiscourseNodeMenu.tsx
+++ b/apps/roam/src/components/DiscourseNodeMenu.tsx
@@ -197,18 +197,18 @@ export const render = (props: Props) => {
 };
 
 // node_modules\@blueprintjs\core\lib\esm\components\hotkeys\hotkeyParser.js
-const isMac = () => {
+export const isMac = () => {
   const platform =
     typeof navigator !== "undefined" ? navigator.platform : undefined;
   return platform == null ? false : /Mac|iPod|iPhone|iPad/.test(platform);
 };
-const MODIFIER_BIT_MASKS = {
+export const MODIFIER_BIT_MASKS = {
   alt: 1,
   ctrl: 2,
   meta: 4,
   shift: 8,
 };
-const ALIASES: { [key: string]: string } = {
+export const ALIASES: { [key: string]: string } = {
   cmd: "meta",
   command: "meta",
   escape: "esc",
@@ -219,7 +219,7 @@ const ALIASES: { [key: string]: string } = {
   return: "enter",
   win: "meta",
 };
-const normalizeKeyCombo = (combo: string) => {
+export const normalizeKeyCombo = (combo: string) => {
   const keys = combo.replace(/\s/g, "").split("+");
   return keys.map(function (key) {
     const keyName = ALIASES[key] != null ? ALIASES[key] : key;

--- a/apps/roam/src/components/DiscourseNodeSearchMenu.tsx
+++ b/apps/roam/src/components/DiscourseNodeSearchMenu.tsx
@@ -544,7 +544,6 @@ export const NodeSearchMenuTriggerComponent = ({
       const comboObj = getKeyCombo(e.nativeEvent);
       if (!comboObj.key) return;
       const specialCharMap = {
-        // Numbers row
         "~": { key: "`", modifiers: 8 },
         "!": { key: "1", modifiers: 8 },
         "@": { key: "2", modifiers: 8 },
@@ -558,8 +557,6 @@ export const NodeSearchMenuTriggerComponent = ({
         ")": { key: "0", modifiers: 8 },
         _: { key: "-", modifiers: 8 },
         "+": { key: "=", modifiers: 8 },
-
-        // Brackets and punctuation
         "{": { key: "[", modifiers: 8 },
         "}": { key: "]", modifiers: 8 },
         "|": { key: "\\", modifiers: 8 },

--- a/apps/roam/src/components/settings/HomePersonalSettings.tsx
+++ b/apps/roam/src/components/settings/HomePersonalSettings.tsx
@@ -3,6 +3,7 @@ import { OnloadArgs } from "roamjs-components/types";
 import { Label, Checkbox } from "@blueprintjs/core";
 import Description from "roamjs-components/components/Description";
 import { NodeMenuTriggerComponent } from "~/components/DiscourseNodeMenu";
+import { NodeSearchMenuTriggerComponent } from "~/components/DiscourseNodeSearchMenu";
 import {
   getOverlayHandler,
   onPageRefObserverChange,
@@ -28,6 +29,17 @@ const HomePersonalSettings = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
         />
         <NodeMenuTriggerComponent extensionAPI={extensionAPI} />
       </Label>
+
+      <Label>
+        Node Search Menu Trigger
+        <Description
+          description={
+            "Customize the trigger key for the Discourse Node Search Menu (default: @). Must refresh after editing."
+          }
+        />
+        <NodeSearchMenuTriggerComponent extensionAPI={extensionAPI} />
+      </Label>
+
       <Checkbox
         defaultChecked={
           extensionAPI.settings.get("discourse-context-overlay") as boolean

--- a/apps/roam/src/utils/initializeObserversAndListeners.ts
+++ b/apps/roam/src/utils/initializeObserversAndListeners.ts
@@ -184,28 +184,18 @@ export const initObservers = async ({
         textarea.value.charAt(cursorPos - 1) === "\n";
 
       if (isBeginningOrAfterSpace) {
-        // Don't insert the trigger for key combinations that already produce the character
-        // (e.g., Shift+2 already produces @)
         const triggerChar = nodeSearchTriggerCombo?.key || "@";
-
-        // The position where the menu should appear (at the start of the trigger character)
         let triggerPosition = cursorPos;
 
-        // For key combinations like Ctrl+key that wouldn't naturally insert characters
         if (!evt.isComposing && evt.key !== triggerChar) {
-          // Insert the trigger character at the cursor position
           const text = textarea.value;
           const newText =
             text.slice(0, cursorPos) + triggerChar + text.slice(cursorPos);
 
-          // Update the text - this needs to use updateBlock because directly modifying
-          // textarea.value doesn't trigger Roam's internal state updates
           const blockUid = getUids(textarea).blockUid;
           if (blockUid) {
             updateBlock({ uid: blockUid, text: newText });
           }
-
-          // The menu should appear at the current cursor position
           triggerPosition = cursorPos;
         }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a customizable trigger key setting for the Discourse Node Search Menu, allowing users to set their preferred shortcut (default "@") via the personal settings UI.
  - Introduced a new UI component for configuring the trigger key, including support for special characters and keyboard shortcuts.

- **Improvements**
  - The Discourse Node Search Menu now responds to the user-defined trigger key, providing a more flexible and personalized experience.
  - Enhanced settings interface with clear explanations and reset functionality for the trigger key configuration.

- **Bug Fixes**
  - Improved handling and detection of trigger key events for the Discourse Node Search Menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->