### PR TITLE
I forgot to checkin package lock in earlier commit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18854,9 +18854,9 @@
       }
     },
     "node_modules/supabase": {
-      "version": "2.26.9",
-      "resolved": "https://registry.npmjs.org/supabase/-/supabase-2.26.9.tgz",
-      "integrity": "sha512-wHl7HtAD2iHMVXL8JZyfSjdI0WYM7EF0ydThp1tSvDANaD2JHCZc8GH1NdzglbwGqdHmjCYeSZ+H28fmucYl7Q==",
+      "version": "2.30.4",
+      "resolved": "https://registry.npmjs.org/supabase/-/supabase-2.30.4.tgz",
+      "integrity": "sha512-AOCyd2vmBBMTXbnahiCU0reRNxKS4n5CrPciUF2tcTrQ8dLzl1HwcLfe5DrG8E0QRcKHPDdzprmh/2+y4Ta5MA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -20177,7 +20177,7 @@
       "version": "0.0.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "supabase": "^2.26.9",
+        "supabase": "^2.30.4",
         "tsx": "^4.20.3"
       }
     },


### PR DESCRIPTION
Should repair
https://github.com/DiscourseGraphs/discourse-graph/actions/runs/16091784551

I'm a bit surprised that it failed now and not at the time of the #258 merge, this way warrant reviewing the github scenarios to make sure such a mistake fails in the branch.