### PR TITLE
[ENG-651] Fix horizontal scroll bar and excessive spacing in setting tab list

### DIFF
--- a/apps/roam/src/components/settings/Settings.tsx
+++ b/apps/roam/src/components/settings/Settings.tsx
@@ -100,6 +100,7 @@ export const SettingsDialog = ({
         <style>{`
           .dg-settings-tabs .bp3-tab-list {
             overflow-y: auto;
+            overflow-x: hidden;
             max-height: 100%;
             /* Firefox */
             scrollbar-width: thin;
@@ -141,7 +142,7 @@ export const SettingsDialog = ({
           <Tab
             id="query-settings"
             title="Queries"
-            className="mb-8 overflow-y-auto"
+            className="overflow-y-auto"
             panel={<QuerySettings extensionAPI={extensionAPI} />}
           />
           <SectionHeader className="text-lg font-semibold text-neutral-dark">


### PR DESCRIPTION
Before: 
<img width="1728" height="1117" alt="image" src="https://github.com/user-attachments/assets/1b165487-fe1b-49a3-8eeb-7752cd9453a3" />

After:
- removed excessive spacing between sections
- remove the horizontal scroll bar
<img width="256" height="605" alt="Screenshot 2025-07-28 at 11 13 25" src="https://github.com/user-attachments/assets/67355c22-6065-4e50-8e97-25ee9126ce3f" />
