### PR TITLE
Roam: Eng-752 node formalization menu doesnt pop up in query results forr

### DIFF
--- a/apps/roam/src/utils/renderNodeTagPopup.tsx
+++ b/apps/roam/src/utils/renderNodeTagPopup.tsx
@@ -49,6 +49,8 @@ export const renderNodeTagPopupButton = (
   const rawBlockText = blockUid ? getTextByBlockUid(blockUid) : "";
   const cleanedBlockText = rawBlockText.replace(textContent, "").trim();
 
+  const rect = parent.getBoundingClientRect();
+
   ReactDOM.render(
     <Popover
       content={
@@ -71,8 +73,8 @@ export const renderNodeTagPopupButton = (
         <span
           style={{
             display: "block",
-            width: "100%",
-            height: "100%",
+            width: `${rect.width}px`,
+            height: `${rect.height}px`,
             pointerEvents: "auto",
           }}
         />

--- a/apps/roam/src/utils/renderNodeTagPopup.tsx
+++ b/apps/roam/src/utils/renderNodeTagPopup.tsx
@@ -14,6 +14,7 @@ export const renderNodeTagPopupButton = (
 ) => {
   if (parent.dataset.attributeButtonRendered === "true") return;
 
+  const rect = parent.getBoundingClientRect();
   parent.dataset.attributeButtonRendered = "true";
   const wrapper = document.createElement("span");
   wrapper.style.position = "relative";
@@ -25,8 +26,8 @@ export const renderNodeTagPopupButton = (
   reactRoot.style.position = "absolute";
   reactRoot.style.top = "0";
   reactRoot.style.left = "0";
-  reactRoot.style.width = "100%";
-  reactRoot.style.height = "100%";
+  reactRoot.style.width = `${rect.width}px`;
+  reactRoot.style.height = `${rect.height}px`;
   reactRoot.style.pointerEvents = "none";
   reactRoot.style.zIndex = "10";
 
@@ -48,8 +49,6 @@ export const renderNodeTagPopupButton = (
 
   const rawBlockText = blockUid ? getTextByBlockUid(blockUid) : "";
   const cleanedBlockText = rawBlockText.replace(textContent, "").trim();
-
-  const rect = parent.getBoundingClientRect();
 
   ReactDOM.render(
     <Popover
@@ -73,8 +72,11 @@ export const renderNodeTagPopupButton = (
         <span
           style={{
             display: "block",
+            top: "0",
+            left: "0",
             width: `${rect.width}px`,
             height: `${rect.height}px`,
+            position: "absolute",
             pointerEvents: "auto",
           }}
         />
@@ -83,7 +85,7 @@ export const renderNodeTagPopupButton = (
       position={Position.TOP}
       modifiers={{
         offset: {
-          offset: "0, 10",
+          offset: `${rect.width / 2}px, 10`,
         },
         arrow: {
           enabled: false,


### PR DESCRIPTION
https://www.loom.com/share/4cfe2885a7154d47bdfbf1af1296f509?sid=02e3e20e-1d9b-4c2f-8a41-da4984a64528

- fix button render in table, make the button
- persistant when hovered

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically formats #tags inside table cells and renders interactive tag popups.
  * Enables tag popups within embedded tables/queries, including a Create action for quick node creation.
  * Improves popup reliability and positioning with portal-based rendering.
  * Ensures popups appear for newly discovered or reformatted tags without page reload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->