### PR TITLE
ENG-582 setting an explicit empty search path for each function definition

### DIFF
--- a/packages/database/supabase/migrations/20250712173945_set_path.sql
+++ b/packages/database/supabase/migrations/20250712173945_set_path.sql
@@ -1,0 +1,128 @@
+ALTER FUNCTION public._local_document_to_db_document SET search_path = '';
+ALTER FUNCTION public._local_content_to_db_content SET search_path = '';
+ALTER FUNCTION public.upsert_platform_account_input SET search_path = '';
+ALTER FUNCTION public.upsert_documents SET search_path = '';
+ALTER FUNCTION public.upsert_content_embedding SET search_path = '';
+ALTER FUNCTION public.upsert_content SET search_path = '';
+ALTER FUNCTION public.get_space_anonymous_email SET search_path = '';
+ALTER FUNCTION public.after_delete_space SET search_path = '';
+ALTER FUNCTION public.extract_references SET search_path = '';
+ALTER FUNCTION public.compute_arity_local SET search_path = '';
+ALTER FUNCTION public._local_concept_to_db_concept SET search_path = '';
+ALTER FUNCTION public.upsert_concepts SET search_path = '';
+ALTER FUNCTION public.get_nodes_needing_sync SET search_path = '';
+ALTER FUNCTION public.alpha_delete_by_source_local_ids SET search_path = '';
+ALTER FUNCTION public.alpha_get_last_update_time SET search_path = '';
+ALTER FUNCTION public.upsert_discourse_nodes SET search_path = '';
+ALTER FUNCTION public.alpha_upsert_discourse_nodes SET search_path = '';
+
+ALTER FUNCTION public.match_content_embeddings SET search_path = 'extensions';
+ALTER FUNCTION public.match_embeddings_for_subset_nodes SET search_path = 'extensions';
+
+CREATE OR REPLACE FUNCTION public.end_sync_task(
+    s_target bigint,
+    s_function character varying,
+    s_worker character varying,
+    s_status public.task_status
+) RETURNS void
+SET search_path = ''
+LANGUAGE plpgsql
+AS $$
+DECLARE t_id INTEGER;
+DECLARE t_worker varchar;
+DECLARE t_status public.task_status;
+DECLARE t_failure_count SMALLINT;
+DECLARE t_last_task_end TIMESTAMP WITH TIME ZONE;
+BEGIN
+    SELECT id, worker, status, failure_count, last_task_end
+        INTO STRICT t_id, t_worker, t_status, t_failure_count, t_last_task_end
+        FROM public.sync_info WHERE sync_target = s_target AND sync_function = s_function;
+    ASSERT s_status > 'active';
+    ASSERT t_worker = s_worker, 'Wrong worker';
+    ASSERT s_status >= t_status, 'do not go back in status';
+    IF s_status = 'complete' THEN
+        t_last_task_end := now();
+        t_failure_count := 0;
+    ELSE
+        IF t_status != s_status THEN
+            t_failure_count := t_failure_count + 1;
+        END IF;
+    END IF;
+
+    UPDATE public.sync_info
+        SET status = s_status,
+            task_times_out_at=null,
+            last_task_end=t_last_task_end,
+            failure_count=t_failure_count
+        WHERE id=t_id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.propose_sync_task(
+    s_target bigint,
+    s_function character varying,
+    s_worker character varying,
+    "timeout" interval,
+    "task_interval" interval
+) RETURNS timestamp with time zone
+SET search_path = ''
+LANGUAGE plpgsql
+AS $$
+DECLARE s_id INTEGER;
+DECLARE start_time TIMESTAMP WITH TIME ZONE := now();
+DECLARE t_status public.task_status;
+DECLARE t_failure_count SMALLINT;
+DECLARE t_last_task_start TIMESTAMP WITH TIME ZONE;
+DECLARE t_last_task_end TIMESTAMP WITH TIME ZONE;
+DECLARE t_times_out_at TIMESTAMP WITH TIME ZONE;
+DECLARE result TIMESTAMP WITH TIME ZONE;
+BEGIN
+    ASSERT timeout * 2 < task_interval;
+    ASSERT timeout >= '1s'::interval;
+    ASSERT task_interval >= '5s'::interval;
+    INSERT INTO public.sync_info (sync_target, sync_function, status, worker, last_task_start, task_times_out_at)
+        VALUES (s_target, s_function, 'active', s_worker, start_time, start_time+timeout)
+        ON CONFLICT (sync_target, sync_function) DO NOTHING
+        RETURNING id INTO s_id;
+    IF s_id IS NOT NULL THEN
+        -- totally new_row, I'm on the task
+        -- return last time it was run successfully
+        SELECT max(last_task_start) INTO result FROM public.sync_info
+            WHERE sync_target = s_target
+            AND sync_function = s_function
+            AND status = 'complete';
+        RETURN result;
+    END IF;
+    -- now we know it pre-existed. Maybe already active.
+    SELECT id INTO STRICT s_id FROM public.sync_info WHERE sync_target = s_target AND sync_function = s_function;
+    PERFORM pg_advisory_lock(s_id);
+    SELECT status, failure_count, last_task_start, last_task_end, task_times_out_at
+        INTO t_status, t_failure_count, t_last_task_start, t_last_task_end, t_times_out_at
+        FROM public.sync_info
+        WHERE id = s_id;
+
+    IF t_status = 'active' AND t_last_task_start >= coalesce(t_last_task_end, t_last_task_start) AND start_time > t_times_out_at THEN
+        t_status := 'timeout';
+        t_failure_count := t_failure_count + 1;
+    END IF;
+    -- basic backoff
+    task_interval := task_interval * (1+t_failure_count);
+    IF coalesce(t_last_task_end, t_last_task_start) + task_interval < now() THEN
+        -- we are ready to take on the task
+        UPDATE public.sync_info
+        SET worker=s_worker, status='active', task_times_out_at = now() + timeout, last_task_start = start_time, failure_count=t_failure_count
+        WHERE id=s_id;
+    ELSE
+        -- the task has been tried recently enough
+        IF t_status = 'timeout' THEN
+            UPDATE public.sync_info
+            SET status=t_status, failure_count=t_failure_count
+            WHERE id=s_id;
+        END IF;
+        result := coalesce(t_last_task_end, t_last_task_start) + task_interval;
+    END IF;
+
+    PERFORM pg_advisory_unlock(s_id);
+    RETURN result;
+END;
+$$;

--- a/packages/database/supabase/schemas/concept.sql
+++ b/packages/database/supabase/schemas/concept.sql
@@ -12,12 +12,20 @@ CREATE TYPE public."EpistemicStatus" AS ENUM (
 
 ALTER TYPE public."EpistemicStatus" OWNER TO postgres;
 
-CREATE OR REPLACE FUNCTION public.extract_references(refs JSONB) RETURNS BIGINT [] LANGUAGE sql IMMUTABLE AS $$
+CREATE OR REPLACE FUNCTION public.extract_references(refs JSONB)
+RETURNS BIGINT [] IMMUTABLE
+SET search_path = ''
+LANGUAGE sql
+AS $$
   SELECT COALESCE(array_agg(i::bigint), '{}') FROM (SELECT DISTINCT jsonb_array_elements(jsonb_path_query_array(refs, '$.*[*]')) i) exrefs;
 $$;
 
 SET check_function_bodies = false;
-CREATE OR REPLACE FUNCTION public.compute_arity_local(schema_id BIGINT, lit_content JSONB) RETURNS smallint LANGUAGE sql IMMUTABLE AS $$
+CREATE OR REPLACE FUNCTION public.compute_arity_local(schema_id BIGINT, lit_content JSONB)
+RETURNS smallint IMMUTABLE
+SET search_path = ''
+LANGUAGE sql
+AS $$
   SELECT CASE WHEN schema_id IS NULL THEN (
     SELECT COALESCE(jsonb_array_length(lit_content->'roles'), 0)
   ) ELSE (
@@ -131,7 +139,11 @@ CREATE TYPE public.concept_local_input AS (
 );
 
 -- private function. Transform concept with local (platform) references to concept with db references
-CREATE OR REPLACE FUNCTION public._local_concept_to_db_concept(data public.concept_local_input) RETURNS public."Concept" LANGUAGE plpgsql STABLE AS $$
+CREATE OR REPLACE FUNCTION public._local_concept_to_db_concept(data public.concept_local_input)
+RETURNS public."Concept" STABLE
+SET search_path = ''
+LANGUAGE plpgsql
+AS $$
 DECLARE
   concept public."Concept"%ROWTYPE;
   reference_content JSONB := jsonb_build_object();
@@ -190,6 +202,7 @@ $$;
 -- name conflicts will cause an insertion failure, and the ID will be given as -1
 CREATE OR REPLACE FUNCTION public.upsert_concepts(v_space_id bigint, data jsonb)
 RETURNS SETOF BIGINT
+SET search_path = ''
 LANGUAGE plpgsql
 AS $$
 DECLARE

--- a/packages/database/supabase/schemas/content.sql
+++ b/packages/database/supabase/schemas/content.sql
@@ -202,7 +202,10 @@ CREATE TYPE public.content_local_input AS (
 
 
 -- private function. Transform document with local (platform) references to document with db references
-CREATE OR REPLACE FUNCTION public._local_document_to_db_document(data public.document_local_input) RETURNS public."Document" LANGUAGE plpgsql STABLE AS $$
+CREATE OR REPLACE FUNCTION public._local_document_to_db_document(data public.document_local_input)
+RETURNS public."Document" LANGUAGE plpgsql STABLE
+SET search_path = ''
+AS $$
 DECLARE
   document public."Document"%ROWTYPE;
   reference_content JSONB := jsonb_build_object();
@@ -228,10 +231,13 @@ BEGIN
 END;
 $$;
 
-COMMENT ON FUNCTION public._local_document_to_db_document IS 'utility function so we have the option to use platform identifiers for document upsert' ;
+COMMENT ON FUNCTION public._local_document_to_db_document IS 'utility function so we have the option to use platform identifiers for document upsert';
 
 -- private function. Transform content with local (platform) references to content with db references
-CREATE OR REPLACE FUNCTION public._local_content_to_db_content (data public.content_local_input) RETURNS public."Content" LANGUAGE plpgsql STABLE AS $$
+CREATE OR REPLACE FUNCTION public._local_content_to_db_content(data public.content_local_input)
+RETURNS public."Content" STABLE
+SET search_path = ''
+LANGUAGE plpgsql AS $$
 DECLARE
   content public."Content"%ROWTYPE;
   reference_content JSONB := jsonb_build_object();
@@ -267,14 +273,15 @@ BEGIN
   END IF;
   RETURN content;
 END;
-$$ ;
+$$;
 
-COMMENT ON FUNCTION public._local_content_to_db_content IS 'utility function so we have the option to use platform identifiers for content upsert' ;
+COMMENT ON FUNCTION public._local_content_to_db_content IS 'utility function so we have the option to use platform identifiers for content upsert';
 
 -- The data should be a PlatformAccount
 -- PlatformAccount is upserted, based on platform and account_local_id. New (or old) ID is returned.
-CREATE OR REPLACE FUNCTION public.upsert_platform_account_input (account_info public."PlatformAccount", p_platform public."Platform")
+CREATE OR REPLACE FUNCTION public.upsert_platform_account_input(account_info public."PlatformAccount", p_platform public."Platform")
 RETURNS BIGINT
+SET search_path = ''
 LANGUAGE sql
 AS $$
     INSERT INTO public."PlatformAccount" (
@@ -302,12 +309,13 @@ AS $$
       agent_type = COALESCE(agent_type(account_info), EXCLUDED.agent_type, 'person'),
       metadata = COALESCE(metadata(account_info), EXCLUDED.metadata, '{}')
   RETURNING id;
-$$ ;
+$$;
 
 -- The data should be an array of LocalDocumentDataInput
 -- Documents are upserted, based on space_id and local_id. New (or old) IDs are returned.
-CREATE OR REPLACE FUNCTION public.upsert_documents (v_space_id bigint, data jsonb)
+CREATE OR REPLACE FUNCTION public.upsert_documents(v_space_id bigint, data jsonb)
 RETURNS SETOF BIGINT
+SET search_path = ''
 LANGUAGE plpgsql
 AS $$
 DECLARE
@@ -356,11 +364,12 @@ BEGIN
     RETURN NEXT upsert_id;
   END LOOP;
 END;
-$$ ;
+$$;
 
-COMMENT ON FUNCTION public.upsert_documents IS 'batch document upsert' ;
+COMMENT ON FUNCTION public.upsert_documents IS 'batch document upsert';
 
-CREATE OR REPLACE FUNCTION public.upsert_content_embedding (content_id bigint, model varchar, embedding_array float []) RETURNS VOID
+CREATE OR REPLACE FUNCTION public.upsert_content_embedding(content_id bigint, model varchar, embedding_array float []) RETURNS VOID
+SET search_path = ''
 LANGUAGE plpgsql
 AS $$
 BEGIN
@@ -376,14 +385,14 @@ BEGIN
         -- do not fail just because of the embedding
     END IF;
 END
-$$ ;
+$$;
 
-COMMENT ON FUNCTION public.upsert_content_embedding IS 'single content embedding upsert' ;
+COMMENT ON FUNCTION public.upsert_content_embedding IS 'single content embedding upsert';
 
 -- The data should be an array of LocalContentDataInput
 -- Contents are upserted, based on space_id and local_id. New (or old) IDs are returned.
 -- This may trigger creation of PlatformAccounts and Documents appropriately.
-CREATE OR REPLACE FUNCTION public.upsert_content (v_space_id bigint, data jsonb, v_creator_id BIGINT, content_as_document boolean DEFAULT true)
+CREATE OR REPLACE FUNCTION public.upsert_content(v_space_id bigint, data jsonb, v_creator_id BIGINT, content_as_document boolean DEFAULT true)
 RETURNS SETOF BIGINT
 LANGUAGE plpgsql
 AS $$
@@ -496,6 +505,6 @@ BEGIN
     RETURN NEXT upsert_id;
   END LOOP;
 END;
-$$ ;
+$$;
 
-COMMENT ON FUNCTION public.upsert_content IS 'batch content upsert' ;
+COMMENT ON FUNCTION public.upsert_content IS 'batch content upsert';

--- a/packages/database/supabase/schemas/embedding.sql
+++ b/packages/database/supabase/schemas/embedding.sql
@@ -40,6 +40,7 @@ content_id bigint,
 roam_uid Text,
 text_content Text,
 similarity double precision)
+SET search_path = 'extensions'
 LANGUAGE sql STABLE
 AS $$
 SELECT
@@ -71,6 +72,7 @@ roam_uid Text,
 text_content Text,
 similarity double precision)
 LANGUAGE sql STABLE
+SET search_path = 'extensions'
 AS $$
 WITH subset_content_with_embeddings AS (
   -- Step 1: Identify content and fetch embeddings ONLY for the nodes in the provided Roam UID subset

--- a/packages/database/supabase/schemas/space.sql
+++ b/packages/database/supabase/schemas/space.sql
@@ -28,13 +28,21 @@ GRANT ALL ON TABLE public."Space" TO anon;
 GRANT ALL ON TABLE public."Space" TO authenticated;
 GRANT ALL ON TABLE public."Space" TO service_role;
 
-CREATE OR REPLACE FUNCTION public.get_space_anonymous_email(platform public."Platform", space_id BIGINT) RETURNS character varying LANGUAGE sql IMMUTABLE AS $$
+CREATE OR REPLACE FUNCTION public.get_space_anonymous_email(platform public."Platform", space_id BIGINT)
+RETURNS character varying IMMUTABLE
+SET search_path = ''
+LANGUAGE sql
+AS $$
     SELECT concat(lower(platform::text), '-', space_id, '-anon@database.discoursegraphs.com')
 $$;
 
 
 -- TODO: on delete trigger anonymous user
-CREATE OR REPLACE FUNCTION public.after_delete_space() RETURNS TRIGGER LANGUAGE plpgsql AS $$
+CREATE OR REPLACE FUNCTION public.after_delete_space()
+RETURNS TRIGGER
+SET search_path = ''
+LANGUAGE plpgsql
+AS $$
 BEGIN
     DELETE FROM auth.users WHERE email = public.get_space_anonymous_email(OLD.platform, OLD.id);
     DELETE FROM public."PlatformAccount"

--- a/packages/database/supabase/schemas/sync.sql
+++ b/packages/database/supabase/schemas/sync.sql
@@ -50,11 +50,12 @@ CREATE OR REPLACE FUNCTION public.end_sync_task(
     s_worker character varying,
     s_status public.task_status
 ) RETURNS void
+SET search_path = ''
 LANGUAGE plpgsql
 AS $$
 DECLARE t_id INTEGER;
 DECLARE t_worker varchar;
-DECLARE t_status task_status;
+DECLARE t_status public.task_status;
 DECLARE t_failure_count SMALLINT;
 DECLARE t_last_task_end TIMESTAMP WITH TIME ZONE;
 BEGIN
@@ -97,11 +98,12 @@ CREATE OR REPLACE FUNCTION public.propose_sync_task(
     "timeout" interval,
     "task_interval" interval
 ) RETURNS timestamp with time zone
+SET search_path = ''
 LANGUAGE plpgsql
 AS $$
 DECLARE s_id INTEGER;
 DECLARE start_time TIMESTAMP WITH TIME ZONE := now();
-DECLARE t_status task_status;
+DECLARE t_status public.task_status;
 DECLARE t_failure_count SMALLINT;
 DECLARE t_last_task_start TIMESTAMP WITH TIME ZONE;
 DECLARE t_last_task_end TIMESTAMP WITH TIME ZONE;
@@ -168,6 +170,7 @@ ALTER FUNCTION public.propose_sync_task(
 
 CREATE OR REPLACE FUNCTION public.get_nodes_needing_sync(nodes_from_roam jsonb)
 RETURNS TABLE (uid_to_sync text)
+SET search_path = ''
 LANGUAGE plpgsql
 AS $function$
     DECLARE

--- a/packages/database/supabase/schemas/upload_temp.sql
+++ b/packages/database/supabase/schemas/upload_temp.sql
@@ -2,6 +2,7 @@ SET check_function_bodies = off;
 
 CREATE OR REPLACE FUNCTION public.alpha_delete_by_source_local_ids(p_space_name text, p_source_local_ids text [])
 RETURNS text
+SET search_path = ''
 LANGUAGE plpgsql
 AS $function$-- TEST EDIT
 DECLARE
@@ -138,6 +139,7 @@ END;$function$
 
 CREATE OR REPLACE FUNCTION public.alpha_get_last_update_time(p_space_name text)
 RETURNS TABLE (last_update_time timestamp with time zone)
+SET search_path = ''
 LANGUAGE plpgsql
 AS $function$
 BEGIN
@@ -157,6 +159,7 @@ $function$
 
 CREATE OR REPLACE FUNCTION public.upsert_discourse_nodes(p_space_name text, p_user_email text, p_user_name text, p_nodes jsonb, p_platform_name text DEFAULT 'roamresearch'::text, p_platform_url text DEFAULT 'https://roamresearch.com'::text, p_space_url text DEFAULT NULL::text, p_agent_type text DEFAULT 'Person'::text, p_content_scale text DEFAULT 'chunk_unit'::text, p_embedding_model text DEFAULT 'openai_text_embedding_3_small_1536'::text, p_document_source_id text DEFAULT NULL::text)
 RETURNS TABLE (content_id bigint, embedding_created boolean, action text)
+SET search_path = ''
 LANGUAGE plpgsql
 AS $function$
 DECLARE


### PR DESCRIPTION
... following supabase recommendation. Note that it cannot be set to empty for the embeddings, because of the <=> operator; and supabase still complains with an explicit non-empty search_path.
Also some linting corrections.