### PR TITLE
schema linting

### DIFF
--- a/packages/database/supabase/schemas/access_token.sql
+++ b/packages/database/supabase/schemas/access_token.sql
@@ -1,14 +1,14 @@
 create table "access_token" (
-  request_id varchar primary key,
-  -- TODO encrypt this (look into supabase vault)
-  access_token varchar not null,
-  code varchar,
-  platform_account_id bigint,
-  created_date timestamp with time zone default timezone('utc'::text, now()) not null,
-  constraint access_token_code_check check (
-    code is not null
-  ),
-  constraint access_token_platform_account_id_fkey foreign key (platform_account_id)
+    request_id varchar primary key,
+    -- TODO encrypt this (look into supabase vault)
+    access_token varchar not null,
+    code varchar,
+    platform_account_id bigint,
+    created_date timestamp with time zone default timezone('utc'::text, now()) not null,
+    constraint access_token_code_check check (
+        code is not null
+    ),
+    constraint access_token_platform_account_id_fkey foreign key (platform_account_id)
     references public."PlatformAccount" (id) on update cascade on delete set null
 );
 

--- a/packages/database/supabase/schemas/account.sql
+++ b/packages/database/supabase/schemas/account.sql
@@ -23,14 +23,14 @@ CREATE TABLE IF NOT EXISTS public."PlatformAccount" (
         'public.entity_id_seq'::regclass
     ) NOT NULL PRIMARY KEY,
     name VARCHAR NOT NULL,
-	platform public."Platform" NOT NULL,
+    platform public."Platform" NOT NULL,
     account_local_id VARCHAR NOT NULL,
-	write_permission BOOLEAN NOT NULL DEFAULT true,
-	active BOOLEAN NOT NULL DEFAULT true,
-	agent_type public."AgentType" NOT NULL DEFAULT 'person',
-	metadata JSONB NOT NULL DEFAULT '{}',
-	dg_account UUID,
-	FOREIGN KEY(dg_account) REFERENCES auth.users (id) ON DELETE SET NULL ON UPDATE CASCADE
+    write_permission BOOLEAN NOT NULL DEFAULT true,
+    active BOOLEAN NOT NULL DEFAULT true,
+    agent_type public."AgentType" NOT NULL DEFAULT 'person',
+    metadata JSONB NOT NULL DEFAULT '{}',
+    dg_account UUID,
+    FOREIGN KEY (dg_account) REFERENCES auth.users (id) ON DELETE SET NULL ON UPDATE CASCADE
 );
 
 ALTER TABLE public."PlatformAccount" OWNER TO "postgres";
@@ -45,12 +45,12 @@ GRANT ALL ON TABLE public."PlatformAccount" TO service_role;
 
 
 CREATE TABLE public."AgentIdentifier" (
-	identifier_type public."AgentIdentifierType" NOT NULL,
-	account_id BIGINT NOT NULL,
-	value VARCHAR NOT NULL,
+    identifier_type public."AgentIdentifierType" NOT NULL,
+    account_id BIGINT NOT NULL,
+    value VARCHAR NOT NULL,
     trusted BOOLEAN NOT NULL DEFAULT false,
     PRIMARY KEY (value, identifier_type, account_id),
-	FOREIGN KEY(account_id) REFERENCES public."PlatformAccount" (id)
+    FOREIGN KEY (account_id) REFERENCES public."PlatformAccount" (id)
 );
 
 ALTER TABLE public."AgentIdentifier" OWNER TO "postgres";
@@ -97,4 +97,3 @@ ADD CONSTRAINT "SpaceAccess_space_id_fkey" FOREIGN KEY (
 GRANT ALL ON TABLE public."SpaceAccess" TO anon;
 GRANT ALL ON TABLE public."SpaceAccess" TO authenticated;
 GRANT ALL ON TABLE public."SpaceAccess" TO service_role;
-

--- a/packages/database/supabase/schemas/concept.sql
+++ b/packages/database/supabase/schemas/concept.sql
@@ -16,17 +16,17 @@ CREATE OR REPLACE FUNCTION extract_references(refs JSONB) RETURNS BIGINT [] LANG
   SELECT COALESCE(array_agg(i::bigint), '{}') FROM (SELECT DISTINCT jsonb_array_elements(jsonb_path_query_array(refs, '$.*[*]')) i) exrefs;
 $$;
 
-CREATE OR REPLACE FUNCTION compute_arity_lit(lit_content JSONB) RETURNS smallint language sql IMMUTABLE AS $$
+CREATE OR REPLACE FUNCTION compute_arity_lit(lit_content JSONB) RETURNS smallint LANGUAGE sql IMMUTABLE AS $$
   SELECT COALESCE(jsonb_array_length(lit_content->'roles'), 0);
 $$;
 
 SET check_function_bodies = false;
-CREATE OR REPLACE FUNCTION compute_arity_id(p_schema_id BIGINT) RETURNS smallint language sql IMMUTABLE AS $$
+CREATE OR REPLACE FUNCTION compute_arity_id(p_schema_id BIGINT) RETURNS smallint LANGUAGE sql IMMUTABLE AS $$
   SELECT COALESCE(jsonb_array_length(literal_content->'roles'), 0) FROM public."Concept" WHERE id=p_schema_id;
 $$;
 SET check_function_bodies = true;
 
-CREATE OR REPLACE FUNCTION compute_arity_local(schema_id BIGINT, lit_content JSONB) RETURNS smallint language sql IMMUTABLE AS $$
+CREATE OR REPLACE FUNCTION compute_arity_local(schema_id BIGINT, lit_content JSONB) RETURNS smallint LANGUAGE sql IMMUTABLE AS $$
   SELECT CASE WHEN schema_id IS NULL THEN compute_arity_lit(lit_content) ELSE compute_arity_id(schema_id) END;
 $$;
 

--- a/packages/database/supabase/schemas/content.sql
+++ b/packages/database/supabase/schemas/content.sql
@@ -228,7 +228,7 @@ BEGIN
 END;
 $$;
 
-COMMENT ON FUNCTION public._local_document_to_db_document IS 'utility function so we have the option to use platform identifiers for document upsert' ;
+COMMENT ON FUNCTION public._local_document_to_db_documentIS 'utility function so we have the option to use platform identifiers for document upsert' ;
 
 -- private function. Transform content with local (platform) references to content with db references
 CREATE OR REPLACE FUNCTION public._local_content_to_db_content (data public.content_local_input) RETURNS public."Content" LANGUAGE plpgsql STABLE AS $$
@@ -269,7 +269,7 @@ BEGIN
 END;
 $$ ;
 
-COMMENT ON FUNCTION public._local_content_to_db_content IS 'utility function so we have the option to use platform identifiers for content upsert' ;
+COMMENT ON FUNCTION public._local_content_to_db_contentIS 'utility function so we have the option to use platform identifiers for content upsert' ;
 
 -- The data should be a PlatformAccount
 -- PlatformAccount is upserted, based on platform and account_local_id. New (or old) ID is returned.
@@ -358,7 +358,7 @@ BEGIN
 END;
 $$ ;
 
-COMMENT ON FUNCTION public.upsert_documents IS 'batch document upsert' ;
+COMMENT ON FUNCTION public.upsert_documentsIS 'batch document upsert' ;
 
 CREATE OR REPLACE FUNCTION public.upsert_content_embedding (content_id bigint, model varchar, embedding_array float []) RETURNS VOID
 LANGUAGE plpgsql
@@ -378,7 +378,7 @@ BEGIN
 END
 $$ ;
 
-COMMENT ON FUNCTION public.upsert_content_embedding IS 'single content embedding upsert' ;
+COMMENT ON FUNCTION public.upsert_content_embeddingIS 'single content embedding upsert' ;
 
 -- The data should be an array of LocalContentDataInput
 -- Contents are upserted, based on space_id and local_id. New (or old) IDs are returned.
@@ -498,4 +498,4 @@ BEGIN
 END;
 $$ ;
 
-COMMENT ON FUNCTION public.upsert_content IS 'batch content upsert' ;
+COMMENT ON FUNCTION public.upsert_contentIS 'batch content upsert' ;

--- a/packages/database/supabase/schemas/embedding.sql
+++ b/packages/database/supabase/schemas/embedding.sql
@@ -98,4 +98,4 @@ ALTER FUNCTION public.match_embeddings_for_subset_nodes (
 "p_query_embedding" extensions.vector, "p_subset_roam_uids" Text [])
 OWNER TO "postgres" ;
 
-RESET ALL;
+RESET ALL ;


### PR DESCRIPTION
This is just applying the `sqruff fix` to the sql schemas, because it errors and fails the lint step, making developing the lint (ENG-369) harder.
I'm ok with the lint being imposed; but we could also do the equivalent of only-warn and not fail the lint, either way. But for now just checking this in, to distinguish it from the rest of 369, to which it's not that deeply related.
