### PR TITLE
ENG-546 reintroduce GITHUB_TOKEN

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -55,7 +55,7 @@
       "cache": false,
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
       "env": ["APP_ID"],
-      "passThroughEnv": ["APP_PRIVATE_KEY"]
+      "passThroughEnv": ["APP_PRIVATE_KEY", "GITHUB_TOKEN"]
     }
   }
 }


### PR DESCRIPTION
Was removed by mistake in ENG-539
https://github.com/DiscourseGraphs/discourse-graph/pull/257