### PR TITLE
[ENG-601] Create settings for canvas and attachment default folder

### DIFF
--- a/apps/obsidian/src/components/GeneralSettings.tsx
+++ b/apps/obsidian/src/components/GeneralSettings.tsx
@@ -69,11 +69,11 @@ const GeneralSettings = () => {
   const [nodesFolderPath, setNodesFolderPath] = useState(
     plugin.settings.nodesFolderPath,
   );
-  const [canvasFolderPath, setCanvasFolderPath] = useState(
+  const [canvasFolderPath, setCanvasFolderPath] = useState<string>(
     plugin.settings.canvasFolderPath,
   );
   const [canvasAttachmentsFolderPath, setCanvasAttachmentsFolderPath] =
-    useState(plugin.settings.canvasAttachmentsFolderPath);
+    useState<string>(plugin.settings.canvasAttachmentsFolderPath);
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
 
   const handleToggleChange = (newValue: boolean) => {

--- a/apps/obsidian/src/components/GeneralSettings.tsx
+++ b/apps/obsidian/src/components/GeneralSettings.tsx
@@ -69,6 +69,11 @@ const GeneralSettings = () => {
   const [nodesFolderPath, setNodesFolderPath] = useState(
     plugin.settings.nodesFolderPath,
   );
+  const [canvasFolderPath, setCanvasFolderPath] = useState(
+    plugin.settings.canvasFolderPath,
+  );
+  const [canvasAttachmentsFolderPath, setCanvasAttachmentsFolderPath] =
+    useState(plugin.settings.canvasAttachmentsFolderPath);
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
 
   const handleToggleChange = (newValue: boolean) => {
@@ -81,9 +86,24 @@ const GeneralSettings = () => {
     setHasUnsavedChanges(true);
   }, []);
 
+  const handleCanvasFolderPathChange = useCallback((newValue: string) => {
+    setCanvasFolderPath(newValue);
+    setHasUnsavedChanges(true);
+  }, []);
+
+  const handleCanvasAttachmentsFolderPathChange = useCallback(
+    (newValue: string) => {
+      setCanvasAttachmentsFolderPath(newValue);
+      setHasUnsavedChanges(true);
+    },
+    [],
+  );
+
   const handleSave = async () => {
     plugin.settings.showIdsInFrontmatter = showIdsInFrontmatter;
     plugin.settings.nodesFolderPath = nodesFolderPath;
+    plugin.settings.canvasFolderPath = canvasFolderPath;
+    plugin.settings.canvasAttachmentsFolderPath = canvasAttachmentsFolderPath;
     await plugin.saveSettings();
     new Notice("General settings saved");
     setHasUnsavedChanges(false);
@@ -122,6 +142,42 @@ const GeneralSettings = () => {
             value={nodesFolderPath}
             onChange={handleFolderPathChange}
             placeholder="Example: folder 1/folder"
+          />
+        </div>
+      </div>
+
+      <div className="setting-item">
+        <div className="setting-item-info">
+          <div className="setting-item-name">Canvas folder path</div>
+          <div className="setting-item-description">
+            Folder where new Discourse Graph canvases will be created. Default:
+            "Discourse Canvas".
+          </div>
+        </div>
+        <div className="setting-item-control">
+          <FolderSuggestInput
+            value={canvasFolderPath}
+            onChange={handleCanvasFolderPathChange}
+            placeholder="Example: Discourse Canvas"
+          />
+        </div>
+      </div>
+
+      <div className="setting-item">
+        <div className="setting-item-info">
+          <div className="setting-item-name">
+            Canvas attachments folder path
+          </div>
+          <div className="setting-item-description">
+            Folder where attachments for canvases are stored. Default:
+            "attachments".
+          </div>
+        </div>
+        <div className="setting-item-control">
+          <FolderSuggestInput
+            value={canvasAttachmentsFolderPath}
+            onChange={handleCanvasAttachmentsFolderPathChange}
+            placeholder="Example: attachments"
           />
         </div>
       </div>

--- a/apps/obsidian/src/components/canvas/TldrawView.tsx
+++ b/apps/obsidian/src/components/canvas/TldrawView.tsx
@@ -74,6 +74,7 @@ export class TldrawView extends TextFileView {
       {
         app: this.app,
         file,
+        plugin: this.plugin,
       },
     );
     const store = this.createStore(fileData, assetStore);

--- a/apps/obsidian/src/components/canvas/stores/assetStore.ts
+++ b/apps/obsidian/src/components/canvas/stores/assetStore.ts
@@ -1,6 +1,7 @@
 import { App, TFile } from "obsidian";
 import { TLAsset, TLAssetStore, TLAssetId, TLAssetContext } from "tldraw";
 import { JsonObject } from "@tldraw/utils";
+import DiscourseGraphPlugin from "~/index";
 
 const ASSET_PREFIX = "obsidian.blockref.";
 type BlockRefAssetId = `${typeof ASSET_PREFIX}${string}`;
@@ -9,6 +10,7 @@ type AssetDataUrl = string;
 type AssetStoreOptions = {
   app: App;
   file: TFile;
+  plugin: DiscourseGraphPlugin;
 };
 
 /**
@@ -131,6 +133,7 @@ class ObsidianMarkdownFileTLAssetStoreProxy {
   private resolvedAssetDataCache = new Map<BlockRefAssetId, AssetDataUrl>();
   private app: App;
   private file: TFile;
+  private plugin: DiscourseGraphPlugin;
 
   /**
    * Safely set a cached Blob URL for an asset id, revoking any previous URL to avoid leaks
@@ -150,6 +153,7 @@ class ObsidianMarkdownFileTLAssetStoreProxy {
   constructor(options: AssetStoreOptions) {
     this.app = options.app;
     this.file = options.file;
+    this.plugin = options.plugin;
   }
 
   storeAsset = async (
@@ -161,11 +165,12 @@ class ObsidianMarkdownFileTLAssetStoreProxy {
     const objectName = `${blockRefId}-${file.name}`.replace(/\W/g, "-");
     const ext = file.type.split("/").at(1);
     const fileName = !ext ? objectName : `${objectName}.${ext}`;
-
-    // TODO: in the future, get this from the user's settings
-    let attachmentFolder = this.app.vault.getFolderByPath("attachments");
+    const attachmentFolderPath =
+      this.plugin.settings.canvasAttachmentsFolderPath ?? "attachments";
+    let attachmentFolder = this.app.vault.getFolderByPath(attachmentFolderPath);
     if (!attachmentFolder) {
-      attachmentFolder = await this.app.vault.createFolder("attachments");
+      attachmentFolder =
+        await this.app.vault.createFolder(attachmentFolderPath);
     }
     const filePath = `${attachmentFolder.path}/${fileName}`;
 

--- a/apps/obsidian/src/components/canvas/utils/tldraw.ts
+++ b/apps/obsidian/src/components/canvas/utils/tldraw.ts
@@ -156,10 +156,12 @@ export const createEmptyTldrawContent = (
 export const createCanvas = async (plugin: DiscourseGraphPlugin) => {
   try {
     const filename = `Canvas-${format(new Date(), "yyyy-MM-dd-HHmm")}`;
-    // TODO: For now we'll create files in this default location, later we can add settings for this
-    const folderpath = "tldraw-dg";
+    const folderpath = plugin.settings.canvasFolderPath;
+    const attachmentsFolder =
+      plugin.settings.canvasAttachmentsFolderPath;
 
     await checkAndCreateFolder(folderpath, plugin.app.vault);
+    await checkAndCreateFolder(attachmentsFolder, plugin.app.vault);
     const fname = getNewUniqueFilepath({
       vault: plugin.app.vault,
       filename: filename + ".md",

--- a/apps/obsidian/src/constants.ts
+++ b/apps/obsidian/src/constants.ts
@@ -61,6 +61,8 @@ export const DEFAULT_SETTINGS: Settings = {
   ],
   showIdsInFrontmatter: false,
   nodesFolderPath: "",
+  canvasFolderPath: "Discourse Canvas",
+  canvasAttachmentsFolderPath: "attachments",
 };
 export const FRONTMATTER_KEY = "tldr-dg";
 export const TLDATA_DELIMITER_START =

--- a/apps/obsidian/src/types.ts
+++ b/apps/obsidian/src/types.ts
@@ -28,6 +28,8 @@ export type Settings = {
   relationTypes: DiscourseRelationType[];
   showIdsInFrontmatter: boolean;
   nodesFolderPath: string;
+  canvasFolderPath: string;
+  canvasAttachmentsFolderPath: string;
 };
 
 export type BulkImportCandidate = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added settings to choose the Canvas folder and Canvas attachments folder.
  * Provided folder suggestions and placeholders to simplify selection.
  * Set sensible defaults: “Discourse Canvas” for canvases and “attachments” for assets.
  * New canvases and their attachments are now created in the selected folders.
  * Folders are automatically created if they don’t exist.
  * Changes are saved via the existing Save flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->