### PR TITLE
ENG-826 inconsistent 'create node' popover for candidate nodes

### DIFF
--- a/apps/roam/src/utils/renderNodeTagPopup.tsx
+++ b/apps/roam/src/utils/renderNodeTagPopup.tsx
@@ -14,6 +14,7 @@ export const renderNodeTagPopupButton = (
 ) => {
   if (parent.dataset.attributeButtonRendered === "true") return;
 
+  const rect = parent.getBoundingClientRect();
   parent.dataset.attributeButtonRendered = "true";
   const wrapper = document.createElement("span");
   wrapper.style.position = "relative";
@@ -25,8 +26,8 @@ export const renderNodeTagPopupButton = (
   reactRoot.style.position = "absolute";
   reactRoot.style.top = "0";
   reactRoot.style.left = "0";
-  reactRoot.style.width = "100%";
-  reactRoot.style.height = "100%";
+  reactRoot.style.width = `${rect.width}px`;
+  reactRoot.style.height = `${rect.height}px`;
   reactRoot.style.pointerEvents = "none";
   reactRoot.style.zIndex = "10";
 
@@ -48,8 +49,6 @@ export const renderNodeTagPopupButton = (
 
   const rawBlockText = blockUid ? getTextByBlockUid(blockUid) : "";
   const cleanedBlockText = rawBlockText.replace(textContent, "").trim();
-
-  const rect = parent.getBoundingClientRect();
 
   ReactDOM.render(
     <Popover
@@ -73,8 +72,11 @@ export const renderNodeTagPopupButton = (
         <span
           style={{
             display: "block",
+            top: "0",
+            left: "0",
             width: `${rect.width}px`,
             height: `${rect.height}px`,
+            position: "absolute",
             pointerEvents: "auto",
           }}
         />
@@ -83,7 +85,7 @@ export const renderNodeTagPopupButton = (
       position={Position.TOP}
       modifiers={{
         offset: {
-          offset: "0, 10",
+          offset: `${rect.width / 2}px, 10`,
         },
         arrow: {
           enabled: false,


### PR DESCRIPTION
https://www.loom.com/share/e0ddc797613f49bfa78cd1e7611157fa?sid=ffc11a76-683a-40d1-8d29-767b70181a5f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Corrects tag popover alignment to center relative to the tag’s width for improved readability.
  - Ensures the overlay precisely matches the tag’s bounds, preventing visual overflow or clipping.
  - Improves popover positioning to appear consistently above/below the tag with appropriate offsets.
  - Resolves issues where the popover could appear shifted due to inaccurate size/position calculations.
  - Enhances overall stability of tag interaction by using reliable element measurements for layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->