### PR TITLE
Fix jumpy new claim button when no claims exist

### DIFF
--- a/apps/roam/src/components/canvas/LabelDialog.tsx
+++ b/apps/roam/src/components/canvas/LabelDialog.tsx
@@ -133,6 +133,9 @@ const LabelDialogAutocomplete = ({
 
   const setValue = useCallback(
     (r: Result) => {
+      // Don't allow selection of disabled items
+      if (r.disabled) return;
+      
       if (action === "creating" && r.uid === initialUid) {
         // replace when migrating from format to specification
         const pageName = format.replace(/{([\w\d-]*)}/g, (_, val) => {
@@ -165,6 +168,9 @@ const LabelDialogAutocomplete = ({
   );
   const setValueFromReferencedNode = useCallback(
     (r: Result) => {
+      // Don't allow selection of disabled items
+      if (r.disabled) return;
+      
       if (!referencedNode) return;
       if (action === "editing") {
         // Hack for default shipped EVD format: [[EVD]] - {content} - {Source},
@@ -195,11 +201,19 @@ const LabelDialogAutocomplete = ({
   );
   const itemToQuery = useCallback((result?: Result) => result?.text || "", []);
   const filterOptions = useCallback(
-    (o: Result[], q: string) =>
-      fuzzy
+    (o: Result[], q: string) => {
+      const filtered = fuzzy
         .filter(q, o, { extract: itemToQuery })
         .map((f) => f.original)
-        .filter((f): f is Result => !!f),
+        .filter((f): f is Result => !!f);
+      
+      // Add "No Nodes Exist Yet" disabled item if no options available
+      if (o.length === 0) {
+        return [{ text: "No Nodes Exist Yet", uid: "", disabled: true }];
+      }
+      
+      return filtered;
+    },
     [itemToQuery],
   );
 

--- a/apps/roam/src/utils/types.ts
+++ b/apps/roam/src/utils/types.ts
@@ -42,6 +42,7 @@ export type ExportTypes = {
 export type Result = {
   text: string;
   uid: string;
+  disabled?: boolean;
 } & Record<`${string}-uid`, string> &
   Record<string, string | number | Date>;
 


### PR DESCRIPTION
Add a disabled "No Nodes Exist Yet" option to the autocomplete to prevent UI jumpiness when no claims are available.

The `AutocompleteInput` component would become "jumpy" when its `options` array was empty, as it had no items to display. This fix introduces a placeholder disabled item to maintain a stable UI and inform the user that no nodes currently exist.

---
Linear Issue: [ENG-840](https://linear.app/discourse-graphs/issue/ENG-840/new-claim-button-in-canvas-jumpy-if-no-claims-to-choose-from-to-choose)

<a href="https://cursor.com/background-agent?bcId=bc-5d70e3e5-9ae2-4392-84b8-41ca2c78d873">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5d70e3e5-9ae2-4392-84b8-41ca2c78d873">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

