### PR TITLE
ENG-636 Add auto canvas relations setting to user preferences

### DIFF
--- a/apps/roam/src/components/canvas/DiscourseNodeUtil.tsx
+++ b/apps/roam/src/components/canvas/DiscourseNodeUtil.tsx
@@ -551,7 +551,7 @@ export class BaseDiscourseNodeUtil extends ShapeUtil<DiscourseNodeShape> {
 
               const autoCanvasRelations = getSetting<boolean>(
                 AUTO_CANVAS_RELATIONS_KEY,
-                true,
+                false,
               );
               if (autoCanvasRelations) {
                 await this.createExistingRelations({

--- a/apps/roam/src/components/canvas/DiscourseNodeUtil.tsx
+++ b/apps/roam/src/components/canvas/DiscourseNodeUtil.tsx
@@ -549,7 +549,6 @@ export class BaseDiscourseNodeUtil extends ShapeUtil<DiscourseNodeShape> {
               const relationIds = getRelationIds();
               this.deleteRelationsInCanvas({ shape, relationIds });
 
-              // Check if auto canvas relations is enabled
               const autoCanvasRelations = getSetting<boolean>(
                 AUTO_CANVAS_RELATIONS_KEY,
                 true,

--- a/apps/roam/src/components/canvas/DiscourseNodeUtil.tsx
+++ b/apps/roam/src/components/canvas/DiscourseNodeUtil.tsx
@@ -38,6 +38,8 @@ import calcCanvasNodeSizeAndImg from "~/utils/calcCanvasNodeSizeAndImg";
 import { createTextJsxFromSpans } from "./DiscourseRelationShape/helpers";
 import { loadImage } from "~/utils/loadImage";
 import { getRelationColor } from "./DiscourseRelationShape/DiscourseRelationUtil";
+import { AUTO_CANVAS_RELATIONS_KEY } from "~/data/userSettings";
+import { getSetting } from "~/utils/extensionSettings";
 
 // TODO REPLACE WITH TLDRAW DEFAULTS
 // https://github.com/tldraw/tldraw/pull/1580/files
@@ -546,11 +548,19 @@ export class BaseDiscourseNodeUtil extends ShapeUtil<DiscourseNodeShape> {
               // Update Shape Relations
               const relationIds = getRelationIds();
               this.deleteRelationsInCanvas({ shape, relationIds });
-              await this.createExistingRelations({
-                shape,
-                relationIds,
-                finalUid: uid,
-              });
+
+              // Check if auto canvas relations is enabled
+              const autoCanvasRelations = getSetting<boolean>(
+                AUTO_CANVAS_RELATIONS_KEY,
+                true,
+              );
+              if (autoCanvasRelations) {
+                await this.createExistingRelations({
+                  shape,
+                  relationIds,
+                  finalUid: uid,
+                });
+              }
 
               editor.setEditingShape(null);
             }}

--- a/apps/roam/src/components/canvas/DiscourseNodeUtil.tsx
+++ b/apps/roam/src/components/canvas/DiscourseNodeUtil.tsx
@@ -546,14 +546,13 @@ export class BaseDiscourseNodeUtil extends ShapeUtil<DiscourseNodeShape> {
               this.updateProps(shape.id, shape.type, { title: text, uid });
 
               // Update Shape Relations
-              const relationIds = getRelationIds();
-              this.deleteRelationsInCanvas({ shape, relationIds });
-
               const autoCanvasRelations = getSetting<boolean>(
                 AUTO_CANVAS_RELATIONS_KEY,
                 false,
               );
               if (autoCanvasRelations) {
+                const relationIds = getRelationIds();
+                this.deleteRelationsInCanvas({ shape, relationIds });
                 await this.createExistingRelations({
                   shape,
                   relationIds,

--- a/apps/roam/src/components/canvas/Tldraw.tsx
+++ b/apps/roam/src/components/canvas/Tldraw.tsx
@@ -82,6 +82,8 @@ import { createMigrations } from "./DiscourseRelationShape/discourseRelationMigr
 import ToastListener, { dispatchToastEvent } from "./ToastListener";
 import sendErrorEmail from "~/utils/sendErrorEmail";
 import { TLDRAW_DATA_ATTRIBUTE } from "./tldrawStyles";
+import { AUTO_CANVAS_RELATIONS_KEY } from "~/data/userSettings";
+import { getSetting } from "~/utils/extensionSettings";
 
 declare global {
   interface Window {
@@ -829,9 +831,16 @@ const InsideEditorAndUiContext = ({
         editor.sideEffects.registerAfterCreateHandler("shape", (shape) => {
           const util = editor.getShapeUtil(shape);
           if (util instanceof BaseDiscourseNodeUtil) {
-            void util.createExistingRelations({
-              shape: shape as DiscourseNodeShape,
-            });
+            // Check if auto canvas relations is enabled
+            const autoCanvasRelations = getSetting<boolean>(
+              AUTO_CANVAS_RELATIONS_KEY,
+              true,
+            );
+            if (autoCanvasRelations) {
+              void util.createExistingRelations({
+                shape: shape as DiscourseNodeShape,
+              });
+            }
           }
         });
 

--- a/apps/roam/src/components/canvas/Tldraw.tsx
+++ b/apps/roam/src/components/canvas/Tldraw.tsx
@@ -831,7 +831,6 @@ const InsideEditorAndUiContext = ({
         editor.sideEffects.registerAfterCreateHandler("shape", (shape) => {
           const util = editor.getShapeUtil(shape);
           if (util instanceof BaseDiscourseNodeUtil) {
-            // Check if auto canvas relations is enabled
             const autoCanvasRelations = getSetting<boolean>(
               AUTO_CANVAS_RELATIONS_KEY,
               true,

--- a/apps/roam/src/components/canvas/Tldraw.tsx
+++ b/apps/roam/src/components/canvas/Tldraw.tsx
@@ -833,7 +833,7 @@ const InsideEditorAndUiContext = ({
           if (util instanceof BaseDiscourseNodeUtil) {
             const autoCanvasRelations = getSetting<boolean>(
               AUTO_CANVAS_RELATIONS_KEY,
-              true,
+              false,
             );
             if (autoCanvasRelations) {
               void util.createExistingRelations({

--- a/apps/roam/src/components/settings/HomePersonalSettings.tsx
+++ b/apps/roam/src/components/settings/HomePersonalSettings.tsx
@@ -146,7 +146,7 @@ const HomePersonalSettings = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
       />
       <Checkbox
         defaultChecked={
-          extensionAPI.settings.get(AUTO_CANVAS_RELATIONS_KEY) !== false
+          extensionAPI.settings.get(AUTO_CANVAS_RELATIONS_KEY) === true
         }
         onChange={(e) => {
           const target = e.target as HTMLInputElement;

--- a/apps/roam/src/components/settings/HomePersonalSettings.tsx
+++ b/apps/roam/src/components/settings/HomePersonalSettings.tsx
@@ -13,6 +13,7 @@ import {
   hideDiscourseFloatingMenu,
 } from "~/components/DiscourseFloatingMenu";
 import { NodeSearchMenuTriggerSetting } from "../DiscourseNodeSearchMenu";
+import { AUTO_CANVAS_RELATIONS_KEY } from "~/data/userSettings";
 
 const HomePersonalSettings = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
   const extensionAPI = onloadArgs.extensionAPI;
@@ -138,6 +139,28 @@ const HomePersonalSettings = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
             <Description
               description={
                 "Hide the 'Send feedback' button at the bottom right of the screen."
+              }
+            />
+          </>
+        }
+      />
+      <Checkbox
+        defaultChecked={
+          extensionAPI.settings.get(AUTO_CANVAS_RELATIONS_KEY) !== false
+        }
+        onChange={(e) => {
+          const target = e.target as HTMLInputElement;
+          void extensionAPI.settings.set(
+            AUTO_CANVAS_RELATIONS_KEY,
+            target.checked,
+          );
+        }}
+        labelElement={
+          <>
+            Auto Canvas Relations
+            <Description
+              description={
+                "Automatically add discourse relations to canvas when a node is added"
               }
             />
           </>

--- a/apps/roam/src/data/userSettings.ts
+++ b/apps/roam/src/data/userSettings.ts
@@ -3,3 +3,4 @@ export const DEFAULT_CANVAS_PAGE_FORMAT_KEY = "default-canvas-page-format";
 export const HIDE_METADATA_KEY = "hide-metadata";
 export const DEFAULT_FILTERS_KEY = "default-filters";
 export const QUERY_BUILDER_SETTINGS_KEY = "query-builder-settings";
+export const AUTO_CANVAS_RELATIONS_KEY = "auto-canvas-relations";


### PR DESCRIPTION
https://www.loom.com/share/954b7fce269d41aea8d6e1600236de23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a “Auto Canvas Relations” toggle in Personal Settings to control automatic creation of discourse relations on the canvas when adding or editing nodes. Default is off.
  - When enabled, relations are auto-created after creating shapes and after editing node labels, preserving previous behavior.
  - Clear in-app description explains the effect of the setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->