### PR TITLE
Eng 418 create and store roam space password

### DIFF
--- a/apps/roam/src/utils/getBlockProps.ts
+++ b/apps/roam/src/utils/getBlockProps.ts
@@ -24,11 +24,12 @@ export const normalizeProps = (props: json): json =>
           )
     : props;
 
+export const getRawBlockProps = (uid: string) =>
+  (window.roamAlphaAPI.pull("[:block/props]", [":block/uid", uid])?.[
+    ":block/props"
+  ] || {}) as Record<string, json>;
+
 const getBlockProps = (uid: string) =>
-  normalizeProps(
-    (window.roamAlphaAPI.pull("[:block/props]", [":block/uid", uid])?.[
-      ":block/props"
-    ] || {}) as Record<string, json>,
-  ) as Record<string, json>;
+  normalizeProps(getRawBlockProps(uid)) as Record<string, json>;
 
 export default getBlockProps;

--- a/apps/roam/src/utils/setBlockProps.ts
+++ b/apps/roam/src/utils/setBlockProps.ts
@@ -1,0 +1,49 @@
+import { type json, getRawBlockProps } from "./getBlockProps";
+import getPageUidByPageTitle from "roamjs-components/queries/getPageUidByPageTitle";
+
+export const deNormalizeProps = (props: json): json =>
+  typeof props === "object"
+    ? props === null
+      ? null
+      : Array.isArray(props)
+        ? props.map(deNormalizeProps)
+        : Object.fromEntries(
+            Object.entries(props).map(([k, v]) => [
+              `:${k}`,
+              typeof v === "object" && v !== null && !Array.isArray(v)
+                ? deNormalizeProps(v)
+                : Array.isArray(v)
+                  ? v.map(deNormalizeProps)
+                  : v,
+            ]),
+          )
+    : props;
+
+const setBlockProps = (
+  uid: string,
+  newProps: Record<string, json>,
+  denormalize: boolean = false,
+) => {
+  const baseProps = getRawBlockProps(uid);
+  if (typeof baseProps === "object" && !Array.isArray(baseProps)) {
+    const props = {
+      ...(baseProps || {}),
+      ...(denormalize
+        ? (deNormalizeProps(newProps) as Record<string, json>)
+        : newProps),
+    } as Record<string, json>;
+    window.roamAlphaAPI.data.block.update({ block: { uid, props } });
+    return props;
+  }
+  return baseProps;
+};
+
+export const testSetBlockProps = (
+  title: string,
+  newProps: Record<string, json>,
+) => {
+  const uid = getPageUidByPageTitle(title);
+  return uid ? setBlockProps(uid, newProps) : null;
+};
+
+export default setBlockProps;


### PR DESCRIPTION
Obtain a password from the roam props of the plugin settings, intended to use for the supabase anonymous user for the space.
Create it and store it otherwise.
Added an utility function to set Props.

Note that I'm basing it on 520, not because I need to yet, but because my next task will use both of those together, and unless the merges come really fast I'll be paralyzed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced the ability to set and update block properties within Roam.
	- Added automatic management and retrieval of a "space password" for enhanced workspace security.

- **Refactor**
	- Improved separation between data retrieval and normalization for block properties, making property handling more modular and maintainable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->