### PR TITLE
A newer turbo crept in the package-lock, revert.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19576,9 +19576,9 @@
       "license": "0BSD"
     },
     "node_modules/tsx": {
-      "version": "4.20.2",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.2.tgz",
-      "integrity": "sha512-He0ZWr41gLa4vD30Au3yuwpe0HXaCZbclvl8RBieUiJ9aFnPMWUPIyvw3RU8+1Crjfcrauvitae2a4tUzRAGsw==",
+      "version": "4.20.3",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.3.tgz",
+      "integrity": "sha512-qjbnuR9Tr+FJOMBqJCW5ehvIo/buZq7vH7qD7JziU98h6l3qGy0a/yPFjwO+y0/T7GFpNgNAvEcPPVfyT8rrPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -19596,27 +19596,27 @@
       }
     },
     "node_modules/turbo": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.5.4.tgz",
-      "integrity": "sha512-kc8ZibdRcuWUG1pbYSBFWqmIjynlD8Lp7IB6U3vIzvOv9VG+6Sp8bzyeBWE3Oi8XV5KsQrznyRTBPvrf99E4mA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.3.0.tgz",
+      "integrity": "sha512-/uOq5o2jwRPyaUDnwBpOR5k9mQq4c3wziBgWNWttiYQPmbhDtrKYPRBxTvA2WpgQwRIbt8UM612RMN8n/TvmHA==",
       "dev": true,
       "license": "MIT",
       "bin": {
         "turbo": "bin/turbo"
       },
       "optionalDependencies": {
-        "turbo-darwin-64": "2.5.4",
-        "turbo-darwin-arm64": "2.5.4",
-        "turbo-linux-64": "2.5.4",
-        "turbo-linux-arm64": "2.5.4",
-        "turbo-windows-64": "2.5.4",
-        "turbo-windows-arm64": "2.5.4"
+        "turbo-darwin-64": "2.3.0",
+        "turbo-darwin-arm64": "2.3.0",
+        "turbo-linux-64": "2.3.0",
+        "turbo-linux-arm64": "2.3.0",
+        "turbo-windows-64": "2.3.0",
+        "turbo-windows-arm64": "2.3.0"
       }
     },
     "node_modules/turbo-darwin-64": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-2.5.4.tgz",
-      "integrity": "sha512-ah6YnH2dErojhFooxEzmvsoZQTMImaruZhFPfMKPBq8sb+hALRdvBNLqfc8NWlZq576FkfRZ/MSi4SHvVFT9PQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-2.3.0.tgz",
+      "integrity": "sha512-pji+D49PhFItyQjf2QVoLZw2d3oRGo8gJgKyOiRzvip78Rzie74quA8XNwSg/DuzM7xx6gJ3p2/LylTTlgZXxQ==",
       "cpu": [
         "x64"
       ],
@@ -19628,9 +19628,9 @@
       ]
     },
     "node_modules/turbo-darwin-arm64": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-2.5.4.tgz",
-      "integrity": "sha512-2+Nx6LAyuXw2MdXb7pxqle3MYignLvS7OwtsP9SgtSBaMlnNlxl9BovzqdYAgkUW3AsYiQMJ/wBRb7d+xemM5A==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-2.3.0.tgz",
+      "integrity": "sha512-AJrGIL9BO41mwDF/IBHsNGwvtdyB911vp8f5mbNo1wG66gWTvOBg7WCtYQBvCo11XTenTfXPRSsAb7w3WAZb6w==",
       "cpu": [
         "arm64"
       ],
@@ -19642,9 +19642,9 @@
       ]
     },
     "node_modules/turbo-linux-64": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-2.5.4.tgz",
-      "integrity": "sha512-5May2kjWbc8w4XxswGAl74GZ5eM4Gr6IiroqdLhXeXyfvWEdm2mFYCSWOzz0/z5cAgqyGidF1jt1qzUR8hTmOA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-2.3.0.tgz",
+      "integrity": "sha512-jZqW6vc2sPJT3M/3ZmV1Cg4ecQVPqsbHncG/RnogHpBu783KCSXIndgxvUQNm9qfgBYbZDBnP1md63O4UTElhw==",
       "cpu": [
         "x64"
       ],
@@ -19656,9 +19656,9 @@
       ]
     },
     "node_modules/turbo-linux-arm64": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-2.5.4.tgz",
-      "integrity": "sha512-/2yqFaS3TbfxV3P5yG2JUI79P7OUQKOUvAnx4MV9Bdz6jqHsHwc9WZPpO4QseQm+NvmgY6ICORnoVPODxGUiJg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-2.3.0.tgz",
+      "integrity": "sha512-HUbDLJlvd/hxuyCNO0BmEWYQj0TugRMvSQeG8vHJH+Lq8qOgDAe7J0K73bFNbZejZQxW3C3XEiZFB3pnpO78+A==",
       "cpu": [
         "arm64"
       ],
@@ -19670,9 +19670,9 @@
       ]
     },
     "node_modules/turbo-windows-64": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-2.5.4.tgz",
-      "integrity": "sha512-EQUO4SmaCDhO6zYohxIjJpOKRN3wlfU7jMAj3CgcyTPvQR/UFLEKAYHqJOnJtymbQmiiM/ihX6c6W6Uq0yC7mA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-2.3.0.tgz",
+      "integrity": "sha512-c5rxrGNTYDWX9QeMzWLFE9frOXnKjHGEvQMp1SfldDlbZYsloX9UKs31TzUThzfTgTiz8NYuShaXJ2UvTMnV/g==",
       "cpu": [
         "x64"
       ],
@@ -19684,9 +19684,9 @@
       ]
     },
     "node_modules/turbo-windows-arm64": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-2.5.4.tgz",
-      "integrity": "sha512-oQ8RrK1VS8lrxkLriotFq+PiF7iiGgkZtfLKF4DDKsmdbPo0O9R2mQxm7jHLuXraRCuIQDWMIw6dpcr7Iykf4A==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-2.3.0.tgz",
+      "integrity": "sha512-7qfUuYhfIVb1AZgs89DxhXK+zZez6O2ocmixEQ4hXZK7ytnBt5vaz2zGNJJKFNYIL5HX1C3tuHolnpNgDNCUIg==",
       "cpu": [
         "arm64"
       ],


### PR DESCRIPTION
I was experimenting with turbo versions in
bb2b6d9c72d7ce0d69be0b2916e172f598790411
I reverted the package.json and npm installed,
but the newer version stuck in the lock.

The newer turbo version seems to work fine on
vercel, but locally I have issues with the
combineStyles step of the Obsidian compile.
Commenting out compile.ts:120 makes the error
go away but is clearly not a solution.