### PR TITLE
Move roam types to shared location

### DIFF
--- a/apps/roam/src/utils/getDiscourseNodes.ts
+++ b/apps/roam/src/utils/getDiscourseNodes.ts
@@ -3,29 +3,14 @@ import getSubTree from "roamjs-components/util/getSubTree";
 import discourseConfigRef from "./discourseConfigRef";
 import getDiscourseRelations from "./getDiscourseRelations";
 import { roamNodeToCondition } from "./parseQuery";
-import { Condition } from "./types";
-import { InputTextNode, RoamBasicNode } from "roamjs-components/types";
+import { Condition, DiscourseNode } from "./types";
+import { RoamBasicNode } from "roamjs-components/types";
 
 export const excludeDefaultNodes = (node: DiscourseNode) => {
   return node.backedBy !== "default";
 };
 
-// TODO - only text and type should be required
-export type DiscourseNode = {
-  text: string;
-  type: string;
-  shortcut: string;
-  specification: Condition[];
-  backedBy: "user" | "default" | "relation";
-  canvasSettings: {
-    [k: string]: string;
-  };
-  // @deprecated - use specification instead
-  format: string;
-  graphOverview?: boolean;
-  description?: string;
-  template?: InputTextNode[];
-};
+export type { DiscourseNode } from "./types";
 
 const DEFAULT_NODES: DiscourseNode[] = [
   {

--- a/apps/roam/src/utils/getDiscourseRelations.ts
+++ b/apps/roam/src/utils/getDiscourseRelations.ts
@@ -3,20 +3,12 @@ import type {
   RoamBasicNode,
   TextNode,
 } from "roamjs-components/types/native";
+import type { DiscourseRelation, Triple } from "./types";
+export type { DiscourseRelation, Triple } from "./types";
 import getSettingValueFromTree from "roamjs-components/util/getSettingValueFromTree";
 import toFlexRegex from "roamjs-components/util/toFlexRegex";
 import DEFAULT_RELATION_VALUES from "~/data/defaultDiscourseRelations";
 import discourseConfigRef from "./discourseConfigRef";
-
-export type Triple = readonly [string, string, string];
-export type DiscourseRelation = {
-  triples: Triple[];
-  id: string;
-  label: string;
-  source: string;
-  destination: string;
-  complement: string;
-};
 
 const matchNodeText = (keyword: string) => {
   return (node: RoamBasicNode | TextNode) =>

--- a/apps/roam/src/utils/types.ts
+++ b/apps/roam/src/utils/types.ts
@@ -1,3 +1,5 @@
+import type { InputTextNode } from "roamjs-components/types/native";
+
 type QBBase = {
   uid: string;
 };
@@ -46,3 +48,30 @@ export type Result = {
   Record<string, string | number | Date>;
 
 export type Column = { key: string; uid: string; selection: string };
+
+export type Triple = readonly [string, string, string];
+
+export type DiscourseRelation = {
+  triples: Triple[];
+  id: string;
+  label: string;
+  source: string;
+  destination: string;
+  complement: string;
+};
+
+export type DiscourseNode = {
+  text: string;
+  type: string;
+  shortcut: string;
+  specification: Condition[];
+  backedBy: "user" | "default" | "relation";
+  canvasSettings: {
+    [k: string]: string;
+  };
+  // @deprecated - use specification instead
+  format: string;
+  graphOverview?: boolean;
+  description?: string;
+  template?: InputTextNode[];
+};


### PR DESCRIPTION
Move `Triple`, `DiscourseRelation`, and `DiscourseNode` types to `apps/roam/src/utils/types.ts` to centralize reusable types within `/apps/roam`.

---

[Open in Web](https://cursor.com/agents?id=bc-45784603-21c1-4ef5-ad89-0cb16dae2bdc) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-45784603-21c1-4ef5-ad89-0cb16dae2bdc) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)