### PR TITLE
ENG-643 add PascalCase to eslint for React Functional Components

### DIFF
--- a/packages/eslint-config/base.js
+++ b/packages/eslint-config/base.js
@@ -30,15 +30,15 @@ export const config = [
       "max-params": ["error", 3],
       "@typescript-eslint/naming-convention": [
         "error",
-        // Default: camelCase for most identifiers
+        // Keep default
         { selector: "default", format: ["camelCase"] },
-        // Const variables can be camelCase or UPPER_CASE
+        // Keep default for const
         {
           selector: "variable",
           modifiers: ["const"],
           format: ["camelCase", "UPPER_CASE"],
         },
-        // Types, interfaces, enums, type aliases in PascalCase
+        // Keep default for types
         { selector: "typeLike", format: ["PascalCase"] },
         // Allow PascalCase for function variables (e.g., React components)
         {

--- a/packages/eslint-config/base.js
+++ b/packages/eslint-config/base.js
@@ -28,7 +28,25 @@ export const config = [
     },
     rules: {
       "max-params": ["error", 3],
-      "@typescript-eslint/naming-convention": "error",
+      "@typescript-eslint/naming-convention": [
+        "error",
+        // Default: camelCase for most identifiers
+        { selector: "default", format: ["camelCase"] },
+        // Const variables can be camelCase or UPPER_CASE
+        {
+          selector: "variable",
+          modifiers: ["const"],
+          format: ["camelCase", "UPPER_CASE"],
+        },
+        // Types, interfaces, enums, type aliases in PascalCase
+        { selector: "typeLike", format: ["PascalCase"] },
+        // Allow PascalCase for function variables (e.g., React components)
+        {
+          selector: "variable",
+          types: ["function"],
+          format: ["camelCase", "PascalCase"],
+        },
+      ],
       "preferArrows/prefer-arrow-functions": [
         "warn",
         {


### PR DESCRIPTION
Allow PascalCase for function variables in ESLint to support React Functional Component naming.

This will be good for now to reduce noise, in the future we can [ENG-729: Allow PascalCase only in some directories](https://linear.app/discourse-graphs/issue/ENG-729/allow-pascalcase-only-in-some-directories)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated code style rules to enforce more specific naming conventions for variables, constants, types, and functions, ensuring consistent naming patterns across the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->