### PR TITLE
allow out-of-sequence migrations

### DIFF
--- a/packages/database/scripts/deploy.ts
+++ b/packages/database/scripts/deploy.ts
@@ -44,7 +44,7 @@ const main = () => {
           if (err) {
             process.exit(err.code);
           }
-          exec("supabase db push", (err, stdout, stderr) => {
+          exec("supabase db push --include-all", (err, stdout, stderr) => {
             console.log(`${stdout}`);
             console.error(`${stderr}`);
             if (err) {


### PR DESCRIPTION
We have many migrations on branches, and main often fails for that reason. Try to be more lenient with sequence.
