### PR TITLE
ENG-620 - update actions to use npm ci

### DIFF
--- a/.github/workflows/roam-main.yaml
+++ b/.github/workflows/roam-main.yaml
@@ -25,7 +25,7 @@ jobs:
           cache: "npm"
 
       - name: Install Dependencies
-        run: npm install
+        run: npm ci
 
       - name: Deploy
         run: npx turbo run deploy --filter=roam

--- a/.github/workflows/roam-pr.yaml
+++ b/.github/workflows/roam-pr.yaml
@@ -29,7 +29,7 @@ jobs:
           cache: "npm"
 
       - name: Install Dependencies
-        run: npm install
+        run: npm ci
 
       - name: Deploy
         run: npx turbo run deploy --filter=roam

--- a/.github/workflows/roam-release.yaml
+++ b/.github/workflows/roam-release.yaml
@@ -24,7 +24,7 @@ jobs:
           cache: "npm"
 
       - name: Install Dependencies
-        run: npm install
+        run: npm ci
 
       - name: Update Roam Depot Extension
         run: npx turbo run publish --filter=roam


### PR DESCRIPTION
https://docs.npmjs.com/cli/v8/commands/npm-ci
This command is similar to [npm install](https://docs.npmjs.com/cli/v8/commands/npm-install), except it's meant to be used in automated environments such as test platforms, continuous integration, and deployment -- or any situation where you want to make sure you're doing a clean install of your dependencies.