### PR TITLE
[ENG-566] Fix node menu disappearing behind sticky section header

### DIFF
--- a/apps/roam/src/components/DiscourseNodeMenu.tsx
+++ b/apps/roam/src/components/DiscourseNodeMenu.tsx
@@ -170,6 +170,7 @@ const NodeMenu = ({
       canEscapeKeyClose
       minimal
       target={trigger || <span />}
+      className="relative z-50"
       position={Position.BOTTOM_LEFT}
       modifiers={{
         flip: { enabled: false },
@@ -242,9 +243,8 @@ export const TextSelectionNodeMenu = ({
 }) => {
   const trigger = (
     <Button
-      minimal
       small
-      className="rounded border border-[#d3d8de] bg-white px-2 py-1 shadow-md hover:border-[#bfccd6] hover:bg-[#f7f9fc]"
+      className="relative z-50 rounded border border-[#d3d8de] bg-white px-2 py-1 shadow-md hover:border-[#bfccd6] hover:bg-[#f7f9fc]"
       icon={
         <div className="flex items-center gap-1">
           <svg


### PR DESCRIPTION
Before

node menu is hidden behind the section header (which has position: sticky)

<img width="299" height="95" alt="Screenshot 2025-07-14 at 16 31 24" src="https://github.com/user-attachments/assets/0fe6371b-6a97-4701-93dc-fdf75ea11f8f" />

After
<img width="547" height="193" alt="Screenshot 2025-07-14 at 16 32 12" src="https://github.com/user-attachments/assets/96a7e3b3-f595-4ffd-a70e-2384f8337dab" />

I tested to ensure that this change won't affect the position of the popover whether triggered through the node menu icon or via Cmd + \
