### PR TITLE
ENG-808 Repair turbo dev

### DIFF
--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -13,8 +13,8 @@
     "check-types": "tsc --noEmit --skipLibCheck"
   },
   "dependencies": {
-    "@repo/types": "*",
     "@repo/ui": "*",
+    "@repo/database": "*",
     "@sindresorhus/slugify": "^2.2.1",
     "@supabase/ssr": "^0.6.1",
     "gray-matter": "^4.0.3",
@@ -31,9 +31,9 @@
     "zod": "^3.24.1"
   },
   "devDependencies": {
-    "@repo/database": "*",
     "@repo/eslint-config": "*",
     "@repo/tailwind-config": "*",
+    "@repo/types": "*",
     "@repo/typescript-config": "*",
     "@tailwindcss/typography": "^0.5.15",
     "@types/node": "^20",

--- a/packages/database/scripts/dev.ts
+++ b/packages/database/scripts/dev.ts
@@ -7,7 +7,6 @@ const projectRoot = join(__dirname, "..");
 
 if (process.env.HOME !== "/vercel") {
   try {
-    execSync("npm run compile", { cwd: projectRoot, stdio: "inherit" });
     if (getVariant() === "none") {
       console.log("Not using the database");
       process.exit(0);

--- a/turbo.json
+++ b/turbo.json
@@ -61,7 +61,7 @@
       "persistent": true,
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
       "dependsOn": [
-        "@repo/database#build",
+        "@repo/utils#build",
         "@repo/ui#build",
         "@repo/database#build"
       ]

--- a/turbo.json
+++ b/turbo.json
@@ -59,7 +59,12 @@
       "passThroughEnv": ["OBSIDIAN_PLUGIN_PATH"],
       "cache": false,
       "persistent": true,
-      "inputs": ["$TURBO_DEFAULT$", ".env*"]
+      "inputs": ["$TURBO_DEFAULT$", ".env*"],
+      "dependsOn": [
+        "@repo/database#build",
+        "@repo/ui#build",
+        "@repo/database#build"
+      ]
     },
     "deploy": {
       "cache": false,

--- a/turbo.json
+++ b/turbo.json
@@ -60,11 +60,7 @@
       "cache": false,
       "persistent": true,
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
-      "dependsOn": [
-        "@repo/utils#build",
-        "@repo/ui#build",
-        "@repo/database#build"
-      ]
+      "dependsOn": ["^build"]
     },
     "deploy": {
       "cache": false,


### PR DESCRIPTION
https://linear.app/discourse-graphs/issue/ENG-808/repair-turbo-dev

On an empty repo, `turbo dev` fails   because `turbo dev -F @repo/database` expects `@repo/utils` to be built.
Adding the turbo dependencies to that effect.
Also making the database a non-dev dependency of website.