### PR TITLE
[ENG-278] Bulk import discourse nodes on Obsidian

### DIFF
--- a/apps/obsidian/scripts/generate-test-data.ts
+++ b/apps/obsidian/scripts/generate-test-data.ts
@@ -1,0 +1,65 @@
+#!/usr/bin/env tsx
+
+import { promises as fs } from "fs";
+import * as path from "path";
+
+/**
+ * Generates a set of markdown files that match the naming pattern
+ * for each default discourse node type. Useful for stress-testing the
+ * bulk-import feature without relying on external data sources.
+ */
+
+const VAULT_PATH = "/Users/trang.doan/Documents/Trang Doan";
+const TEST_FOLDER = "test-bulk-import-generated";
+const FILES_PER_TYPE = 300;
+
+/** Minimal representation of the default node types. */
+const DEFAULT_NODE_TYPES: { name: string; format: string }[] = [
+  { name: "Question", format: "QUE - {content}" },
+  { name: "Claim", format: "CLM - {content}" },
+  { name: "Evidence", format: "EVD - {content}" },
+];
+
+async function main() {
+  const targetDir = path.join(VAULT_PATH, TEST_FOLDER);
+
+  console.log("🧪 Generating test files for bulk import…\n");
+
+  // Clean existing folder if present
+  try {
+    await fs.rm(targetDir, { recursive: true, force: true });
+    console.log("🧹 Removed existing test folder (if any)");
+  } catch (_) {
+    /* noop */
+  }
+
+  // Ensure target directory exists
+  await fs.mkdir(targetDir, { recursive: true });
+  console.log(`📁 Created test folder: ${targetDir}\n`);
+
+  for (const nodeType of DEFAULT_NODE_TYPES) {
+    console.log(`📄 Creating ${FILES_PER_TYPE} ${nodeType.name} files…`);
+
+    for (let i = 1; i <= FILES_PER_TYPE; i++) {
+      const contentPlaceholder = `${nodeType.name} ${String(i).padStart(3, "0")}`;
+      const title = nodeType.format.replace("{content}", contentPlaceholder);
+      const filename = `${title}.md`;
+      const filePath = path.join(targetDir, filename);
+
+      const body = `# ${title}\n\nAutomatically generated for bulk-import testing.`;
+      await fs.writeFile(filePath, body, "utf8");
+    }
+
+    console.log(`   ✅ Done (${FILES_PER_TYPE} files)`);
+  }
+
+  console.log("\n🎉 Test file generation complete!");
+  console.log(`📍 Location: ${targetDir}\n`);
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error("💥 Generation failed:", err);
+    process.exit(1);
+  });
+}

--- a/apps/obsidian/scripts/setup-test-data.ts
+++ b/apps/obsidian/scripts/setup-test-data.ts
@@ -1,0 +1,128 @@
+#!/usr/bin/env tsx
+
+import { promises as fs } from "fs";
+import * as path from "path";
+
+const VAULT_PATH = "/Users/trang.doan/Documents/Trang Doan";
+const TEST_FOLDER = "test-bulk-import";
+const SOURCE_DIR = "/Users/trang.doan/Downloads/notes-hugo/discourse-graph";
+
+async function setupTestData() {
+  const testFolderPath = path.join(VAULT_PATH, TEST_FOLDER);
+
+  console.log("🧪 Setting up bulk import test data...");
+
+  try {
+    // Remove existing test folder if it exists
+    try {
+      await fs.access(testFolderPath);
+      console.log("📁 Removing existing test folder...");
+      await fs.rm(testFolderPath, { recursive: true, force: true });
+    } catch (error) {
+      // Folder doesn't exist, which is fine
+    }
+
+    // Check if source directory exists
+    try {
+      await fs.access(SOURCE_DIR);
+      console.log("✅ Source directory found");
+    } catch (error) {
+      console.error(`❌ Source directory not found: ${SOURCE_DIR}`);
+      process.exit(1);
+    }
+
+    // Show source directory structure and counts
+    console.log("📊 Analyzing source directory...");
+    await showDirectoryStats(SOURCE_DIR);
+
+    // Create test folder
+    console.log("📁 Creating test folder...");
+    await fs.mkdir(testFolderPath, { recursive: true });
+
+    // Copy files from source to test folder
+    console.log("📄 Copying test files...");
+    const fileCount = await copyDirectoryRecursive(SOURCE_DIR, testFolderPath);
+
+    console.log(`🎉 Successfully created test folder with ${fileCount} files!`);
+    console.log(`📍 Location: ${testFolderPath}`);
+  } catch (error) {
+    console.error("❌ Error setting up test data:", error);
+    process.exit(1);
+  }
+}
+
+async function copyDirectoryRecursive(
+  source: string,
+  target: string,
+): Promise<number> {
+  let fileCount = 0;
+
+  const copyRecursive = async (src: string, dest: string): Promise<void> => {
+    const items = await fs.readdir(src, { withFileTypes: true });
+
+    for (const item of items) {
+      const srcPath = path.join(src, item.name);
+      const destPath = path.join(dest, item.name);
+
+      if (item.isDirectory()) {
+        console.log(`📁 Creating folder: ${path.relative(target, destPath)}`);
+        await fs.mkdir(destPath, { recursive: true });
+        await copyRecursive(srcPath, destPath);
+      } else if (
+        item.isFile() &&
+        (item.name.endsWith(".md") || item.name.endsWith(".txt"))
+      ) {
+        // Only copy markdown and text files
+        console.log(`📄 Copying: ${path.relative(target, destPath)}`);
+        await fs.copyFile(srcPath, destPath);
+        fileCount++;
+      }
+    }
+  };
+
+  await copyRecursive(source, target);
+  return fileCount;
+}
+
+async function showDirectoryStats(
+  dir: string,
+  level: number = 0,
+): Promise<void> {
+  const indent = "  ".repeat(level);
+  const items = await fs.readdir(dir, { withFileTypes: true });
+
+  let fileCount = 0;
+  let dirCount = 0;
+
+  for (const item of items) {
+    if (item.isDirectory()) {
+      dirCount++;
+    } else if (
+      item.isFile() &&
+      (item.name.endsWith(".md") || item.name.endsWith(".txt"))
+    ) {
+      fileCount++;
+    }
+  }
+
+  console.log(
+    `${indent}📁 ${path.basename(dir)}: ${fileCount} files, ${dirCount} subdirectories`,
+  );
+
+  // Recursively show subdirectories (but limit depth to avoid clutter)
+  if (level < 2) {
+    for (const item of items) {
+      if (item.isDirectory()) {
+        await showDirectoryStats(path.join(dir, item.name), level + 1);
+      }
+    }
+  }
+}
+
+// Run the script
+if (require.main === module) {
+  setupTestData().catch((error) => {
+    console.error("💥 Script failed:", error);
+    process.exit(1);
+  });
+}

--- a/apps/obsidian/src/components/BulkImportModal.tsx
+++ b/apps/obsidian/src/components/BulkImportModal.tsx
@@ -4,6 +4,7 @@ import { StrictMode, useState, useEffect, useCallback, useRef } from "react";
 import type DiscourseGraphPlugin from "../index";
 import { BulkImportCandidate, BulkImportPattern } from "~/types";
 import { QueryEngine } from "~/services/QueryEngine";
+import { TFile } from "obsidian";
 
 type BulkImportModalProps = {
   plugin: DiscourseGraphPlugin;
@@ -30,11 +31,10 @@ const BulkImportContent = ({ plugin, onClose }: BulkImportModalProps) => {
     }
   }, [plugin.app]);
 
-  const getDirectoryPath = (filePath: string): string => {
-    const pathParts = filePath.split("/");
-    pathParts.pop();
-    const dirPath = pathParts.join("/");
-    return "/" + (dirPath || "(Root)");
+  const getDirectoryPath = (file: TFile): string => {
+    return file.parent?.path !== "/" && file.parent?.path
+      ? "/" + file.parent?.path
+      : "(Root)";
   };
 
   useEffect(() => {
@@ -100,11 +100,11 @@ const BulkImportContent = ({ plugin, onClose }: BulkImportModalProps) => {
   const handleFolderToggle = (folderPath: string) => {
     setCandidates((prev) => {
       const folderCandidates = prev.filter(
-        (c) => getDirectoryPath(c.file.path) === folderPath,
+        (c) => getDirectoryPath(c.file) === folderPath,
       );
       const allSelected = folderCandidates.every((c) => c.selected);
       return prev.map((c) =>
-        getDirectoryPath(c.file.path) === folderPath
+        getDirectoryPath(c.file) === folderPath
           ? { ...c, selected: !allSelected }
           : c,
       );
@@ -279,7 +279,7 @@ const BulkImportContent = ({ plugin, onClose }: BulkImportModalProps) => {
       { candidate: BulkImportCandidate; index: number }[]
     > = {};
     candidates.forEach((candidate, idx) => {
-      const dir = getDirectoryPath(candidate.file.path);
+      const dir = getDirectoryPath(candidate.file);
       if (!grouped[dir]) grouped[dir] = [];
       grouped[dir].push({ candidate, index: idx });
     });

--- a/apps/obsidian/src/components/BulkImportModal.tsx
+++ b/apps/obsidian/src/components/BulkImportModal.tsx
@@ -1,0 +1,363 @@
+import { App, Modal, Notice } from "obsidian";
+import { createRoot, Root } from "react-dom/client";
+import { StrictMode, useState, useEffect, useCallback, useRef } from "react";
+import type DiscourseGraphPlugin from "../index";
+import { BulkImportCandidate, BulkImportPattern } from "~/types";
+import { QueryEngine } from "~/services/QueryEngine";
+
+type BulkImportModalProps = {
+  plugin: DiscourseGraphPlugin;
+  onClose: () => void;
+};
+
+const BulkImportContent = ({ plugin, onClose }: BulkImportModalProps) => {
+  const [step, setStep] = useState<"patterns" | "review" | "importing">(
+    "patterns",
+  );
+  const [patterns, setPatterns] = useState<BulkImportPattern[]>([]);
+  const [candidates, setCandidates] = useState<BulkImportCandidate[]>([]);
+  const [isScanning, setIsScanning] = useState(false);
+  const [importProgress, setImportProgress] = useState({
+    current: 0,
+    total: 0,
+  });
+
+  const queryEngineRef = useRef<QueryEngine | null>(null);
+
+  useEffect(() => {
+    if (!queryEngineRef.current) {
+      queryEngineRef.current = new QueryEngine(plugin.app);
+    }
+  }, [plugin.app]);
+
+  const getDirectoryPath = (filePath: string): string => {
+    const pathParts = filePath.split("/");
+    pathParts.pop();
+    const dirPath = pathParts.join("/");
+    return "/" + (dirPath || "(Root)");
+  };
+
+  useEffect(() => {
+    const initialPatterns = plugin.settings.nodeTypes.map((nodeType) => ({
+      nodeTypeId: nodeType.id,
+      alternativePattern: nodeType.format,
+      enabled: false,
+    }));
+    setPatterns(initialPatterns);
+  }, [plugin.settings.nodeTypes]);
+
+  const handlePatternChange = (
+    index: number,
+    field: keyof BulkImportPattern,
+    value: string | boolean,
+  ) => {
+    setPatterns((prev) =>
+      prev.map((pattern, i) =>
+        i === index ? { ...pattern, [field]: value } : pattern,
+      ),
+    );
+  };
+
+  const handleScanVault = useCallback(async () => {
+    const enabledPatterns = patterns.filter(
+      (p) => p.enabled && p.alternativePattern.trim(),
+    );
+
+    if (!queryEngineRef.current) {
+      new Notice("Query engine not initialized");
+      return;
+    }
+
+    setIsScanning(true);
+    try {
+      const validNodeTypeIds = new Set(
+        plugin.settings.nodeTypes.map((nt) => nt.id),
+      );
+      const foundCandidates =
+        await queryEngineRef.current.scanForBulkImportCandidates(
+          enabledPatterns,
+          validNodeTypeIds,
+        );
+
+      // Resolve node types for candidates
+      const resolvedCandidates = foundCandidates
+        .map((candidate) => {
+          const nodeType = plugin.settings.nodeTypes.find(
+            (nt) => nt.id === candidate.matchedNodeType.id,
+          );
+          return {
+            ...candidate,
+            matchedNodeType: nodeType!,
+          };
+        })
+        .filter((candidate) => candidate.matchedNodeType); // Filter out any that couldn't be resolved
+
+      setCandidates(resolvedCandidates);
+      setStep("review");
+    } catch (error) {
+      console.error("Error scanning vault:", error);
+      new Notice("Error scanning vault for candidates");
+    } finally {
+      setIsScanning(false);
+    }
+  }, [patterns, plugin]);
+
+  const handleCandidateToggle = (index: number) => {
+    setCandidates((prev) =>
+      prev.map((candidate, i) =>
+        i === index
+          ? { ...candidate, selected: !candidate.selected }
+          : candidate,
+      ),
+    );
+  };
+
+  const handleBulkImport = async () => {
+    const selectedCandidates = candidates.filter((c) => c.selected);
+    setStep("importing");
+    setImportProgress({ current: 0, total: selectedCandidates.length });
+
+    try {
+      for (let i = 0; i < selectedCandidates.length; i++) {
+        const candidate = selectedCandidates[i];
+        if (!candidate) {
+          continue;
+        }
+
+        await plugin.app.fileManager.processFrontMatter(
+          candidate.file,
+          (fm) => {
+            fm.nodeTypeId = candidate.matchedNodeType.id;
+          },
+        );
+
+        setImportProgress({ current: i + 1, total: selectedCandidates.length });
+      }
+
+      new Notice(
+        `Successfully processed ${selectedCandidates.length} files as discourse nodes`,
+      );
+      onClose();
+    } catch (error) {
+      console.error("Error during bulk import:", error);
+      new Notice("Error during bulk import");
+    }
+  };
+
+  const renderPatternsStep = () => (
+    <div>
+      <h3 className="mb-4">Configure Import Patterns</h3>
+      <p className="text-muted mb-4 text-sm">
+        Files with title matching these patterns will be converted to discourse
+        nodes.
+      </p>
+
+      <div className="mb-4">
+        <button
+          onClick={() =>
+            setPatterns((prev) => prev.map((p) => ({ ...p, enabled: true })))
+          }
+          className="mr-2 rounded border px-3 py-1 text-sm"
+        >
+          Enable All
+        </button>
+        <button
+          onClick={() =>
+            setPatterns((prev) => prev.map((p) => ({ ...p, enabled: false })))
+          }
+          className="rounded border px-3 py-1 text-sm"
+        >
+          Disable All
+        </button>
+      </div>
+
+      <div className="flex flex-col gap-4">
+        {patterns.map((pattern, index) => {
+          const nodeType = plugin.settings.nodeTypes.find(
+            (n) => n.id === pattern.nodeTypeId,
+          );
+          return (
+            <div key={pattern.nodeTypeId} className="rounded border">
+              <div
+                className="mb-2 flex items-center"
+                onClick={() => {
+                  handlePatternChange(index, "enabled", !pattern.enabled);
+                }}
+              >
+                <input
+                  type="checkbox"
+                  checked={pattern.enabled}
+                  onChange={() => {
+                    handlePatternChange(index, "enabled", !pattern.enabled);
+                  }}
+                  className="mr-2"
+                />
+                <span className="font-medium">{nodeType?.name}</span>
+              </div>
+
+              {pattern.enabled && (
+                <div>
+                  <input
+                    type="text"
+                    placeholder={`e.g., for "${nodeType?.format}" you might use "C - {content}"`}
+                    value={pattern.alternativePattern}
+                    onChange={(e) =>
+                      handlePatternChange(
+                        index,
+                        "alternativePattern",
+                        e.target.value,
+                      )
+                    }
+                    className="w-full rounded border p-2"
+                  />
+                  <div className="text-muted mt-1 text-xs">
+                    Use {"{content}"} as placeholder for the main content
+                  </div>
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="mt-6 flex justify-between">
+        <button onClick={onClose} className="px-4 py-2">
+          Cancel
+        </button>
+        <button
+          onClick={handleScanVault}
+          disabled={isScanning || patterns.every((p) => !p.enabled)}
+          className="!bg-accent !text-on-accent rounded px-4 py-2"
+        >
+          {isScanning ? "Scanning..." : "Scan Vault"}
+        </button>
+      </div>
+    </div>
+  );
+
+  const renderReviewStep = () => (
+    <div>
+      <h3 className="mb-4">Review Import Candidates</h3>
+      <p className="text-muted mb-4 text-sm">
+        {candidates.length} potential matches found. Review and select which
+        files to import.
+      </p>
+
+      <div className="mb-4">
+        <button
+          onClick={() =>
+            setCandidates((prev) => prev.map((c) => ({ ...c, selected: true })))
+          }
+          className="mr-2 rounded border px-3 py-1 text-sm"
+        >
+          Select All
+        </button>
+        <button
+          onClick={() =>
+            setCandidates((prev) =>
+              prev.map((c) => ({ ...c, selected: false })),
+            )
+          }
+          className="rounded border px-3 py-1 text-sm"
+        >
+          Deselect All
+        </button>
+      </div>
+
+      <div className="max-h-96 overflow-y-auto rounded border">
+        {candidates.map((candidate, index) => (
+          <div
+            key={candidate.file.path}
+            className="flex items-start border-b p-3"
+          >
+            <input
+              type="checkbox"
+              checked={candidate.selected}
+              onChange={() => handleCandidateToggle(index)}
+              className="mr-3 mt-1 flex-shrink-0"
+            />
+            <div className="min-w-0 flex-1">
+              <div className="line-clamp-3 font-medium">
+                {candidate.file.basename}
+              </div>
+              <div className="text-muted text-sm">
+                {getDirectoryPath(candidate.file.path)}
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="mt-6 flex justify-between">
+        <button onClick={() => setStep("patterns")} className="px-4 py-2">
+          Back
+        </button>
+        <button
+          onClick={handleBulkImport}
+          className="!bg-accent !text-on-accent rounded px-4 py-2"
+          disabled={candidates.filter((c) => c.selected).length === 0}
+        >
+          Import Selected ({candidates.filter((c) => c.selected).length})
+        </button>
+      </div>
+    </div>
+  );
+
+  const renderImportingStep = () => (
+    <div className="text-center">
+      <h3 className="mb-4">Importing Files</h3>
+      <div className="mb-4">
+        <div className="bg-modifier-border mb-2 h-2 rounded-full">
+          <div
+            className="bg-accent h-2 rounded-full transition-all duration-300"
+            style={{
+              width: `${(importProgress.current / importProgress.total) * 100}%`,
+            }}
+          />
+        </div>
+        <div className="text-muted text-sm">
+          {importProgress.current} of {importProgress.total} files processed
+        </div>
+      </div>
+    </div>
+  );
+
+  switch (step) {
+    case "patterns":
+      return renderPatternsStep();
+    case "review":
+      return renderReviewStep();
+    case "importing":
+      return renderImportingStep();
+    default:
+      return null;
+  }
+};
+
+export class BulkImportModal extends Modal {
+  private plugin: DiscourseGraphPlugin;
+  private root: Root | null = null;
+
+  constructor(app: App, plugin: DiscourseGraphPlugin) {
+    super(app);
+    this.plugin = plugin;
+  }
+
+  onOpen() {
+    const { contentEl } = this;
+    contentEl.empty();
+    this.root = createRoot(contentEl);
+    this.root.render(
+      <StrictMode>
+        <BulkImportContent plugin={this.plugin} onClose={() => this.close()} />
+      </StrictMode>,
+    );
+  }
+
+  onClose() {
+    if (this.root) {
+      this.root.unmount();
+      this.root = null;
+    }
+  }
+}

--- a/apps/obsidian/src/components/BulkImportModal.tsx
+++ b/apps/obsidian/src/components/BulkImportModal.tsx
@@ -70,29 +70,14 @@ const BulkImportContent = ({ plugin, onClose }: BulkImportModalProps) => {
 
     setIsScanning(true);
     try {
-      const validNodeTypeIds = new Set(
-        plugin.settings.nodeTypes.map((nt) => nt.id),
-      );
+      const validNodeTypes = plugin.settings.nodeTypes;
       const foundCandidates =
         await queryEngineRef.current.scanForBulkImportCandidates(
           enabledPatterns,
-          validNodeTypeIds,
+          validNodeTypes,
         );
 
-      // Resolve node types for candidates
-      const resolvedCandidates = foundCandidates
-        .map((candidate) => {
-          const nodeType = plugin.settings.nodeTypes.find(
-            (nt) => nt.id === candidate.matchedNodeType.id,
-          );
-          return {
-            ...candidate,
-            matchedNodeType: nodeType!,
-          };
-        })
-        .filter((candidate) => candidate.matchedNodeType); // Filter out any that couldn't be resolved
-
-      setCandidates(resolvedCandidates);
+      setCandidates(foundCandidates);
       setStep("review");
     } catch (error) {
       console.error("Error scanning vault:", error);
@@ -171,53 +156,57 @@ const BulkImportContent = ({ plugin, onClose }: BulkImportModalProps) => {
         </button>
       </div>
 
-      <div className="flex flex-col gap-4">
-        {patterns.map((pattern, index) => {
-          const nodeType = plugin.settings.nodeTypes.find(
-            (n) => n.id === pattern.nodeTypeId,
-          );
-          return (
-            <div key={pattern.nodeTypeId} className="rounded border">
-              <div
-                className="mb-2 flex items-center"
-                onClick={() => {
-                  handlePatternChange(index, "enabled", !pattern.enabled);
-                }}
-              >
-                <input
-                  type="checkbox"
-                  checked={pattern.enabled}
-                  onChange={() => {
+      <div className="bg-accent/10 mb-4 rounded p-3 text-sm">
+        <strong>💡 </strong> Use <code>{"{content}"}</code> as placeholder for
+        the main content in your alternative patterns.
+      </div>
+
+      <div className="mb-6 h-80 overflow-y-auto rounded border p-4">
+        <div className="flex flex-col gap-4">
+          {patterns.map((pattern, index) => {
+            const nodeType = plugin.settings.nodeTypes.find(
+              (n) => n.id === pattern.nodeTypeId,
+            );
+            return (
+              <div key={pattern.nodeTypeId} className="rounded border p-3">
+                <div
+                  className="mb-2 flex cursor-pointer items-center"
+                  onClick={() => {
                     handlePatternChange(index, "enabled", !pattern.enabled);
                   }}
-                  className="mr-2"
-                />
-                <span className="font-medium">{nodeType?.name}</span>
-              </div>
-
-              {pattern.enabled && (
-                <div>
+                >
                   <input
-                    type="text"
-                    placeholder={`e.g., for "${nodeType?.format}" you might use "C - {content}"`}
-                    value={pattern.alternativePattern}
-                    onChange={(e) =>
-                      handlePatternChange(
-                        index,
-                        "alternativePattern",
-                        e.target.value,
-                      )
-                    }
-                    className="w-full rounded border p-2"
+                    type="checkbox"
+                    checked={pattern.enabled}
+                    onChange={() => {
+                      handlePatternChange(index, "enabled", !pattern.enabled);
+                    }}
+                    className="mr-2"
                   />
-                  <div className="text-muted mt-1 text-xs">
-                    Use {"{content}"} as placeholder for the main content
-                  </div>
+                  <span className="font-medium">{nodeType?.name}</span>
                 </div>
-              )}
-            </div>
-          );
-        })}
+
+                {pattern.enabled && (
+                  <div className="mt-2">
+                    <input
+                      type="text"
+                      placeholder={`e.g., for "${nodeType?.format}" you might use "C - {content}"`}
+                      value={pattern.alternativePattern}
+                      onChange={(e) =>
+                        handlePatternChange(
+                          index,
+                          "alternativePattern",
+                          e.target.value,
+                        )
+                      }
+                      className="w-full rounded border p-2"
+                    />
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
       </div>
 
       <div className="mt-6 flex justify-between">

--- a/apps/obsidian/src/components/DiscourseContextView.tsx
+++ b/apps/obsidian/src/components/DiscourseContextView.tsx
@@ -1,7 +1,7 @@
 import { ItemView, TFile, WorkspaceLeaf } from "obsidian";
 import { createRoot, Root } from "react-dom/client";
 import DiscourseGraphPlugin from "~/index";
-import { getDiscourseNodeFormatExpression } from "~/utils/getDiscourseNodeFormatExpression";
+import { extractContentFromTitle } from "~/utils/extractContentFromTitle";
 import { RelationshipSection } from "~/components/RelationshipSection";
 import { VIEW_TYPE_DISCOURSE_CONTEXT } from "~/types";
 import { PluginProvider, usePlugin } from "~/components/PluginContext";
@@ -12,16 +12,6 @@ type DiscourseContextProps = {
 
 const DiscourseContext = ({ activeFile }: DiscourseContextProps) => {
   const plugin = usePlugin();
-
-  const extractContentFromTitle = (
-    format: string | undefined,
-    title: string,
-  ): string => {
-    if (!format) return "";
-    const regex = getDiscourseNodeFormatExpression(format);
-    const match = title.match(regex);
-    return match?.[1] ?? title;
-  };
 
   const renderContent = () => {
     if (!activeFile) {

--- a/apps/obsidian/src/components/DiscourseContextView.tsx
+++ b/apps/obsidian/src/components/DiscourseContextView.tsx
@@ -1,7 +1,7 @@
 import { ItemView, TFile, WorkspaceLeaf } from "obsidian";
 import { createRoot, Root } from "react-dom/client";
 import DiscourseGraphPlugin from "~/index";
-import { extractContentFromTitle } from "~/utils/extractContentFromTitle";
+import { getDiscourseNodeFormatExpression } from "~/utils/getDiscourseNodeFormatExpression";
 import { RelationshipSection } from "~/components/RelationshipSection";
 import { VIEW_TYPE_DISCOURSE_CONTEXT } from "~/types";
 import { PluginProvider, usePlugin } from "~/components/PluginContext";
@@ -12,6 +12,13 @@ type DiscourseContextProps = {
 
 const DiscourseContext = ({ activeFile }: DiscourseContextProps) => {
   const plugin = usePlugin();
+
+  const extractContentFromTitle = (format: string, title: string): string => {
+    if (!format) return "";
+    const regex = getDiscourseNodeFormatExpression(format);
+    const match = title.match(regex);
+    return match?.[1] ?? title;
+  };
 
   const renderContent = () => {
     if (!activeFile) {

--- a/apps/obsidian/src/services/QueryEngine.ts
+++ b/apps/obsidian/src/services/QueryEngine.ts
@@ -194,11 +194,20 @@ export class QueryEngine {
                 fileName,
               );
 
+              const matchedNodeType = validNodeTypes.find(
+                (nt) => nt.id === pattern.nodeTypeId,
+              );
+
+              if (!matchedNodeType) {
+                console.warn(
+                  `No matching node type found for pattern with nodeTypeId: ${pattern.nodeTypeId}`,
+                );
+                continue;
+              }
+
               candidates.push({
                 file,
-                matchedNodeType: validNodeTypes.find(
-                  (nt) => nt.id === pattern.nodeTypeId,
-                )!,
+                matchedNodeType,
                 alternativePattern: pattern.alternativePattern,
                 extractedContent,
                 selected: true,
@@ -251,11 +260,20 @@ export class QueryEngine {
             fileName,
           );
 
+          const matchedNodeType = validNodeTypes.find(
+            (nt) => nt.id === pattern.nodeTypeId,
+          );
+
+          if (!matchedNodeType) {
+            console.warn(
+              `No matching node type found for pattern with nodeTypeId: ${pattern.nodeTypeId}`,
+            );
+            continue;
+          }
+
           candidates.push({
             file,
-            matchedNodeType: validNodeTypes.find(
-              (nt) => nt.id === pattern.nodeTypeId,
-            )!,
+            matchedNodeType,
             alternativePattern: pattern.alternativePattern,
             extractedContent,
             selected: true,

--- a/apps/obsidian/src/types.ts
+++ b/apps/obsidian/src/types.ts
@@ -27,4 +27,18 @@ export type Settings = {
   nodesFolderPath: string;
 };
 
+export type BulkImportCandidate = {
+  file: import("obsidian").TFile;
+  matchedNodeType: DiscourseNode;
+  alternativePattern: string;
+  extractedContent: string;
+  selected: boolean;
+};
+
+export type BulkImportPattern = {
+  nodeTypeId: string;
+  alternativePattern: string;
+  enabled: boolean;
+};
+
 export const VIEW_TYPE_DISCOURSE_CONTEXT = "discourse-context-view";

--- a/apps/obsidian/src/types.ts
+++ b/apps/obsidian/src/types.ts
@@ -1,3 +1,5 @@
+import { TFile } from "obsidian";
+
 export type DiscourseNode = {
   id: string;
   name: string;
@@ -28,7 +30,7 @@ export type Settings = {
 };
 
 export type BulkImportCandidate = {
-  file: import("obsidian").TFile;
+  file: TFile;
   matchedNodeType: DiscourseNode;
   alternativePattern: string;
   extractedContent: string;

--- a/apps/obsidian/src/utils/extractContentFromTitle.ts
+++ b/apps/obsidian/src/utils/extractContentFromTitle.ts
@@ -1,9 +1,6 @@
 import { getDiscourseNodeFormatExpression } from "./getDiscourseNodeFormatExpression";
 
-export const extractContentFromTitle = (
-  format: string | undefined,
-  title: string,
-): string => {
+export const extractContentFromTitle = (format: string, title: string): string => {
   if (!format) return title;
 
   const regex = getDiscourseNodeFormatExpression(format);

--- a/apps/obsidian/src/utils/extractContentFromTitle.ts
+++ b/apps/obsidian/src/utils/extractContentFromTitle.ts
@@ -1,0 +1,13 @@
+import { getDiscourseNodeFormatExpression } from "./getDiscourseNodeFormatExpression";
+
+export const extractContentFromTitle = (
+  format: string | undefined,
+  title: string,
+): string => {
+  if (!format) return title;
+
+  const regex = getDiscourseNodeFormatExpression(format);
+  const match = title.match(regex);
+
+  return match?.[1]?.trim() || title;
+};

--- a/apps/obsidian/src/utils/registerCommands.ts
+++ b/apps/obsidian/src/utils/registerCommands.ts
@@ -2,7 +2,7 @@ import { Editor } from "obsidian";
 import type DiscourseGraphPlugin from "~/index";
 import { NodeTypeModal } from "~/components/NodeTypeModal";
 import { CreateNodeModal } from "~/components/CreateNodeModal";
-import { BulkImportModal } from "~/components/BulkImportModal";
+import { BulkIdentifyDiscourseNodesModal } from "~/components/BulkIdentifyDiscourseNodesModal";
 import { createDiscourseNode } from "./createNode";
 
 export const registerCommands = (plugin: DiscourseGraphPlugin) => {
@@ -52,10 +52,10 @@ export const registerCommands = (plugin: DiscourseGraphPlugin) => {
   });
 
   plugin.addCommand({
-    id: "bulk-import-discourse-nodes",
-    name: "Bulk Import Discourse Nodes",
+    id: "bulk-identify-discourse-nodes",
+    name: "Bulk Identify Discourse Nodes",
     callback: () => {
-      new BulkImportModal(plugin.app, plugin).open();
+      new BulkIdentifyDiscourseNodesModal(plugin.app, plugin).open();
     },
   });
 

--- a/apps/obsidian/src/utils/registerCommands.ts
+++ b/apps/obsidian/src/utils/registerCommands.ts
@@ -2,6 +2,7 @@ import { Editor } from "obsidian";
 import type DiscourseGraphPlugin from "~/index";
 import { NodeTypeModal } from "~/components/NodeTypeModal";
 import { CreateNodeModal } from "~/components/CreateNodeModal";
+import { BulkImportModal } from "~/components/BulkImportModal";
 import { createDiscourseNode } from "./createNode";
 
 export const registerCommands = (plugin: DiscourseGraphPlugin) => {
@@ -47,6 +48,14 @@ export const registerCommands = (plugin: DiscourseGraphPlugin) => {
           });
         },
       }).open();
+    },
+  });
+
+  plugin.addCommand({
+    id: "bulk-import-discourse-nodes",
+    name: "Bulk Import Discourse Nodes",
+    callback: () => {
+      new BulkImportModal(plugin.app, plugin).open();
     },
   });
 


### PR DESCRIPTION
https://www.loom.com/share/ac8da868954c49fc9143e4416784e269
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

@mdroidian available for testing via [this BRAT release](https://github.com/DiscourseGraphs/discourse-graph-obsidian/releases/tag/v0.1.1-alpha-bulk-import)

## Summary by CodeRabbit

- **New Features**
  - Introduced a bulk import modal for importing discourse nodes, guiding users through pattern configuration, candidate review, and import steps.
  - Added controls for enabling/disabling patterns, selecting/deselecting candidates, and visualizing import progress.
  - Implemented a new command to launch the bulk import modal from the command palette.
- **Enhancements**
  - Improved candidate file scanning with pattern matching and fallback mechanisms for robust import candidate discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->