### PR TITLE
ENG-805 - Set default font to sans for Discourse Nodes on Canvas

### DIFF
--- a/apps/roam/src/components/Export.tsx
+++ b/apps/roam/src/components/Export.tsx
@@ -351,7 +351,7 @@ const ExportDialog: ExportDialogComponent = ({
           uid: r.uid,
           title: String(r[firstColumnKey]),
           imageUrl,
-          size: "m",
+          size: "s",
           fontFamily: "sans",
         },
         parentId: pageKey,

--- a/apps/roam/src/components/Export.tsx
+++ b/apps/roam/src/components/Export.tsx
@@ -352,7 +352,7 @@ const ExportDialog: ExportDialogComponent = ({
           title: String(r[firstColumnKey]),
           imageUrl,
           size: "m",
-          fontFamily: "draw",
+          fontFamily: "sans",
         },
         parentId: pageKey,
         y: shapeY,

--- a/apps/roam/src/components/canvas/DiscourseNodeUtil.tsx
+++ b/apps/roam/src/components/canvas/DiscourseNodeUtil.tsx
@@ -122,6 +122,7 @@ export const createNodeShapeTools = (
           type: this.shapeType,
           x: currentPagePoint.x,
           y: currentPagePoint.y,
+          props: { fontFamily: "sans", size: "s" },
         });
         this.editor.setEditingShape(shapeId);
         this.editor.setCurrentTool("select");
@@ -200,8 +201,8 @@ export class BaseDiscourseNodeUtil extends ShapeUtil<DiscourseNodeShape> {
       h: 64,
       uid: window.roamAlphaAPI.util.generateUID(),
       title: "",
-      size: "m",
-      fontFamily: "draw",
+      size: "s",
+      fontFamily: "sans",
     };
   }
 

--- a/apps/roam/src/components/canvas/DiscourseToolPanel.tsx
+++ b/apps/roam/src/components/canvas/DiscourseToolPanel.tsx
@@ -157,6 +157,7 @@ const DiscourseGraphPanel = ({
               type: current.item.id,
               x: pagePoint.x,
               y: pagePoint.y,
+              props: { fontFamily: "sans", size: "s" },
             });
             editor.setEditingShape(shapeId);
             editor.setCurrentTool("select");

--- a/apps/roam/src/components/canvas/Tldraw.tsx
+++ b/apps/roam/src/components/canvas/Tldraw.tsx
@@ -502,8 +502,8 @@ const TldrawCanvas = ({ title }: { title: string }) => {
             props: {
               uid: e.detail.uid,
               title: e.detail.val,
-              size: "m",
-              fontFamily: "draw",
+              size: "s",
+              fontFamily: "sans",
             },
             ...position,
           },

--- a/apps/roam/src/components/canvas/uiOverrides.tsx
+++ b/apps/roam/src/components/canvas/uiOverrides.tsx
@@ -103,7 +103,15 @@ const convertToDiscourseNode = async ({
     {
       type,
       id: createShapeId(),
-      props: { uid, title: nodeText, h, w, imageUrl },
+      props: {
+        uid,
+        title: nodeText,
+        h,
+        w,
+        imageUrl,
+        fontFamily: "sans",
+        size: "s",
+      },
       x,
       y,
     },


### PR DESCRIPTION
Settings default size back to `s` as well, as Discourse Nodes are general long titles.

<img width="983" height="1435" alt="image" src="https://github.com/user-attachments/assets/f15fb632-40fd-42b4-a553-ee110e7c12a2" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * New discourse nodes now default to a sans font and small size for a cleaner, more consistent appearance.
  * Change applies across all creation paths (tool panel, query action, conversions, and exports).
  * Exported canvases render shape titles with a sans font for improved readability; existing nodes remain unchanged.
* **Chores**
  * No changes to public APIs or signatures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->