### PR TITLE
ENG-764 Bulk account uploading

### DIFF
--- a/packages/database/src/dbTypes.ts
+++ b/packages/database/src/dbTypes.ts
@@ -673,6 +673,17 @@ export type Database = {
         Args: { p_account_id: number }
         Returns: boolean
       }
+      upsert_account_in_space: {
+        Args: {
+          local_account: Database["public"]["CompositeTypes"]["account_local_input"]
+          space_id_: number
+        }
+        Returns: number
+      }
+      upsert_accounts_in_space: {
+        Args: { accounts: Json; space_id_: number }
+        Returns: number[]
+      }
       upsert_concepts: {
         Args: { data: Json; v_space_id: number }
         Returns: number[]
@@ -746,6 +757,13 @@ export type Database = {
       task_status: "active" | "timeout" | "complete" | "failed"
     }
     CompositeTypes: {
+      account_local_input: {
+        name: string | null
+        account_local_id: string | null
+        email: string | null
+        email_trusted: boolean | null
+        space_editor: boolean | null
+      }
       concept_local_input: {
         epistemic_status: Database["public"]["Enums"]["EpistemicStatus"] | null
         name: string | null
@@ -786,10 +804,10 @@ export type Database = {
           | Database["public"]["CompositeTypes"]["document_local_input"]
           | null
         author_inline:
-          | Database["public"]["Tables"]["PlatformAccount"]["Row"]
+          | Database["public"]["CompositeTypes"]["account_local_input"]
           | null
         creator_inline:
-          | Database["public"]["Tables"]["PlatformAccount"]["Row"]
+          | Database["public"]["CompositeTypes"]["account_local_input"]
           | null
         embedding_inline:
           | Database["public"]["CompositeTypes"]["inline_embedding_input"]
@@ -808,7 +826,7 @@ export type Database = {
         author_local_id: string | null
         space_url: string | null
         author_inline:
-          | Database["public"]["Tables"]["PlatformAccount"]["Row"]
+          | Database["public"]["CompositeTypes"]["account_local_input"]
           | null
       }
       inline_embedding_input: {

--- a/packages/database/supabase/migrations/20250823135620_bulk_account_upsert.sql
+++ b/packages/database/supabase/migrations/20250823135620_bulk_account_upsert.sql
@@ -1,217 +1,90 @@
-CREATE TYPE public."Scale" AS ENUM (
-    'document',
-    'post',
-    'chunk_unit',
-    'section',
-    'block',
-    'field',
-    'paragraph',
-    'quote',
-    'sentence',
-    'phrase'
-);
+CREATE TYPE public.account_local_input AS (
+-- PlatformAccount columns
+name VARCHAR,
+account_local_id VARCHAR,
+-- local values
+email VARCHAR,
+email_trusted BOOLEAN,
+space_editor BOOLEAN
+) ;
 
-ALTER TYPE public."Scale" OWNER TO postgres;
+CREATE OR REPLACE FUNCTION public.upsert_account_in_space(
+    space_id_ BIGINT,
+    local_account public.account_local_input
+) RETURNS BIGINT
+SECURITY DEFINER
+SET search_path = ''
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    platform_ public."Platform";
+    account_id_ BIGINT;
+BEGIN
+    SELECT platform INTO STRICT platform_ FROM public."Space" WHERE id = space_id_;
+    INSERT INTO public."PlatformAccount" AS pa (
+            account_local_id, name, platform
+        ) VALUES (
+            local_account.account_local_id, local_account.name, platform_
+        ) ON CONFLICT (account_local_id, platform) DO UPDATE SET
+            name = coalesce(local_account.name, pa.name)
+        RETURNING id INTO STRICT account_id_;
+    INSERT INTO public."SpaceAccess" as sa (space_id, account_id, editor) values (space_id_, account_id_, COALESCE(local_account.space_editor, true))
+        ON CONFLICT (space_id, account_id)
+        DO UPDATE SET editor = COALESCE(local_account.space_editor, sa.editor, true);
+    IF local_account.email IS NOT NULL THEN
+        -- TODO: how to distinguish basic untrusted from platform placeholder email?
+        INSERT INTO public."AgentIdentifier" as ai (account_id, value, identifier_type, trusted) VALUES (account_id_, local_account.email, 'email', COALESCE(local_account.email_trusted, false))
+        ON CONFLICT (value, identifier_type, account_id)
+        DO UPDATE SET trusted = COALESCE(local_account.email_trusted, ai.trusted, false);
+    END IF;
+    RETURN account_id_;
+END;
+$$;
 
-CREATE TYPE public."ContentVariant" AS ENUM (
-    'direct',
-    'direct_and_children',
-    'direct_and_description'
-);
+CREATE OR REPLACE FUNCTION public.upsert_accounts_in_space (
+space_id_ BIGINT,
+accounts JSONB
+) RETURNS SETOF BIGINT
+SECURITY DEFINER
+SET search_path = ''
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    platform_ public."Platform";
+    account_id_ BIGINT;
+    account_row JSONB;
+    local_account public.account_local_input;
+BEGIN
+    SELECT platform INTO STRICT platform_ FROM public."Space" WHERE id = space_id_;
+    FOR account_row IN SELECT * FROM jsonb_array_elements(accounts)
+    LOOP
+        local_account := jsonb_populate_record(NULL::public.account_local_input, account_row);
+        RETURN NEXT public.upsert_account_in_space(space_id_, local_account);
+    END LOOP;
+END;
+$$;
 
-ALTER TYPE public."ContentVariant" OWNER TO postgres;
+-- legacy
+CREATE OR REPLACE FUNCTION public.create_account_in_space (
+space_id_ BIGINT,
+account_local_id_ varchar,
+name_ varchar,
+email_ varchar = null,
+email_trusted boolean = true,
+editor_ boolean = true
+) RETURNS BIGINT
+SECURITY DEFINER
+SET search_path = ''
+LANGUAGE sql
+AS $$
+    SELECT public.upsert_account_in_space(space_id_, ROW(name_, account_local_id_ ,email_, email_trusted, editor_)::public.account_local_input);
+$$ ;
 
-CREATE TABLE IF NOT EXISTS public."Document" (
-    id bigint DEFAULT nextval(
-        'public.entity_id_seq'::regclass
-    ) NOT NULL,
-    space_id bigint,
-    source_local_id character varying,
-    url character varying,
-    "created" timestamp without time zone NOT NULL,
-    metadata jsonb DEFAULT '{}'::jsonb NOT NULL,
-    last_modified timestamp without time zone NOT NULL,
-    author_id bigint NOT NULL,
-    contents oid
-);
+ALTER TYPE public.document_local_input ALTER ATTRIBUTE author_inline TYPE public.account_local_input ;
 
-ALTER TABLE ONLY public."Document"
-ADD CONSTRAINT "Document_pkey" PRIMARY KEY (id);
+ALTER TYPE public.content_local_input ALTER ATTRIBUTE author_inline TYPE public.account_local_input ;
+ALTER TYPE public.content_local_input ALTER ATTRIBUTE creator_inline TYPE public.account_local_input ;
 
-ALTER TABLE ONLY public."Document"
-ADD CONSTRAINT "Document_author_id_fkey" FOREIGN KEY (
-    author_id
-) REFERENCES public."PlatformAccount" (id) ON UPDATE CASCADE ON DELETE CASCADE;
-
-ALTER TABLE ONLY public."Document"
-ADD CONSTRAINT "Document_space_id_fkey" FOREIGN KEY (
-    space_id
-) REFERENCES public."Space" (
-    id
-) ON UPDATE CASCADE ON DELETE CASCADE;
-
-CREATE UNIQUE INDEX document_space_and_local_id_idx ON public."Document" USING btree (space_id, source_local_id)
-NULLS DISTINCT;
-
-CREATE UNIQUE INDEX document_url_idx ON public."Document" USING btree (url);
-
-ALTER TABLE public."Document" OWNER TO "postgres";
-
-COMMENT ON COLUMN public."Document".space_id IS 'The space in which the content is located';
-
-COMMENT ON COLUMN public."Document".source_local_id IS 'The unique identifier of the content in the remote source';
-
-COMMENT ON COLUMN public."Document".created IS 'The time when the content was created in the remote source';
-
-COMMENT ON COLUMN public."Document".last_modified IS 'The last time the content was modified in the remote source';
-
-COMMENT ON COLUMN public."Document".author_id IS 'The author of content';
-
-COMMENT ON COLUMN public."Document".contents IS 'A large object OID for the downloaded raw content';
-
-
-CREATE TABLE IF NOT EXISTS public."Content" (
-    id bigint DEFAULT nextval(
-        'public.entity_id_seq'::regclass
-    ) NOT NULL,
-    document_id bigint NOT NULL,
-    source_local_id character varying,
-    variant public."ContentVariant" NOT NULL DEFAULT 'direct',
-    author_id bigint,
-    creator_id bigint,
-    created timestamp without time zone NOT NULL,
-    text text NOT NULL,
-    metadata jsonb DEFAULT '{}'::jsonb NOT NULL,
-    scale public."Scale" NOT NULL,
-    space_id bigint,
-    last_modified timestamp without time zone NOT NULL,
-    part_of_id bigint
-);
-
-ALTER TABLE ONLY public."Content"
-ADD CONSTRAINT "Content_pkey" PRIMARY KEY (id);
-
-ALTER TABLE ONLY public."Content"
-ADD CONSTRAINT "Content_author_id_fkey" FOREIGN KEY (
-    author_id
-) REFERENCES public."PlatformAccount" (id) ON UPDATE CASCADE ON DELETE SET NULL;
-
-ALTER TABLE ONLY public."Content"
-ADD CONSTRAINT "Content_creator_id_fkey" FOREIGN KEY (
-    creator_id
-) REFERENCES public."PlatformAccount" (id) ON UPDATE CASCADE ON DELETE SET NULL;
-
-ALTER TABLE ONLY public."Content"
-ADD CONSTRAINT "Content_document_id_fkey" FOREIGN KEY (
-    document_id
-) REFERENCES public."Document" (id) ON UPDATE CASCADE ON DELETE CASCADE;
-
-ALTER TABLE ONLY public."Content"
-ADD CONSTRAINT "Content_part_of_id_fkey" FOREIGN KEY (
-    part_of_id
-) REFERENCES public."Content" (id) ON UPDATE CASCADE ON DELETE SET NULL;
-
-ALTER TABLE ONLY public."Content"
-ADD CONSTRAINT "Content_space_id_fkey" FOREIGN KEY (
-    space_id
-) REFERENCES public."Space" (
-    id
-) ON UPDATE CASCADE ON DELETE CASCADE;
-
-CREATE INDEX "Content_document" ON public."Content" USING btree (
-    document_id
-);
-
-CREATE INDEX "Content_part_of" ON public."Content" USING btree (
-    part_of_id
-);
-
-CREATE INDEX "Content_space" ON public."Content" USING btree (space_id);
-
-CREATE UNIQUE INDEX content_space_local_id_variant_idx ON public."Content" USING btree (
-    space_id, source_local_id, variant
-) NULLS DISTINCT;
-
-CREATE INDEX "Content_text" ON public."Content" USING pgroonga (text);
-
-ALTER TABLE public."Content" OWNER TO "postgres";
-
-COMMENT ON TABLE public."Content" IS 'A unit of content';
-
-COMMENT ON COLUMN public."Content".source_local_id IS 'The unique identifier of the content in the remote source';
-
-COMMENT ON COLUMN public."Content".author_id IS 'The author of content';
-
-COMMENT ON COLUMN public."Content".creator_id IS 'The creator of a logical structure, such as a content subdivision';
-
-COMMENT ON COLUMN public."Content".created IS 'The time when the content was created in the remote source';
-
-COMMENT ON COLUMN public."Content".space_id IS 'The space in which the content is located';
-
-COMMENT ON COLUMN public."Content".last_modified IS 'The last time the content was modified in the remote source';
-
-COMMENT ON COLUMN public."Content".part_of_id IS 'This content is part of a larger content unit';
-
-
-REVOKE ALL ON TABLE public."Document" FROM anon;
-GRANT ALL ON TABLE public."Document" TO authenticated;
-GRANT ALL ON TABLE public."Document" TO service_role;
-
-REVOKE ALL ON TABLE public."Content" FROM anon;
-GRANT ALL ON TABLE public."Content" TO authenticated;
-GRANT ALL ON TABLE public."Content" TO service_role;
-
-CREATE TYPE public.document_local_input AS (
-    -- document columns
-    space_id bigint,
-    source_local_id character varying,
-    url character varying,
-    "created" timestamp without time zone,
-    metadata jsonb,
-    last_modified timestamp without time zone,
-    author_id bigint,
-    contents oid,
-    -- local values
-    author_local_id character varying,
-    space_url character varying,
-    -- inline values
-    author_inline public.account_local_input
-);
-
-CREATE TYPE public.inline_embedding_input AS (
-    model varchar,
-    vector float []
-);
-
-CREATE TYPE public.content_local_input AS (
-    -- content columns
-    document_id bigint,
-    source_local_id character varying,
-    author_id bigint,
-    creator_id bigint,
-    created timestamp without time zone,
-    text text,
-    metadata jsonb,
-    scale public."Scale",
-    space_id bigint,
-    last_modified timestamp without time zone,
-    part_of_id bigint,
-    -- local values
-    document_local_id character varying,
-    creator_local_id character varying,
-    author_local_id character varying,
-    part_of_local_id character varying,
-    space_url character varying,
-    -- inline values
-    document_inline public.document_local_input,
-    author_inline public.account_local_input,
-    creator_inline public.account_local_input,
-    embedding_inline public.inline_embedding_input,
-    variant public."ContentVariant"
-);
-
-
--- private function. Transform document with local (platform) references to document with db references
 CREATE OR REPLACE FUNCTION public._local_document_to_db_document(data public.document_local_input)
 RETURNS public."Document" LANGUAGE plpgsql STABLE
 SET search_path = ''
@@ -244,9 +117,6 @@ BEGIN
 END;
 $$;
 
-COMMENT ON FUNCTION public._local_document_to_db_document IS 'utility function so we have the option to use platform identifiers for document upsert';
-
--- private function. Transform content with local (platform) references to content with db references
 CREATE OR REPLACE FUNCTION public._local_content_to_db_content(data public.content_local_input)
 RETURNS public."Content" STABLE
 SET search_path = ''
@@ -294,10 +164,6 @@ BEGIN
 END;
 $$;
 
-COMMENT ON FUNCTION public._local_content_to_db_content IS 'utility function so we have the option to use platform identifiers for content upsert';
-
--- The data should be an array of LocalDocumentDataInput
--- Documents are upserted, based on space_id and local_id. New (or old) IDs are returned.
 CREATE OR REPLACE FUNCTION public.upsert_documents(v_space_id bigint, data jsonb)
 RETURNS SETOF BIGINT
 SET search_path = ''
@@ -358,32 +224,6 @@ BEGIN
 END;
 $$;
 
-COMMENT ON FUNCTION public.upsert_documents IS 'batch document upsert';
-
-CREATE OR REPLACE FUNCTION public.upsert_content_embedding(content_id bigint, model varchar, embedding_array float []) RETURNS VOID
-SET search_path = ''
-LANGUAGE plpgsql
-AS $$
-BEGIN
-    IF  model = 'openai_text_embedding_3_small_1536' AND array_length(embedding_array, 1) = 1536 THEN
-        INSERT INTO public."ContentEmbedding_openai_text_embedding_3_small_1536" (target_id, model, vector, obsolete)
-            VALUES (content_id, model::public."EmbeddingName", embedding_array::extensions.VECTOR, false)
-        ON CONFLICT (target_id)
-        DO UPDATE
-            SET vector = embedding_array::extensions.VECTOR,
-            obsolete = false;
-    ELSE
-        RAISE WARNING 'Invalid vector name % or length % for embedding', model, array_length(embedding_array, 1);
-        -- do not fail just because of the embedding
-    END IF;
-END
-$$;
-
-COMMENT ON FUNCTION public.upsert_content_embedding IS 'single content embedding upsert';
-
--- The data should be an array of LocalContentDataInput
--- Contents are upserted, based on space_id and local_id. New (or old) IDs are returned.
--- This may trigger creation of PlatformAccounts and Documents appropriately.
 CREATE OR REPLACE FUNCTION public.upsert_content(v_space_id bigint, data jsonb, v_creator_id BIGINT, content_as_document boolean DEFAULT true)
 RETURNS SETOF BIGINT
 SET search_path = ''
@@ -509,35 +349,3 @@ BEGIN
   END LOOP;
 END;
 $$;
-
-COMMENT ON FUNCTION public.upsert_content IS 'batch content upsert';
-
-CREATE OR REPLACE FUNCTION public.content_in_space(content_id BIGINT) RETURNS boolean
-STABLE
-SET search_path = ''
-LANGUAGE sql
-AS $$
-    SELECT public.in_space(space_id) FROM public."Content" WHERE id=content_id
-$$;
-
-COMMENT ON FUNCTION public.content_in_space IS 'security utility: does current user have access to this content''s space?';
-
-CREATE OR REPLACE FUNCTION public.document_in_space(document_id BIGINT) RETURNS boolean
-STABLE
-SET search_path = ''
-LANGUAGE sql
-AS $$
-    SELECT public.in_space(space_id) FROM public."Document" WHERE id=document_id
-$$;
-
-COMMENT ON FUNCTION public.document_in_space IS 'security utility: does current user have access to this document''s space?';
-
-ALTER TABLE public."Document" ENABLE ROW LEVEL SECURITY;
-
-DROP POLICY IF EXISTS document_policy ON public."Document";
-CREATE POLICY document_policy ON public."Document" FOR ALL USING (public.in_space(space_id));
-
-ALTER TABLE public."Content" ENABLE ROW LEVEL SECURITY;
-
-DROP POLICY IF EXISTS content_policy ON public."Content";
-CREATE POLICY content_policy ON public."Content" FOR ALL USING (public.in_space(space_id));


### PR DESCRIPTION
https://linear.app/discourse-graphs/issue/ENG-764/bulk-account-uploading

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bulk account upsert: add or update multiple space members in one request.
  * Inline account support in document and content upserts, auto-creating/updating authors/creators as needed.
  * Backward-compatible single-account creation preserved.

* **Refactor**
  * Unified composite account input across APIs for consistent name/email/editor handling.
  * Client types updated to include the new account input.
  * Small change to embedding match response field ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->