### PR TITLE
adding SUPABASE_PROJECT_ID to turbo env

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -11,6 +11,7 @@
     "POSTGRES_PRISMA_URL",
     "POSTGRES_URL",
     "POSTGRES_URL_NON_POOLING",
+    "SUPABASE_PROJECT_ID",
     "SUPABASE_URL"
   ],
   "globalPassThroughEnv": [


### PR DESCRIPTION
deploy task complains about this variable, which is new. May have to do with newer supabase.