### PR TITLE
ENG-527 resolve block embeds for page export not working for embed

### DIFF
--- a/apps/roam/src/utils/getExportTypes.ts
+++ b/apps/roam/src/utils/getExportTypes.ts
@@ -164,13 +164,13 @@ const toMarkdown = ({
     flatten = false,
   } = opts;
   const processedText = c.text
-    .replace(refs ? BLOCK_REF_REGEX : MATCHES_NONE, (_, blockUid) => {
-      const reference = getTextByBlockUid(blockUid);
-      return reference || blockUid;
-    })
     .replace(embeds ? EMBED_REGEX : MATCHES_NONE, (_, blockUid) => {
       const reference = getFullTreeByParentUid(blockUid);
       return toMarkdown({ c: reference, i, v, opts });
+    })
+    .replace(refs ? BLOCK_REF_REGEX : MATCHES_NONE, (_, blockUid) => {
+      const reference = getTextByBlockUid(blockUid);
+      return reference || blockUid;
     })
     .replace(/{{\[\[TODO\]\]}}/g, v === "bullet" ? "[ ]" : "- [ ]")
     .replace(/{{\[\[DONE\]\]}}/g, v === "bullet" ? "[x]" : "- [x]")

--- a/apps/roam/src/utils/getExportTypes.ts
+++ b/apps/roam/src/utils/getExportTypes.ts
@@ -129,6 +129,9 @@ const MATCHES_NONE = /$.+^/;
 const EMBED_REGEX =
   /{{\[\[(?:embed|embed-path)\]\]:\s*\(\(+\s*([\w\d-]{9,10})\s*\)\)+\s*}}/;
 
+// Roam embed-children syntax: {{[[embed-children]]: ((block-uid)) }}
+const EMBED_CHILDREN_REGEX =
+  /{{\[\[embed-children\]\]:\s*\(\(+\s*([\w\d-]{9,10})\s*\)\)+\s*}}/;
 
 const toLink = (filename: string, uid: string, linkType: string) => {
   const extensionRemoved = filename.replace(/\.\w+$/, "");
@@ -173,6 +176,12 @@ const toMarkdown = ({
     .replace(embeds ? EMBED_REGEX : MATCHES_NONE, (_, blockUid) => {
       const reference = getFullTreeByParentUid(blockUid);
       return toMarkdown({ c: reference, i, v, opts });
+    })
+    .replace(embeds ? EMBED_CHILDREN_REGEX : MATCHES_NONE, (_, blockUid) => {
+      const reference = getFullTreeByParentUid(blockUid);
+      return reference.children
+        .map((child) => toMarkdown({ c: child, i, v, opts }))
+        .join("\n");
     })
     .replace(refs ? BLOCK_REF_REGEX : MATCHES_NONE, (_, blockUid) => {
       const reference = getTextByBlockUid(blockUid);

--- a/apps/roam/src/utils/getExportTypes.ts
+++ b/apps/roam/src/utils/getExportTypes.ts
@@ -217,7 +217,12 @@ const toMarkdown = ({
           .join("") || processedText
       : processedText;
   const indentation = flatten ? "" : "".padStart(i * 4, " ");
-  const viewTypePrefix = viewTypeToPrefix[v];
+  // If this block contains an embed, treat it as document to avoid extra prefixes
+  const effectiveViewType =
+    embeds && (EMBED_REGEX.test(c.text) || EMBED_CHILDREN_REGEX.test(c.text))
+      ? "document"
+      : v;
+  const viewTypePrefix = viewTypeToPrefix[effectiveViewType];
   const headingPrefix = c.heading ? `${"".padStart(c.heading, "#")} ` : "";
   const childrenMarkdown = (c.children || [])
     .filter((nested) => !!nested.text || !!nested.children?.length)

--- a/apps/roam/src/utils/getExportTypes.ts
+++ b/apps/roam/src/utils/getExportTypes.ts
@@ -122,7 +122,13 @@ const collectUids = (t: TreeNode): string[] => [
 ];
 
 const MATCHES_NONE = /$.+^/;
-const EMBED_REGEX = /{{(?:\[\[)embed(?:\]\]):\s*\(\(([\w\d-]{9,10})\)\)\s*}}/;
+
+// Roam embed syntax: {{[[embed]]: ((block-uid)) }}
+// Roam embed syntax: {{[[embed-path]]: ((block-uid)) }}
+// Also handles multiple parentheses: {{[[embed]]: ((((block-uid)))) }}
+const EMBED_REGEX =
+  /{{\[\[(?:embed|embed-path)\]\]:\s*\(\(+\s*([\w\d-]{9,10})\s*\)\)+\s*}}/;
+
 
 const toLink = (filename: string, uid: string, linkType: string) => {
   const extensionRemoved = filename.replace(/\.\w+$/, "");


### PR DESCRIPTION
Multiple fixes for embedding blocks in DG - Export

- [move embed_regex above block_ref_regex](https://github.com/DiscourseGraphs/discourse-graph/commit/d9a40fef2e63725017cc36b16a63bf43e6753949) (block_ref was overriding embed_regex)

- [support embed-path](https://github.com/DiscourseGraphs/discourse-graph/commit/cb45157148923ca5be8ef510393761cb71d3d0cb)
- [support embed-children](https://github.com/DiscourseGraphs/discourse-graph/commit/c228a3631fd0ef557115294dc004122a42470d62)


- [fix bug where double prefix added for embedded block](https://github.com/DiscourseGraphs/discourse-graph/commit/8c4a4ba488b464c0a3208a9ff5029d227fd84d6f)



![image](https://github.com/user-attachments/assets/3a399478-175e-432d-9365-454f106e1ed0)

![image](https://github.com/user-attachments/assets/c40600e9-ec87-4a17-b87c-f81ee3baec02)
(note: the original blocks are manually numbered which is why there is a bullet and number)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved recognition and rendering of various Roam embed syntaxes during markdown export, including enhanced support for `embed`, `embed-path`, and `embed-children` formats.

* **Bug Fixes**
  * Adjusted markdown formatting to better handle embedded content, ensuring correct processing order and more accurate document structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->