### PR TITLE
[ENG-337] - Create Similarity Ranking Route

### DIFF
--- a/apps/website/app/api/supabase/similarity-rank/route.ts
+++ b/apps/website/app/api/supabase/similarity-rank/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse, NextRequest } from "next/server";
+import { createClient } from "~/utils/supabase/server";
+import {
+  createApiResponse,
+  handleRouteError,
+  defaultOptionsHandler,
+  asPostgrestFailure,
+} from "~/utils/supabase/apiUtils";
+
+type SimilarityRankInput = {
+  embedding: number[];
+  subsetRoamUids: string[];
+};
+
+export const POST = async (request: NextRequest): Promise<NextResponse> => {
+  try {
+    const body: SimilarityRankInput = await request.json();
+    const { embedding, subsetRoamUids } = body;
+
+    if (!embedding || !subsetRoamUids?.length) {
+      return createApiResponse(
+        request,
+        asPostgrestFailure(
+          "Missing required fields: embedding and subsetRoamUids",
+          "invalid",
+        ),
+      );
+    }
+    const supabase = await createClient();
+    const response = await supabase.rpc("match_embeddings_for_subset_nodes", {
+      p_query_embedding: JSON.stringify(embedding),
+      p_subset_roam_uids: subsetRoamUids,
+    });
+
+    return createApiResponse(request, response);
+  } catch (e: unknown) {
+    return handleRouteError(request, e, "/api/supabase/similarity-rank");
+  }
+};
+
+export const OPTIONS = defaultOptionsHandler;

--- a/apps/website/app/api/supabase/similarity-rank/route.ts
+++ b/apps/website/app/api/supabase/similarity-rank/route.ts
@@ -17,7 +17,11 @@ export const POST = async (request: NextRequest): Promise<NextResponse> => {
     const body: SimilarityRankInput = await request.json();
     const { embedding, subsetRoamUids } = body;
 
-    if (!embedding || !subsetRoamUids?.length) {
+    if (
+      !Array.isArray(embedding) ||
+      !Array.isArray(subsetRoamUids) ||
+      !subsetRoamUids.length
+    ) {
       return createApiResponse(
         request,
         asPostgrestFailure(


### PR DESCRIPTION
This route
- takes embedding and array of UID's as input.
- Calls `match_embeddings_for_subset_nodes` RPC
- Returns sorted list

### Test
![image](https://github.com/user-attachments/assets/da3b88f4-ea69-4537-ae65-15c3ed6dfea3)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new API endpoint for similarity ranking, allowing users to submit embedding data and a subset of Roam UIDs to receive ranked results based on similarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->