### PR TITLE
ENG-737 Use Node Color to style Node Tags

### DIFF
--- a/apps/roam/src/utils/initializeObserversAndListeners.ts
+++ b/apps/roam/src/utils/initializeObserversAndListeners.ts
@@ -47,21 +47,21 @@ import { renderNodeTagPopupButton } from "./renderNodeTagPopup";
 import { formatHexColor } from "~/components/settings/DiscourseNodeCanvasSettings";
 
 let discourseNodes: DiscourseNode[] = [];
-let discourseTagToStyle: Record<string, { backgroundColor: string }> = {};
+let discourseTagToStyle: Record<string, { color: string }> = {};
 
 const refreshDiscourseNodeCache = () => {
   discourseNodes = getDiscourseNodes();
   discourseTagToStyle = discourseNodes.reduce(
     (acc, n) => {
       if (n.tag && n.canvasSettings?.color) {
-        const backgroundColor = formatHexColor(n.canvasSettings.color);
+        const color = formatHexColor(n.canvasSettings.color);
         acc[n.tag.toLowerCase()] = {
-          backgroundColor,
+          color,
         };
       }
       return acc;
     },
-    {} as Record<string, { backgroundColor: string }>,
+    {} as Record<string, { color: string }>,
   );
 };
 
@@ -128,7 +128,7 @@ export const initObservers = async ({
         const style = discourseTagToStyle[tag.toLowerCase()];
         if (style) {
           renderNodeTagPopupButton(s, discourseNodes, onloadArgs.extensionAPI);
-          s.style.backgroundColor = style.backgroundColor;
+          s.style.color = style.color;
           s.style.padding = "2px 4px";
           s.style.borderRadius = "4px";
         }


### PR DESCRIPTION
<img width="746" height="198" alt="image" src="https://github.com/user-attachments/assets/c09b161a-1993-4499-a518-876113764ceb" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Tag badges in the node tag popup now display consistent colors derived from the tag’s canvas color.
  - Improved readability with added padding and rounded corners on tag badges.
  - More reliable color rendering through normalization for a uniform look across tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->