### PR TITLE
ENG-804 Load Settings Bug

### DIFF
--- a/apps/roam/tsconfig.json
+++ b/apps/roam/tsconfig.json
@@ -11,6 +11,7 @@
     "baseUrl": ".",
     "outDir": "dist",
     "allowJs": false,
+    "jsx": "react",
     "noUncheckedIndexedAccess": false
   }
 }


### PR DESCRIPTION
https://linear.app/discourse-graphs/issue/ENG-804/load-settings-bug

Restoring the previous jsx setting fixes the bug. 
Not sure about the semantics of that flag, interesting that it's different in roam vs all other react projects.

I also found out that the issue centres on the loop at Settings.tsx:194-201. Removing those lines also allows the panel to appear the first time. Replacing the content of the loop with something trivial does not help.