### PR TITLE
[ENG-844] Add color setting for relation types

### DIFF
--- a/apps/obsidian/src/components/RelationshipTypeSettings.tsx
+++ b/apps/obsidian/src/components/RelationshipTypeSettings.tsx
@@ -12,15 +12,15 @@ const RelationshipTypeSettings = () => {
   );
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
 
-  const handleRelationTypeChange = async (
+  const handleRelationTypeChange = (
     index: number,
     field: keyof DiscourseRelationType,
     value: string,
-  ): Promise<void> => {
+  ): void => {
     const updatedRelationTypes = [...relationTypes];
     if (!updatedRelationTypes[index]) {
       const newId = generateUid("rel");
-      updatedRelationTypes[index] = { id: newId, label: "", complement: "" };
+      updatedRelationTypes[index] = { id: newId, label: "", complement: "", color: "black" };
     }
 
     updatedRelationTypes[index][field] = value;
@@ -37,6 +37,7 @@ const RelationshipTypeSettings = () => {
         id: newId,
         label: "",
         complement: "",
+        color: "black",
       },
     ];
     setRelationTypes(updatedRelationTypes);
@@ -77,7 +78,7 @@ const RelationshipTypeSettings = () => {
 
   const handleSave = async (): Promise<void> => {
     for (const relType of relationTypes) {
-      if (!relType.id || !relType.label || !relType.complement) {
+      if (!relType.id || !relType.label || !relType.complement || !relType.color) {
         new Notice("All fields are required for relation types.");
         return;
       }
@@ -124,6 +125,15 @@ const RelationshipTypeSettings = () => {
                   handleRelationTypeChange(index, "complement", e.target.value)
                 }
                 className="flex-1"
+              />
+              <input
+                type="color"
+                value={relationType.color}
+                onChange={(e) =>
+                  handleRelationTypeChange(index, "color", e.target.value)
+                }
+                className="w-12 h-8 rounded border"
+                title="Relation color"
               />
               <button
                 onClick={() => confirmDeleteRelationType(index)}

--- a/apps/obsidian/src/components/RelationshipTypeSettings.tsx
+++ b/apps/obsidian/src/components/RelationshipTypeSettings.tsx
@@ -20,7 +20,12 @@ const RelationshipTypeSettings = () => {
     const updatedRelationTypes = [...relationTypes];
     if (!updatedRelationTypes[index]) {
       const newId = generateUid("rel");
-      updatedRelationTypes[index] = { id: newId, label: "", complement: "", color: "black" };
+      updatedRelationTypes[index] = {
+        id: newId,
+        label: "",
+        complement: "",
+        color: "#000000",
+      };
     }
 
     updatedRelationTypes[index][field] = value;
@@ -37,7 +42,7 @@ const RelationshipTypeSettings = () => {
         id: newId,
         label: "",
         complement: "",
-        color: "black",
+        color: "#000000",
       },
     ];
     setRelationTypes(updatedRelationTypes);
@@ -48,6 +53,7 @@ const RelationshipTypeSettings = () => {
     const relationType = relationTypes[index] || {
       label: "Unnamed",
       complement: "",
+      color: "#000000",
     };
     const modal = new ConfirmationModal(plugin.app, {
       title: "Delete Relation Type",

--- a/apps/obsidian/src/constants.ts
+++ b/apps/obsidian/src/constants.ts
@@ -26,19 +26,19 @@ export const DEFAULT_RELATION_TYPES: Record<string, DiscourseRelationType> = {
     id: generateUid("relation"),
     label: "supports",
     complement: "is supported by",
-    color: "green",
+    color: "#008000",
   },
   opposes: {
     id: generateUid("relation"),
     label: "opposes",
     complement: "is opposed by",
-    color: "red",
+    color: "#FF0000",
   },
   informs: {
     id: generateUid("relation"),
     label: "informs",
     complement: "is informed by",
-    color: "blue",
+    color: "#0000FF",
   },
 };
 

--- a/apps/obsidian/src/constants.ts
+++ b/apps/obsidian/src/constants.ts
@@ -26,16 +26,19 @@ export const DEFAULT_RELATION_TYPES: Record<string, DiscourseRelationType> = {
     id: generateUid("relation"),
     label: "supports",
     complement: "is supported by",
+    color: "green",
   },
   opposes: {
     id: generateUid("relation"),
     label: "opposes",
     complement: "is opposed by",
+    color: "red",
   },
   informs: {
     id: generateUid("relation"),
     label: "informs",
     complement: "is informed by",
+    color: "blue",
   },
 };
 

--- a/apps/obsidian/src/constants.ts
+++ b/apps/obsidian/src/constants.ts
@@ -26,19 +26,19 @@ export const DEFAULT_RELATION_TYPES: Record<string, DiscourseRelationType> = {
     id: generateUid("relation"),
     label: "supports",
     complement: "is supported by",
-    color: "#008000",
+    color: "#099268",
   },
   opposes: {
     id: generateUid("relation"),
     label: "opposes",
     complement: "is opposed by",
-    color: "#FF0000",
+    color: "#e03131",
   },
   informs: {
     id: generateUid("relation"),
     label: "informs",
     complement: "is informed by",
-    color: "#0000FF",
+    color: "#adb5bd",
   },
 };
 

--- a/apps/obsidian/src/types.ts
+++ b/apps/obsidian/src/types.ts
@@ -14,6 +14,7 @@ export type DiscourseRelationType = {
   id: string;
   label: string;
   complement: string;
+  color: string;
 };
 
 export type DiscourseRelation = {

--- a/apps/roam/src/components/DiscourseNodeSearchMenu.tsx
+++ b/apps/roam/src/components/DiscourseNodeSearchMenu.tsx
@@ -193,7 +193,7 @@ const NodeSearchMenu = ({
   }, [filteredTypes, searchResults]);
 
   const onSelect = useCallback(
-    async (item: Result) => {
+    (item: Result) => {
       void waitForBlock(blockUid, textarea.value).then(() => {
         onClose();
 

--- a/apps/roam/src/components/DiscourseNodeSearchMenu.tsx
+++ b/apps/roam/src/components/DiscourseNodeSearchMenu.tsx
@@ -193,8 +193,8 @@ const NodeSearchMenu = ({
   }, [filteredTypes, searchResults]);
 
   const onSelect = useCallback(
-    (item: Result) => {
-      waitForBlock(blockUid, textarea.value).then(() => {
+    async (item: Result) => {
+      void waitForBlock(blockUid, textarea.value).then(() => {
         onClose();
 
         setTimeout(() => {
@@ -205,11 +205,11 @@ const NodeSearchMenu = ({
           const pageRef = `[[${item.text}]]`;
 
           const newText = `${prefix}${pageRef}${suffix}`;
-          updateBlock({ uid: blockUid, text: newText }).then(() => {
+          void updateBlock({ uid: blockUid, text: newText }).then(() => {
             const newCursorPosition = triggerPosition + pageRef.length;
 
             if (window.roamAlphaAPI.ui.setBlockFocusAndSelection) {
-              window.roamAlphaAPI.ui.setBlockFocusAndSelection({
+              void window.roamAlphaAPI.ui.setBlockFocusAndSelection({
                 location: {
                   "block-uid": blockUid,
                   "window-id": windowId,


### PR DESCRIPTION

<img width="754" height="566" alt="Screenshot 2025-09-12 at 17 44 28" src="https://github.com/user-attachments/assets/c3443c71-05c4-400f-964a-7dd7ed09f514" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Relation types now support colors. You can set a color for each relation type via a new color input.
  - Default colors applied to built-ins: Supports (green), Opposes (red), Informs (blue).
  - New relation types default to black and must include a color to save.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->