### PR TITLE
ENG-818 Make dbDotEnv explicitly a module

### DIFF
--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -11,9 +11,9 @@
     },
     "./dbDotEnv": {
       "types": "./types/dbDotEnv.d.ts",
-      "import": "./src/dbDotEnv.js",
-      "require": "./src/dbDotEnv.js",
-      "default": "./src/dbDotEnv.js"
+      "import": "./src/dbDotEnv.mjs",
+      "require": "./src/dbDotEnv.mjs",
+      "default": "./src/dbDotEnv.mjs"
     },
     "./dbTypes": {
       "types": "./dist/src/dbTypes.d.ts",

--- a/packages/database/src/dbDotEnv.mjs
+++ b/packages/database/src/dbDotEnv.mjs
@@ -3,6 +3,10 @@ import { join, dirname, basename } from "node:path";
 import { fileURLToPath } from "node:url";
 import dotenv from "dotenv";
 
+// Note: This file is written as mjs so it can be used before typescript compilation.
+// This means the corresponding .d.ts file is currently maintained by hand.
+// Remember to update it as needed.
+
 const findRoot = () => {
   let dir = fileURLToPath(import.meta.url);
   while (basename(dir) !== "database") {


### PR DESCRIPTION
https://linear.app/discourse-graphs/issue/ENG-818/make-dbdotenv-explicitly-a-module

Context: builds in some (but not all) dev environments have complained about the implicit module conventions in this file. Let us make the module convention explicit.