### PR TITLE
ENG-619 - add initial ci.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,26 @@
+name: CI
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches: [main]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+
+      - name: Install Dependencies
+        run: npm ci
+
+        # TODO: Add future linting, testing, style checks, etc.
+        # name: Lint
+        # run: npm run lint


### PR DESCRIPTION
Introducing an initial general ci check on pr's and merges to main

Currently we only have roam/db actions, which leaves the other packages/apps more vulnerable

This is intended to grow/change over time

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated workflow to install dependencies and set up the environment on pull requests and pushes to the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->