### PR TITLE
ENG-851 Get left sidebar sections and settings from config page

### DIFF
--- a/apps/roam/src/components/settings/GeneralSettings.tsx
+++ b/apps/roam/src/components/settings/GeneralSettings.tsx
@@ -10,6 +10,7 @@ const DiscourseGraphHome = () => {
     return getFormattedConfigTree();
   }, []);
 
+  console.log("settings", settings);
   return (
     <div className="flex flex-col gap-4 p-1">
       <TextPanel

--- a/apps/roam/src/components/settings/GeneralSettings.tsx
+++ b/apps/roam/src/components/settings/GeneralSettings.tsx
@@ -10,7 +10,6 @@ const DiscourseGraphHome = () => {
     return getFormattedConfigTree();
   }, []);
 
-  console.log("settings", settings);
   return (
     <div className="flex flex-col gap-4 p-1">
       <TextPanel

--- a/apps/roam/src/utils/discourseConfigRef.ts
+++ b/apps/roam/src/utils/discourseConfigRef.ts
@@ -11,6 +11,10 @@ import {
   getSuggestiveModeConfigAndUids,
   SuggestiveModeConfigWithUids,
 } from "./getSuggestiveModeConfigSettings";
+import {
+  getLeftSidebarSettings,
+  LeftSidebarConfig,
+} from "./getLeftSidebarSettings";
 
 const configTreeRef: {
   tree: RoamBasicNode[];
@@ -26,6 +30,7 @@ type FormattedConfigTree = {
   export: ExportConfigWithUids;
   canvasPageFormat: StringSetting;
   suggestiveMode: SuggestiveModeConfigWithUids;
+  leftSidebar: LeftSidebarConfig;
 };
 
 export const getFormattedConfigTree = (): FormattedConfigTree => {
@@ -53,6 +58,7 @@ export const getFormattedConfigTree = (): FormattedConfigTree => {
       text: "Canvas Page Format",
     }),
     suggestiveMode: getSuggestiveModeConfigAndUids(configTreeRef.tree),
+    leftSidebar: getLeftSidebarSettings(configTreeRef.tree),
   };
 };
 export default configTreeRef;

--- a/apps/roam/src/utils/getLeftSidebarSettings.ts
+++ b/apps/roam/src/utils/getLeftSidebarSettings.ts
@@ -13,12 +13,11 @@ import getCurrentUserDisplayName from "roamjs-components/queries/getCurrentUserD
 type LeftSidebarPersonalSectionSettings = {
   uid: string;
   truncateResult: IntSetting;
-  collapsable: BooleanSetting;
   folded: BooleanSetting;
   alias: StringSetting | null;
 };
 
-type LeftSidebarPersonalSectionConfig = {
+export type LeftSidebarPersonalSectionConfig = {
   uid: string;
   text: string;
   sectionWithoutSettingsAndChildren: boolean;
@@ -29,6 +28,7 @@ type LeftSidebarPersonalSectionConfig = {
 
 type LeftSidebarGlobalSectionConfig = {
   uid: string;
+  collapsable: BooleanSetting;
   folded: BooleanSetting;
   children: RoamBasicNode[];
   childrenUid: string;
@@ -50,8 +50,6 @@ const getLeftSidebarGlobalSectionConfig = (
     key: "Global-Section",
   });
   const globalChildren = globalSectionNode?.children || [];
-  const getBoolean = (text: string) =>
-    getUidAndBooleanSetting({ tree: globalChildren, text });
 
   const childrenNode = getSubTree({
     tree: globalChildren,
@@ -60,7 +58,11 @@ const getLeftSidebarGlobalSectionConfig = (
 
   return {
     uid: globalSectionNode?.uid || "",
-    folded: getBoolean("Folded"),
+    collapsable: getUidAndBooleanSetting({
+      tree: globalChildren,
+      text: "Collapsable",
+    }),
+    folded: getUidAndBooleanSetting({ tree: globalChildren, text: "Folded" }),
     children: childrenNode?.children || [],
     childrenUid: childrenNode?.uid || "",
   };
@@ -79,13 +81,9 @@ const getPersonalSectionSettings = (
   if (truncateResultSetting.value === 0) {
     truncateResultSetting.value = 75;
   }
-  const collapsableSetting = getUidAndBooleanSetting({
-    tree: settingsTree,
-    text: "Collapsable?",
-  });
   const foldedSetting = getUidAndBooleanSetting({
     tree: settingsTree,
-    text: "Folded?",
+    text: "Folded",
   });
 
   const aliasString = getUidAndStringSetting({
@@ -101,7 +99,6 @@ const getPersonalSectionSettings = (
   return {
     uid: settingsNode.uid,
     truncateResult: truncateResultSetting,
-    collapsable: collapsableSetting,
     folded: foldedSetting,
     alias,
   };
@@ -116,6 +113,13 @@ const getLeftSidebarPersonalSectionConfig = (
     tree: leftSidebarChildren,
     key: userName + "/Personal-Section",
   });
+
+  if (personalLeftSidebarNode.uid === "") {
+    return {
+      uid: "",
+      sections: [],
+    };
+  }
 
   const sections = (personalLeftSidebarNode?.children || []).map(
     (sectionNode): LeftSidebarPersonalSectionConfig => {

--- a/apps/roam/src/utils/getLeftSidebarSettings.ts
+++ b/apps/roam/src/utils/getLeftSidebarSettings.ts
@@ -136,18 +136,11 @@ const getLeftSidebarPersonalSectionConfig = (
   leftSidebarChildren: RoamBasicNode[],
 ): { uid: string; sections: LeftSidebarPersonalSectionConfig[] } => {
   const userName = getCurrentUserDisplayName();
-  console.log(
-    "userName",
-    userName,
-    leftSidebarChildren,
-    "[[" + userName + "]]/Personal-Section",
-  );
 
   const personalLeftSidebarNode = getSubTree({
     tree: leftSidebarChildren,
-    key: "\\\\[\\\\[" + userName + "\\\\]\\\\]/Personal-Section",
+    key: userName + "/Personal-Section",
   });
-  console.log("personalLeftSidebarNode", personalLeftSidebarNode);
 
   if (personalLeftSidebarNode.uid === "") {
     return {

--- a/apps/roam/src/utils/getLeftSidebarSettings.ts
+++ b/apps/roam/src/utils/getLeftSidebarSettings.ts
@@ -8,7 +8,6 @@ import {
   StringSetting,
 } from "./getExportSettings";
 import { getSubTree } from "roamjs-components/util";
-import getCurrentUserDisplayName from "roamjs-components/queries/getCurrentUserDisplayName";
 
 type LeftSidebarPersonalSectionSettings = {
   uid: string;
@@ -135,11 +134,11 @@ const getPersonalSectionSettings = (
 const getLeftSidebarPersonalSectionConfig = (
   leftSidebarChildren: RoamBasicNode[],
 ): { uid: string; sections: LeftSidebarPersonalSectionConfig[] } => {
-  const userName = getCurrentUserDisplayName();
+  const userUid = window.roamAlphaAPI.user.uid();
 
   const personalLeftSidebarNode = getSubTree({
     tree: leftSidebarChildren,
-    key: userName + "/Personal-Section",
+    key: userUid + "/Personal-Section",
   });
 
   if (personalLeftSidebarNode.uid === "") {

--- a/apps/roam/src/utils/getLeftSidebarSettings.ts
+++ b/apps/roam/src/utils/getLeftSidebarSettings.ts
@@ -26,10 +26,15 @@ export type LeftSidebarPersonalSectionConfig = {
   childrenUid?: string;
 };
 
-type LeftSidebarGlobalSectionConfig = {
+type LeftSidebarGlobalSectionSettings = {
   uid: string;
   collapsable: BooleanSetting;
   folded: BooleanSetting;
+};
+
+type LeftSidebarGlobalSectionConfig = {
+  uid: string;
+  settings?: LeftSidebarGlobalSectionSettings;
   children: RoamBasicNode[];
   childrenUid: string;
 };
@@ -39,6 +44,25 @@ export type LeftSidebarConfig = {
   personal: {
     uid: string;
     sections: LeftSidebarPersonalSectionConfig[];
+  };
+};
+
+const getGlobalSectionSettings = (
+  settingsNode: RoamBasicNode,
+): LeftSidebarGlobalSectionSettings => {
+  const settingsTree = settingsNode?.children || [];
+  const collapsableSetting = getUidAndBooleanSetting({
+    tree: settingsTree,
+    text: "Collapsable",
+  });
+  const foldedSetting = getUidAndBooleanSetting({
+    tree: settingsTree,
+    text: "Folded",
+  });
+  return {
+    uid: settingsNode.uid,
+    collapsable: collapsableSetting,
+    folded: foldedSetting,
   };
 };
 
@@ -56,13 +80,17 @@ const getLeftSidebarGlobalSectionConfig = (
     key: "Children",
   });
 
+  const settingsNode = getSubTree({
+    tree: globalChildren,
+    key: "Settings",
+  });
+  const settings = settingsNode
+    ? getGlobalSectionSettings(settingsNode)
+    : undefined;
+
   return {
     uid: globalSectionNode?.uid || "",
-    collapsable: getUidAndBooleanSetting({
-      tree: globalChildren,
-      text: "Collapsable",
-    }),
-    folded: getUidAndBooleanSetting({ tree: globalChildren, text: "Folded" }),
+    settings,
     children: childrenNode?.children || [],
     childrenUid: childrenNode?.uid || "",
   };
@@ -108,11 +136,18 @@ const getLeftSidebarPersonalSectionConfig = (
   leftSidebarChildren: RoamBasicNode[],
 ): { uid: string; sections: LeftSidebarPersonalSectionConfig[] } => {
   const userName = getCurrentUserDisplayName();
+  console.log(
+    "userName",
+    userName,
+    leftSidebarChildren,
+    "[[" + userName + "]]/Personal-Section",
+  );
 
   const personalLeftSidebarNode = getSubTree({
     tree: leftSidebarChildren,
-    key: userName + "/Personal-Section",
+    key: "\\\\[\\\\[" + userName + "\\\\]\\\\]/Personal-Section",
   });
+  console.log("personalLeftSidebarNode", personalLeftSidebarNode);
 
   if (personalLeftSidebarNode.uid === "") {
     return {

--- a/apps/roam/src/utils/getLeftSidebarSettings.ts
+++ b/apps/roam/src/utils/getLeftSidebarSettings.ts
@@ -1,0 +1,171 @@
+import { RoamBasicNode } from "roamjs-components/types";
+import {
+  BooleanSetting,
+  getUidAndBooleanSetting,
+  getUidAndStringSetting,
+  IntSetting,
+  getUidAndIntSetting,
+  StringSetting,
+} from "./getExportSettings";
+import { getSubTree } from "roamjs-components/util";
+import getCurrentUserDisplayName from "roamjs-components/queries/getCurrentUserDisplayName";
+
+type LeftSidebarPersonalSectionSettings = {
+  uid: string;
+  truncateResult: IntSetting;
+  collapsable: BooleanSetting;
+  folded: BooleanSetting;
+  alias: StringSetting | null;
+};
+
+type LeftSidebarPersonalSectionConfig = {
+  uid: string;
+  text: string;
+  sectionWithoutSettingsAndChildren: boolean;
+  settings?: LeftSidebarPersonalSectionSettings;
+  children?: RoamBasicNode[];
+  childrenUid?: string;
+};
+
+type LeftSidebarGlobalSectionConfig = {
+  uid: string;
+  folded: BooleanSetting;
+  children: RoamBasicNode[];
+  childrenUid: string;
+};
+
+export type LeftSidebarConfig = {
+  global: LeftSidebarGlobalSectionConfig;
+  personal: {
+    uid: string;
+    sections: LeftSidebarPersonalSectionConfig[];
+  };
+};
+
+const getLeftSidebarGlobalSectionConfig = (
+  leftSidebarChildren: RoamBasicNode[],
+): LeftSidebarGlobalSectionConfig => {
+  const globalSectionNode = getSubTree({
+    tree: leftSidebarChildren,
+    key: "Global-Section",
+  });
+  const globalChildren = globalSectionNode?.children || [];
+  const getBoolean = (text: string) =>
+    getUidAndBooleanSetting({ tree: globalChildren, text });
+
+  const childrenNode = getSubTree({
+    tree: globalChildren,
+    key: "Children",
+  });
+
+  return {
+    uid: globalSectionNode?.uid || "",
+    folded: getBoolean("Folded"),
+    children: childrenNode?.children || [],
+    childrenUid: childrenNode?.uid || "",
+  };
+};
+
+const getPersonalSectionSettings = (
+  settingsNode: RoamBasicNode,
+): LeftSidebarPersonalSectionSettings => {
+  const settingsTree = settingsNode?.children || [];
+
+  const truncateResultSetting = getUidAndIntSetting({
+    tree: settingsTree,
+    text: "Truncate-result?",
+  });
+
+  if (truncateResultSetting.value === 0) {
+    truncateResultSetting.value = 75;
+  }
+  const collapsableSetting = getUidAndBooleanSetting({
+    tree: settingsTree,
+    text: "Collapsable?",
+  });
+  const foldedSetting = getUidAndBooleanSetting({
+    tree: settingsTree,
+    text: "Folded?",
+  });
+
+  const aliasString = getUidAndStringSetting({
+    tree: settingsTree,
+    text: "Alias",
+  });
+  const alias =
+    aliasString.value === "Alias" ||
+    (aliasString.value === "" && aliasString.uid)
+      ? null
+      : aliasString;
+
+  return {
+    uid: settingsNode.uid,
+    truncateResult: truncateResultSetting,
+    collapsable: collapsableSetting,
+    folded: foldedSetting,
+    alias,
+  };
+};
+
+const getLeftSidebarPersonalSectionConfig = (
+  leftSidebarChildren: RoamBasicNode[],
+): { uid: string; sections: LeftSidebarPersonalSectionConfig[] } => {
+  const userName = getCurrentUserDisplayName();
+
+  const personalLeftSidebarNode = getSubTree({
+    tree: leftSidebarChildren,
+    key: userName + "/Personal-Section",
+  });
+
+  const sections = (personalLeftSidebarNode?.children || []).map(
+    (sectionNode): LeftSidebarPersonalSectionConfig => {
+      const settingsNode = sectionNode.children?.find(
+        (child) => child.text === "Settings",
+      );
+      const childrenNode = sectionNode.children?.find(
+        (child) => child.text === "Children",
+      );
+
+      const sectionWithoutSettingsAndChildren = !settingsNode && !childrenNode;
+
+      if (sectionWithoutSettingsAndChildren) {
+        return {
+          uid: sectionNode.uid,
+          text: sectionNode.text,
+          sectionWithoutSettingsAndChildren: true,
+        };
+      } else {
+        return {
+          uid: sectionNode.uid,
+          text: sectionNode.text,
+          settings: settingsNode
+            ? getPersonalSectionSettings(settingsNode)
+            : undefined,
+          children: childrenNode?.children || [],
+          childrenUid: childrenNode?.uid || "",
+          sectionWithoutSettingsAndChildren: false,
+        };
+      }
+    },
+  );
+
+  return {
+    uid: personalLeftSidebarNode.uid,
+    sections,
+  };
+};
+
+export const getLeftSidebarSettings = (
+  globalTree: RoamBasicNode[],
+): LeftSidebarConfig => {
+  const leftSidebarNode = globalTree.find(
+    (node) => node.text === "Left Sidebar",
+  );
+  const leftSidebarChildren = leftSidebarNode?.children || [];
+  const global = getLeftSidebarGlobalSectionConfig(leftSidebarChildren);
+  const personal = getLeftSidebarPersonalSectionConfig(leftSidebarChildren);
+  return {
+    global,
+    personal,
+  };
+};


### PR DESCRIPTION
The settings are going to be saved in `roam/js/discourse-graph` page, the structure is going to be as in following example:

- Left Sidebar
    - siddharth yadav/Personal-Section
        - CLM
        - July 16th, 2025
            - Settings
                - Folded
                - Collapsable?
                - Truncate-result?
                    - 75
                - Alias
                    - happy day 2
            - Children
                - Test/Home
                - July 16th, 2025
        - 📝 Daily Notes {{Create Today's Entry:SmartBlock:UserDNPToday:RemoveButton=false}} {{Pick A Day:SmartBlock:UserDNPDateSelect:RemoveButton=false}}
            - Settings
                - Collapsable?
                - Folded
                - Truncate-result?
                    - 75
                - Alias
                    - Daily notes
            - Children
    - Global-Section
        - Folded
        - Children
            - Canvas
            - May 13th, 2025

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
    - Added left sidebar configuration support with global and per-user sections.
    - Sidebar now honors settings like collapsible sections, folded state, truncation length, and aliases.
    - Personal sections are tailored to the current user with sensible defaults when settings are missing.
    - Improved handling of sidebar children and structure for more consistent rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->