### PR TITLE
ENG-796 Canvas Hide Block CSS Fix

### DIFF
--- a/apps/roam/src/components/canvas/Tldraw.tsx
+++ b/apps/roam/src/components/canvas/Tldraw.tsx
@@ -936,21 +936,13 @@ const renderTldrawCanvasHelper = ({
     childFromRoot.parentElement &&
     !childFromRoot.hasAttribute(TLDRAW_DATA_ATTRIBUTE)
   ) {
+    rootElement.setAttribute(TLDRAW_DATA_ATTRIBUTE, "true");
     childFromRoot.setAttribute(TLDRAW_DATA_ATTRIBUTE, "true");
     const parentEl = childFromRoot.parentElement;
     parentEl.appendChild(canvasWrapperEl);
     canvasWrapperEl.style.minHeight = minHeight;
     canvasWrapperEl.style.height = height;
   }
-
-  // console.log(
-  //   "blockChildrenContainer.parentElement",
-  //   articleChildren.parentElement,
-  // );
-  // articleChildren.parentElement?.insertBefore(
-  //   canvasWrapperEl,
-  //   articleChildren.nextSibling,
-  // );
 
   const unmount = renderWithUnmount(
     <ExtensionApiContextProvider {...onloadArgs}>

--- a/apps/roam/src/components/canvas/Tldraw.tsx
+++ b/apps/roam/src/components/canvas/Tldraw.tsx
@@ -955,6 +955,7 @@ const renderTldrawCanvasHelper = ({
   return () => {
     originalUnmount();
     childFromRoot.removeAttribute(TLDRAW_DATA_ATTRIBUTE);
+    rootElement.removeAttribute(TLDRAW_DATA_ATTRIBUTE);
     canvasWrapperEl.remove();
   };
 };

--- a/apps/roam/src/components/canvas/tldrawStyles.ts
+++ b/apps/roam/src/components/canvas/tldrawStyles.ts
@@ -2,12 +2,12 @@
 export const TLDRAW_DATA_ATTRIBUTE = "dg-tldraw-canvas-wrapper";
 export default `
   /* Hide Roam Blocks only when canvas is present */
-  .roam-article .rm-block-children[${TLDRAW_DATA_ATTRIBUTE}="true"]  {
+  .roam-article[${TLDRAW_DATA_ATTRIBUTE}="true"] .rm-block-children  {
     display: none;
   }
   
   /* Hide Roam Blocks in sidebar when canvas is present */
-  .rm-sidebar-outline .rm-block-children[${TLDRAW_DATA_ATTRIBUTE}="true"] {
+  .rm-sidebar-outline[${TLDRAW_DATA_ATTRIBUTE}="true"] .rm-block-children {
     display: none;
   }
   


### PR DESCRIPTION
We were using attrs on the child block, but these were being created after render, so not being hidden.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Correctly hides Roam blocks when a canvas is present by applying visibility rules to the parent container, fixing inconsistent hiding in the main page and sidebar.
  * Reliably marks the canvas root container to ensure consistent show/hide behavior and reduce layout flicker.

* **Chores**
  * Removed unused insertion logic and debug logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->