### PR TITLE
Roam: ENG-693 handle node tags with # in front and update placeholder to use #

### DIFF
--- a/apps/roam/src/components/DiscourseNodeMenu.tsx
+++ b/apps/roam/src/components/DiscourseNodeMenu.tsx
@@ -113,7 +113,7 @@ const NodeMenu = ({
         setTimeout(() => {
           const currentText = textarea.value;
           const cursorPos = textarea.selectionStart;
-          const textToInsert = `#${tag} `;
+          const textToInsert = `#${tag.replace(/^#/, "")} `;
 
           const newText = `${currentText.substring(
             0,
@@ -249,9 +249,13 @@ const NodeMenu = ({
               <MenuItem
                 key={item.text}
                 data-node={item.type}
-                data-tag={item.tag}
+                data-tag={item.tag?.replace(/^#/, "")}
                 text={
-                  showNodeTypes ? item.text : item.tag ? `#${item.tag}` : ""
+                  showNodeTypes
+                    ? item.text
+                    : item.tag
+                      ? `#${item.tag.replace(/^#/, "")}`
+                      : ""
                 }
                 active={i === activeIndex}
                 onMouseEnter={() => setActiveIndex(i)}

--- a/apps/roam/src/components/settings/NodeConfig.tsx
+++ b/apps/roam/src/components/settings/NodeConfig.tsx
@@ -229,7 +229,7 @@ const NodeConfig = ({
                 onChange={handleTagChange}
                 onBlur={handleTagBlur}
                 error={tagError}
-                placeholder={`${node.text}`}
+                placeholder={`#${node.text.toLowerCase()}`}
               />
             </div>
           }

--- a/apps/roam/src/utils/renderNodeTagPopup.tsx
+++ b/apps/roam/src/utils/renderNodeTagPopup.tsx
@@ -36,11 +36,15 @@ export const renderNodeTagPopupButton = (
   const tag = tagAttr.replace(/^#/, "").toLowerCase();
   const discourseNodes = getDiscourseNodes();
   const discourseTagSet = new Set(
-    discourseNodes.map((n) => n.tag?.toLowerCase()).filter(Boolean),
+    discourseNodes
+      .map((n) => n.tag?.replace(/^#/, "").toLowerCase())
+      .filter(Boolean),
   );
   if (!discourseTagSet.has(tag)) return;
 
-  const matchedNode = discourseNodes.find((n) => n.tag?.toLowerCase() === tag);
+  const matchedNode = discourseNodes.find(
+    (n) => n.tag?.replace(/^#/, "").toLowerCase() === tag,
+  );
 
   if (!matchedNode) return;
 
@@ -67,7 +71,7 @@ export const renderNodeTagPopupButton = (
               initialTitle: cleanedBlockText,
             });
           }}
-          text={`Create ${matchedNode.text}`}
+          text={`Create #${matchedNode.tag?.replace(/^#/, "").toLowerCase()}`}
         />
       }
       target={


### PR DESCRIPTION
https://www.loom.com/share/7aaa1d3cb17b4d25ba58451d21c2ed4a?sid=8d65c3d8-861f-44e4-b3c5-92b4a000a5c1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Ensures tags are consistently normalized: a single leading “#” is displayed, stored, and used in menus and popups.
  - Tag matching is case-insensitive and ignores an initial “#”, improving accuracy when suggesting or creating tags.
- Style
  - Tag input placeholder now shows a normalized suggestion (e.g., “#example”) using lowercase.
  - Create button label in the tag popup displays the normalized tag with a single “#” for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->