### PR TITLE
turbo is complaning about ouputs in packages/database.

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -13,7 +13,7 @@
       ],
       "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
-      "outputs": [".next/**", "!.next/cache/**", "dist/**"]
+      "outputs": [".next/**", "!.next/cache/**", "dist/**", "types.gen.ts"]
     },
     "lint": {
       "dependsOn": ["^lint"]


### PR DESCRIPTION
 Specifying this file silences the warning.
 ETA: can be tested with `turbo -F @repo/database`.