### PR TITLE
ENG-788 - Add Discourse Context Overlay to tldraw canvas

### DIFF
--- a/apps/roam/src/components/DiscourseContextOverlay.tsx
+++ b/apps/roam/src/components/DiscourseContextOverlay.tsx
@@ -15,6 +15,7 @@ import getDiscourseNodes from "~/utils/getDiscourseNodes";
 import getDiscourseRelations from "~/utils/getDiscourseRelations";
 import ExtensionApiContextProvider from "roamjs-components/components/ExtensionApiContext";
 import { OnloadArgs } from "roamjs-components/types/native";
+import getPageTitleByPageUid from "roamjs-components/queries/getPageTitleByPageUid";
 
 type DiscourseData = {
   results: Awaited<ReturnType<typeof getDiscourseContextResults>>;
@@ -57,15 +58,24 @@ const getOverlayInfo = async (tag: string): Promise<DiscourseData> => {
   }
 };
 
-const DiscourseContextOverlay = ({ tag, id }: { tag: string; id: string }) => {
-  const tagUid = useMemo(() => getPageUidByPageTitle(tag), [tag]);
+type DiscourseContextOverlayProps =
+  | { id: string; tag: string; uid?: never }
+  | { id: string; uid: string; tag?: never }
+  | { id: string; tag: string; uid: string };
+const DiscourseContextOverlay = ({
+  tag,
+  id,
+  uid,
+}: DiscourseContextOverlayProps) => {
+  const newTag = tag ?? (uid ? (getPageTitleByPageUid(uid) ?? "") : "");
+  const tagUid = uid || getPageUidByPageTitle(newTag);
   const [loading, setLoading] = useState(true);
   const [results, setResults] = useState<DiscourseData["results"]>([]);
   const [refs, setRefs] = useState(0);
   const [score, setScore] = useState<number | string>(0);
   const getInfo = useCallback(
     () =>
-      getOverlayInfo(tag)
+      getOverlayInfo(newTag)
         .then(({ refs, results }) => {
           const discourseNode = findDiscourseNode(tagUid);
           if (discourseNode) {

--- a/apps/roam/src/components/canvas/DiscourseNodeUtil.tsx
+++ b/apps/roam/src/components/canvas/DiscourseNodeUtil.tsx
@@ -43,7 +43,6 @@ import {
   DISCOURSE_CONTEXT_OVERLAY_IN_CANVAS_KEY,
 } from "~/data/userSettings";
 import { getSetting } from "~/utils/extensionSettings";
-import { getPageTitleByPageUid } from "roamjs-components/queries/getPageTitleByPageUid";
 import DiscourseContextOverlay from "~/components/DiscourseContextOverlay";
 
 // TODO REPLACE WITH TLDRAW DEFAULTS

--- a/apps/roam/src/components/canvas/DiscourseNodeUtil.tsx
+++ b/apps/roam/src/components/canvas/DiscourseNodeUtil.tsx
@@ -541,7 +541,7 @@ export class BaseDiscourseNodeUtil extends ShapeUtil<DiscourseNodeShape> {
                 onPointerDown={(e) => e.stopPropagation()}
               >
                 <DiscourseContextOverlay
-                  tag={getPageTitleByPageUid(shape.props.uid)}
+                  uid={shape.props.uid}
                   id={`${shape.id}-overlay`}
                 />
               </div>

--- a/apps/roam/src/components/settings/HomePersonalSettings.tsx
+++ b/apps/roam/src/components/settings/HomePersonalSettings.tsx
@@ -15,9 +15,11 @@ import {
 import { NodeSearchMenuTriggerSetting } from "../DiscourseNodeSearchMenu";
 import {
   AUTO_CANVAS_RELATIONS_KEY,
+  DISCOURSE_CONTEXT_OVERLAY_IN_CANVAS_KEY,
   DISCOURSE_TOOL_SHORTCUT_KEY,
 } from "~/data/userSettings";
 import KeyboardShortcutInput from "./KeyboardShortcutInput";
+import { getSetting, setSetting } from "~/utils/extensionSettings";
 
 const HomePersonalSettings = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
   const extensionAPI = onloadArgs.extensionAPI;
@@ -172,6 +174,26 @@ const HomePersonalSettings = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
             <Description
               description={
                 "Automatically add discourse relations to canvas when a node is added"
+              }
+            />
+          </>
+        }
+      />
+      <Checkbox
+        defaultChecked={getSetting(
+          DISCOURSE_CONTEXT_OVERLAY_IN_CANVAS_KEY,
+          false,
+        )}
+        onChange={(e) => {
+          const target = e.target as HTMLInputElement;
+          setSetting(DISCOURSE_CONTEXT_OVERLAY_IN_CANVAS_KEY, target.checked);
+        }}
+        labelElement={
+          <>
+            (BETA) Overlay in Canvas
+            <Description
+              description={
+                "Whether or not to overlay Discourse Context information over Canvas Nodes."
               }
             />
           </>

--- a/apps/roam/src/data/userSettings.ts
+++ b/apps/roam/src/data/userSettings.ts
@@ -5,3 +5,5 @@ export const DEFAULT_FILTERS_KEY = "default-filters";
 export const QUERY_BUILDER_SETTINGS_KEY = "query-builder-settings";
 export const AUTO_CANVAS_RELATIONS_KEY = "auto-canvas-relations";
 export const DISCOURSE_TOOL_SHORTCUT_KEY = "discourse-tool-shortcut";
+export const DISCOURSE_CONTEXT_OVERLAY_IN_CANVAS_KEY =
+  "discourse-context-overlay-in-canvas";


### PR DESCRIPTION
BETA, WIP
https://www.loom.com/share/01f8363289bf43a3a7546dc3ff60212a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Optional Discourse Context overlay on Canvas nodes (beta). Appears on hover in the node’s top-right and doesn’t interfere with canvas interactions.
  * Overlay now recognizes either a tag or a page UID, improving context accuracy.

* **Settings**
  * Added “(BETA) Overlay in Canvas” toggle in Personal Settings (off by default). Preference is saved.

* **UX Improvements**
  * Smoother, on-demand overlay mounting with unchanged loading and display states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->