### PR TITLE
[ENG-658] Add existing node flow

### DIFF
--- a/apps/obsidian/src/components/RelationshipSection.tsx
+++ b/apps/obsidian/src/components/RelationshipSection.tsx
@@ -148,12 +148,12 @@ const AddRelationship = ({ activeFile }: RelationshipSectionProps) => {
         const nodeTypeIdsToSearch = compatibleNodeTypes.map((type) => type.id);
 
         const results =
-          await queryEngineRef.current?.searchCompatibleNodeByTitle(
+          await queryEngineRef.current.searchCompatibleNodeByTitle({
             query,
-            nodeTypeIdsToSearch,
+            compatibleNodeTypeIds: nodeTypeIdsToSearch,
             activeFile,
             selectedRelationType,
-          );
+          });
 
         if (results.length === 0 && query.length >= 2) {
           setSearchError(

--- a/apps/obsidian/src/components/SearchBar.tsx
+++ b/apps/obsidian/src/components/SearchBar.tsx
@@ -102,6 +102,7 @@ const SearchBar = <T,>({
       (item) => {
         setSelected(item);
         onSelect(item);
+        inputRef.current?.blur();
       },
       {
         getItemText: (item: T) => getItemText(item),
@@ -127,14 +128,12 @@ const SearchBar = <T,>({
   }, [onSelect]);
 
   return (
-    <div className="relative">
+    <div className="relative flex items-center">
       <input
         ref={inputRef}
         type="text"
         placeholder={placeholder || "Search..."}
-        className={`w-full p-2 ${
-          selected ? "pr-9" : ""
-        } border-modifier-border rounded border bg-${
+        className={`border-modifier-border flex-1 rounded border p-2 pr-8 bg-${
           selected || disabled ? "secondary" : "primary"
         } ${disabled ? "cursor-not-allowed opacity-70" : "cursor-text"} ${className}`}
         readOnly={!!selected || disabled}
@@ -143,7 +142,7 @@ const SearchBar = <T,>({
       {selected && !disabled && (
         <button
           onClick={clearSelection}
-          className="text-muted absolute right-1 top-1/2 -translate-y-1/2 cursor-pointer rounded border-0 bg-transparent p-1"
+          className="text-muted hover:text-normal absolute right-2 flex h-4 w-4 cursor-pointer items-center justify-center rounded border-0 bg-transparent text-xs"
           aria-label="Clear selection"
         >
           ✕

--- a/apps/obsidian/src/components/canvas/DiscourseNodePanel.tsx
+++ b/apps/obsidian/src/components/canvas/DiscourseNodePanel.tsx
@@ -13,6 +13,7 @@ import { openCreateDiscourseNodeAt } from "./utils/nodeCreationFlow";
 import { getNodeTypeById } from "~/utils/utils";
 import { useEffect } from "react";
 import { setDiscourseNodeToolContext } from "./DiscourseNodeTool";
+import { ExistingNodeSearch } from "./ExistingNodeSearch";
 
 export const DiscourseNodePanel = ({
   plugin,
@@ -26,8 +27,8 @@ export const DiscourseNodePanel = ({
   const rDraggingImage = React.useRef<HTMLDivElement>(null);
   const didDragRef = React.useRef(false);
   const [focusedNodeTypeId, setFocusedNodeTypeId] = React.useState<
-    string | null
-  >(null);
+    string | undefined
+  >(undefined);
 
   type DragState =
     | { name: "idle" }
@@ -188,7 +189,7 @@ export const DiscourseNodePanel = ({
   useEffect(() => {
     if (!focusedNodeTypeId) return;
     const exists = !!getNodeTypeById(plugin, focusedNodeTypeId);
-    if (!exists) setFocusedNodeTypeId(null);
+    if (!exists) setFocusedNodeTypeId(undefined);
   }, [focusedNodeTypeId, plugin]);
 
   const focusedNodeType = focusedNodeTypeId
@@ -208,7 +209,7 @@ export const DiscourseNodePanel = ({
   const handleItemClick = (id: string) => {
     if (didDragRef.current) return;
     if (focusedNodeTypeId) {
-      setFocusedNodeTypeId(null);
+      setFocusedNodeTypeId(undefined);
       return;
     }
     setFocusedNodeTypeId(id);
@@ -217,26 +218,31 @@ export const DiscourseNodePanel = ({
   };
 
   return (
-    <div className="tlui-layout__top__right">
-      <div
-        className="tlui-style-panel tlui-style-panel__wrapper"
-        ref={rPanelContainer}
-      >
-        <div className="flex flex-col">
-          {displayNodeTypes.map((nodeType) => (
-            <NodeTypeButton
-              key={nodeType.id}
-              nodeType={nodeType}
-              handlers={handlers}
-              didDragRef={didDragRef}
-              onClickNoDrag={() => handleItemClick(nodeType.id)}
-            />
-          ))}
-        </div>
-        <div ref={rDraggingImage}>
-          {state.name === "dragging"
-            ? (getNodeTypeById(plugin, state.nodeTypeId)?.name ?? "")
-            : null}
+    <div className="flex flex-row">
+      <ExistingNodeSearch
+        plugin={plugin}
+        canvasFile={canvasFile}
+        getEditor={() => editor}
+        nodeTypeId={focusedNodeTypeId}
+      />
+      <div className="tlui-layout__top__right">
+        <div className="tlui-style-panel tlui-style-panel__wrapper" ref={rPanelContainer}>
+          <div className="flex flex-col">
+            {displayNodeTypes.map((nodeType) => (
+              <NodeTypeButton
+                key={nodeType.id}
+                nodeType={nodeType}
+                handlers={handlers}
+                didDragRef={didDragRef}
+                onClickNoDrag={() => handleItemClick(nodeType.id)}
+              />
+            ))}
+          </div>
+          <div ref={rDraggingImage}>
+            {state.name === "dragging"
+              ? (getNodeTypeById(plugin, state.nodeTypeId)?.name ?? "")
+              : null}
+          </div>
         </div>
       </div>
     </div>

--- a/apps/obsidian/src/components/canvas/ExistingNodeSearch.tsx
+++ b/apps/obsidian/src/components/canvas/ExistingNodeSearch.tsx
@@ -6,7 +6,6 @@ import { QueryEngine } from "~/services/QueryEngine";
 import SearchBar from "~/components/SearchBar";
 import { addWikilinkBlockrefForFile } from "./stores/assetStore";
 import { getFrontmatterForFile } from "./shapes/discourseNodeShapeUtils";
-import { DiscourseNode } from "~/types";
 
 export const ExistingNodeSearch = ({
   plugin,
@@ -23,7 +22,7 @@ export const ExistingNodeSearch = ({
 
   const search = useCallback(
     async (query: string) => {
-      return engine.searchDiscourseNodesByTitle(query, nodeTypeId);
+      return await engine.searchDiscourseNodesByTitle(query, nodeTypeId);
     },
     [engine, nodeTypeId],
   );

--- a/apps/obsidian/src/components/canvas/ExistingNodeSearch.tsx
+++ b/apps/obsidian/src/components/canvas/ExistingNodeSearch.tsx
@@ -1,0 +1,90 @@
+import { useCallback, useState } from "react";
+import { TFile } from "obsidian";
+import { createShapeId, Editor } from "tldraw";
+import DiscourseGraphPlugin from "~/index";
+import { QueryEngine } from "~/services/QueryEngine";
+import SearchBar from "~/components/SearchBar";
+import { addWikilinkBlockrefForFile } from "./stores/assetStore";
+import { getFrontmatterForFile } from "./shapes/discourseNodeShapeUtils";
+import { DiscourseNode } from "~/types";
+
+export const ExistingNodeSearch = ({
+  plugin,
+  canvasFile,
+  getEditor,
+  nodeTypeId,
+}: {
+  plugin: DiscourseGraphPlugin;
+  canvasFile: TFile;
+  getEditor: () => Editor | null;
+  nodeTypeId?: string;
+}) => {
+  const [engine] = useState(() => new QueryEngine(plugin.app));
+
+  const search = useCallback(
+    async (query: string) => {
+      return engine.searchDiscourseNodesByTitle(query, nodeTypeId);
+    },
+    [engine, nodeTypeId],
+  );
+
+  const getItemText = useCallback((file: TFile) => file.basename, []);
+
+  const renderItem = useCallback((file: TFile, el: HTMLElement) => {
+    const wrapper = el.createEl("div", {
+      cls: "file-suggestion",
+      attr: { style: "display:flex; align-items:center; gap:8px;" },
+    });
+    wrapper.createEl("div", { text: "📄" });
+    wrapper.createEl("div", { text: file.basename });
+  }, []);
+
+  const handleSelect = useCallback(
+    (file: TFile | null) => {
+      const editor = getEditor();
+      if (!file || !editor) return;
+      void (async () => {
+        const pagePoint = editor.getViewportScreenCenter();
+        try {
+          const src = await addWikilinkBlockrefForFile({
+            app: plugin.app,
+            canvasFile,
+            linkedFile: file,
+          });
+          const id = createShapeId();
+          editor.createShape({
+            id,
+            type: "discourse-node",
+            x: pagePoint.x - Math.random() * 100,
+            y: pagePoint.y - Math.random() * 100,
+            props: {
+              w: 200,
+              h: 100,
+              src,
+              title: file.basename,
+              nodeTypeId: getFrontmatterForFile(plugin.app, file)?.nodeTypeId,
+            },
+          });
+          editor.markHistoryStoppingPoint("add existing discourse node");
+          editor.setSelectedShapes([id]);
+        } catch (error) {
+          console.error("Error in handleSelect:", error);
+        }
+      })();
+    },
+    [canvasFile, getEditor, plugin.app],
+  );
+
+  return (
+    <div className="pointer-events-auto rounded-md p-1">
+      <SearchBar<TFile>
+        onSelect={handleSelect}
+        placeholder="Node search"
+        getItemText={getItemText}
+        renderItem={renderItem}
+        asyncSearch={search}
+        className="!bg-[var(--color-panel)] !text-[var(--color-text)]"
+      />
+    </div>
+  );
+};

--- a/apps/obsidian/src/components/canvas/TldrawView.tsx
+++ b/apps/obsidian/src/components/canvas/TldrawView.tsx
@@ -7,6 +7,7 @@ import React from "react";
 import DiscourseGraphPlugin from "~/index";
 import { processInitialData, TLData } from "~/components/canvas/utils/tldraw";
 import { ObsidianTLAssetStore } from "~/components/canvas/stores/assetStore";
+import { PluginProvider } from "../PluginContext";
 
 export class TldrawView extends TextFileView {
   plugin: DiscourseGraphPlugin;
@@ -147,12 +148,14 @@ export class TldrawView extends TextFileView {
 
     root.render(
       <React.StrictMode>
-        <TldrawPreviewComponent
-          store={store}
-          plugin={this.plugin}
-          file={this.file}
-          assetStore={this.assetStore}
-        />
+        <PluginProvider plugin={this.plugin}>
+          <TldrawPreviewComponent
+            store={store}
+            plugin={this.plugin}
+            file={this.file}
+            assetStore={this.assetStore}
+          />
+        </PluginProvider>
       </React.StrictMode>,
     );
     return root;

--- a/apps/obsidian/src/components/canvas/TldrawView.tsx
+++ b/apps/obsidian/src/components/canvas/TldrawView.tsx
@@ -151,7 +151,6 @@ export class TldrawView extends TextFileView {
         <PluginProvider plugin={this.plugin}>
           <TldrawPreviewComponent
             store={store}
-            plugin={this.plugin}
             file={this.file}
             assetStore={this.assetStore}
           />

--- a/apps/obsidian/src/components/canvas/TldrawViewComponent.tsx
+++ b/apps/obsidian/src/components/canvas/TldrawViewComponent.tsx
@@ -20,7 +20,6 @@ import {
   TLData,
   processInitialData,
 } from "~/components/canvas/utils/tldraw";
-import DiscourseGraphPlugin from "~/index";
 import {
   DEFAULT_SAVE_DELAY,
   TLDATA_DELIMITER_END,
@@ -32,17 +31,16 @@ import { ObsidianTLAssetStore } from "~/components/canvas/stores/assetStore";
 import { DiscourseNodeUtil } from "~/components/canvas/shapes/DiscourseNodeShape";
 import { DiscourseNodeTool } from "./DiscourseNodeTool";
 import { DiscourseNodePanel } from "./DiscourseNodePanel";
+import { usePlugin } from "~/components/PluginContext";
 
 interface TldrawPreviewProps {
   store: TLStore;
-  plugin: DiscourseGraphPlugin;
   file: TFile;
   assetStore: ObsidianTLAssetStore;
 }
 
 export const TldrawPreviewComponent = ({
   store,
-  plugin,
   file,
   assetStore,
 }: TldrawPreviewProps) => {
@@ -52,6 +50,7 @@ export const TldrawPreviewComponent = ({
   const saveTimeoutRef = useRef<NodeJS.Timeout>();
   const lastSavedDataRef = useRef<string>("");
   const editorRef = useRef<Editor>();
+  const plugin = usePlugin();
 
   const customShapeUtils = [
     ...defaultShapeUtils,

--- a/apps/obsidian/src/services/QueryEngine.ts
+++ b/apps/obsidian/src/services/QueryEngine.ts
@@ -9,20 +9,31 @@ type AppWithPlugins = App & {
   plugins: {
     plugins: {
       [key: string]: {
-        api: any;
+        api: unknown;
       };
     };
   };
 };
 
+type DatacorePage = {
+  $name: string;
+  $path?: string;
+};
+
 export class QueryEngine {
   private app: App;
-  private dc: any;
+  private dc:
+    | {
+        query: (query: string) => DatacorePage[];
+      }
+    | undefined;
   private readonly MIN_QUERY_LENGTH = 2;
 
   constructor(app: App) {
     const appWithPlugins = app as AppWithPlugins;
-    this.dc = appWithPlugins.plugins?.plugins?.["datacore"]?.api;
+    this.dc = appWithPlugins.plugins?.plugins?.["datacore"]?.api as
+      | { query: (query: string) => DatacorePage[] }
+      | undefined;
     this.app = app;
   }
 
@@ -49,19 +60,19 @@ export class QueryEngine {
         : "@page and exists(nodeTypeId)";
       const potentialNodes = await this.dc.query(dcQuery);
 
-      const searchResults = potentialNodes.filter((p: any) =>
+      const searchResults = potentialNodes.filter((p: DatacorePage) =>
         this.fuzzySearch(p.$name, query),
       );
 
       const files = searchResults
-        .map((dcFile: any) => {
+        .map((dcFile: DatacorePage) => {
           if (dcFile && dcFile.$path) {
             const realFile = this.app.vault.getAbstractFileByPath(dcFile.$path);
             if (realFile && realFile instanceof TFile) return realFile;
           }
-          return dcFile as TFile;
+          return null;
         })
-        .filter((f: TFile | null): f is TFile => Boolean(f));
+        .filter((f): f is TFile => f instanceof TFile);
 
       return files;
     } catch (error) {
@@ -97,31 +108,32 @@ export class QueryEngine {
         .join(" or ")}`;
 
       const potentialNodes = this.dc.query(dcQuery);
-      const searchResults = potentialNodes.filter((p: any) => {
+      const searchResults = potentialNodes.filter((p: DatacorePage) => {
         return this.fuzzySearch(p.$name, query);
       });
 
       let existingRelatedFiles: string[] = [];
       if (selectedRelationType) {
         const fileCache = this.app.metadataCache.getFileCache(activeFile);
-        const existingRelations =
-          fileCache?.frontmatter?.[selectedRelationType] || [];
+        const existingRelations: string[] =
+          (fileCache?.frontmatter?.[selectedRelationType] as string[]) || [];
 
         existingRelatedFiles = existingRelations.map((relation: string) => {
           const match = relation.match(/\[\[(.*?)(?:\|.*?)?\]\]/);
-          return match ? match[1] : relation.replace(/^\[\[|\]\]$/g, "");
+          return match?.[1] ?? relation.replace(/^\[\[|\]\]$/g, "");
         });
       }
       const finalResults = searchResults
-        .map((dcFile: any) => {
+        .map((dcFile: DatacorePage) => {
           if (dcFile && dcFile.$path) {
             const realFile = this.app.vault.getAbstractFileByPath(dcFile.$path);
             if (realFile && realFile instanceof TFile) {
               return realFile;
             }
           }
-          return dcFile as TFile;
+          return null;
         })
+        .filter((f): f is TFile => f instanceof TFile)
         .filter((file: TFile) => {
           if (file.path === activeFile.path) return false;
 
@@ -236,6 +248,7 @@ export class QueryEngine {
           );
 
           if (regex.test(fileName)) {
+            if (!page.$path) continue;
             const file = this.app.vault.getAbstractFileByPath(page.$path);
             if (file && file instanceof TFile) {
               const extractedContent = extractContentFromTitle(


### PR DESCRIPTION
https://www.loom.com/share/826ab70ee976490f940ed41b7b428af2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an “Existing Node” search in the canvas to find notes by title and drop them as discourse-node shapes with automatic linking and metadata.
- Style
  - Search bar now supports custom CSS classes for easier theming.
- Refactor
  - Improved reliability and consistency of node search results.
  - Provided plugin context to the canvas view for better extensibility (no user-facing changes).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->