### PR TITLE
[ENG-603] Add existing relations

### DIFF
--- a/apps/obsidian/src/components/canvas/DiscourseRelationTool.ts
+++ b/apps/obsidian/src/components/canvas/DiscourseRelationTool.ts
@@ -2,7 +2,7 @@ import { StateNode, TLEventHandlers, TLStateNodeConstructor } from "@tldraw/edit
 import { createShapeId } from "tldraw";
 import type { TFile } from "obsidian";
 import DiscourseGraphPlugin from "~/index";
-import { getRelationTypeById } from "./utils/relationUtils";
+import { getRelationTypeById } from "~/utils/utils";
 import { DiscourseRelationShape } from "./shapes/DiscourseRelationShape";
 import { getNodeTypeById } from "~/utils/utils";
 import { showToast } from "./utils/toastUtils";

--- a/apps/obsidian/src/components/canvas/TldrawViewComponent.tsx
+++ b/apps/obsidian/src/components/canvas/TldrawViewComponent.tsx
@@ -41,6 +41,7 @@ import {
   BaseRelationBindingUtil,
 } from "~/components/canvas/shapes/DiscourseRelationBinding";
 import ToastListener from "./ToastListener";
+import { RelationsOverlay } from "./overlays/RelationOverlay";
 
 interface TldrawPreviewProps {
   store: TLStore;
@@ -279,6 +280,9 @@ export const TldrawPreviewComponent = ({
                   </DefaultToolbar>
                 );
               },
+              InFrontOfTheCanvas: () => (
+                <RelationsOverlay plugin={plugin} file={file} />
+              ),
             }}
           />
         </ErrorBoundary>

--- a/apps/obsidian/src/components/canvas/overlays/RelationOverlay.tsx
+++ b/apps/obsidian/src/components/canvas/overlays/RelationOverlay.tsx
@@ -1,0 +1,106 @@
+import { useEffect, useState } from "react";
+import { TFile } from "obsidian";
+import { useEditor, useValue } from "tldraw";
+import DiscourseGraphPlugin from "~/index";
+import { DiscourseNodeShape } from "~/components/canvas/shapes/DiscourseNodeShape";
+import { RelationsPanel } from "~/components/canvas/overlays/RelationPanel";
+
+type RelationsOverlayProps = {
+  plugin: DiscourseGraphPlugin;
+  file: TFile;
+};
+
+export const RelationsOverlay = ({ plugin, file }: RelationsOverlayProps) => {
+  const editor = useEditor();
+  const [isOpen, setIsOpen] = useState(false);
+
+  // Currently selected discourse-node shape (first one found)
+  const selectedNode = useValue<DiscourseNodeShape | null>(
+    "selectedDiscourseNode",
+    () => {
+      const shape = editor.getOnlySelectedShape();
+      if (shape && shape.type === "discourse-node") {
+        return shape as DiscourseNodeShape;
+      }
+      return null;
+    },
+    [editor],
+  );
+
+  // Close the panel if selection is cleared or not a discourse-node
+  useEffect(() => {
+    if (!selectedNode) setIsOpen(false);
+  }, [selectedNode]);
+
+  // Compute viewport position for the floating button (center-top of selection)
+  const buttonPosition = useValue<{ left: number; top: number } | null>(
+    "relationsButtonPosition",
+    () => {
+      if (!selectedNode) return null;
+      const bounds = editor.getSelectionRotatedPageBounds();
+      if (!bounds) return null;
+
+      const topLeft = editor.pageToViewport({ x: bounds.minX, y: bounds.minY });
+      const topRight = editor.pageToViewport({
+        x: bounds.maxX,
+        y: bounds.minY,
+      });
+      const width = topRight.x - topLeft.x;
+      const left = topLeft.x + width / 2;
+      const top = topLeft.y - 8; // a bit above the shape
+      return { left, top };
+    },
+    [editor, selectedNode?.id],
+  );
+
+  const handleOpen = () => setIsOpen(true);
+  const handleClose = () => setIsOpen(false);
+
+  const showButton = !!selectedNode && !!buttonPosition && !isOpen;
+
+  return (
+    <div
+      style={{ position: "absolute", inset: 0, pointerEvents: "none" }}
+      // Container overlay above the canvas
+    >
+      {showButton && (
+        <button
+          onClick={handleOpen}
+          style={{
+            left: `${buttonPosition.left}px`,
+            top: `${buttonPosition.top}px`,
+            transform: "translate(-50%, -100%)",
+            pointerEvents: "all",
+          }}
+          className="absolute z-10 rounded px-3 py-1 text-xs text-white"
+        >
+          Relations
+        </button>
+      )}
+
+      {isOpen && selectedNode && (
+        <div
+          style={{
+            position: "absolute",
+            left: 12,
+            top: 12,
+            maxHeight: "calc(100% - 24px)",
+            pointerEvents: "all",
+            overflow: "auto",
+            zIndex: 10,
+          }}
+          onMouseDown={(e) => e.stopPropagation()}
+          onMouseUp={(e) => e.stopPropagation()}
+          onClick={(e) => e.stopPropagation()}
+        >
+          <RelationsPanel
+            nodeShape={selectedNode}
+            plugin={plugin}
+            canvasFile={file}
+            onClose={handleClose}
+          />
+        </div>
+      )}
+    </div>
+  );
+};

--- a/apps/obsidian/src/components/canvas/overlays/RelationPanel.tsx
+++ b/apps/obsidian/src/components/canvas/overlays/RelationPanel.tsx
@@ -1,0 +1,544 @@
+import { useEffect, useMemo, useState } from "react";
+import type { TFile } from "obsidian";
+import type DiscourseGraphPlugin from "~/index";
+import { DiscourseNodeShape } from "~/components/canvas/shapes/DiscourseNodeShape";
+import {
+  ensureBlockRefForFile,
+  resolveLinkedFileFromSrc,
+  extractBlockRefId,
+} from "~/components/canvas/stores/assetStore";
+import { TLShapeId, createShapeId, useEditor } from "tldraw";
+import { DiscourseRelationShape } from "~/components/canvas/shapes/DiscourseRelationShape";
+import {
+  createOrUpdateArrowBinding,
+  getArrowBindings,
+} from "~/components/canvas/utils/relationUtils";
+import { getFrontmatterForFile } from "~/components/canvas/shapes/discourseNodeShapeUtils";
+import { getRelationTypeById } from "~/utils/utils";
+import { showToast } from "~/components/canvas/utils/toastUtils";
+
+type GroupedRelation = {
+  key: string;
+  label: string;
+  isSource: boolean;
+  relationTypeId: string;
+  linkedFiles: TFile[];
+};
+
+type RelationFileItemProps = {
+  file: TFile;
+  group: GroupedRelation;
+  checkExistingRelation: (
+    targetFile: TFile,
+    relationTypeId: string,
+  ) => Promise<DiscourseRelationShape | null>;
+  handleCreateRelationTo: (
+    targetFile: TFile,
+    relationTypeId: string,
+    isSource: boolean,
+  ) => Promise<void>;
+  handleDeleteRelation: (
+    targetFile: TFile,
+    relationTypeId: string,
+  ) => Promise<void>;
+};
+
+export type RelationsPanelProps = {
+  plugin: DiscourseGraphPlugin;
+  canvasFile: TFile;
+  nodeShape: DiscourseNodeShape;
+  onClose: () => void;
+};
+
+const RelationFileItem = ({
+  file,
+  group,
+  checkExistingRelation,
+  handleCreateRelationTo,
+  handleDeleteRelation,
+}: RelationFileItemProps) => {
+  const [hasExistingRelation, setHasExistingRelation] = useState<
+    boolean | null
+  >(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  // Check if relation exists when component mounts
+  useEffect(() => {
+    const checkRelation = async () => {
+      try {
+        const existingRelation = await checkExistingRelation(
+          file,
+          group.relationTypeId,
+        );
+        setHasExistingRelation(!!existingRelation);
+      } catch (e) {
+        console.error("Failed to check existing relation", e);
+        setHasExistingRelation(false);
+      }
+    };
+    void checkRelation();
+  }, [file, group.relationTypeId, checkExistingRelation]);
+
+  const handleButtonClick = async (e: React.MouseEvent) => {
+    e.preventDefault();
+    if (isLoading) return;
+
+    setIsLoading(true);
+    try {
+      if (hasExistingRelation) {
+        await handleDeleteRelation(file, group.relationTypeId);
+        setHasExistingRelation(false);
+      } else {
+        await handleCreateRelationTo(
+          file,
+          group.relationTypeId,
+          group.isSource,
+        );
+        setHasExistingRelation(true);
+      }
+    } catch (e) {
+      showToast({
+        severity: "error",
+        title: "Failed to Handle Relation Action",
+        description: "Could not handle relation action",
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const getButtonProps = () => {
+    if (hasExistingRelation === null) {
+      return {
+        className:
+          "ml-2 rounded bg-gray-300 px-2 py-0.5 text-xs text-white cursor-not-allowed",
+        title: "Checking relation status...",
+        disabled: true,
+        children: "?",
+      };
+    }
+
+    if (hasExistingRelation) {
+      return {
+        className:
+          "ml-2 rounded bg-red-500 px-2 py-0.5 text-xs text-white hover:bg-red-600 disabled:bg-red-300",
+        title: "Remove this relation from canvas",
+        disabled: isLoading,
+        children: "−",
+      };
+    }
+
+    return {
+      className:
+        "ml-2 rounded bg-blue-500 px-2 py-0.5 text-xs text-white hover:bg-blue-600 disabled:bg-blue-300",
+      title: "Add this relation to canvas",
+      disabled: isLoading,
+      children: "+",
+    };
+  };
+
+  const buttonProps = getButtonProps();
+
+  return (
+    <li className="flex items-center gap-2">
+      <a href="#" className="text-accent-text">
+        {file.basename}
+      </a>
+      <button {...buttonProps} onClick={(e) => void handleButtonClick(e)} />
+    </li>
+  );
+};
+
+export const RelationsPanel = ({
+  plugin,
+  canvasFile,
+  nodeShape,
+  onClose,
+}: RelationsPanelProps) => {
+  const editor = useEditor();
+  const [groups, setGroups] = useState<GroupedRelation[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Resolve the file from the shape's src
+  useEffect(() => {
+    const load = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const src = nodeShape.props.src ?? undefined;
+        if (!src) {
+          setGroups([]);
+          setError("This node is not linked to a file.");
+          return;
+        }
+        const file = await resolveLinkedFileFromSrc({
+          app: plugin.app,
+          canvasFile,
+          src,
+        });
+        if (!file) {
+          setGroups([]);
+          setError("Linked file not found.");
+          return;
+        }
+        const g = computeRelations(plugin, file);
+        setGroups(g);
+      } catch (e) {
+        showToast({
+          severity: "error",
+          title: "Failed to Load Relations",
+          description: "Could not load relations",
+        });
+        setError("Failed to load relations.");
+      } finally {
+        setLoading(false);
+      }
+    };
+    void load();
+  }, [plugin, canvasFile, nodeShape.id, nodeShape.props.src, editor]);
+
+  const headerTitle = useMemo(() => {
+    return nodeShape.props.title || "Selected node";
+  }, [nodeShape.props.title]);
+
+  const ensureNodeShapeForFile = async (
+    file: TFile,
+  ): Promise<DiscourseNodeShape> => {
+    // Try to find an existing node shape that points to this file via block ref
+    const blockRef = await ensureBlockRefForFile({
+      app: plugin.app,
+      canvasFile,
+      targetFile: file,
+    });
+    const shapes = editor.getCurrentPageShapes();
+    const existing = shapes.find((s) => {
+      if (s.type !== "discourse-node") return false;
+      const src = (s as DiscourseNodeShape).props.src ?? "";
+      return extractBlockRefId(src) === blockRef;
+    }) as DiscourseNodeShape | undefined;
+
+    if (existing) return existing;
+
+    // Create a new node shape near the selected node
+    const newId = createShapeId();
+    const src = `asset:obsidian.blockref.${blockRef}`;
+    const x = nodeShape.x + nodeShape.props.w + 80;
+    const y = nodeShape.y;
+
+    const nodeTypeId = getFrontmatterForFile(plugin.app, file)
+      ?.nodeTypeId as string;
+
+    const created: DiscourseNodeShape = {
+      id: newId,
+      typeName: "shape",
+      type: "discourse-node",
+      x,
+      y,
+      rotation: 0,
+      index: editor.getHighestIndexForParent(editor.getCurrentPageId()),
+      parentId: editor.getCurrentPageId(),
+      isLocked: false,
+      opacity: 1,
+      meta: {},
+      props: {
+        w: 200,
+        h: 100,
+        src,
+        title: file.basename,
+        nodeTypeId: nodeTypeId,
+      },
+    };
+
+    editor.createShape(created);
+    return created;
+  };
+
+  // Check if a relation already exists between the selected node and a target file
+  const checkExistingRelation = async (
+    targetFile: TFile,
+    relationTypeId: string,
+  ): Promise<DiscourseRelationShape | null> => {
+    try {
+      // Get all shapes on the canvas
+      const allShapes = editor.getCurrentPageShapes();
+
+      // Find the target node shape that corresponds to the file
+      const targetBlockRef = await ensureBlockRefForFile({
+        app: plugin.app,
+        canvasFile,
+        targetFile,
+      });
+      const targetNodeShape = allShapes.find((shape) => {
+        if (shape.type !== "discourse-node") return false;
+        const src = (shape as DiscourseNodeShape).props.src ?? "";
+        return extractBlockRefId(src) === targetBlockRef;
+      }) as DiscourseNodeShape | undefined;
+
+      if (!targetNodeShape) return null;
+
+      // Find relation shapes that connect the selected node and target node
+      const relationShapes = allShapes.filter(
+        (shape) =>
+          shape.type === "discourse-relation" &&
+          (shape as DiscourseRelationShape).props.relationTypeId ===
+            relationTypeId,
+      ) as DiscourseRelationShape[];
+
+      for (const relationShape of relationShapes) {
+        const bindings = getArrowBindings(editor, relationShape);
+
+        // Check if this relation connects our two nodes in ANY direction
+        // The relation could exist as either:
+        // 1. selectedNode -> targetNode (forward direction)
+        // 2. targetNode -> selectedNode (reverse direction)
+        const isConnectedForward =
+          bindings.start?.toId === nodeShape.id &&
+          bindings.end?.toId === targetNodeShape.id;
+
+        const isConnectedReverse =
+          bindings.start?.toId === targetNodeShape.id &&
+          bindings.end?.toId === nodeShape.id;
+
+        if (isConnectedForward || isConnectedReverse) {
+          return relationShape;
+        }
+      }
+
+      return null;
+    } catch (e) {
+      console.error("Failed to check existing relation", e);
+      return null;
+    }
+  };
+
+  const handleDeleteRelationShape = async (
+    targetFile: TFile,
+    relationTypeId: string,
+  ) => {
+    try {
+      const existingRelation = await checkExistingRelation(
+        targetFile,
+        relationTypeId,
+      );
+      if (existingRelation) {
+        editor.deleteShapes([existingRelation.id]);
+      }
+    } catch (e) {
+      showToast({
+        severity: "error",
+        title: "Failed to Delete Relation",
+        description: "Could not delete relation",
+      });
+      console.error("Failed to delete relation", e);
+    }
+  };
+
+  const handleCreateRelationTo = async (
+    targetFile: TFile,
+    relationTypeId: string,
+    isSource: boolean,
+  ) => {
+    try {
+      const targetNode = await ensureNodeShapeForFile(targetFile);
+      const relationType = getRelationTypeById(plugin, relationTypeId);
+      const relationLabel = relationType?.label ?? "";
+
+      const id: TLShapeId = createShapeId();
+
+      // Determine source and destination nodes
+      const sourceNode = isSource ? nodeShape : targetNode;
+      const destNode = isSource ? targetNode : nodeShape;
+
+      // Calculate connection points on the edges of the nodes
+      const sourcePoint = {
+        x: sourceNode.x + sourceNode.props.w,
+        y: sourceNode.y + sourceNode.props.h / 2,
+      };
+
+      // Position the relation shape at the source point
+      const shape: DiscourseRelationShape = {
+        id,
+        typeName: "shape",
+        type: "discourse-relation",
+        x: sourcePoint.x,
+        y: sourcePoint.y,
+        rotation: 0,
+        index: editor.getHighestIndexForParent(editor.getCurrentPageId()),
+        parentId: editor.getCurrentPageId(),
+        isLocked: false,
+        opacity: 1,
+        meta: {},
+        props: {
+          // Use defaults from DiscourseRelationUtil.getDefaultProps()
+          dash: "draw",
+          size: "m",
+          fill: "none",
+          color: "blue",
+          labelColor: "blue",
+          bend: 0,
+          // Will be updated by bindings
+          start: { x: 0, y: 0 },
+          end: { x: 100, y: 0 },
+          arrowheadStart: "none",
+          arrowheadEnd: "arrow",
+          text: relationLabel,
+          labelPosition: 0.5,
+          font: "draw",
+          scale: 1,
+          kind: "arc",
+          elbowMidPoint: 0,
+          relationTypeId,
+        },
+      };
+
+      editor.createShape(shape);
+
+      // Create bindings using the proper utility function
+      // This follows the same pattern as DiscourseRelationTool and onHandleDrag
+      createOrUpdateArrowBinding(editor, shape, sourceNode.id, {
+        terminal: "start",
+        normalizedAnchor: { x: 1, y: 0.5 }, // Right edge of source node
+        isPrecise: false,
+        isExact: false,
+        snap: "none",
+      });
+
+      createOrUpdateArrowBinding(editor, shape, destNode.id, {
+        terminal: "end",
+        normalizedAnchor: { x: 0, y: 0.5 }, // Left edge of dest node
+        isPrecise: false,
+        isExact: false,
+        snap: "none",
+      });
+    } catch (e) {
+      console.error("Failed to create relation to file", e);
+      showToast({
+        severity: "error",
+        title: "Failed to Create Relation",
+        description: "Could not create relation to file",
+      });
+    }
+  };
+
+  return (
+    <div className="min-w-80 max-w-md rounded-lg border bg-white p-4 shadow-lg">
+      <div className="mb-3 flex items-center justify-between">
+        <h3 className="text-lg font-semibold">Relations</h3>
+        <button
+          onClick={onClose}
+          className="text-gray-500 hover:text-gray-700"
+          aria-label="Close"
+        >
+          ✕
+        </button>
+      </div>
+
+      <div className="mb-3">
+        <div className="text-sm font-medium text-gray-700">{headerTitle}</div>
+      </div>
+
+      {loading ? (
+        <div className="text-center text-gray-500">Loading relations...</div>
+      ) : error ? (
+        <div className="text-center text-red-600">{error}</div>
+      ) : groups.length === 0 ? (
+        <div className="text-center text-gray-500">No relations found.</div>
+      ) : (
+        <ul className="m-0 list-none space-y-2 p-0">
+          {groups.map((group) => (
+            <li key={group.key} className="rounded border p-2">
+              <div className="mb-1 flex items-center gap-2">
+                <span className="text-xs text-gray-500">
+                  {group.isSource ? "→" : "←"}
+                </span>
+                <span className="text-sm font-medium">{group.label}</span>
+              </div>
+              {group.linkedFiles.length === 0 ? (
+                <div className="text-xs text-gray-500">None</div>
+              ) : (
+                <ul className="m-0 list-none space-y-1 p-0 pl-5">
+                  {group.linkedFiles.map((f) => {
+                    return (
+                      <RelationFileItem
+                        key={f.path}
+                        file={f}
+                        group={group}
+                        checkExistingRelation={checkExistingRelation}
+                        handleCreateRelationTo={handleCreateRelationTo}
+                        handleDeleteRelation={handleDeleteRelationShape}
+                      />
+                    );
+                  })}
+                </ul>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+const computeRelations = (
+  plugin: DiscourseGraphPlugin,
+  file: TFile,
+): GroupedRelation[] => {
+  const fileCache = plugin.app.metadataCache.getFileCache(file);
+  if (!fileCache?.frontmatter) return [];
+
+  const activeNodeTypeId = fileCache.frontmatter.nodeTypeId as string;
+  if (!activeNodeTypeId) return [];
+
+  const result = new Map<string, GroupedRelation>();
+
+  for (const relationType of plugin.settings.relationTypes) {
+    const frontmatterLinks = fileCache.frontmatter[relationType.id] as unknown;
+    if (!frontmatterLinks) continue;
+
+    const links = Array.isArray(frontmatterLinks)
+      ? (frontmatterLinks as unknown[])
+      : [frontmatterLinks];
+
+    const relation = plugin.settings.discourseRelations.find(
+      (rel) =>
+        (rel.sourceId === activeNodeTypeId ||
+          rel.destinationId === activeNodeTypeId) &&
+        rel.relationshipTypeId === relationType.id,
+    );
+    if (!relation) continue;
+
+    const isSource = relation.sourceId === activeNodeTypeId;
+    const label = isSource ? relationType.label : relationType.complement;
+    const key = `${relationType.id}-${isSource}`;
+
+    if (!result.has(key)) {
+      result.set(key, {
+        key,
+        label,
+        isSource,
+        relationTypeId: relationType.id,
+        linkedFiles: [],
+      });
+    }
+
+    for (const link of links) {
+      const match = String(link).match(/\[\[(.*?)\]\]/);
+      if (!match) continue;
+      const linkedFileName = match[1] ?? "";
+      const linked = plugin.app.metadataCache.getFirstLinkpathDest(
+        linkedFileName,
+        file.path,
+      );
+      if (!linked) continue;
+
+      const group = result.get(key);
+      if (group && !group.linkedFiles.some((f) => f.path === linked.path)) {
+        group.linkedFiles.push(linked);
+      }
+    }
+  }
+
+  return Array.from(result.values());
+};
+

--- a/apps/obsidian/src/components/canvas/utils/relationUtils.tsx
+++ b/apps/obsidian/src/components/canvas/utils/relationUtils.tsx
@@ -2645,12 +2645,3 @@ function centerOfCircleFromThreePoints(a: VecLike, b: VecLike, c: VecLike) {
       u,
   );
 }
-
-export const getRelationTypeById = (
-  plugin: DiscourseGraphPlugin,
-  relationTypeId: string,
-) => {
-  return plugin.settings.relationTypes.find(
-    (type) => type.id === relationTypeId,
-  );
-};

--- a/apps/obsidian/src/utils/utils.ts
+++ b/apps/obsidian/src/utils/utils.ts
@@ -1,9 +1,18 @@
 import type DiscourseGraphPlugin from "~/index";
-import { DiscourseNode } from "~/types";
+import { DiscourseNode, DiscourseRelationType } from "~/types";
 
 export const getNodeTypeById = (
   plugin: DiscourseGraphPlugin,
   nodeTypeId: string,
 ): DiscourseNode | undefined => {
   return plugin.settings.nodeTypes.find((node) => node.id === nodeTypeId);
+};
+
+export const getRelationTypeById = (
+  plugin: DiscourseGraphPlugin,
+  relationTypeId: string,
+): DiscourseRelationType | undefined => {
+  return plugin.settings.relationTypes.find(
+    (relation) => relation.id === relationTypeId,
+  );
 };


### PR DESCRIPTION
https://www.loom.com/share/3641f2a642714b0d849262344e8c6ee5?sid=0614c657-e541-4bfd-92df-9b1aa60945b6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a Relations overlay on the canvas that shows a “Relations” button when a discourse node is selected.
  - Introduced a Relations panel to view and manage relations for the selected node, including adding or removing links, with clear loading/error states.
  - Overlay appears above the canvas without disrupting existing tools.

- Chores
  - Consolidated relation-type lookup into shared utilities and updated imports. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->