### PR TITLE
ENG-583-add-target-type-column

### DIFF
--- a/packages/database/supabase/migrations/20250712193216_sync_target_entity_type.sql
+++ b/packages/database/supabase/migrations/20250712193216_sync_target_entity_type.sql
@@ -1,0 +1,1 @@
+ALTER TABLE public.sync_info ADD COLUMN target_type public."EntityType" NOT NULL DEFAULT 'Space'::public."EntityType";

--- a/packages/database/supabase/schemas/sync.sql
+++ b/packages/database/supabase/schemas/sync.sql
@@ -10,6 +10,7 @@ ALTER TYPE public.task_status OWNER TO "postgres";
 CREATE TABLE IF NOT EXISTS public.sync_info (
     id integer NOT NULL,
     sync_target bigint,
+    target_type public."EntityType" NOT NULL DEFAULT 'Space'::public."EntityType",
     sync_function character varying(20),
     status public.task_status DEFAULT 'active'::public.task_status,
     worker character varying(100) NOT NULL,


### PR DESCRIPTION
As described in [eng-583](https://linear.app/discourse-graphs/issue/ENG-583/complete-the-universal-foreign-key-in-the-sync-table):
The sync_info table was designed so the target could be a member of any table, i.e. not an explicit foreign key. This is an implementation of my favoured path, adding an EntityType column so we can ensure proper logic.
Having this allows me to add RLS to that table.
