### PR TITLE
ENG-420-create-space-and-anonymous-account

### DIFF
--- a/apps/roam/src/utils/supabaseContext.ts
+++ b/apps/roam/src/utils/supabaseContext.ts
@@ -4,14 +4,19 @@ import getCurrentUserDisplayName from "roamjs-components/queries/getCurrentUserD
 import getPageUidByPageTitle from "roamjs-components/queries/getPageUidByPageTitle";
 import getRoamUrl from "roamjs-components/dom/getRoamUrl";
 
-import { Database } from "@repo/database/types.gen";
+import { Enums } from "@repo/database/types.gen";
 import { DISCOURSE_CONFIG_PAGE_TITLE } from "~/utils/renderNodeConfigPage";
 import getBlockProps from "~/utils/getBlockProps";
 import setBlockProps from "~/utils/setBlockProps";
+import {
+  createClient,
+  type DGSupabaseClient,
+} from "@repo/ui/lib/supabase/client";
+import { spaceAnonUserEmail } from "@repo/ui/lib/utils";
 
 declare const crypto: { randomUUID: () => string };
 
-type Platform = Database["public"]["Enums"]["Platform"];
+type Platform = Enums<"Platform">;
 
 export type SupabaseContext = {
   platform: Platform;
@@ -44,12 +49,15 @@ const getOrCreateSpacePassword = () => {
   return password;
 };
 
-// Note: Some of this will be more typesafe if rewritten with direct supabase access eventually.
-// We're going through nextjs until we have settled security.
+// Note: calls in this file will still use vercel endpoints.
+// It is better if this is still at least protected by CORS.
+// But calls anywhere else should use the supabase client directly.
 
-const fetchOrCreateSpaceId = async (): Promise<number> => {
+const fetchOrCreateSpaceId = async (
+  user_account_id: number,
+  anon_password: string,
+): Promise<number> => {
   const url = getRoamUrl();
-  const urlParts = url.split("/");
   const name = window.roamAlphaAPI.graph.name;
   const platform: Platform = "Roam";
   const response = await fetch(base_url + "/space", {
@@ -57,7 +65,11 @@ const fetchOrCreateSpaceId = async (): Promise<number> => {
     headers: {
       "Content-Type": "application/json",
     },
-    body: JSON.stringify({ url, name, platform }),
+    body: JSON.stringify({
+      space: { url, name, platform },
+      password: anon_password,
+      account_id: user_account_id,
+    }),
   });
   if (!response.ok)
     throw new Error(
@@ -120,21 +132,41 @@ const fetchOrCreatePlatformAccount = async ({
 export const getSupabaseContext = async (): Promise<SupabaseContext | null> => {
   if (CONTEXT_CACHE === null) {
     try {
-      const spaceId = await fetchOrCreateSpaceId();
       const accountLocalId = window.roamAlphaAPI.user.uid();
+      const spacePassword = getOrCreateSpacePassword();
       const personEmail = getCurrentUserEmail();
       const personName = getCurrentUserDisplayName();
-      const spacePassword = getOrCreateSpacePassword();
       const userId = await fetchOrCreatePlatformAccount({
         accountLocalId,
         personName,
         personEmail,
       });
-      CONTEXT_CACHE = { platform: "Roam", spaceId, userId, spacePassword };
+      const spaceId = await fetchOrCreateSpaceId(userId, spacePassword);
+      CONTEXT_CACHE = {
+        platform: "Roam",
+        spaceId,
+        userId,
+        spacePassword,
+      };
     } catch (error) {
       console.error(error);
       return null;
     }
   }
   return CONTEXT_CACHE;
+};
+
+let LOGGED_IN_CLIENT: DGSupabaseClient | null = null;
+
+export const getLoggedInClient = async (): Promise<DGSupabaseClient> => {
+  if (LOGGED_IN_CLIENT === null) {
+    const context = await getSupabaseContext();
+    if (context === null) throw new Error("Could not create context");
+    LOGGED_IN_CLIENT = createClient();
+    await LOGGED_IN_CLIENT.auth.signInWithPassword({
+      email: spaceAnonUserEmail(context.platform, context.spaceId),
+      password: context.spacePassword,
+    });
+  }
+  return LOGGED_IN_CLIENT;
 };

--- a/apps/website/app/api/supabase/space/route.ts
+++ b/apps/website/app/api/supabase/space/route.ts
@@ -3,7 +3,6 @@ import {
   type PostgrestSingleResponse,
   PostgrestError,
   type User,
-  type SupabaseClient,
 } from "@supabase/supabase-js";
 import { createClient } from "~/utils/supabase/server";
 import { getOrCreateEntity, ItemValidator } from "~/utils/supabase/dbUtils";

--- a/packages/database/supabase/migrations/20250627172412_upsert_space.sql
+++ b/packages/database/supabase/migrations/20250627172412_upsert_space.sql
@@ -1,0 +1,17 @@
+ALTER TYPE public."AgentType" ADD VALUE IF NOT EXISTS 'anonymous';
+
+CREATE OR REPLACE FUNCTION public.get_space_anonymous_email(platform public."Platform", space_id BIGINT) RETURNS character varying LANGUAGE sql IMMUTABLE AS $$
+    SELECT concat(lower(platform::text), '-', space_id, '-anon@database.discoursegraphs.com')
+$$;
+
+CREATE OR REPLACE FUNCTION public.after_delete_space() RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+    DELETE FROM auth.users WHERE email = public.get_space_anonymous_email(OLD.platform, OLD.id);
+    DELETE FROM public."PlatformAccount"
+        WHERE platform = OLD.platform
+        AND account_local_id = public.get_space_anonymous_email(OLD.platform, OLD.id);
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER on_delete_space_trigger AFTER DELETE ON public."Space" FOR EACH ROW EXECUTE FUNCTION public.after_delete_space();

--- a/packages/database/supabase/schemas/account.sql
+++ b/packages/database/supabase/schemas/account.sql
@@ -1,7 +1,8 @@
 CREATE TYPE public."AgentType" AS ENUM (
     'person',
     'organization',
-    'automated_agent'
+    'automated_agent',
+    'anonymous'
 );
 
 ALTER TYPE public."AgentType" OWNER TO postgres;

--- a/packages/database/supabase/schemas/space.sql
+++ b/packages/database/supabase/schemas/space.sql
@@ -27,3 +27,21 @@ ALTER TABLE public."Space" OWNER TO "postgres";
 GRANT ALL ON TABLE public."Space" TO anon;
 GRANT ALL ON TABLE public."Space" TO authenticated;
 GRANT ALL ON TABLE public."Space" TO service_role;
+
+CREATE OR REPLACE FUNCTION public.get_space_anonymous_email(platform public."Platform", space_id BIGINT) RETURNS character varying LANGUAGE sql IMMUTABLE AS $$
+    SELECT concat(platform, '-', space_id, '-anon@database.discoursegraphs.com')
+$$;
+
+
+-- TODO: on delete trigger anonymous user
+CREATE OR REPLACE FUNCTION public.after_delete_space() RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+    DELETE FROM auth.users WHERE email = public.get_space_anonymous_email(OLD.platform, OLD.id);
+    DELETE FROM public."PlatformAccount"
+        WHERE platform = OLD.platform
+        AND account_local_id = public.get_space_anonymous_email(OLD.platform, OLD.id);
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER on_delete_space_trigger AFTER DELETE ON public."Space" FOR EACH ROW EXECUTE FUNCTION public.after_delete_space();

--- a/packages/database/supabase/schemas/space.sql
+++ b/packages/database/supabase/schemas/space.sql
@@ -29,7 +29,7 @@ GRANT ALL ON TABLE public."Space" TO authenticated;
 GRANT ALL ON TABLE public."Space" TO service_role;
 
 CREATE OR REPLACE FUNCTION public.get_space_anonymous_email(platform public."Platform", space_id BIGINT) RETURNS character varying LANGUAGE sql IMMUTABLE AS $$
-    SELECT concat(platform, '-', space_id, '-anon@database.discoursegraphs.com')
+    SELECT concat(lower(platform), '-', space_id, '-anon@database.discoursegraphs.com')
 $$;
 
 

--- a/packages/database/types.gen.ts
+++ b/packages/database/types.gen.ts
@@ -612,6 +612,13 @@ export type Database = {
           uid_to_sync: string
         }[]
       }
+      get_space_anonymous_email: {
+        Args: {
+          platform: Database["public"]["Enums"]["Platform"]
+          space_id: number
+        }
+        Returns: string
+      }
       match_content_embeddings: {
         Args: {
           query_embedding: string
@@ -696,7 +703,7 @@ export type Database = {
     }
     Enums: {
       AgentIdentifierType: "email" | "orcid"
-      AgentType: "person" | "organization" | "automated_agent"
+      AgentType: "person" | "organization" | "automated_agent" | "anonymous"
       EmbeddingName:
         | "openai_text_embedding_ada2_1536"
         | "openai_text_embedding_3_small_512"
@@ -922,7 +929,7 @@ export const Constants = {
   public: {
     Enums: {
       AgentIdentifierType: ["email", "orcid"],
-      AgentType: ["person", "organization", "automated_agent"],
+      AgentType: ["person", "organization", "automated_agent", "anonymous"],
       EmbeddingName: [
         "openai_text_embedding_ada2_1536",
         "openai_text_embedding_3_small_512",

--- a/packages/ui/src/lib/supabase/client.ts
+++ b/packages/ui/src/lib/supabase/client.ts
@@ -13,8 +13,12 @@ export type DGSupabaseClient = SupabaseClient<
 >;
 
 export const createClient = (): DGSupabaseClient => {
-  return createSupabaseClient<Database, "public", Database["public"]>(
-    process.env.SUPABASE_URL!,
-    process.env.SUPABASE_ANON_KEY!,
-  );
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_ANON_KEY;
+
+  if (!url || !key) {
+    throw new Error("Missing required Supabase environment variables");
+  }
+
+  return createSupabaseClient<Database, "public", Database["public"]>(url, key);
 };

--- a/packages/ui/src/lib/supabase/client.ts
+++ b/packages/ui/src/lib/supabase/client.ts
@@ -1,14 +1,20 @@
-import { createClient as createSupabaseClient } from "@supabase/supabase-js";
+import {
+  type SupabaseClient,
+  createClient as createSupabaseClient,
+} from "@supabase/supabase-js";
 import { Database } from "@repo/database/types.gen.ts";
-
-declare const SUPABASE_URL: string;
-declare const SUPABASE_ANON_KEY: string;
 
 // Inspired by https://supabase.com/ui/docs/react/password-based-auth
 
-export const createClient = () => {
+export type DGSupabaseClient = SupabaseClient<
+  Database,
+  "public",
+  Database["public"]
+>;
+
+export const createClient = (): DGSupabaseClient => {
   return createSupabaseClient<Database, "public", Database["public"]>(
-    SUPABASE_URL,
-    SUPABASE_ANON_KEY,
+    process.env.SUPABASE_URL!,
+    process.env.SUPABASE_ANON_KEY!,
   );
 };

--- a/packages/ui/src/lib/utils.ts
+++ b/packages/ui/src/lib/utils.ts
@@ -4,3 +4,6 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+export const spaceAnonUserEmail = (platform: string, space_id: number) =>
+  `${platform.toLowerCase()}-${space_id}-anon@database.discoursegraphs.com`;


### PR DESCRIPTION
Upon space creation, create an anonymous supabase user for the space.
Ensure it is written in as a space "participant" (for future RLS function)
Trigger to delete it when the space is deleted.
All this machinery is tied to getContext.
Auxiliary function to get a supabase client logged in with that anonymous user.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced support for anonymous users, allowing spaces to have associated anonymous accounts.
  * Added utility to generate standardized anonymous user emails for each space and platform.
  * Enhanced API to create or retrieve spaces with linked anonymous user accounts and access control.

* **Improvements**
  * Improved handling and cleanup of anonymous users and related records when a space is deleted.
  * Strengthened type definitions and validation for account and space management.

* **Bug Fixes**
  * Ensured idempotent creation and linking of user, account, and access records to prevent partial failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->