### PR TITLE
ENG-816 deploy should depend on build

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -64,6 +64,7 @@
     },
     "deploy": {
       "cache": false,
+      "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"]
     },
     "publish": {


### PR DESCRIPTION
https://linear.app/discourse-graphs/issue/ENG-816/deploy-should-depend-on-build

The deploy script relies on the compile script, but this only ensures local dependency, not recursive building of packages. Adding the dependency at the turbo level.
