### PR TITLE
[ENG-404] Fix multiple things about node search menu

### DIFF
--- a/apps/obsidian/src/utils/generateUid.ts
+++ b/apps/obsidian/src/utils/generateUid.ts
@@ -1,4 +1,4 @@
-import { nanoid } from "nanoid";
+import nanoid from "nanoid";
 
 const generateUid = (prefix = "dg") => {
   return `${prefix}_${nanoid()}`;

--- a/apps/roam/src/components/DiscourseNodeSearchMenu.tsx
+++ b/apps/roam/src/components/DiscourseNodeSearchMenu.tsx
@@ -57,6 +57,7 @@ const NodeSearchMenu = ({
   triggerPosition,
   triggerText,
 }: { onClose: () => void } & Props) => {
+  const MENU_WIDTH = 400;
   const [activeIndex, setActiveIndex] = useState(0);
   const [searchTerm, setSearchTerm] = useState("");
   const [isFilterMenuOpen, setIsFilterMenuOpen] = useState(true);
@@ -361,20 +362,17 @@ const NodeSearchMenu = ({
 
   let currentGlobalIndex = -1;
 
-    const refocusTextarea = useCallback(() => {
-      setTimeout(() => {
-        if (!textarea) return;
-        textarea.focus();
-        const cursorPos = textarea.selectionStart;
-        textarea.setSelectionRange(cursorPos, cursorPos);
-      }, 0);
-    }, [textarea]);
+  const refocusTextarea = useCallback(() => {
+    setTimeout(() => {
+      if (!textarea) return;
+      textarea.focus();
+      const cursorPos = textarea.selectionStart;
+      textarea.setSelectionRange(cursorPos, cursorPos);
+    }, 0);
+  }, [textarea]);
 
   const handleTypeCheckChange = useCallback(
-    (typeKey: string, e: React.MouseEvent) => {
-      e.preventDefault();
-      e.stopPropagation();
-
+    (typeKey: string) => {
       setCheckedTypes((prev) => ({
         ...prev,
         [typeKey]: !prev[typeKey],
@@ -442,7 +440,7 @@ const NodeSearchMenu = ({
       content={
         <div
           className="discourse-node-search-menu"
-          style={{ width: "400px" }}
+          style={{ width: MENU_WIDTH }}
           onMouseDown={remainFocusOnTextarea}
           onClick={remainFocusOnTextarea}
         >
@@ -452,7 +450,7 @@ const NodeSearchMenu = ({
             <>
               <div
                 className="discourse-node-search-menu"
-                style={{ width: "400px" }}
+                style={{ width: MENU_WIDTH }}
                 onMouseDown={remainFocusOnTextarea}
                 onClick={remainFocusOnTextarea}
               >
@@ -474,20 +472,7 @@ const NodeSearchMenu = ({
                     <div className="mb-2 flex items-center justify-between text-sm">
                       <div>Filter by type:</div>
                       <div>
-                        <div
-                          onPointerDown={(e) => {
-                            e.preventDefault();
-                            e.stopPropagation();
-                          }}
-                          onMouseDown={(e) => {
-                            e.preventDefault();
-                            e.stopPropagation();
-                          }}
-                          onClick={(e) => {
-                            e.stopPropagation();
-                          }}
-                          className="inline-flex items-center gap-2 align-middle text-sm"
-                        >
+                        <div className="inline-flex items-center gap-2 align-middle text-sm">
                           <span className="align-middle font-semibold leading-none">
                             Select All
                           </span>
@@ -495,10 +480,9 @@ const NodeSearchMenu = ({
                             className="m-0 align-middle"
                             style={{ marginBottom: 0 }}
                             checked={isAllSelected}
-                            onFocus={() => refocusTextarea()}
-                            onChange={() => {
-                              handleToggleAll(!isAllSelected);
-                            }}
+                            aria-label="Select All"
+                            onMouseDown={(e) => e.preventDefault()}
+                            onChange={() => handleToggleAll(!isAllSelected)}
                           />
                         </div>
                       </div>
@@ -506,18 +490,14 @@ const NodeSearchMenu = ({
 
                     <div className="flex flex-wrap gap-2">
                       {discourseTypes.map((type) => (
-                        <div
+                        <Checkbox
                           key={type.type}
-                          className="inline-flex cursor-pointer items-center"
-                          onClick={(e) => handleTypeCheckChange(type.type, e)}
-                        >
-                          <Checkbox
-                            label={type.text}
-                            checked={checkedTypes[type.type]}
-                            onChange={() => {}}
-                            className="m-0"
-                          />
-                        </div>
+                          label={type.text}
+                          checked={checkedTypes[type.type]}
+                          onMouseDown={(e) => e.preventDefault()}
+                          onChange={() => handleTypeCheckChange(type.type)}
+                          className="m-0"
+                        />
                       ))}
                     </div>
                   </div>

--- a/apps/roam/src/components/DiscourseNodeSearchMenu.tsx
+++ b/apps/roam/src/components/DiscourseNodeSearchMenu.tsx
@@ -184,8 +184,6 @@ const NodeSearchMenu = ({
       .filter((type) => searchResults[type.type]?.length > 0);
   }, [discourseTypes, checkedTypes, searchResults]);
 
-  // derived selection set from checkedTypes; no separate selected list needed
-
   const allItems = useMemo(() => {
     const items: {
       typeIndex: number;
@@ -393,9 +391,28 @@ const NodeSearchMenu = ({
       return (
         <MenuItem
           key={item.type}
-          className="group"
-          text={item.text}
-          icon={isSelected ? "tick" : "blank"}
+          className="group !p-0"
+          text={
+            <div className="flex w-full items-center justify-between">
+              <div className="flex flex-1 items-center px-2 py-1.5">
+                <span className="mr-2">{isSelected ? "✓" : " "}</span>
+                <span>{item.text}</span>
+              </div>
+              <Button
+                minimal
+                small
+                className="flex !h-full items-center justify-center !rounded-none px-3 opacity-0 transition-opacity group-hover:opacity-100"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleSelectOnly(item);
+                }}
+                onMouseDown={(e) => e.preventDefault()}
+              >
+                Only
+              </Button>
+            </div>
+          }
+          icon={null}
           shouldDismissPopover={false}
           onClick={(e) => {
             e.preventDefault();
@@ -403,19 +420,6 @@ const NodeSearchMenu = ({
             handleTypeCheckChange(item.type);
           }}
           onMouseDown={(e) => e.preventDefault()}
-          labelElement={
-            <Button
-              minimal
-              small
-              className="opacity-0 transition-opacity group-hover:opacity-100"
-              onClick={(e) => {
-                e.stopPropagation();
-                handleSelectOnly(item);
-              }}
-            >
-              Only
-            </Button>
-          }
         />
       );
     },

--- a/apps/roam/src/components/DiscourseNodeSearchMenu.tsx
+++ b/apps/roam/src/components/DiscourseNodeSearchMenu.tsx
@@ -65,6 +65,7 @@ const NodeSearchMenu = ({
   const [searchResults, setSearchResults] = useState<Record<string, Result[]>>(
     {},
   );
+  const [isFilterMenuVisible, setIsFilterMenuVisible] = useState(false);
   const typeIds = useMemo(
     () => discourseTypes.map((t) => t.type),
     [discourseTypes],
@@ -204,7 +205,7 @@ const NodeSearchMenu = ({
 
   const onSelect = useCallback(
     (item: Result) => {
-      waitForBlock(blockUid, textarea.value).then(() => {
+      void waitForBlock(blockUid, textarea.value).then(() => {
         onClose();
 
         setTimeout(() => {
@@ -362,17 +363,6 @@ const NodeSearchMenu = ({
 
   let currentGlobalIndex = -1;
 
-  const refocusTextarea = useCallback(() => {
-    setTimeout(() => {
-      console.log("refocusing textarea", Date.now());
-      if (!textarea) return;
-      textarea.focus();
-      const cursorPos = textarea.selectionStart;
-      console.log("cursorPos", cursorPos);
-      textarea.setSelectionRange(cursorPos, cursorPos);
-    }, 0);
-  }, [textarea]);
-
   const handleTypeCheckChange = useCallback((typeKey: string) => {
     setCheckedTypes((prev) => ({
       ...prev,
@@ -409,6 +399,7 @@ const NodeSearchMenu = ({
           shouldDismissPopover={false}
           onClick={(e) => {
             e.preventDefault();
+            e.stopPropagation();
             handleTypeCheckChange(item.type);
           }}
           onMouseDown={(e) => e.preventDefault()}
@@ -468,42 +459,46 @@ const NodeSearchMenu = ({
                 style={{ width: MENU_WIDTH }}
               >
                 <div className="flex items-center justify-between border-b border-gray-200 p-2">
-                  <Popover
+                  <Button
+                    icon="filter"
                     minimal
-                    position={Position.BOTTOM_LEFT}
-                    autoFocus={false}
-                    enforceFocus={false}
-                    usePortal={false}
-                    content={
-                      <div className="w-64 p-2">
-                        <div className="mb-2 flex items-center justify-between text-sm">
-                          <Button
-                            small
-                            intent={
-                              isAllSelected ? Intent.SUCCESS : Intent.PRIMARY
-                            }
-                            icon={isAllSelected ? "tick" : "multi-select"}
-                            onMouseDown={(e) => e.preventDefault()}
-                            onClick={() => handleToggleAll(!isAllSelected)}
-                          >
-                            {isAllSelected ? "All selected" : "Select all"}
-                          </Button>
-                        </div>
-                        <Menu>
-                          {discourseTypes.map((t) => renderTypeItem(t))}
-                        </Menu>
-                      </div>
-                    }
-                    onClosed={() => refocusTextarea()}
-                  >
-                    <Button
-                      icon="filter"
-                      minimal
-                      small
-                      title="Filter by type"
-                    />
-                  </Popover>
+                    small
+                    title="Filter by type"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      e.preventDefault();
+                      setIsFilterMenuVisible(!isFilterMenuVisible);
+                    }}
+                    onMouseDown={(e) => e.preventDefault()}
+                  />
                 </div>
+                {isFilterMenuVisible && (
+                  <div>
+                    <div className="flex items-center justify-between px-3 py-2">
+                      <span className="text-sm font-medium text-gray-700">
+                        Filter by Type
+                      </span>
+                      <Button
+                        small
+                        intent={isAllSelected ? Intent.SUCCESS : Intent.PRIMARY}
+                        icon={isAllSelected ? "tick" : "multi-select"}
+                        onMouseDown={(e) => e.preventDefault()}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          e.preventDefault();
+                          handleToggleAll(!isAllSelected);
+                        }}
+                      >
+                        {isAllSelected ? "All selected" : "Select all"}
+                      </Button>
+                    </div>
+                    <div className="max-h-48 overflow-y-auto">
+                      <Menu>
+                        {discourseTypes.map((t) => renderTypeItem(t))}
+                      </Menu>
+                    </div>
+                  </div>
+                )}
               </div>
               <div className="h-64 overflow-y-auto" ref={scrollContainerRef}>
                 {filteredTypes.map((type) => (


### PR DESCRIPTION
https://www.loom.com/share/b8cf4939d1f549f0a792b88a286b9212

## Note:
- I ended up not using the Multi-select because the interface to select/ deselect all that it offers is fitting for our context. I think that having all the nodes available be stationary is a better UI than being added to a "selected list". but happy to switch if you think Multi-select is better
- This PR address these following Linear tickets: [ENG-404: Node summoning menu multi-select filter UI](https://linear.app/discourse-graphs/issue/ENG-404/node-summoning-menu-multi-select-filter-ui), [ENG-673: node summoning menu items should wrap text](https://linear.app/discourse-graphs/issue/ENG-673/node-summoning-menu-items-should-wrap-text), and widening the menu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - New menu-driven “Filter by Type” with per-type selection and an “Only” action.
  - Bulk select/deselect all types.

- Improvements
  - Wider, scrollable filter panel with streamlined layout.
  - Results now support multiline display and keep the menu open for faster selection.
  - Enhanced keyboard navigation and active states.
  - Improved popover behavior and focus preservation during interactions.

- Chores
  - Updated dependency import style in a utility module; no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->