### PR TITLE
ENG-332 content to concept conversion functions

### DIFF
--- a/apps/roam/src/utils/conceptConversion.ts
+++ b/apps/roam/src/utils/conceptConversion.ts
@@ -225,7 +225,7 @@ export const orderConceptsByDependency = (
   const ordered: LocalConceptDataInput[] = [];
   let missing: Set<string> = new Set();
   while (Object.keys(conceptById).length > 0) {
-    const first = conceptById[concepts[0].represented_by_local_id!];
+    const first = Object.values(conceptById)[0];
     missing = missing.union(orderConceptsRec(ordered, first, conceptById));
   }
   return { ordered, missing: [...missing] };

--- a/apps/roam/src/utils/conceptConversion.ts
+++ b/apps/roam/src/utils/conceptConversion.ts
@@ -60,9 +60,15 @@ export function discourseNodeSchemaToLocalConcept(
 
 export function discourseNodeBlockToLocalConcept(
   context: SupabaseContext,
-  node_uid: string,
-  schema_uid: string,
-  text: string
+  {
+    node_uid,
+    schema_uid,
+    text
+  }: {
+    node_uid: string,
+    schema_uid: string,
+    text: string
+  }
 ): LocalConceptDataInput {
   const extra_data = getNodeExtraData(node_uid);
   return {

--- a/apps/roam/src/utils/conceptConversion.ts
+++ b/apps/roam/src/utils/conceptConversion.ts
@@ -4,12 +4,18 @@ import type { DiscourseRelation } from "./getDiscourseRelations";
 import { Database } from "@repo/database/types.gen";
 import type { SupabaseContext } from "~/utils/supabaseContext";
 
-// When it's merged: import type { LocalConceptDataInput } from '@repo/database/input_types';
-type LocalConceptDataInput = Partial<Database["public"]["CompositeTypes"]["concept_local_input"]>;
+import type { LocalConceptDataInput } from "@repo/database/input_types";
 
-// Get data from roam about the node
-const getNodeExtraData = (node_uid: string): { author_uid: string, created: string, last_modified: string, page_uid: string } => {
-  const result = window.roamAlphaAPI.q(`[
+const getNodeExtraData = (
+  node_uid: string,
+): {
+  author_uid: string;
+  created: string;
+  last_modified: string;
+  page_uid: string;
+} => {
+  const result = window.roamAlphaAPI.q(
+    `[
     :find
       ?author_uid
       ?page_uid
@@ -24,155 +30,185 @@ const getNodeExtraData = (node_uid: string): { author_uid: string, created: stri
       [?block :edit/time ?last_modified]
       [(get-else $ ?block :block/page ?block) ?page_id]
       [?page_id :block/uid ?page_uid]
-  ]`, node_uid);
-  if (result.length != 1 || result[0].length != 4)
+  ]`,
+    node_uid,
+  );
+  if (result.length !== 1 || result[0].length !== 4)
     throw new Error("Invalid result from Roam query");
 
-  const [author_uid, page_uid, created_t, last_modified_t] = result[0] as [string, string, number, number];
+  const [author_uid, page_uid, created_t, last_modified_t] = result[0] as [
+    string,
+    string,
+    number,
+    number,
+  ];
   const created = new Date(created_t).toISOString();
   const last_modified = new Date(last_modified_t).toISOString();
   return {
     author_uid,
     created,
     last_modified,
-    page_uid
-  }
-}
+    page_uid,
+  };
+};
 
-
-export function discourseNodeSchemaToLocalConcept(
+export const discourseNodeSchemaToLocalConcept = (
   context: SupabaseContext,
-  node: DiscourseNode, // contains type, uid, text
-): LocalConceptDataInput {
-  const extra_data = getNodeExtraData(node.type);
-  const title_parts = node.text.split('/');
+  node: DiscourseNode,
+): LocalConceptDataInput => {
+  const titleParts = node.text.split("/");
   return {
     space_id: context.spaceId,
-    author_local_id: extra_data.author_uid,
-    created: extra_data.created,
-    last_modified: extra_data.last_modified,
-    name: title_parts[title_parts.length - 1],
+    name: titleParts[titleParts.length - 1],
     represented_by_local_id: node.type,
     is_schema: true,
+    ...getNodeExtraData(node.type),
   };
-}
+};
 
-
-export function discourseNodeBlockToLocalConcept(
+export const discourseNodeBlockToLocalConcept = (
   context: SupabaseContext,
   {
     node_uid,
     schema_uid,
-    text
+    text,
   }: {
-    node_uid: string,
-    schema_uid: string,
-    text: string
-  }
-): LocalConceptDataInput {
-  const extra_data = getNodeExtraData(node_uid);
+    node_uid: string;
+    schema_uid: string;
+    text: string;
+  },
+): LocalConceptDataInput => {
   return {
     space_id: context.spaceId,
-    author_local_id: extra_data.author_uid,
-    created: extra_data.created,
-    last_modified: extra_data.last_modified,
     name: text,
     represented_by_local_id: node_uid,
     schema_represented_by_local_id: schema_uid,
     is_schema: false,
+    ...getNodeExtraData(node_uid),
   };
-
-}
+};
 
 const STANDARD_ROLES = ["source", "target"];
 
-export function discourseRelationSchemaToLocalConcept(
+export const discourseRelationSchemaToLocalConcept = (
   context: SupabaseContext,
-  relation: DiscourseRelation, // contains type, uid, text
-): LocalConceptDataInput {
-  const extra_data = getNodeExtraData(relation.id);
+  relation: DiscourseRelation,
+): LocalConceptDataInput => {
   return {
     space_id: context.spaceId,
     represented_by_local_id: relation.id,
-    author_local_id: extra_data.author_uid,
-    created: extra_data.created,
-    last_modified: extra_data.last_modified,
-    name: `${relation.id}-${relation.label}`,  // the label is not unique
+    // Not using the label directly, because it is not unique and name should be unique
+    name: `${relation.id}-${relation.label}`,
     is_schema: true,
     local_reference_content: Object.fromEntries(
-      Object.entries(relation)
-        .filter(([key, v]) => STANDARD_ROLES.includes(key))
-      ) as { [key: string]: string },
+      Object.entries(relation).filter(([key, v]) =>
+        STANDARD_ROLES.includes(key),
+      ),
+    ) as { [key: string]: string },
     literal_content: {
       roles: STANDARD_ROLES,
       label: relation.label,
       complement: relation.complement,
-      representation: relation.triples.map(t=>t[0]),
+      representation: relation.triples.map((t) => t[0]),
     },
+    ...getNodeExtraData(relation.id),
   };
-}
+};
 
-export function discourseRelationDataToLocalConcept(
+export const discourseRelationDataToLocalConcept = (
   context: SupabaseContext,
   relationSchemaUid: string,
   relationNodes: { [role: string]: string },
-): LocalConceptDataInput {
-  const roamRelation = getDiscourseRelations().find(r => r.id === relationSchemaUid);
+): LocalConceptDataInput => {
+  const roamRelation = getDiscourseRelations().find(
+    (r) => r.id === relationSchemaUid,
+  );
   if (roamRelation === undefined) {
-    throw new Error(`Invalid roam relation id ${relationSchemaUid}`)
+    throw new Error(`Invalid roam relation id ${relationSchemaUid}`);
   }
   const relation = discourseRelationSchemaToLocalConcept(context, roamRelation);
-  const lit_content = ((relation.literal_content)? relation.literal_content: {}) as unknown as {[key: string]: any};
-  const roles = (lit_content['roles'] as string[] | undefined)  || STANDARD_ROLES;
-  const casting = Object.fromEntries(
+  const litContent = (relation.literal_content
+    ? relation.literal_content
+    : {}) as unknown as { [key: string]: any };
+  const roles = (litContent["roles"] as string[] | undefined) || STANDARD_ROLES;
+  const casting: { [role: string]: string } = Object.fromEntries(
     roles
       .map((role) => [role, relationNodes[role]])
-      .filter(([, uid]) => uid !== undefined)
+      .filter(([, uid]) => uid !== undefined),
   );
   if (Object.keys(casting).length === 0) {
-    throw new Error(`No valid node UIDs supplied for roles ${roles.join(", ")}`);
+    throw new Error(
+      `No valid node UIDs supplied for roles ${roles.join(", ")}`,
+    );
   }
   // TODO: Also get the nodes from the representation, using QueryBuilder. That will likely give me the relation object
   const nodeData = Object.values(casting).map((v) => getNodeExtraData(v));
   // roundabout way to do a max from stringified dates
-  const last_modified = new Date(Math.max(...nodeData.map((nd) => new Date(nd.last_modified).getTime()))).toISOString();
+  const last_modified = new Date(
+    Math.max(...nodeData.map((nd) => new Date(nd.last_modified).getTime())),
+  ).toISOString();
   // creation is actually creation of the relation node, not the rest of the cast, but this will do as a first approximation.
   // Still using max, since the relation cannot be created before its cast
-  const created = new Date(Math.max(...nodeData.map((nd) => new Date(nd.created).getTime()))).toISOString();
-  const author_local_id: string = nodeData[0].author_uid;  // take any one; again until I get the relation object
-  const represented_by_local_id = (casting["target"] || Object.values(casting)[0]); // This one is tricky. Prefer the target for now.
+  const created = new Date(
+    Math.max(...nodeData.map((nd) => new Date(nd.created).getTime())),
+  ).toISOString();
+  const author_local_id: string = nodeData[0].author_uid; // take any one; again until I get the relation object
+  const represented_by_local_id =
+    casting["target"] || Object.values(casting)[0]; // This one is tricky. Prefer the target for now.
   return {
     space_id: context.spaceId,
     represented_by_local_id,
     author_local_id,
     created,
     last_modified,
-    name: `${relationSchemaUid}-${Object.values(casting).join('-')}`,
+    name: `${relationSchemaUid}-${Object.values(casting).join("-")}`,
     is_schema: false,
     schema_represented_by_local_id: relationSchemaUid,
     local_reference_content: casting,
   };
-}
+};
 
 const relatedConcepts = (concept: LocalConceptDataInput): string[] => {
   const relations = Object.values(concept.local_reference_content || {}).flat();
   if (concept.schema_represented_by_local_id) {
-    relations.push(concept.schema_represented_by_local_id)
+    relations.push(concept.schema_represented_by_local_id);
   }
   // remove duplicates
   return [...new Set(relations)];
-}
+};
 
-const contentRelatedToConcept = (concept: LocalConceptDataInput): string[] => {
-  const relations = relatedConcepts(concept);
-  if (concept.represented_by_local_id && !relations.includes(concept.represented_by_local_id)) {
-    relations.push(concept.represented_by_local_id)
+const orderConceptsRec = (
+  ordered: LocalConceptDataInput[],
+  concept: LocalConceptDataInput,
+  remainder: { [key: string]: LocalConceptDataInput },
+): undefined => {
+  const relatedConceptIds = relatedConcepts(concept);
+  while (relatedConceptIds.length > 0) {
+    const relatedConceptId = relatedConceptIds.unshift();
+    const relatedConcept = remainder[relatedConceptId];
+    if (relatedConcept !== undefined) {
+      orderConceptsRec(ordered, relatedConcept, remainder);
+      delete remainder[relatedConceptId];
+    }
   }
-  return relations;
-}
+  ordered.push(concept);
+  delete remainder[concept.represented_by_local_id!];
+};
 
-// From those two, a function could in theory ensure that a concept's dependent concepts are already in the database.
-// It is probably going to be best done in bulk.
+// This can be used by a sync function to order upserts.
+// It assumes all input has defined represented_by_local_id,
+// and that nodes that are not in the upsert set are already in the database.
+export const orderConceptsByDependency = (
+  concepts: LocalConceptDataInput[],
+): LocalConceptDataInput[] => {
+  if (concepts.length === 0) return concepts;
+  const conceptById: { [key: string]: LocalConceptDataInput } =
+    Object.fromEntries(concepts.map((c) => [c, c.represented_by_local_id]));
+  const ordered: LocalConceptDataInput[] = [];
+  const first = conceptById[concepts[0].represented_by_local_id!];
+  orderConceptsRec(ordered, first, conceptById);
+  return ordered;
+};
 
 // the input to the upsert method would look like this:
 

--- a/apps/roam/src/utils/conceptConversion.ts
+++ b/apps/roam/src/utils/conceptConversion.ts
@@ -1,10 +1,9 @@
 import { DiscourseNode } from "./getDiscourseNodes";
 import getDiscourseRelations from "./getDiscourseRelations";
 import type { DiscourseRelation } from "./getDiscourseRelations";
-import { Database } from "@repo/database/types.gen";
 import type { SupabaseContext } from "~/utils/supabaseContext";
 
-import type { LocalConceptDataInput } from "@repo/database/input_types";
+import type { LocalConceptDataInput } from "@repo/database/inputTypes";
 
 const getNodeExtraData = (
   node_uid: string,
@@ -69,22 +68,22 @@ export const discourseNodeSchemaToLocalConcept = (
 export const discourseNodeBlockToLocalConcept = (
   context: SupabaseContext,
   {
-    node_uid,
-    schema_uid,
+    nodeUid,
+    schemaUid,
     text,
   }: {
-    node_uid: string;
-    schema_uid: string;
+    nodeUid: string;
+    schemaUid: string;
     text: string;
   },
 ): LocalConceptDataInput => {
   return {
     space_id: context.spaceId,
     name: text,
-    represented_by_local_id: node_uid,
-    schema_represented_by_local_id: schema_uid,
+    represented_by_local_id: nodeUid,
+    schema_represented_by_local_id: schemaUid,
     is_schema: false,
-    ...getNodeExtraData(node_uid),
+    ...getNodeExtraData(nodeUid),
   };
 };
 

--- a/apps/roam/src/utils/conceptConversion.ts
+++ b/apps/roam/src/utils/conceptConversion.ts
@@ -118,7 +118,14 @@ export function discourseRelationDataToLocalConcept(
   const relation = discourseRelationSchemaToLocalConcept(context, roamRelation);
   const lit_content = ((relation.literal_content)? relation.literal_content: {}) as unknown as {[key: string]: any};
   const roles = (lit_content['roles'] as string[] | undefined)  || STANDARD_ROLES;
-  const casting = Object.fromEntries(roles.map((role) => [role, relationNodes[role]]));
+  const casting = Object.fromEntries(
+    roles
+      .map((role) => [role, relationNodes[role]])
+      .filter(([, uid]) => uid !== undefined)
+  );
+  if (Object.keys(casting).length === 0) {
+    throw new Error(`No valid node UIDs supplied for roles ${roles.join(", ")}`);
+  }
   // TODO: Also get the nodes from the representation, using QueryBuilder. That will likely give me the relation object
   const nodeData = Object.values(casting).map((v) => getNodeExtraData(v));
   // roundabout way to do a max from stringified dates

--- a/apps/roam/src/utils/conceptConversion.ts
+++ b/apps/roam/src/utils/conceptConversion.ts
@@ -1,0 +1,171 @@
+import { DiscourseNode } from "./getDiscourseNodes";
+import getDiscourseRelations from "./getDiscourseRelations";
+import type { DiscourseRelation } from "./getDiscourseRelations";
+import { Database } from "@repo/database/types.gen";
+import type { SupabaseContext } from "~/utils/supabaseContext";
+
+// When it's merged: import type { LocalConceptDataInput } from '@repo/database/input_types';
+type LocalConceptDataInput = Partial<Database["public"]["CompositeTypes"]["concept_local_input"]>;
+
+// Get data from roam about the node
+const getNodeExtraData = (node_uid: string): { author_uid: string, created: string, last_modified: string, page_uid: string } => {
+  const result = window.roamAlphaAPI.q(`[
+    :find
+      ?author_uid
+      ?page_uid
+      ?created
+      ?last_modified
+      :in $ ?block_uid
+      :where
+      [?block :block/uid ?block_uid]
+      [?block :create/user ?author_id]
+      [?author_id :user/uid ?author_uid]
+      [?block :create/time ?created]
+      [?block :edit/time ?last_modified]
+      [(get-else $ ?block :block/page ?block) ?page_id]
+      [?page_id :block/uid ?page_uid]
+  ]`, node_uid);
+  if (result.length != 1 || result[0].length != 4)
+    throw new Error("Invalid result from Roam query");
+
+  const [author_uid, page_uid, created_t, last_modified_t] = result[0] as [string, string, number, number];
+  const created = new Date(created_t).toISOString();
+  const last_modified = new Date(last_modified_t).toISOString();
+  return {
+    author_uid,
+    created,
+    last_modified,
+    page_uid
+  }
+}
+
+
+export function discourseNodeSchemaToLocalConcept(
+  context: SupabaseContext,
+  node: DiscourseNode, // contains type, uid, text
+): LocalConceptDataInput {
+  const extra_data = getNodeExtraData(node.type);
+  const title_parts = node.text.split('/');
+  return {
+    space_id: context.spaceId,
+    author_local_id: extra_data.author_uid,
+    created: extra_data.created,
+    last_modified: extra_data.last_modified,
+    name: title_parts[title_parts.length - 1],
+    represented_by_local_id: node.type,
+    is_schema: true,
+  };
+}
+
+
+export function discourseNodeBlockToLocalConcept(
+  context: SupabaseContext,
+  node_uid: string,
+  schema_uid: string,
+  text: string
+): LocalConceptDataInput {
+  const extra_data = getNodeExtraData(node_uid);
+  return {
+    space_id: context.spaceId,
+    author_local_id: extra_data.author_uid,
+    created: extra_data.created,
+    last_modified: extra_data.last_modified,
+    name: text,
+    represented_by_local_id: node_uid,
+    schema_represented_by_local_id: schema_uid,
+    is_schema: false,
+  };
+
+}
+
+const STANDARD_ROLES = ["source", "target"];
+
+export function discourseRelationSchemaToLocalConcept(
+  context: SupabaseContext,
+  relation: DiscourseRelation, // contains type, uid, text
+): LocalConceptDataInput {
+  const extra_data = getNodeExtraData(relation.id);
+  return {
+    space_id: context.spaceId,
+    represented_by_local_id: relation.id,
+    author_local_id: extra_data.author_uid,
+    created: extra_data.created,
+    last_modified: extra_data.last_modified,
+    name: `${relation.id}-${relation.label}`,  // the label is not unique
+    is_schema: true,
+    local_reference_content: Object.fromEntries(
+      Object.entries(relation)
+        .filter(([key, v]) => STANDARD_ROLES.includes(key))
+      ) as { [key: string]: string },
+    literal_content: {
+      roles: STANDARD_ROLES,
+      label: relation.label,
+      complement: relation.complement,
+      representation: relation.triples.map(t=>t[0]),
+    },
+  };
+}
+
+export function discourseRelationDataToLocalConcept(
+  context: SupabaseContext,
+  relationSchemaUid: string,
+  relationNodes: { [role: string]: string },
+): LocalConceptDataInput {
+  const roamRelation = getDiscourseRelations().find(r => r.id === relationSchemaUid);
+  if (roamRelation === undefined) {
+    throw new Error(`Invalid roam relation id ${relationSchemaUid}`)
+  }
+  const relation = discourseRelationSchemaToLocalConcept(context, roamRelation);
+  const lit_content = ((relation.literal_content)? relation.literal_content: {}) as unknown as {[key: string]: any};
+  const roles = (lit_content['roles'] as string[] | undefined)  || STANDARD_ROLES;
+  const casting = Object.fromEntries(roles.map((role) => [role, relationNodes[role]]));
+  // TODO: Also get the nodes from the representation, using QueryBuilder. That will likely give me the relation object
+  const nodeData = Object.values(casting).map((v) => getNodeExtraData(v));
+  // roundabout way to do a max from stringified dates
+  const last_modified = new Date(Math.max(...nodeData.map((nd) => new Date(nd.last_modified).getTime()))).toISOString();
+  // creation is actually creation of the relation node, not the rest of the cast, but this will do as a first approximation.
+  // Still using max, since the relation cannot be created before its cast
+  const created = new Date(Math.max(...nodeData.map((nd) => new Date(nd.created).getTime()))).toISOString();
+  const author_local_id: string = nodeData[0].author_uid;  // take any one; again until I get the relation object
+  const represented_by_local_id = (casting["target"] || Object.values(casting)[0]); // This one is tricky. Prefer the target for now.
+  return {
+    space_id: context.spaceId,
+    represented_by_local_id,
+    author_local_id,
+    created,
+    last_modified,
+    name: `${relationSchemaUid}-${Object.values(casting).join('-')}`,
+    is_schema: false,
+    schema_represented_by_local_id: relationSchemaUid,
+    local_reference_content: casting,
+  };
+}
+
+const relatedConcepts = (concept: LocalConceptDataInput): string[] => {
+  const relations = Object.values(concept.local_reference_content || {}).flat();
+  if (concept.schema_represented_by_local_id) {
+    relations.push(concept.schema_represented_by_local_id)
+  }
+  // remove duplicates
+  return [...new Set(relations)];
+}
+
+const contentRelatedToConcept = (concept: LocalConceptDataInput): string[] => {
+  const relations = relatedConcepts(concept);
+  if (concept.represented_by_local_id && !relations.includes(concept.represented_by_local_id)) {
+    relations.push(concept.represented_by_local_id)
+  }
+  return relations;
+}
+
+// From those two, a function could in theory ensure that a concept's dependent concepts are already in the database.
+// It is probably going to be best done in bulk.
+
+// the input to the upsert method would look like this:
+
+// const idata: LocalConceptDataInput[] = [
+//   { "name": "Claim", "author_local_id": "sR22zZ470dNPkIf9PpjQXXdTBjG2", "represented_by_local_id": "a_roam_uid", "created": "2000/01/01", "last_modified": "2001/01/02", "is_schema": true },
+//   { "name": "A Claim", "author_local_id": "sR22zZ470dNPkIf9PpjQXXdTBjG2", "represented_by_local_id": "a_roam_uid2", "created": "2000/01/03", "last_modified": "2001/01/04", "is_schema": false, "schema_represented_by_local_id": "a_roam_uid" },
+//   { "name": "test2", "author_local_id": "sR22zZ470dNPkIf9PpjQXXdTBjG2", "created": "2000/01/04", "last_modified": "2001/01/05", "is_schema": false, "literal_content": { "source": "a_roam_uid", "target": ["a_roam_uid", "a_roam_uid2"] }, "local_reference_content": { "source": "a_roam_uid", "target": ["a_roam_uid", "a_roam_uid2"] } }]
+
+// const { data, error } = await supabase_client.rpc("upsert_concepts", { v_space_id: 12, data: idata });


### PR DESCRIPTION
These are the proposed functions to materialize nodes in the concept database.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added new functionality to convert Roam Research discourse nodes and relations into a local concept format for database integration.
  - Enhanced extraction and aggregation of related concept information, including metadata such as author, creation time, and references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Also wrote functions to order concepts in order of dependency. Not strictly needed in the current scenario, but could be needed down the road, and adds to the understanding of constraints of the sync function.