### PR TITLE
ENG-741 Allow Canvas to be opened in Sidebar

### DIFF
--- a/apps/roam/src/components/canvas/tldrawStyles.ts
+++ b/apps/roam/src/components/canvas/tldrawStyles.ts
@@ -1,7 +1,13 @@
 // tldrawStyles.ts because some of these styles need to be inlined
+export const TLDRAW_DATA_ATTRIBUTE = "dg-tldraw-canvas-wrapper";
 export default `
-  /* Hide Roam Blocks */
-  .roam-article .rm-block-children {
+  /* Hide Roam Blocks only when canvas is present */
+  .roam-article div[${TLDRAW_DATA_ATTRIBUTE}="true"] .rm-block-children {
+    display: none;
+  }
+  
+  /* Hide Roam Blocks in sidebar when canvas is present */
+  .rm-sidebar-outline[${TLDRAW_DATA_ATTRIBUTE}="true"] .rm-block-children {
     display: none;
   }
   
@@ -13,7 +19,7 @@ export default `
   /* CANVAS */
   /* fixes drawing arrows in north-west direction */
   /* and selection context not being shown */
-  #roamjs-tldraw-canvas-container svg {
+  .roamjs-tldraw-canvas-container svg {
     overflow: visible;
   }
   
@@ -43,7 +49,7 @@ export default `
     padding: initial;
   }
   
-  /* #roamjs-tldraw-canvas-container
+  /* .roamjs-tldraw-canvas-container
     .tl-shape
     .roamjs-tldraw-node
     .rm-block-main

--- a/apps/roam/src/components/canvas/tldrawStyles.ts
+++ b/apps/roam/src/components/canvas/tldrawStyles.ts
@@ -2,7 +2,7 @@
 export const TLDRAW_DATA_ATTRIBUTE = "dg-tldraw-canvas-wrapper";
 export default `
   /* Hide Roam Blocks only when canvas is present */
-  .roam-article div[${TLDRAW_DATA_ATTRIBUTE}="true"] .rm-block-children {
+  .roam-article[${TLDRAW_DATA_ATTRIBUTE}="true"] .rm-block-children {
     display: none;
   }
   

--- a/apps/roam/src/utils/initializeObserversAndListeners.ts
+++ b/apps/roam/src/utils/initializeObserversAndListeners.ts
@@ -6,13 +6,16 @@ import {
 import { createBlock } from "roamjs-components/writes";
 import { renderLinkedReferenceAdditions } from "~/utils/renderLinkedReferenceAdditions";
 import { createConfigObserver } from "roamjs-components/components/ConfigPage";
-import { renderTldrawCanvas } from "~/components/canvas/Tldraw";
+import {
+  renderTldrawCanvas,
+  renderTldrawCanvasInSidebar,
+} from "~/components/canvas/Tldraw";
 import { renderQueryPage, renderQueryBlock } from "~/components/QueryBuilder";
 import {
   DISCOURSE_CONFIG_PAGE_TITLE,
   renderNodeConfigPage,
 } from "~/utils/renderNodeConfigPage";
-import { isCurrentPageCanvas as isCanvasPage } from "~/utils/isCanvasPage";
+import { isCurrentPageCanvas, isSidebarCanvas } from "~/utils/isCanvasPage";
 import { isDiscourseNodeConfigPage as isNodeConfigPage } from "~/utils/isDiscourseNodeConfigPage";
 import { isQueryPage } from "~/utils/isQueryPage";
 import {
@@ -74,7 +77,8 @@ export const initObservers = async ({
 
       if (isNodeConfigPage(title)) renderNodeConfigPage(props);
       else if (isQueryPage(props)) renderQueryPage(props);
-      else if (isCanvasPage(props)) renderTldrawCanvas(props);
+      else if (isCurrentPageCanvas(props)) renderTldrawCanvas(props);
+      else if (isSidebarCanvas(props)) renderTldrawCanvasInSidebar(props);
     },
   });
 

--- a/apps/roam/src/utils/isCanvasPage.ts
+++ b/apps/roam/src/utils/isCanvasPage.ts
@@ -17,3 +17,13 @@ export const isCurrentPageCanvas = ({
 }) => {
   return isCanvasPage({ title }) && !!h1.closest(".roam-article");
 };
+
+export const isSidebarCanvas = ({
+  title,
+  h1,
+}: {
+  title: string;
+  h1: HTMLHeadingElement;
+}) => {
+  return isCanvasPage({ title }) && !!h1.closest(".rm-sidebar-outline");
+};


### PR DESCRIPTION
https://www.loom.com/share/bf2e0a05c2b54f0fba6528eb02a489aa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Canvas can now be rendered in the sidebar, not just the main page.
  - More reliable canvas insertion reduces duplicate or missed renders.

- Bug Fixes
  - Prevents non-canvas content from being hidden; hiding now applies only within canvas areas.
  - Improved cleanup when canvases are removed.

- Style
  - Updated selectors for consistent canvas styling across page and sidebar.
  - Ensures SVG elements within the canvas are styled uniformly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->