### PR TITLE
ENG-675 correction to roam client and test

### DIFF
--- a/packages/database/features/step-definitions/stepdefs.ts
+++ b/packages/database/features/step-definitions/stepdefs.ts
@@ -6,7 +6,7 @@ import { getVariant, config } from "@repo/database/dbDotEnv";
 
 import {
   spaceAnonUserEmail,
-  fetchOrCreateSpaceIndirect,
+  fetchOrCreateSpaceDirect,
   fetchOrCreatePlatformAccount,
 } from "@repo/ui/lib/supabase/contextFunctions";
 
@@ -121,7 +121,7 @@ When(
     if (PLATFORMS.indexOf(platform) < 0)
       throw new Error(`Platform must be one of ${PLATFORMS}`);
     const localRefs: Record<string, any> = world.localRefs || {};
-    const spaceResponse = await fetchOrCreateSpaceIndirect({
+    const spaceResponse = await fetchOrCreateSpaceDirect({
       password: SPACE_ANONYMOUS_PASSWORD,
       url: `https://roamresearch.com/#/app/${spaceName}`,
       name: spaceName,

--- a/packages/ui/src/lib/supabase/client.ts
+++ b/packages/ui/src/lib/supabase/client.ts
@@ -3,7 +3,6 @@ import {
   createClient as createSupabaseClient,
 } from "@supabase/supabase-js";
 import { Database } from "@repo/database/types.gen";
-import { envContents } from "@repo/database/dbDotEnv";
 
 // Inspired by https://supabase.com/ui/docs/react/password-based-auth
 
@@ -14,9 +13,8 @@ export type DGSupabaseClient = SupabaseClient<
 >;
 
 export const createClient = (): DGSupabaseClient => {
-  const env = envContents();
-  const url = env.SUPABASE_URL;
-  const key = env.SUPABASE_ANON_KEY;
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_ANON_KEY;
 
   if (!url || !key) {
     throw new Error("Missing required Supabase environment variables");


### PR DESCRIPTION
Two 
1. packages/ui/src/lib/supabase/client should not use dbDotEnv, but injected variables from the build process
   This made the compile step fail when the client was included.
3. There was a discrepancy between getSupabaseContext and the cucumber step mimicking it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated environment variable handling for connecting to Supabase.
  * Made internal adjustments to how spaces are created or fetched when opening a plugin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->