### PR TITLE
[ENG-299] Trigger setting for DG summoning menu

### DIFF
--- a/apps/roam/src/components/DiscourseNodeSearchMenu.tsx
+++ b/apps/roam/src/components/DiscourseNodeSearchMenu.tsx
@@ -256,8 +256,6 @@ const NodeSearchMenu = ({
     }
   }, [textarea, onClose, debouncedSearchTerm, triggerPosition, triggerText]);
 
-  console.log(activeIndex);
-
   const keydownListener = useCallback(
     (e: KeyboardEvent) => {
       if (e.key === "ArrowDown" && allItems.length) {
@@ -282,7 +280,7 @@ const NodeSearchMenu = ({
         e.stopPropagation();
       }
     },
-    [allItems, setActiveIndex, onSelect, onClose],
+    [allItems, activeIndex, setActiveIndex, onSelect, onClose],
   );
 
   useEffect(() => {

--- a/apps/roam/src/components/DiscourseNodeSearchMenu.tsx
+++ b/apps/roam/src/components/DiscourseNodeSearchMenu.tsx
@@ -30,6 +30,7 @@ type Props = {
   textarea: HTMLTextAreaElement;
   triggerPosition: number;
   onClose: () => void;
+  triggerText: string;
 };
 
 const waitForBlock = (
@@ -53,6 +54,7 @@ const NodeSearchMenu = ({
   onClose,
   textarea,
   triggerPosition,
+  triggerText,
 }: { onClose: () => void } & Props) => {
   const [activeIndex, setActiveIndex] = useState(0);
   const [searchTerm, setSearchTerm] = useState("");
@@ -238,19 +240,23 @@ const NodeSearchMenu = ({
   );
 
   const handleTextAreaInput = useCallback(() => {
-    const atTriggerRegex = /@(.*)$/;
+    const triggerRegex = new RegExp(
+      `${triggerText.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}(.*)$`,
+    );
     const textBeforeCursor = textarea.value.substring(
       triggerPosition,
       textarea.selectionStart,
     );
-    const match = atTriggerRegex.exec(textBeforeCursor);
+    const match = triggerRegex.exec(textBeforeCursor);
     if (match) {
       debouncedSearchTerm(match[1]);
     } else {
       onClose();
       return;
     }
-  }, [textarea, onClose, debouncedSearchTerm, triggerPosition]);
+  }, [textarea, onClose, debouncedSearchTerm, triggerPosition, triggerText]);
+
+  console.log(activeIndex);
 
   const keydownListener = useCallback(
     (e: KeyboardEvent) => {

--- a/apps/roam/src/components/DiscourseNodeSearchMenu.tsx
+++ b/apps/roam/src/components/DiscourseNodeSearchMenu.tsx
@@ -553,7 +553,7 @@ export const NodeSearchMenuTriggerSetting = ({
     <InputGroup
       value={nodeSearchTrigger}
       onChange={handleNodeSearchTriggerChange}
-      placeholder="@"
+      placeholder="Click to set trigger"
       maxLength={5}
     />
   );

--- a/apps/roam/src/components/DiscourseNodeSearchMenu.tsx
+++ b/apps/roam/src/components/DiscourseNodeSearchMenu.tsx
@@ -12,6 +12,7 @@ import {
   Position,
   Checkbox,
   Button,
+  InputGroup,
 } from "@blueprintjs/core";
 import ReactDOM from "react-dom";
 import getUids from "roamjs-components/dom/getUids";
@@ -19,6 +20,7 @@ import getTextByBlockUid from "roamjs-components/queries/getTextByBlockUid";
 import updateBlock from "roamjs-components/writes/updateBlock";
 import posthog from "posthog-js";
 import { getCoordsFromTextarea } from "roamjs-components/components/CursorMenu";
+import { OnloadArgs } from "roamjs-components/types";
 import getDiscourseNodes, { DiscourseNode } from "~/utils/getDiscourseNodes";
 import getDiscourseNodeFormatExpression from "~/utils/getDiscourseNodeFormatExpression";
 import { escapeCljString } from "~/utils/formatUtils";
@@ -519,5 +521,39 @@ export const renderDiscourseNodeSearchMenu = (props: Props) => {
     parent,
   );
 };
+
+export const NodeSearchMenuTriggerSetting = ({
+  onloadArgs,
+}: {
+  onloadArgs: OnloadArgs;
+}) => {
+  const extensionAPI = onloadArgs.extensionAPI;
+  const [nodeSearchTrigger, setNodeSearchTrigger] = useState<string>(
+    extensionAPI.settings.get("node-search-trigger") as string,
+  );
+
+  const handleNodeSearchTriggerChange = (
+    e: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    const value = e.target.value.trim();
+    const trigger = value
+      .replace(/"/g, "")
+      .replace(/\\/g, "\\\\")
+      .replace(/\+/g, "\\+")
+      .trim();
+
+    setNodeSearchTrigger(trigger);
+    extensionAPI.settings.set("node-search-trigger", trigger);
+  };
+  return (
+    <InputGroup
+      value={nodeSearchTrigger}
+      onChange={handleNodeSearchTriggerChange}
+      placeholder="@"
+      maxLength={5}
+    />
+  );
+};
+
 
 export default NodeSearchMenu;

--- a/apps/roam/src/components/settings/HomePersonalSettings.tsx
+++ b/apps/roam/src/components/settings/HomePersonalSettings.tsx
@@ -12,6 +12,7 @@ import {
   hideFeedbackButton,
   showFeedbackButton,
 } from "~/components/BirdEatsBugs";
+import { NodeSearchMenuTriggerSetting } from "../DiscourseNodeSearchMenu";
 
 const HomePersonalSettings = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
   const extensionAPI = onloadArgs.extensionAPI;
@@ -27,6 +28,15 @@ const HomePersonalSettings = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
           }
         />
         <NodeMenuTriggerComponent extensionAPI={extensionAPI} />
+      </Label>
+      <Label>
+        Node Search Menu Trigger
+        <Description
+          description={
+            "Set the trigger character for the Node Search Menu. Must refresh after editing."
+          }
+        />
+        <NodeSearchMenuTriggerSetting onloadArgs={onloadArgs} />
       </Label>
       <Checkbox
         defaultChecked={

--- a/apps/roam/src/index.ts
+++ b/apps/roam/src/index.ts
@@ -107,7 +107,7 @@ export default runExtension(async (onloadArgs) => {
   document.addEventListener("roamjs:query-builder:action", pageActionListener);
   window.addEventListener("hashchange", hashChangeListener);
   document.addEventListener("keydown", nodeMenuTriggerListener);
-  document.addEventListener("keydown", discourseNodeSearchTriggerListener);
+  document.addEventListener("input", discourseNodeSearchTriggerListener);
 
   const { extensionAPI } = onloadArgs;
   window.roamjs.extension.queryBuilder = {
@@ -138,10 +138,7 @@ export default runExtension(async (onloadArgs) => {
       );
       window.removeEventListener("hashchange", hashChangeListener);
       document.removeEventListener("keydown", nodeMenuTriggerListener);
-      document.removeEventListener(
-        "keydown",
-        discourseNodeSearchTriggerListener,
-      );
+      document.removeEventListener("input", discourseNodeSearchTriggerListener);
       window.roamAlphaAPI.ui.graphView.wholeGraph.removeCallback({
         label: "discourse-node-styling",
       });

--- a/apps/roam/src/utils/initializeObserversAndListeners.ts
+++ b/apps/roam/src/utils/initializeObserversAndListeners.ts
@@ -224,8 +224,10 @@ export const initObservers = async ({
           cursorPos === lastTriggerPos + customTrigger.length;
 
         if (isValidTriggerPosition && isCursorAfterTrigger) {
-          const location = window.roamAlphaAPI.ui.getFocusedBlock();
-          if (!location) return;
+          // Double-check we have an active block context via Roam's API
+          // This guards against edge cases where the DOM shows an input but Roam's internal state disagrees
+          const isEditingBlock = !!window.roamAlphaAPI.ui.getFocusedBlock();
+          if (!isEditingBlock) return;
 
           renderDiscourseNodeSearchMenu({
             onClose: () => {},

--- a/apps/roam/src/utils/initializeObserversAndListeners.ts
+++ b/apps/roam/src/utils/initializeObserversAndListeners.ts
@@ -190,10 +190,8 @@ export const initObservers = async ({
     const evt = e as KeyboardEvent;
     const target = evt.target as HTMLElement;
 
-    // Don't process if the menu is already open
     if (document.querySelector(".discourse-node-search-menu")) return;
 
-    // Only handle for textarea inputs in Roam blocks
     if (
       target.tagName === "TEXTAREA" &&
       target.classList.contains("rm-block-input")
@@ -202,23 +200,18 @@ export const initObservers = async ({
       const location = window.roamAlphaAPI.ui.getFocusedBlock();
       if (!location) return;
 
-      // Get custom trigger from settings
       const customTrigger = onloadArgs.extensionAPI.settings.get(
         "node-search-trigger",
       ) as string;
 
-      // If no trigger is set, don't activate the menu
       if (!customTrigger) return;
 
       const cursorPos = textarea.selectionStart;
       const textBeforeCursor = textarea.value.substring(0, cursorPos);
 
-      // Find the last instance of the trigger before cursor
       const lastTriggerPos = textBeforeCursor.lastIndexOf(customTrigger);
 
-      // Only proceed if we found the trigger in the text
       if (lastTriggerPos >= 0) {
-        // Check if the trigger is at the beginning of text or after whitespace
         const charBeforeTrigger =
           lastTriggerPos > 0
             ? textBeforeCursor.charAt(lastTriggerPos - 1)
@@ -229,42 +222,16 @@ export const initObservers = async ({
           charBeforeTrigger === " " ||
           charBeforeTrigger === "\n";
 
-        // Check if cursor is right after the trigger
         const isCursorAfterTrigger =
           cursorPos === lastTriggerPos + customTrigger.length;
 
-        // Only open the menu if the trigger is valid and the cursor is right after it
         if (isValidTriggerPosition && isCursorAfterTrigger) {
-          // If user pressed a key that isn't part of navigation/editing
-          const isActionKey =
-            evt.ctrlKey ||
-            evt.altKey ||
-            evt.metaKey ||
-            [
-              "Shift",
-              "Control",
-              "Alt",
-              "Meta",
-              "CapsLock",
-              "Escape",
-              "ArrowLeft",
-              "ArrowRight",
-              "ArrowUp",
-              "ArrowDown",
-              "Home",
-              "End",
-              "PageUp",
-              "PageDown",
-            ].includes(evt.key);
-
-          if (!isActionKey) {
-            renderDiscourseNodeSearchMenu({
-              onClose: () => {},
-              textarea: textarea,
-              triggerPosition: lastTriggerPos,
-              triggerText: customTrigger,
-            });
-          }
+          renderDiscourseNodeSearchMenu({
+            onClose: () => {},
+            textarea: textarea,
+            triggerPosition: lastTriggerPos,
+            triggerText: customTrigger,
+          });
         }
       }
     }

--- a/apps/roam/src/utils/initializeObserversAndListeners.ts
+++ b/apps/roam/src/utils/initializeObserversAndListeners.ts
@@ -186,6 +186,10 @@ export const initObservers = async ({
     }
   };
 
+  const customTrigger = onloadArgs.extensionAPI.settings.get(
+    "node-search-trigger",
+  ) as string;
+
   const discourseNodeSearchTriggerListener = (e: Event) => {
     const evt = e as KeyboardEvent;
     const target = evt.target as HTMLElement;
@@ -199,10 +203,6 @@ export const initObservers = async ({
       const textarea = target as HTMLTextAreaElement;
       const location = window.roamAlphaAPI.ui.getFocusedBlock();
       if (!location) return;
-
-      const customTrigger = onloadArgs.extensionAPI.settings.get(
-        "node-search-trigger",
-      ) as string;
 
       if (!customTrigger) return;
 

--- a/apps/roam/src/utils/initializeObserversAndListeners.ts
+++ b/apps/roam/src/utils/initializeObserversAndListeners.ts
@@ -201,8 +201,6 @@ export const initObservers = async ({
       target.classList.contains("rm-block-input")
     ) {
       const textarea = target as HTMLTextAreaElement;
-      const location = window.roamAlphaAPI.ui.getFocusedBlock();
-      if (!location) return;
 
       if (!customTrigger) return;
 
@@ -226,6 +224,9 @@ export const initObservers = async ({
           cursorPos === lastTriggerPos + customTrigger.length;
 
         if (isValidTriggerPosition && isCursorAfterTrigger) {
+          const location = window.roamAlphaAPI.ui.getFocusedBlock();
+          if (!location) return;
+
           renderDiscourseNodeSearchMenu({
             onClose: () => {},
             textarea: textarea,

--- a/apps/roam/src/utils/initializeObserversAndListeners.ts
+++ b/apps/roam/src/utils/initializeObserversAndListeners.ts
@@ -189,28 +189,82 @@ export const initObservers = async ({
   const discourseNodeSearchTriggerListener = (e: Event) => {
     const evt = e as KeyboardEvent;
     const target = evt.target as HTMLElement;
+
+    // Don't process if the menu is already open
     if (document.querySelector(".discourse-node-search-menu")) return;
 
-    if (evt.key === "@" || (evt.key === "2" && evt.shiftKey)) {
-      if (
-        target.tagName === "TEXTAREA" &&
-        target.classList.contains("rm-block-input")
-      ) {
-        const textarea = target as HTMLTextAreaElement;
-        const location = window.roamAlphaAPI.ui.getFocusedBlock();
-        if (!location) return;
+    // Only handle for textarea inputs in Roam blocks
+    if (
+      target.tagName === "TEXTAREA" &&
+      target.classList.contains("rm-block-input")
+    ) {
+      const textarea = target as HTMLTextAreaElement;
+      const location = window.roamAlphaAPI.ui.getFocusedBlock();
+      if (!location) return;
 
-        const cursorPos = textarea.selectionStart;
-        const isBeginningOrAfterSpace =
-          cursorPos === 0 ||
-          textarea.value.charAt(cursorPos - 1) === " " ||
-          textarea.value.charAt(cursorPos - 1) === "\n";
-        if (isBeginningOrAfterSpace) {
-          renderDiscourseNodeSearchMenu({
-            onClose: () => {},
-            textarea: textarea,
-            triggerPosition: cursorPos,
-          });
+      // Get custom trigger from settings
+      const customTrigger = onloadArgs.extensionAPI.settings.get(
+        "node-search-trigger",
+      ) as string;
+
+      // If no trigger is set, don't activate the menu
+      if (!customTrigger) return;
+
+      const cursorPos = textarea.selectionStart;
+      const textBeforeCursor = textarea.value.substring(0, cursorPos);
+
+      // Find the last instance of the trigger before cursor
+      const lastTriggerPos = textBeforeCursor.lastIndexOf(customTrigger);
+
+      // Only proceed if we found the trigger in the text
+      if (lastTriggerPos >= 0) {
+        // Check if the trigger is at the beginning of text or after whitespace
+        const charBeforeTrigger =
+          lastTriggerPos > 0
+            ? textBeforeCursor.charAt(lastTriggerPos - 1)
+            : null;
+
+        const isValidTriggerPosition =
+          lastTriggerPos === 0 ||
+          charBeforeTrigger === " " ||
+          charBeforeTrigger === "\n";
+
+        // Check if cursor is right after the trigger
+        const isCursorAfterTrigger =
+          cursorPos === lastTriggerPos + customTrigger.length;
+
+        // Only open the menu if the trigger is valid and the cursor is right after it
+        if (isValidTriggerPosition && isCursorAfterTrigger) {
+          // If user pressed a key that isn't part of navigation/editing
+          const isActionKey =
+            evt.ctrlKey ||
+            evt.altKey ||
+            evt.metaKey ||
+            [
+              "Shift",
+              "Control",
+              "Alt",
+              "Meta",
+              "CapsLock",
+              "Escape",
+              "ArrowLeft",
+              "ArrowRight",
+              "ArrowUp",
+              "ArrowDown",
+              "Home",
+              "End",
+              "PageUp",
+              "PageDown",
+            ].includes(evt.key);
+
+          if (!isActionKey) {
+            renderDiscourseNodeSearchMenu({
+              onClose: () => {},
+              textarea: textarea,
+              triggerPosition: lastTriggerPos,
+              triggerText: customTrigger,
+            });
+          }
         }
       }
     }


### PR DESCRIPTION
## Context:
- The DG summoning menu. This PR is the final piece for our v0!!
- Creates the custom trigger setting to open the node search menu.
## Testing:
https://www.loom.com/share/9f23f6b7dab8401c97918f3fd2f5bd8b 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability for users to customize the trigger string that opens the Node Search Menu, allowing for multi-character triggers.
  - Introduced a new settings section in personal settings where users can configure the Node Search Menu trigger.

- **Refactor**
  - Improved detection logic for the Node Search Menu trigger, supporting dynamic and multi-character triggers instead of a hardcoded "@".

- **Chores**
  - Updated event handling to listen for input events instead of keydown events for better trigger detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->