### PR TITLE
[ENG-516, ENG-515] Change Defaults for showIdsInFrontmatter and folderPath

### DIFF
--- a/apps/obsidian/src/components/GeneralSettings.tsx
+++ b/apps/obsidian/src/components/GeneralSettings.tsx
@@ -123,7 +123,7 @@ const GeneralSettings = () => {
           <FolderSuggestInput
             value={nodesFolderPath}
             onChange={handleFolderPathChange}
-            placeholder="Discourse Nodes"
+            placeholder="Example: folder 1/folder"
           />
         </div>
       </div>

--- a/apps/obsidian/src/constants.ts
+++ b/apps/obsidian/src/constants.ts
@@ -56,6 +56,6 @@ export const DEFAULT_SETTINGS: Settings = {
       relationshipTypeId: DEFAULT_RELATION_TYPES.opposes!.id,
     },
   ],
-  showIdsInFrontmatter: true,
-  nodesFolderPath: "Discourse Nodes",
+  showIdsInFrontmatter: false,
+  nodesFolderPath: "",
 };


### PR DESCRIPTION
[ENG-515: Show IDs in frontmatter should be toggled off by default](https://linear.app/discourse-graphs/issue/ENG-515/show-ids-in-frontmatter-should-be-toggled-off-by-default)
> In their current state, node IDs are not functionally useful for the user, so should be hidden by default

[ENG-516: Discourse nodes folder path should be empty by default](https://linear.app/discourse-graphs/issue/ENG-516/discourse-nodes-folder-path-should-be-empty-by-default)
> So that nodes are created in the root folder as the default behavior. New placeholder text for this empty state should be: "Example: folder 1/folder" 