### PR TITLE
[ENG-554] Close the mouse-only node creation menu when Node Menu hotkey is pressed

### DIFF
--- a/apps/roam/src/utils/initializeObserversAndListeners.ts
+++ b/apps/roam/src/utils/initializeObserversAndListeners.ts
@@ -159,6 +159,7 @@ export const initObservers = async ({
       target.tagName === "TEXTAREA" &&
       target.classList.contains("rm-block-input")
     ) {
+      removeTextSelectionPopup();
       renderDiscourseNodeMenu({
         textarea: target as HTMLTextAreaElement,
         extensionAPI: onloadArgs.extensionAPI,


### PR DESCRIPTION
Before 

https://www.loom.com/share/57b9eea3151843e490bedbb6558614d6?sid=ee612157-6b4f-47de-b452-66394c337de2

After

https://www.loom.com/share/635e31d3c4cc42e097907885dab70e43?sid=94ae881d-e04d-45e5-84cf-48848a62b42b