### PR TITLE
ENG-777 - Comment out the call to createOrUpdateDiscourseEmbedding.  Needs to be opt in.

### DIFF
--- a/apps/roam/src/index.ts
+++ b/apps/roam/src/index.ts
@@ -137,7 +137,7 @@ export default runExtension(async (onloadArgs) => {
   };
 
   // TODO: REMOVE AFTER TESTING
-  await createOrUpdateDiscourseEmbedding(onloadArgs.extensionAPI);
+  // await createOrUpdateDiscourseEmbedding(onloadArgs.extensionAPI);
 
   installDiscourseFloatingMenu(onloadArgs.extensionAPI);
 


### PR DESCRIPTION
cc @sid597 

This needs to be opt in as we are dealing with users data to our/llm servers.

Also, we need to gracefully handle the dev environment.  We should not expect dev's to always have supabase loaded.
[ENG-778: Create Opt In flow for node sync + llm suggestions](https://linear.app/discourse-graphs/issue/ENG-778/create-opt-in-flow-for-node-sync-llm-suggestions)