### PR TITLE
ENG-831 - Refactor tldraw maximize to stop canvas jumping around

### DIFF
--- a/apps/roam/src/components/canvas/Tldraw.tsx
+++ b/apps/roam/src/components/canvas/Tldraw.tsx
@@ -134,11 +134,13 @@ const TldrawCanvas = ({ title }: { title: string }) => {
 
   const updateViewportScreenBounds = (el: HTMLDivElement) => {
     // Use tldraw's built-in viewport bounds update with centering
-    const rect = el.getBoundingClientRect();
-    appRef.current?.updateViewportScreenBounds(
-      new Box(rect.left, rect.top, rect.width, rect.height),
-      true,
-    );
+    requestAnimationFrame(() => {
+      const rect = el.getBoundingClientRect();
+      appRef.current?.updateViewportScreenBounds(
+        new Box(rect.left, rect.top, rect.width, rect.height),
+        true,
+      );
+    });
   };
   const handleMaximizedChange = () => {
     // Direct DOM manipulation to avoid React re-renders

--- a/apps/roam/src/components/canvas/Tldraw.tsx
+++ b/apps/roam/src/components/canvas/Tldraw.tsx
@@ -419,7 +419,7 @@ const TldrawCanvas = ({ title }: { title: string }) => {
     allNodes,
     allRelationNames,
     allAddReferencedNodeByAction,
-    setMaximized: handleMaximizedChange,
+    toggleMaximized: handleMaximizedChange,
     setConvertToDialogOpen,
     discourseContext,
   });

--- a/apps/roam/src/components/canvas/tldrawStyles.ts
+++ b/apps/roam/src/components/canvas/tldrawStyles.ts
@@ -1,6 +1,6 @@
 // tldrawStyles.ts because some of these styles need to be inlined
 export const TLDRAW_DATA_ATTRIBUTE = "dg-tldraw-canvas-wrapper";
-export default `
+export default /* css */ `
   /* Hide Roam Blocks only when canvas is present */
   .roam-article[${TLDRAW_DATA_ATTRIBUTE}="true"] .rm-block-children  {
     display: none;
@@ -75,5 +75,12 @@ export default `
   background-image: url("data:image/svg+xml,%3Csvg width='256' height='264' viewBox='0 0 256 264' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M156.705 252.012C140.72 267.995 114.803 267.995 98.8183 252.012L11.9887 165.182C-3.99622 149.197 -3.99622 123.28 11.9886 107.296L55.4035 63.8807C63.3959 55.8881 76.3541 55.8881 84.3467 63.8807C92.3391 71.8731 92.3391 84.8313 84.3467 92.8239L69.8751 107.296C53.8901 123.28 53.8901 149.197 69.8751 165.182L113.29 208.596C121.282 216.589 134.241 216.589 142.233 208.596C150.225 200.604 150.225 187.646 142.233 179.653L127.761 165.182C111.777 149.197 111.777 123.28 127.761 107.296C143.746 91.3105 143.746 65.3939 127.761 49.4091L113.29 34.9375C105.297 26.9452 105.297 13.9868 113.29 5.99432C121.282 -1.99811 134.241 -1.99811 142.233 5.99434L243.533 107.296C259.519 123.28 259.519 149.197 243.533 165.182L156.705 252.012ZM200.119 121.767C192.127 113.775 179.168 113.775 171.176 121.767C163.184 129.76 163.184 142.718 171.176 150.71C179.168 158.703 192.127 158.703 200.119 150.71C208.112 142.718 208.112 129.76 200.119 121.767Z' fill='%23000000'/%3E%3C/svg%3E");
   background-size: contain;
   background-repeat: no-repeat;
+}
+
+/* Maximize Tldraw Canvas */
+/* Used in conjunction with tailwind classes on the canvas container */
+.roam-body .roam-app .roam-main .roam-article.dg-tldraw-maximized,
+.roam-body .roam-app .roam-main .rm-sidebar-outline.dg-tldraw-maximized {
+  position: static;
 }
 `;

--- a/apps/roam/src/components/canvas/uiOverrides.tsx
+++ b/apps/roam/src/components/canvas/uiOverrides.tsx
@@ -317,14 +317,14 @@ export const createUiOverrides = ({
   allRelationNames,
   allAddReferencedNodeByAction,
   discourseContext,
-  setMaximized,
+  toggleMaximized,
   setConvertToDialogOpen,
 }: {
   allNodes: DiscourseNode[];
   allRelationNames: string[];
   allAddReferencedNodeByAction: AddReferencedNodeType;
   discourseContext: DiscourseContextType;
-  setMaximized: () => void;
+  toggleMaximized: () => void;
   setConvertToDialogOpen: (open: boolean) => void;
 }): TLUiOverrides => ({
   tools: (editor, tools) => {
@@ -421,7 +421,7 @@ export const createUiOverrides = ({
       id: "toggle-full-screen",
       label: "action.toggle-full-screen" as TLUiTranslationKey,
       kbd: "!3",
-      onSelect: () => setMaximized(),
+      onSelect: () => toggleMaximized(),
       readonlyOk: true,
     };
 

--- a/apps/roam/src/components/canvas/uiOverrides.tsx
+++ b/apps/roam/src/components/canvas/uiOverrides.tsx
@@ -317,7 +317,6 @@ export const createUiOverrides = ({
   allRelationNames,
   allAddReferencedNodeByAction,
   discourseContext,
-  maximized,
   setMaximized,
   setConvertToDialogOpen,
 }: {
@@ -325,8 +324,7 @@ export const createUiOverrides = ({
   allRelationNames: string[];
   allAddReferencedNodeByAction: AddReferencedNodeType;
   discourseContext: DiscourseContextType;
-  maximized: boolean;
-  setMaximized: (maximized: boolean) => void;
+  setMaximized: () => void;
   setConvertToDialogOpen: (open: boolean) => void;
 }): TLUiOverrides => ({
   tools: (editor, tools) => {
@@ -423,7 +421,7 @@ export const createUiOverrides = ({
       id: "toggle-full-screen",
       label: "action.toggle-full-screen" as TLUiTranslationKey,
       kbd: "!3",
-      onSelect: () => setMaximized(!maximized),
+      onSelect: () => setMaximized(),
       readonlyOk: true,
     };
 


### PR DESCRIPTION
Before:
We were updating state which would re-render tldraw.  We also are currently not handling/saving the camera (at the moment).
So this would jump the camera to the original/last save state on minimize or maximize.  Very jarring and poor UX.

After:
Instead of state we manipulate the DOM directly.  Additionally, we use some of tldraw's built in utilities to to move the camera based on the new viewport.  It's not 100% but it is much less jarring.  We could spend a bit more time finessing it, but it is now diminishing returns.  Sidebar was not fully handled, also diminishing returns.

https://www.loom.com/share/9ff85d293fb14f11af0d7d321b9e6a6e

If we want to do sidebar:
- rm-sidebar-outline-wrapper = position:static
- .rm-sidebar-window = position:static;
- .rm-sidebar-window = rm margin left/right

and hope they don't have 2 canvas' open in sidebar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a maximize/fullscreen toggle for the canvas with smoother transitions and automatic viewport adjustment.

* **Bug Fixes**
  * Canvas now reliably fills the screen when maximized and restores the previous layout on exit.
  * Prevents layout shifting or overlap in the main content and sidebar during maximize/unmaximize.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->