### PR TITLE
ENG-567 Refactor getContext so the PlatformAccount is created in a Space.

### DIFF
--- a/apps/roam/scripts/compile.ts
+++ b/apps/roam/scripts/compile.ts
@@ -132,6 +132,7 @@ export const compile = ({
       define: {
         "process.env.SUPABASE_URL": `"${process.env.SUPABASE_URL}"`,
         "process.env.SUPABASE_ANON_KEY": `"${process.env.SUPABASE_ANON_KEY}"`,
+        "process.env.NEXT_API_ROOT": `"${process.env.NEXT_API_ROOT || ""}"`,
       },
       sourcemap: process.env.NODE_ENV === "production" ? undefined : "inline",
       minify: process.env.NODE_ENV === "production",

--- a/apps/roam/src/utils/supabaseContext.ts
+++ b/apps/roam/src/utils/supabaseContext.ts
@@ -7,11 +7,7 @@ import { Enums } from "@repo/database/types.gen";
 import { DISCOURSE_CONFIG_PAGE_TITLE } from "~/utils/renderNodeConfigPage";
 import getBlockProps from "~/utils/getBlockProps";
 import setBlockProps from "~/utils/setBlockProps";
-import {
-  createClient,
-  type DGSupabaseClient,
-} from "@repo/ui/lib/supabase/client";
-import { spaceAnonUserEmail } from "@repo/ui/lib/utils";
+import { type DGSupabaseClient } from "@repo/ui/lib/supabase/client";
 import {
   fetchOrCreateSpaceId,
   fetchOrCreatePlatformAccount,

--- a/packages/database/supabase/migrations/20250713185603_create_account_in_space.sql
+++ b/packages/database/supabase/migrations/20250713185603_create_account_in_space.sql
@@ -1,0 +1,34 @@
+CREATE OR REPLACE FUNCTION public.create_account_in_space(
+    space_id_ BIGINT,
+    account_local_id_ varchar,
+    name_ varchar,
+    email_ varchar = NULL,
+    email_trusted boolean = true,
+    editor_ boolean = true
+) RETURNS BIGINT
+SECURITY DEFINER
+SET search_path = ''
+LANGUAGE plpgsql  AS $$
+DECLARE
+    platform_ public."Platform";
+    account_id_ BIGINT;
+BEGIN
+    SELECT platform INTO platform_ STRICT FROM public."Space" WHERE id = space_id_;
+    INSERT INTO public."PlatformAccount" AS pa (
+            account_local_id, name, platform
+        ) VALUES (
+            account_local_id_, name_, platform_
+        ) ON CONFLICT (account_local_id, platform) DO UPDATE SET
+            name = coalesce(name_, pa.name)
+        RETURNING id INTO STRICT account_id_;
+    INSERT INTO public."SpaceAccess" (space_id, account_id, editor) values (space_id_, account_id_, editor_)
+        ON CONFLICT (space_id, account_id)
+        DO UPDATE SET editor = editor_;
+    IF email_ IS NOT NULL THEN
+        INSERT INTO public."AgentIdentifier" (account_id, value, identifier_type, trusted) VALUES (account_id_, email_, 'email', email_trusted)
+         ON CONFLICT (value, identifier_type, account_id)
+         DO UPDATE SET trusted = email_trusted;
+    END IF;
+    RETURN account_id_;
+END;
+$$;

--- a/packages/database/supabase/schemas/account.sql
+++ b/packages/database/supabase/schemas/account.sql
@@ -98,3 +98,39 @@ ADD CONSTRAINT "SpaceAccess_space_id_fkey" FOREIGN KEY (
 GRANT ALL ON TABLE public."SpaceAccess" TO anon;
 GRANT ALL ON TABLE public."SpaceAccess" TO authenticated;
 GRANT ALL ON TABLE public."SpaceAccess" TO service_role;
+
+CREATE OR REPLACE FUNCTION public.create_account_in_space(
+    space_id_ BIGINT,
+    account_local_id_ varchar,
+    name_ varchar,
+    email_ varchar = NULL,
+    email_trusted boolean = true,
+    editor_ boolean = true
+) RETURNS BIGINT
+SECURITY DEFINER
+SET search_path = ''
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    platform_ public."Platform";
+    account_id_ BIGINT;
+BEGIN
+    SELECT platform INTO platform_ STRICT FROM public."Space" WHERE id = space_id_;
+    INSERT INTO public."PlatformAccount" AS pa (
+            account_local_id, name, platform
+        ) VALUES (
+            account_local_id_, name_, platform_
+        ) ON CONFLICT (account_local_id, platform) DO UPDATE SET
+            name = coalesce(name_, pa.name)
+        RETURNING id INTO STRICT account_id_;
+    INSERT INTO public."SpaceAccess" (space_id, account_id, editor) values (space_id_, account_id_, editor_)
+        ON CONFLICT (space_id, account_id)
+        DO UPDATE SET editor = editor_;
+    IF email_ IS NOT NULL THEN
+        INSERT INTO public."AgentIdentifier" (account_id, value, identifier_type, trusted) VALUES (account_id_, email_, 'email', email_trusted)
+         ON CONFLICT (value, identifier_type, account_id)
+         DO UPDATE SET trusted = email_trusted;
+    END IF;
+    RETURN account_id_;
+END;
+$$;

--- a/packages/database/types.gen.ts
+++ b/packages/database/types.gen.ts
@@ -563,7 +563,7 @@ export type Database = {
         }
       }
       alpha_delete_by_source_local_ids: {
-        Args: { p_space_name: string; p_source_local_ids: string[] }
+        Args: { p_source_local_ids: string[]; p_space_name: string }
         Returns: string
       }
       alpha_get_last_update_time: {
@@ -575,30 +575,33 @@ export type Database = {
       alpha_upsert_discourse_nodes: {
         Args: {
           p_nodes: Json
-          p_user_email: string
           p_space_name: string
+          p_user_email: string
           p_user_name: string
         }
         Returns: string
-      }
-      compute_arity_id: {
-        Args: { p_schema_id: number }
-        Returns: number
-      }
-      compute_arity_lit: {
-        Args: { lit_content: Json }
-        Returns: number
       }
       compute_arity_local: {
         Args: { lit_content: Json; schema_id: number }
         Returns: number
       }
+      create_account_in_space: {
+        Args: {
+          space_id_: number
+          account_local_id_: string
+          name_: string
+          editor_?: boolean
+          email_trusted?: boolean
+          email_?: string
+        }
+        Returns: number
+      }
       end_sync_task: {
         Args: {
           s_target: number
-          s_status: Database["public"]["Enums"]["task_status"]
-          s_worker: string
           s_function: string
+          s_worker: string
+          s_status: Database["public"]["Enums"]["task_status"]
         }
         Returns: undefined
       }
@@ -614,8 +617,8 @@ export type Database = {
       }
       get_space_anonymous_email: {
         Args: {
-          platform: Database["public"]["Enums"]["Platform"]
           space_id: number
+          platform: Database["public"]["Enums"]["Platform"]
         }
         Returns: string
       }
@@ -629,74 +632,74 @@ export type Database = {
         Returns: {
           content_id: number
           roam_uid: string
-          text_content: string
           similarity: number
+          text_content: string
         }[]
       }
       match_embeddings_for_subset_nodes: {
         Args: { p_query_embedding: string; p_subset_roam_uids: string[] }
         Returns: {
-          text_content: string
-          similarity: number
           content_id: number
           roam_uid: string
+          text_content: string
+          similarity: number
         }[]
       }
       propose_sync_task: {
         Args: {
-          s_target: number
           timeout: unknown
+          s_function: string
+          s_target: number
           task_interval: unknown
           s_worker: string
-          s_function: string
         }
         Returns: string
       }
       upsert_concepts: {
-        Args: { data: Json; v_space_id: number }
+        Args: { v_space_id: number; data: Json }
         Returns: number[]
       }
       upsert_content: {
         Args: {
-          v_space_id: number
-          data: Json
-          v_creator_id: number
           content_as_document?: boolean
+          v_creator_id: number
+          data: Json
+          v_space_id: number
         }
         Returns: number[]
       }
       upsert_content_embedding: {
-        Args: { model: string; content_id: number; embedding_array: number[] }
+        Args: { content_id: number; embedding_array: number[]; model: string }
         Returns: undefined
       }
       upsert_discourse_nodes: {
         Args: {
+          p_platform_name?: string
+          p_space_url?: string
+          p_document_source_id?: string
+          p_embedding_model?: string
+          p_content_scale?: string
+          p_agent_type?: string
           p_space_name: string
           p_user_email: string
           p_user_name: string
           p_nodes: Json
-          p_platform_name?: string
           p_platform_url?: string
-          p_space_url?: string
-          p_agent_type?: string
-          p_content_scale?: string
-          p_embedding_model?: string
-          p_document_source_id?: string
         }
         Returns: {
           action: string
-          content_id: number
           embedding_created: boolean
+          content_id: number
         }[]
       }
       upsert_documents: {
-        Args: { data: Json; v_space_id: number }
+        Args: { v_space_id: number; data: Json }
         Returns: number[]
       }
       upsert_platform_account_input: {
         Args: {
-          account_info: Database["public"]["Tables"]["PlatformAccount"]["Row"]
           p_platform: Database["public"]["Enums"]["Platform"]
+          account_info: Database["public"]["Tables"]["PlatformAccount"]["Row"]
         }
         Returns: number
       }

--- a/packages/ui/src/lib/supabase/contextFunctions.ts
+++ b/packages/ui/src/lib/supabase/contextFunctions.ts
@@ -7,7 +7,7 @@ import {
 
 type Platform = Enums<"Platform">;
 
-const base_url = nextApiRoot() + "/supabase";
+const baseUrl = nextApiRoot() + "/supabase";
 
 export const fetchOrCreateSpaceId = async (data: {
   password: string;
@@ -15,7 +15,7 @@ export const fetchOrCreateSpaceId = async (data: {
   name: string;
   platform: Platform;
 }): Promise<number> => {
-  const response = await fetch(base_url + "/space", {
+  const response = await fetch(baseUrl + "/space", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",

--- a/packages/ui/src/lib/supabase/contextFunctions.ts
+++ b/packages/ui/src/lib/supabase/contextFunctions.ts
@@ -1,0 +1,76 @@
+import { Enums } from "@repo/database/types.gen.ts";
+import { nextApiRoot, spaceAnonUserEmail } from "@repo/ui/lib/utils";
+import {
+  createClient,
+  type DGSupabaseClient,
+} from "@repo/ui/lib/supabase/client";
+
+type Platform = Enums<"Platform">;
+
+const base_url = nextApiRoot() + "/supabase";
+
+export const fetchOrCreateSpaceId = async (data: {
+  password: string;
+  url: string;
+  name: string;
+  platform: Platform;
+}): Promise<number> => {
+  const response = await fetch(base_url + "/space", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(data),
+  });
+  if (!response.ok)
+    throw new Error(
+      `Platform API failed: ${response.status} ${response.statusText} ${await response.text()}`,
+    );
+  const space = await response.json();
+  if (typeof space.id !== "number") throw new Error("API did not return space");
+  return space.id;
+};
+
+export const createLoggedInClient = async (
+  platform: Platform,
+  spaceId: number,
+  password: string,
+): Promise<DGSupabaseClient> => {
+  const loggedInClient: DGSupabaseClient = createClient();
+  const { error } = await loggedInClient.auth.signInWithPassword({
+    email: spaceAnonUserEmail(platform, spaceId),
+    password: password,
+  });
+  if (error) {
+    throw new Error(`Authentication failed: ${error.message}`);
+  }
+  return loggedInClient;
+};
+
+export const fetchOrCreatePlatformAccount = async ({
+  platform,
+  accountLocalId,
+  name,
+  email,
+  spaceId,
+  password,
+}: {
+  platform: Platform;
+  accountLocalId: string;
+  name: string;
+  email: string | undefined;
+  spaceId: number;
+  password: string;
+}): Promise<number> => {
+  const supabase = await createLoggedInClient(platform, spaceId, password);
+
+  const result = await supabase.rpc("create_account_in_space", {
+    space_id_: spaceId,
+    account_local_id_: accountLocalId,
+    name_: name,
+    email_: email,
+  });
+
+  if (result.error) throw Error(result.error.message); // account created but not connected, try again
+  return result.data;
+};

--- a/packages/ui/src/lib/utils.ts
+++ b/packages/ui/src/lib/utils.ts
@@ -10,7 +10,7 @@ export function cn(...inputs: ClassValue[]) {
 export const spaceAnonUserEmail = (platform: string, space_id: number) =>
   `${platform.toLowerCase()}-${space_id}-anon@database.discoursegraphs.com`;
 
-export const IS_DEV = process.env.NODE_ENV !== "production";
+const IS_DEV = process.env.NODE_ENV !== "production";
 
 export const nextApiRoot = (): string => {
   if (

--- a/packages/ui/src/lib/utils.ts
+++ b/packages/ui/src/lib/utils.ts
@@ -1,9 +1,24 @@
 import { type ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
 
+declare const process: { env: Record<string, any> };
+
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
 export const spaceAnonUserEmail = (platform: string, space_id: number) =>
   `${platform.toLowerCase()}-${space_id}-anon@database.discoursegraphs.com`;
+
+export const IS_DEV = process.env.NODE_ENV !== "production";
+
+export const nextApiRoot = (): string => {
+  if (
+    process.env.NEXT_API_ROOT !== undefined &&
+    process.env.NEXT_API_ROOT !== ""
+  )
+    return process.env.NEXT_API_ROOT;
+  return IS_DEV
+    ? "http://localhost:3000/api"
+    : "https://discoursegraphs.com/api";
+};


### PR DESCRIPTION
Factor out some of the functions that call next from roam to ui code. 
Also work on a generic way to know the Next endpoint. (as described in #249, in [this file](https://github.com/DiscourseGraphs/discourse-graph/blob/ENG-520-supabase-dev-instructions/packages/database/README.md) )
The reason for doing that it that it is safer, in terms of PlatformAccount access, to always start from a Space login, even though the PlatformAccount is not bound to a single space.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added utility to determine the API root URL based on environment, improving environment-based configuration.
  * Introduced functions for streamlined creation and authentication of platform spaces and accounts.
  * Added password validation requiring at least 8 characters during space creation.

* **Refactor**
  * Centralized and simplified Supabase account and space management logic, reducing code duplication and manual error handling.
  * Updated space creation input structure and validation to enhance consistency and security.

* **Bug Fixes**
  * Corrected import paths for utility functions to ensure proper module resolution.

* **Style**
  * Minor formatting improvements for code clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->