### PR TITLE
Disable print binding in tldraw

### DIFF
--- a/apps/roam/src/components/canvas/uiOverrides.tsx
+++ b/apps/roam/src/components/canvas/uiOverrides.tsx
@@ -400,6 +400,7 @@ export const createUiOverrides = ({
 
     const originalCopyAsSvgAction = actions["copy-as-svg"];
     const originalCopyAsPngAction = actions["copy-as-png"];
+    const originalPrintAction = actions["print"];
 
     actions["copy-as-svg"] = {
       ...originalCopyAsSvgAction,
@@ -417,6 +418,15 @@ export const createUiOverrides = ({
         addToast({ title: "Copied as PNG" });
       },
     };
+    
+    // Disable print keyboard binding to prevent conflict with command palette
+    if (originalPrintAction) {
+      actions["print"] = {
+        ...originalPrintAction,
+        kbd: "", // Remove keyboard shortcut to prevent conflict
+      };
+    }
+    
     return actions;
   },
   translations: {


### PR DESCRIPTION
Disable tldraw's print keyboard binding to resolve a conflict with the default command palette.

---
Linear Issue: [ENG-743](https://linear.app/discourse-graphs/issue/ENG-743/disable-print-keyboard-binding-for-tldraw)

<a href="https://cursor.com/background-agent?bcId=bc-351ae09b-9564-436e-8cb8-d2da452d811b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-351ae09b-9564-436e-8cb8-d2da452d811b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a shortcut conflict with the command palette by disabling the print keyboard shortcut.
  * Printing remains available via the app’s menu or system print options; only the keyboard shortcut is affected.
  * Improves overall keyboard navigation reliability without altering other user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->