### PR TITLE
ENG-448: Query Roam Discourse Nodes created or modified since the last update

### DIFF
--- a/apps/roam/src/utils/getAllDiscourseNodesSince.ts
+++ b/apps/roam/src/utils/getAllDiscourseNodesSince.ts
@@ -1,22 +1,22 @@
 import isDiscourseNode from "./isDiscourseNode";
 
-type RoamEntityFromQuery = {
-  uid: string;
-  title?: string;
-  createTime?: number;
-  editTime?: number;
-  userUuid?: string;
-  username?: string;
+export type DiscourseGraphContent = {
+  author_local_id: string;
+  source_local_id: string;
+  scale: string;
+  created: string;
+  last_modified: string;
+  text: string;
 };
 
 export const getAllDiscourseNodesSince = async (
   since: string,
-): Promise<RoamEntityFromQuery[]> => {
+): Promise<DiscourseGraphContent[]> => {
   const roamAlpha = (window as any).roamAlphaAPI;
   const sinceMs = new Date(since).getTime();
 
   const query = `[:find ?uid ?create-time ?edit-time ?user-uuid ?username ?title
-     :keys  uid   createTime    editTime    userUuid   username title
+     :keys  source_local_id created last_modified author_local_id author_name text 
      :in $ ?since 
      :where
       [?e :node/title ?title]
@@ -28,13 +28,13 @@ export const getAllDiscourseNodesSince = async (
       [?e :edit/time ?edit-time]
       [(> ?edit-time ?since)]]`;
 
-  const result = roamAlpha.data.q(query, sinceMs) as RoamEntityFromQuery[];
+  const result = roamAlpha.data.q(query, sinceMs) as DiscourseGraphContent[];
 
   return result.filter(
     (entity) =>
-      entity.uid &&
-      isDiscourseNode(entity.uid) &&
-      entity.title &&
-      entity.title.trim() !== "",
+      entity.source_local_id &&
+      isDiscourseNode(entity.source_local_id) &&
+      entity.text &&
+      entity.text.trim() !== "",
   );
 };

--- a/apps/roam/src/utils/getAllDiscourseNodesSince.ts
+++ b/apps/roam/src/utils/getAllDiscourseNodesSince.ts
@@ -1,0 +1,40 @@
+import isDiscourseNode from "./isDiscourseNode";
+
+type RoamEntityFromQuery = {
+  uid: string;
+  title?: string;
+  createTime?: number;
+  editTime?: number;
+  userUuid?: string;
+  username?: string;
+};
+
+export const getAllDiscourseNodesSince = async (
+  since: string,
+): Promise<RoamEntityFromQuery[]> => {
+  const roamAlpha = (window as any).roamAlphaAPI;
+  const sinceMs = new Date(since).getTime();
+
+  const query = `[:find ?uid ?create-time ?edit-time ?user-uuid ?username ?title
+     :keys  uid   createTime    editTime    userUuid   username title
+     :in $ ?since 
+     :where
+      [?e :node/title ?title]
+      [?e :block/uid ?uid] 
+      [?e :create/user ?user-id]
+      [?user-id :user/uid ?user-uuid]
+      [?user-id :user/display-name ?username]
+      [?e :create/time ?create-time]
+      [?e :edit/time ?edit-time]
+      [(> ?edit-time ?since)]]`;
+
+  const result = roamAlpha.data.q(query, sinceMs) as RoamEntityFromQuery[];
+
+  return result.filter(
+    (entity) =>
+      entity.uid &&
+      isDiscourseNode(entity.uid) &&
+      entity.title &&
+      entity.title.trim() !== "",
+  );
+};


### PR DESCRIPTION
Here is the result of using this function 

![image](https://github.com/user-attachments/assets/e2ad3874-64bd-4aa5-b192-0d68723254e1)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to fetch and display discourse nodes that have been edited since a specific date, including details such as author, timestamps, and content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->