### PR TITLE
ENG-593 Change from Dev to Admin Panel

### DIFF
--- a/apps/roam/src/components/settings/AdminPanel.tsx
+++ b/apps/roam/src/components/settings/AdminPanel.tsx
@@ -1,13 +1,6 @@
-import React, { useState } from "react";
+import React, { useState, useMemo } from "react";
 import type { OnloadArgs } from "roamjs-components/types";
-import {
-  HTMLTable,
-  HTMLInputProps,
-  HTMLDivProps,
-  Button,
-  MenuItem,
-  InputGroup,
-} from "@blueprintjs/core";
+import { HTMLTable, Button, MenuItem } from "@blueprintjs/core";
 import { Select } from "@blueprintjs/select";
 import {
   getSupabaseContext,
@@ -15,23 +8,22 @@ import {
   SupabaseContext,
 } from "~/utils/supabaseContext";
 import type { Tables } from "@repo/database/dbTypes";
+import {
+  getNodes,
+  getNodeSchemas,
+  nodeSchemaSignature,
+  type NodeSignature,
+  type PConcept,
+} from "@repo/database/lib/queries";
+import { DGSupabaseClient } from "@repo/database/lib/client";
 
 type AdminPanelProps = {
   onloadArgs: OnloadArgs;
 };
 
-type NodeSignature = { id: number; name: string };
-
-const nodeSchemaSignature: NodeSignature = { id: 0, name: "Node types" };
-
-type PDocument = Partial<Tables<"Document">>;
-type PContent = Partial<Tables<"Content">> & {
-  Document: PDocument | null;
-};
-type PConcept = Partial<Tables<"Concept">> & { Content: PContent | null };
-
 type AdminPanelState = {
   context: SupabaseContext | null;
+  supabase: DGSupabaseClient | null;
   schemas: NodeSignature[];
   showingSchema: NodeSignature;
   nodes: PConcept[];
@@ -39,6 +31,7 @@ type AdminPanelState = {
 
 const defaultState: AdminPanelState = {
   context: null,
+  supabase: null,
   schemas: [],
   showingSchema: nodeSchemaSignature,
   nodes: [],
@@ -55,14 +48,19 @@ class AdminPanel extends React.Component<AdminPanelProps, AdminPanelState> {
       const context = await getSupabaseContext();
       this.setState({ ...this.state, context });
       if (context) {
-        const schemas = await this.getNodeSchemas();
-        const nodes = await this.getNodes(0);
-        this.setState({
-          context,
-          schemas,
-          nodes,
-          showingSchema: nodeSchemaSignature,
-        });
+        const spaceId = context.spaceId;
+        const supabase = await getLoggedInClient();
+        if (supabase) {
+          const schemas = await getNodeSchemas(supabase, spaceId);
+          const nodes = await getNodes({ supabase, spaceId });
+          this.setState({
+            context,
+            supabase,
+            schemas,
+            nodes,
+            showingSchema: nodeSchemaSignature,
+          });
+        }
       }
     } catch (e) {
       console.error("AdminPanel init failed", e);
@@ -85,14 +83,20 @@ class AdminPanel extends React.Component<AdminPanelProps, AdminPanelState> {
                 items={this.state.schemas}
                 onItemSelect={(choice) => {
                   this.setState({ ...this.state, showingSchema: choice });
-                  this.getNodes(choice.id).then((nodes) =>
-                    this.setState({ ...this.state, nodes }),
-                  );
+                  if (
+                    this.state.supabase !== null &&
+                    this.state.context !== null
+                  )
+                    getNodes({
+                      supabase: this.state.supabase,
+                      spaceId: this.state.context.spaceId,
+                      schemaLocalIds: choice.sourceLocalId,
+                    }).then((nodes) => this.setState({ ...this.state, nodes }));
                 }}
                 itemRenderer={(node, { handleClick, modifiers }) => (
                   <MenuItem
                     active={modifiers.active}
-                    key={node.id}
+                    key={node.sourceLocalId}
                     label={node.name}
                     onClick={handleClick}
                     text={node.name}
@@ -186,79 +190,6 @@ class AdminPanel extends React.Component<AdminPanelProps, AdminPanelState> {
         )}
       </div>
     );
-  }
-
-  async getNodeSchemas(): Promise<NodeSignature[]> {
-    if (!this.state.context?.spaceId) return [];
-    const supabase = await getLoggedInClient();
-    const res = await supabase
-      .from("Concept")
-      .select("id,name")
-      .eq("space_id", this.state.context.spaceId)
-      .eq("is_schema", true)
-      .eq("arity", 0);
-    if (res.error) {
-      console.error("getNodeSchemas failed", res.error);
-      return [nodeSchemaSignature];
-    }
-    return [nodeSchemaSignature, ...(res.data || [])];
-  }
-
-  async getNodes(schema: number): Promise<PConcept[]> {
-    if (!this.state.context?.spaceId) return [];
-    const supabase = await getLoggedInClient();
-    let query = supabase
-      .from("Concept")
-      .select(
-        `
-          id,
-          name,
-          description,
-          author_id,
-          created,
-          last_modified,
-          space_id,
-          arity,
-          literal_content,
-          reference_content,
-          refs,
-          is_schema,
-          represented_by_id,
-          Content (
-              id,
-              source_local_id,
-              variant,
-              author_id,
-              creator_id,
-              created,
-              text,
-              metadata,
-              scale,
-              space_id,
-              last_modified,
-              part_of_id,
-              Document (
-                  space_id,
-                  source_local_id,
-                  url,
-                  created,
-                  metadata,
-                  last_modified,
-                  author_id
-              ))`,
-      )
-      .eq("space_id", this.state.context.spaceId);
-    if (schema > 0) {
-      query = query.eq("is_schema", false).eq("schema_id", schema);
-    } else {
-      query = query.eq("is_schema", true).eq("arity", 0);
-    }
-    const { error, data } = await query;
-    if (error) {
-      console.error("getNodes failed", error);
-      return [];
-    }
-    return data || [];
   }
 }
 

--- a/apps/roam/src/components/settings/AdminPanel.tsx
+++ b/apps/roam/src/components/settings/AdminPanel.tsx
@@ -14,6 +14,7 @@ import {
   type PConcept,
 } from "@repo/database/lib/queries";
 import { DGSupabaseClient } from "@repo/database/lib/client";
+import { OnLoadArgs } from "esbuild";
 
 const NodeRow = ({ node }: { node: PConcept }) => {
   return (
@@ -113,7 +114,7 @@ const AdminPanel = () => {
           setSupabase(await getLoggedInClient());
         }
       } catch (e) {
-        setError(`${e}`);
+        setError((e as Error).message);
         console.error("AdminPanel init failed", e);
       }
     })();
@@ -129,7 +130,7 @@ const AdminPanel = () => {
         try {
           setSchemas(await getNodeSchemas(supabase, context.spaceId));
         } catch (e) {
-          setError(`${e}`);
+          setError((e as Error).message);
           console.error("getNodeSchemas failed", e);
         }
       }
@@ -161,7 +162,7 @@ const AdminPanel = () => {
           );
           setLoadingNodes(false);
         } catch (e) {
-          setError(`${e}`);
+          setError((e as Error).message);
           console.error("getNodes failed", e);
         }
       }

--- a/apps/roam/src/components/settings/AdminPanel.tsx
+++ b/apps/roam/src/components/settings/AdminPanel.tsx
@@ -131,7 +131,33 @@ class AdminPanel extends React.Component<AdminPanelProps, AdminPanelState> {
                           data-link-uid="{node.Content?.source_local_id}"
                         >
                           <span className="rm-page-ref__brackets">[[</span>
-                          <span className="rm-page-ref rm-page-ref--link">
+                          <span
+                            className="rm-page-ref rm-page-ref--link"
+                            onClick={async (event) => {
+                              if (event.shiftKey) {
+                                if (node.Content?.source_local_id) {
+                                  await window.roamAlphaAPI.ui.rightSidebar.addWindow(
+                                    {
+                                      window: {
+                                        // @ts-expect-error TODO: fix this
+                                        "block-uid":
+                                          node.Content.source_local_id,
+                                        type: "outline",
+                                      },
+                                    },
+                                  );
+                                }
+                              } else if (
+                                node.Content?.Document?.source_local_id
+                              ) {
+                                window.roamAlphaAPI.ui.mainWindow.openPage({
+                                  page: {
+                                    uid: node.Content.Document.source_local_id,
+                                  },
+                                });
+                              }
+                            }}
+                          >
                             {node.Content?.text}
                           </span>
                           <span className="rm-page-ref__brackets">]]</span>

--- a/apps/roam/src/components/settings/AdminPanel.tsx
+++ b/apps/roam/src/components/settings/AdminPanel.tsx
@@ -1,0 +1,224 @@
+import React, { useState } from "react";
+import type { OnloadArgs } from "roamjs-components/types";
+import {
+  HTMLTable,
+  HTMLInputProps,
+  HTMLDivProps,
+  Button,
+  MenuItem,
+  InputGroup,
+} from "@blueprintjs/core";
+import { Select } from "@blueprintjs/select";
+import {
+  getSupabaseContext,
+  getLoggedInClient,
+  SupabaseContext,
+} from "~/utils/supabaseContext";
+import type { Tables } from "@repo/database/dbTypes";
+
+type AdminPanelProps = {
+  onloadArgs: OnloadArgs;
+};
+
+type NodeSignature = { id: number; name: string };
+
+const nodeSchemaSignature: NodeSignature = { id: 0, name: "Node types" };
+
+type PDocument = Partial<Tables<"Document">>;
+type PContent = Partial<Tables<"Content">> & {
+  Document: PDocument | null;
+};
+type PConcept = Partial<Tables<"Concept">> & { Content: PContent | null };
+
+type AdminPanelState = {
+  context: SupabaseContext | null;
+  schemas: NodeSignature[];
+  showingSchema: NodeSignature;
+  nodes: PConcept[];
+};
+
+const defaultState: AdminPanelState = {
+  context: null,
+  schemas: [],
+  showingSchema: nodeSchemaSignature,
+  nodes: [],
+};
+
+class AdminPanel extends React.Component<AdminPanelProps, AdminPanelState> {
+  constructor({ onloadArgs }: { onloadArgs: OnloadArgs }) {
+    super({ onloadArgs });
+    this.state = defaultState;
+    setTimeout(async () => {
+      const context = await getSupabaseContext();
+      this.setState({ ...this.state, context });
+      if (context) {
+        const schemas = await this.getNodeSchemas();
+        const nodes = await this.getNodes(0);
+        this.setState({
+          context,
+          schemas,
+          nodes,
+          showingSchema: nodeSchemaSignature,
+        });
+      } else {
+        this.setState({ context });
+      }
+    }, 0);
+  }
+  render() {
+    return (
+      <div>
+        <p>
+          Context: <code>{JSON.stringify(this.state.context)}</code>
+        </p>
+        {Object.keys(this.state.schemas).length > 0 ? (
+          <div>
+            <div>
+              <Select
+                items={this.state.schemas}
+                onItemSelect={(choice) => {
+                  this.setState({ ...this.state, showingSchema: choice });
+                  this.getNodes(choice.id).then((nodes) =>
+                    this.setState({ ...this.state, nodes }),
+                  );
+                }}
+                itemRenderer={(node, { handleClick, modifiers }) => (
+                  <MenuItem
+                    active={modifiers.active}
+                    key={node.id}
+                    label={node.name}
+                    onClick={handleClick}
+                    text={node.name}
+                  />
+                )}
+              >
+                <Button text={`display: ${this.state.showingSchema.name}`} />
+              </Select>
+            </div>
+            <div>
+              <HTMLTable>
+                <thead>
+                  <tr>
+                    <th>Name</th>
+                    <th>Created</th>
+                    <th>Last Modified</th>
+                    <th>Concept</th>
+                    <th>Content</th>
+                    <th>Document</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {this.state.nodes.map((node: PConcept) => (
+                    <tr key={node.id}>
+                      <td>{node.name}</td>
+                      <td>{node.created}</td>
+                      <td>{node.last_modified}</td>
+                      <td>
+                        <pre>
+                          {JSON.stringify({ ...node, Content: null }, null, 2)}
+                        </pre>
+                      </td>
+                      <td>
+                        <pre>
+                          {JSON.stringify(
+                            { ...node.Content, Document: null },
+                            null,
+                            2,
+                          )}
+                        </pre>
+                        <span
+                          data-link-title="{node.Content?.text}"
+                          data-link-uid="{node.Content?.source_local_id}"
+                        >
+                          <span className="rm-page-ref__brackets">[[</span>
+                          <span className="rm-page-ref rm-page-ref--link">
+                            {node.Content?.text}
+                          </span>
+                          <span className="rm-page-ref__brackets">]]</span>
+                        </span>
+                      </td>
+                      <td>
+                        <pre>
+                          {JSON.stringify(node.Content?.Document, null, 2)}
+                        </pre>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </HTMLTable>
+            </div>
+          </div>
+        ) : (
+          <p>No node schemas found</p>
+        )}
+      </div>
+    );
+  }
+
+  async getNodeSchemas(): Promise<NodeSignature[]> {
+    if (!this.state.context?.spaceId) return [];
+    const supabase = await getLoggedInClient();
+    const res = await supabase
+      .from("Concept")
+      .select("id,name")
+      .eq("space_id", this.state.context.spaceId)
+      .eq("is_schema", true)
+      .eq("arity", 0);
+    return [nodeSchemaSignature, ...(res.data || [])];
+  }
+
+  async getNodes(schema: number): Promise<PConcept[]> {
+    if (!this.state.context?.spaceId) return [];
+    const supabase = await getLoggedInClient();
+    let query = supabase
+      .from("Concept")
+      .select(
+        `
+          id,
+          name,
+          description,
+          author_id,
+          created,
+          last_modified,
+          space_id,
+          arity,
+          literal_content,
+          reference_content,
+          refs,
+          is_schema,
+          represented_by_id,
+          Content (
+              id,
+              source_local_id,
+              variant,
+              author_id,
+              creator_id,
+              created,
+              text,
+              metadata,
+              scale,
+              space_id,
+              last_modified,
+              part_of_id,
+              Document (
+                  space_id,
+                  source_local_id,
+                  url,
+                  created,
+                  metadata,
+                  last_modified,
+                  author_id
+              ))`,
+      )
+      .eq("space_id", this.state.context.spaceId);
+    if (schema > 0) {
+      query = query.eq("is_schema", false).eq("schema_id", schema);
+    } else {
+      query = query.eq("is_schema", true).eq("arity", 0);
+    }
+    const { error, data } = await query;
+    return data || [];
+  }
+}
+
+export default AdminPanel;

--- a/apps/roam/src/components/settings/AdminPanel.tsx
+++ b/apps/roam/src/components/settings/AdminPanel.tsx
@@ -115,6 +115,7 @@ const AdminPanel = () => {
         }
       } catch (e) {
         setError((e as Error).message);
+        setLoading(false);
         console.error("AdminPanel init failed", e);
       }
     })();
@@ -133,8 +134,8 @@ const AdminPanel = () => {
           setError((e as Error).message);
           console.error("getNodeSchemas failed", e);
         }
+        setLoading(false);
       }
-      setLoading(false);
     })();
     return () => {
       ignore = true;

--- a/apps/roam/src/components/settings/Settings.tsx
+++ b/apps/roam/src/components/settings/Settings.tsx
@@ -213,7 +213,7 @@ export const SettingsDialog = ({
             id="secret-admin-panel"
             title="Secret Admin Panel"
             className="overflow-y-auto"
-            panel={<AdminPanel onloadArgs={onloadArgs} />}
+            panel={<AdminPanel />}
           />
         </Tabs>
       </div>

--- a/apps/roam/src/components/settings/Settings.tsx
+++ b/apps/roam/src/components/settings/Settings.tsx
@@ -16,12 +16,12 @@ import { getFormattedConfigTree } from "~/utils/discourseConfigRef";
 import DiscourseGraphHome from "./GeneralSettings";
 import DiscourseGraphExport from "./ExportSettings";
 import QuerySettings from "./QuerySettings";
+import AdminPanel from "./AdminPanel";
 import DiscourseNodeConfigPanel from "./DiscourseNodeConfigPanel";
 import getDiscourseNodes, {
   excludeDefaultNodes,
 } from "~/utils/getDiscourseNodes";
 import NodeConfig from "./NodeConfig";
-import sendErrorEmail from "~/utils/sendErrorEmail";
 import HomePersonalSettings from "./HomePersonalSettings";
 import refreshConfigTree from "~/utils/refreshConfigTree";
 import { FeedbackWidget } from "~/components/BirdEatsBugs";
@@ -76,10 +76,10 @@ export const SettingsDialog = ({
 
   useEffect(() => {
     const handleKeyPress = (e: KeyboardEvent) => {
-      if (e.ctrlKey && e.shiftKey && e.key === "D") {
+      if (e.ctrlKey && e.shiftKey && e.key === "A") {
         e.stopPropagation();
         e.preventDefault();
-        setSelectedTabId("secret-dev-panel");
+        setSelectedTabId("secret-admin-panel");
       }
     };
 
@@ -210,31 +210,10 @@ export const SettingsDialog = ({
           {/* Secret Dev Panel */}
           <Tab
             hidden={true}
-            id="secret-dev-panel"
-            title="Secret Dev Panel"
+            id="secret-admin-panel"
+            title="Secret Admin Panel"
             className="overflow-y-auto"
-            panel={
-              <div className="flex gap-4 p-4">
-                <Button
-                  onClick={() => {
-                    console.log("NODE_ENV:", process.env.NODE_ENV);
-                  }}
-                >
-                  Log Node Env
-                </Button>
-                <Button
-                  onClick={() => {
-                    console.log("sending error email");
-                    sendErrorEmail({
-                      error: new Error("test"),
-                      type: "Test",
-                    });
-                  }}
-                >
-                  sendErrorEmail()
-                </Button>
-              </div>
-            }
+            panel={<AdminPanel onloadArgs={onloadArgs} />}
           />
         </Tabs>
       </div>

--- a/apps/roam/src/index.ts
+++ b/apps/roam/src/index.ts
@@ -141,6 +141,9 @@ export default runExtension(async (onloadArgs) => {
     getDiscourseNodes: getDiscourseNodes,
   };
 
+  // TODO: REMOVE AFTER TESTING
+  // await createOrUpdateDiscourseEmbedding(onloadArgs.extensionAPI);
+
   installDiscourseFloatingMenu(onloadArgs);
 
   return {

--- a/apps/roam/src/index.ts
+++ b/apps/roam/src/index.ts
@@ -141,9 +141,6 @@ export default runExtension(async (onloadArgs) => {
     getDiscourseNodes: getDiscourseNodes,
   };
 
-  // TODO: REMOVE AFTER TESTING
-  // await createOrUpdateDiscourseEmbedding(onloadArgs.extensionAPI);
-
   installDiscourseFloatingMenu(onloadArgs);
 
   return {

--- a/packages/database/src/lib/queries.ts
+++ b/packages/database/src/lib/queries.ts
@@ -122,7 +122,7 @@ export const getNodeSchemas = async (
     };
     result = Object.values(NODE_SCHEMA_CACHE)
       .filter((x) => typeof x === "object")
-      .filter((x) => x.spaceId === spaceId);
+      .filter((x) => x.spaceId === spaceId || x.spaceId === 0);
   }
   return result;
 };

--- a/packages/database/src/lib/queries.ts
+++ b/packages/database/src/lib/queries.ts
@@ -98,8 +98,8 @@ export const getNodeSchemas = async (
 ): Promise<NodeSignature[]> => {
   let result = Object.values(NODE_SCHEMA_CACHE)
     .filter((x) => typeof x === "object")
-    .filter((x) => x.spaceId === spaceId);
-  if (forceCacheReload || result.length === 0) {
+    .filter((x) => x.spaceId === spaceId || x.spaceId === 0);
+  if (forceCacheReload || result.length === 1) {
     const q = composeQuery({ supabase, spaceId });
     const res = (await q) as PostgrestResponse<defaultQueryShape>;
     if (res.error) {


### PR DESCRIPTION
https://linear.app/discourse-graphs/issue/ENG-593/change-from-dev-to-admin-panel

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a Secret Admin Panel with a schema picker and a table of nodes.
  - Interactive content actions: Shift+click opens blocks in the sidebar; open pages when available.

- Changes
  - Renamed hidden tab to “Secret Admin Panel.”
  - Temporarily disabled automatic discourse embedding initialization during startup.
  - Schema picker now includes global/shared schemas in addition to workspace-specific ones.

- Refactor
  - Moved admin tools from inline UI into the dedicated panel.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->