### PR TITLE
ENG-607 - Handle canvas already upgraded

### DIFF
--- a/apps/roam/package.json
+++ b/apps/roam/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roam",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "Discourse Graph Plugin for roamresearch.com",
   "scripts": {
     "postinstall": "patch-package",

--- a/apps/roam/src/components/canvas/Tldraw.tsx
+++ b/apps/roam/src/components/canvas/Tldraw.tsx
@@ -878,7 +878,7 @@ const TldrawCanvas = ({ title }: Props) => {
           <div className="text-center">
             <h2 className="mb-2 text-2xl font-semibold">Canvas Upgraded</h2>
             <p className="mb-4 text-gray-600">
-              This Canvas is using the latest version.
+              This canvas is using the latest version.
               <br />
               Please upgrade your Discourse Graph extension to view this canvas.
             </p>

--- a/apps/roam/src/components/canvas/Tldraw.tsx
+++ b/apps/roam/src/components/canvas/Tldraw.tsx
@@ -689,7 +689,7 @@ const TldrawCanvas = ({ title }: Props) => {
   const lastInsertRef = useRef<Vec2dModel>();
   const containerRef = useRef<HTMLDivElement>(null);
   const [maximized, setMaximized] = useState(false);
-  const { store, instanceId, userId } = useRoamStore({
+  const { store, instanceId, userId, isAlreadyUpgraded } = useRoamStore({
     config: customTldrawConfig,
     title,
   });
@@ -873,6 +873,17 @@ const TldrawCanvas = ({ title }: Props) => {
       </style>
       {isLoading ? (
         <></>
+      ) : isAlreadyUpgraded || !store ? (
+        <div className="flex h-full items-center justify-center">
+          <div className="text-center">
+            <h2 className="mb-2 text-2xl font-semibold">Canvas Upgraded</h2>
+            <p className="mb-4 text-gray-600">
+              This Canvas is using the latest version.
+              <br />
+              Please upgrade your Discourse Graph extension to view this canvas.
+            </p>
+          </div>
+        </div>
       ) : (
         <TldrawEditor
           baseUrl="https://samepage.network/assets/tldraw/"

--- a/apps/roam/src/utils/useRoamStore.ts
+++ b/apps/roam/src/utils/useRoamStore.ts
@@ -45,13 +45,18 @@ export const useRoamStore = ({
     }
     const instanceId = TLInstance.createCustomId(pageUid);
     const userId = TLUser.createCustomId(getCurrentUserUid());
+
     const props = getBlockProps(pageUid) as Record<string, unknown>;
     const rjsqb = props["roamjs-query-builder"] as Record<string, unknown>;
     const data = rjsqb?.tldraw as Parameters<TLStore["deserialize"]>[0];
-    return { data, instanceId, userId };
+
+    const isAlreadyUpgraded = !!rjsqb?.legacyTldraw;
+
+    return { data, instanceId, userId, isAlreadyUpgraded };
   }, [tree, pageUid]);
 
   const store = useMemo(() => {
+    if (initialData.isAlreadyUpgraded) return null;
     const _store = config.createStore({
       initialData: initialData.data,
       instanceId: initialData.instanceId,
@@ -186,6 +191,7 @@ export const useRoamStore = ({
   };
 
   useEffect(() => {
+    if (initialData.isAlreadyUpgraded || !store) return;
     const pullWatchProps: Parameters<AddPullWatch> = [
       "[:edit/user :block/props :block/string {:block/children ...}]",
       `[:block/uid "${pageUid}"]`,
@@ -220,5 +226,6 @@ export const useRoamStore = ({
     store,
     instanceId: initialData.instanceId,
     userId: initialData.userId,
+    isAlreadyUpgraded: initialData.isAlreadyUpgraded,
   };
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -506,7 +506,7 @@
       "license": "0BSD"
     },
     "apps/roam": {
-      "version": "0.14.2",
+      "version": "0.14.3",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {


### PR DESCRIPTION
When a canvas has been upgraded by someone using the alpha branch, a there is no error handling for a user viewing that canvas in the current version.  This adds a message to let the user know what happened.

<img width="766" height="683" alt="image" src="https://github.com/user-attachments/assets/61587df9-1b20-4e25-b4b0-4ffe69387625" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a message to inform users when the canvas has already been upgraded, with instructions to upgrade the Discourse Graph extension to view the canvas.

* **Bug Fixes**
  * Prevented the canvas editor from rendering for already upgraded canvases, improving clarity and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->