### PR TITLE
ENG-853 left sidebar global and personal settings

### DIFF
--- a/apps/roam/src/components/LeftSidebarView.tsx
+++ b/apps/roam/src/components/LeftSidebarView.tsx
@@ -23,7 +23,7 @@ const parseReference = (text: string) => {
   if (text.startsWith("((") && text.endsWith("))")) {
     return { type: "block" as const, uid: extracted, display: text };
   } else {
-    return { type: "page" as const, title: extracted, display: extracted };
+    return { type: "page" as const, display: text };
   }
 };
 
@@ -141,23 +141,7 @@ const PersonalSectionItem = ({
   );
   const alias = section.settings?.alias?.value;
 
-  if (section.sectionWithoutSettingsAndChildren) {
-    const onClick = (e: React.MouseEvent<HTMLDivElement>) => {
-      return void openTarget(e, section.text);
-    };
-    return (
-      <>
-        <div
-          className="sidebar-title-button cursor-pointer rounded-sm py-1 font-semibold leading-normal"
-          onClick={onClick}
-        >
-          {(blockText || titleRef.title)?.toUpperCase()}
-        </div>
-      </>
-    );
-  }
-
-  const handleChevronClick = (e: React.MouseEvent) => {
+  const handleChevronClick = () => {
     if (!section.settings) return;
 
     toggleFoldedState({

--- a/apps/roam/src/components/LeftSidebarView.tsx
+++ b/apps/roam/src/components/LeftSidebarView.tsx
@@ -17,6 +17,7 @@ import { createBlock } from "roamjs-components/writes";
 import deleteBlock from "roamjs-components/writes/deleteBlock";
 import getTextByBlockUid from "roamjs-components/queries/getTextByBlockUid";
 import refreshConfigTree from "~/utils/refreshConfigTree";
+import { Dispatch, SetStateAction } from "react";
 
 const parseReference = (text: string) => {
   const extracted = extractRef(text);
@@ -68,7 +69,7 @@ const toggleFoldedState = ({
   parentUid,
 }: {
   isOpen: boolean;
-  setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  setIsOpen: Dispatch<SetStateAction<boolean>>;
   folded: { uid?: string; value: boolean };
   parentUid: string;
 }) => {

--- a/apps/roam/src/components/LeftSidebarView.tsx
+++ b/apps/roam/src/components/LeftSidebarView.tsx
@@ -1,10 +1,14 @@
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import ReactDOM from "react-dom";
 import { Collapse, Icon } from "@blueprintjs/core";
 import getPageUidByPageTitle from "roamjs-components/queries/getPageUidByPageTitle";
 import openBlockInSidebar from "roamjs-components/writes/openBlockInSidebar";
 import extractRef from "roamjs-components/util/extractRef";
-import { getFormattedConfigTree } from "~/utils/discourseConfigRef";
+import {
+  getFormattedConfigTree,
+  notify,
+  subscribe,
+} from "~/utils/discourseConfigRef";
 import type {
   LeftSidebarConfig,
   LeftSidebarPersonalSectionConfig,
@@ -12,6 +16,7 @@ import type {
 import { createBlock } from "roamjs-components/writes";
 import deleteBlock from "roamjs-components/writes/deleteBlock";
 import getTextByBlockUid from "roamjs-components/queries/getTextByBlockUid";
+import refreshConfigTree from "~/utils/refreshConfigTree";
 
 const parseReference = (text: string) => {
   const extracted = extractRef(text);
@@ -250,8 +255,30 @@ const GlobalSection = ({ config }: { config: LeftSidebarConfig["global"] }) => {
   );
 };
 
+export const useConfig = () => {
+  const [config, setConfig] = useState(
+    () => getFormattedConfigTree().leftSidebar,
+  );
+  useEffect(() => {
+    const handleUpdate = () => {
+      setConfig(getFormattedConfigTree().leftSidebar);
+    };
+    const unsubscribe = subscribe(handleUpdate);
+    return () => {
+      unsubscribe();
+    };
+  }, []);
+  return config;
+};
+
+export const refreshAndNotify = () => {
+  refreshConfigTree();
+  notify();
+};
+
+
 const LeftSidebarView = () => {
-  const config = useMemo(() => getFormattedConfigTree().leftSidebar, []);
+  const config = useConfig();
 
   return (
     <>

--- a/apps/roam/src/components/settings/LeftSidebarGlobalSettings.tsx
+++ b/apps/roam/src/components/settings/LeftSidebarGlobalSettings.tsx
@@ -59,12 +59,11 @@ const LeftSidebarGlobalSectionsContent = ({
     const initialize = async () => {
       setIsInitializing(true);
       const globalSectionText = "Global-Section";
+      let config = getLeftSidebarGlobalSectionConfig(leftSidebar.children);
 
       const existingGlobalSection = leftSidebar.children.find(
         (n) => n.text === globalSectionText,
       );
-      const config = getLeftSidebarGlobalSectionConfig(leftSidebar.children);
-      setGlobalSection(config);
 
       if (!existingGlobalSection) {
         try {
@@ -85,7 +84,7 @@ const LeftSidebarGlobalSectionsContent = ({
               ],
             },
           });
-
+          config = getLeftSidebarGlobalSectionConfig(leftSidebar.children);
           setChildrenUid(childrenUid || null);
           setPages([]);
         } catch (error) {
@@ -95,6 +94,7 @@ const LeftSidebarGlobalSectionsContent = ({
         setChildrenUid(config.childrenUid || null);
         setPages(config.children || []);
       }
+      setGlobalSection(config);
       setIsInitializing(false);
     };
 
@@ -178,27 +178,36 @@ const LeftSidebarGlobalSectionsContent = ({
 
   return (
     <div className="flex flex-col gap-4 p-1">
-      <div className="rounded-md border p-3">
-        <div className="mb-2 text-sm font-medium text-gray-700">Settings</div>
+      <div
+        className="global-section-settings rounded-md p-3 hover:bg-gray-50"
+        style={{
+          border: "1px solid rgba(51, 51, 51, 0.2)",
+        }}
+      >
         <FlagPanel
           title="Folded"
-          description="Start with global section collapsed in left sidebar"
+          description="If children are present, start with global section collapsed in left sidebar"
           order={0}
-          uid={globalSection.folded?.uid || ""}
+          uid={globalSection.settings?.folded?.uid || ""}
           parentUid={globalSection.uid || parentUid}
-          value={globalSection.folded?.value || false}
+          disabled={!globalSection.children?.length}
         />
         <FlagPanel
           title="Collapsable"
           description="Make global section collapsable"
           order={1}
-          uid={globalSection.collapsable?.uid || ""}
+          uid={globalSection.settings?.collapsable?.uid || ""}
           parentUid={globalSection.uid || parentUid}
-          value={globalSection.collapsable?.value || false}
+          value={globalSection.settings?.collapsable?.value || false}
         />
       </div>
 
-      <div className="rounded-md border p-3">
+      <div
+        className="global-section-children rounded-md p-3 hover:bg-gray-50"
+        style={{
+          border: "1px solid rgba(51, 51, 51, 0.2)",
+        }}
+      >
         <div className="mb-2 flex items-center justify-between">
           <div className="flex items-center gap-2">
             <Button

--- a/apps/roam/src/components/settings/LeftSidebarGlobalSettings.tsx
+++ b/apps/roam/src/components/settings/LeftSidebarGlobalSettings.tsx
@@ -1,0 +1,278 @@
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { Button, Collapse } from "@blueprintjs/core";
+import FlagPanel from "roamjs-components/components/ConfigPanels/FlagPanel";
+import AutocompleteInput from "roamjs-components/components/AutocompleteInput";
+import getAllPageNames from "roamjs-components/queries/getAllPageNames";
+import createBlock from "roamjs-components/writes/createBlock";
+import deleteBlock from "roamjs-components/writes/deleteBlock";
+import type { RoamBasicNode } from "roamjs-components/types";
+import { getSubTree } from "roamjs-components/util";
+import getPageUidByPageTitle from "roamjs-components/queries/getPageUidByPageTitle";
+import discourseConfigRef from "~/utils/discourseConfigRef";
+import { DISCOURSE_CONFIG_PAGE_TITLE } from "~/utils/renderNodeConfigPage";
+import { getLeftSidebarGlobalSectionConfig } from "~/utils/getLeftSidebarSettings";
+import { LeftSidebarGlobalSectionConfig } from "~/utils/getLeftSidebarSettings";
+
+const PageItem = React.memo(
+  ({
+    page,
+    onRemove,
+  }: {
+    page: RoamBasicNode;
+    onRemove: (page: RoamBasicNode) => void;
+  }) => {
+    return (
+      <div className="flex items-center justify-between rounded bg-gray-50 p-2 hover:bg-gray-100">
+        <span className="flex-grow truncate">{page.text}</span>
+        <Button
+          icon="trash"
+          minimal
+          small
+          intent="danger"
+          onClick={() => onRemove(page)}
+          title="Remove page"
+        />
+      </div>
+    );
+  },
+);
+
+PageItem.displayName = "PageItem";
+
+const LeftSidebarGlobalSectionsContent = ({
+  leftSidebar,
+}: {
+  leftSidebar: RoamBasicNode;
+}) => {
+  const [globalSection, setGlobalSection] =
+    useState<LeftSidebarGlobalSectionConfig | null>(null);
+  const [pages, setPages] = useState<RoamBasicNode[]>([]);
+  const [childrenUid, setChildrenUid] = useState<string | null>(null);
+  const [newPageInput, setNewPageInput] = useState("");
+  const [autocompleteKey, setAutocompleteKey] = useState(0);
+  const [isInitializing, setIsInitializing] = useState(true);
+  const [isExpanded, setIsExpanded] = useState(true);
+
+  const pageNames = useMemo(() => getAllPageNames(), []);
+
+  useEffect(() => {
+    const initialize = async () => {
+      setIsInitializing(true);
+      const globalSectionText = "Global-Section";
+
+      const existingGlobalSection = leftSidebar.children.find(
+        (n) => n.text === globalSectionText,
+      );
+
+      if (!existingGlobalSection) {
+        try {
+          const childrenUid = window.roamAlphaAPI.util.generateUID();
+          await createBlock({
+            parentUid: leftSidebar.uid,
+            order: 0,
+            node: {
+              text: globalSectionText,
+              children: [
+                {
+                  text: "Folded",
+                },
+                {
+                  text: "Children",
+                  uid: childrenUid,
+                },
+              ],
+            },
+          });
+
+          const config = getLeftSidebarGlobalSectionConfig(
+            leftSidebar.children,
+          );
+          setGlobalSection(config);
+          setChildrenUid(childrenUid || null);
+          setPages([]);
+        } catch (error) {
+          console.error("Failed to create global section:", error);
+        }
+      } else {
+        const config = getLeftSidebarGlobalSectionConfig(
+          existingGlobalSection.children,
+        );
+        setGlobalSection(config);
+        setChildrenUid(config.childrenUid || null);
+        setPages(config.children || []);
+      }
+      setIsInitializing(false);
+    };
+
+    void initialize();
+  }, [leftSidebar]);
+
+  const addPage = useCallback(
+    async (pageName: string) => {
+      if (!pageName || !childrenUid) return;
+
+      if (pages.some((p) => p.text === pageName)) {
+        console.warn(`Page "${pageName}" already exists in global section`);
+        return;
+      }
+
+      try {
+        const newPageUid = await createBlock({
+          parentUid: childrenUid,
+          order: "last",
+          node: { text: pageName },
+        });
+
+        const newPage: RoamBasicNode = {
+          text: pageName,
+          uid: newPageUid,
+          children: [],
+        };
+
+        setPages((prev) => [...prev, newPage]);
+        setNewPageInput("");
+        setAutocompleteKey((prev) => prev + 1);
+      } catch (error) {
+        console.error("Failed to add page:", error);
+      }
+    },
+    [childrenUid, pages],
+  );
+
+  const removePage = useCallback(async (page: RoamBasicNode) => {
+    try {
+      await deleteBlock(page.uid);
+      setPages((prev) => prev.filter((p) => p.uid !== page.uid));
+    } catch (error) {
+      console.error("Failed to remove page:", error);
+    }
+  }, []);
+
+  const handlePageInputChange = useCallback((value: string) => {
+    setNewPageInput(value);
+  }, []);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Enter" && newPageInput) {
+        e.preventDefault();
+        e.stopPropagation();
+        void addPage(newPageInput);
+      }
+    },
+    [newPageInput, addPage],
+  );
+
+  const toggleChildren = useCallback(() => {
+    setIsExpanded((prev) => !prev);
+  }, []);
+
+  const isAddButtonDisabled = useMemo(
+    () => !newPageInput || pages.some((p) => p.text === newPageInput),
+    [newPageInput, pages],
+  );
+
+  const parentUid = leftSidebar.uid;
+
+  if (isInitializing || !globalSection) {
+    return (
+      <div className="flex items-center justify-center p-4">
+        <span className="text-gray-500">Loading...</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4 p-1">
+      <div className="rounded-md border p-3">
+        <div className="mb-2 text-sm font-medium text-gray-700">Settings</div>
+        <FlagPanel
+          title="Folded"
+          description="Start with global section collapsed in left sidebar"
+          order={0}
+          uid={globalSection.folded?.uid || ""}
+          parentUid={globalSection.uid || parentUid}
+          value={globalSection.folded?.value || false}
+        />
+        <FlagPanel
+          title="Collapsable"
+          description="Make global section collapsable"
+          order={1}
+          uid={globalSection.collapsable?.uid || ""}
+          parentUid={globalSection.uid || parentUid}
+          value={globalSection.collapsable?.value || false}
+        />
+      </div>
+
+      <div className="rounded-md border p-3">
+        <div className="mb-2 flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <Button
+              icon={isExpanded ? "chevron-down" : "chevron-right"}
+              minimal
+              small
+              onClick={toggleChildren}
+            />
+            <span className="text-sm font-medium text-gray-700">Children</span>
+          </div>
+          <span className="text-sm text-gray-500">
+            {pages.length} {pages.length === 1 ? "page" : "pages"}
+          </span>
+        </div>
+
+        <Collapse isOpen={isExpanded}>
+          <div className="ml-6">
+            <div className="mb-2 text-sm text-gray-600">
+              Add pages that will appear for all users
+            </div>
+            <div
+              className="mb-3 flex items-center gap-2"
+              onKeyDown={handleKeyDown}
+            >
+              <AutocompleteInput
+                key={autocompleteKey}
+                value={newPageInput}
+                setValue={handlePageInputChange}
+                placeholder="Add page…"
+                options={pageNames}
+                maxItemsDisplayed={50}
+              />
+              <Button
+                icon="plus"
+                small
+                minimal
+                disabled={isAddButtonDisabled}
+                onClick={() => void addPage(newPageInput)}
+                title="Add page"
+              />
+            </div>
+            {pages.length > 0 ? (
+              <div className="space-y-1">
+                {pages.map((page) => (
+                  <PageItem key={page.uid} page={page} onRemove={removePage} />
+                ))}
+              </div>
+            ) : (
+              <div className="text-sm italic text-gray-400">
+                No pages added yet
+              </div>
+            )}
+          </div>
+        </Collapse>
+      </div>
+    </div>
+  );
+};
+
+export const LeftSidebarGlobalSections = () => {
+  const configPageUid = getPageUidByPageTitle(DISCOURSE_CONFIG_PAGE_TITLE);
+  const settings = discourseConfigRef.tree;
+
+  const leftSidebar = getSubTree({
+    tree: settings,
+    parentUid: configPageUid,
+    key: "Left Sidebar",
+  });
+
+  return <LeftSidebarGlobalSectionsContent leftSidebar={leftSidebar} />;
+};

--- a/apps/roam/src/components/settings/LeftSidebarGlobalSettings.tsx
+++ b/apps/roam/src/components/settings/LeftSidebarGlobalSettings.tsx
@@ -12,6 +12,7 @@ import discourseConfigRef from "~/utils/discourseConfigRef";
 import { DISCOURSE_CONFIG_PAGE_TITLE } from "~/utils/renderNodeConfigPage";
 import { getLeftSidebarGlobalSectionConfig } from "~/utils/getLeftSidebarSettings";
 import { LeftSidebarGlobalSectionConfig } from "~/utils/getLeftSidebarSettings";
+import { render as renderToast } from "roamjs-components/components/Toast";
 
 const PageItem = React.memo(
   ({
@@ -88,7 +89,11 @@ const LeftSidebarGlobalSectionsContent = ({
           setChildrenUid(childrenUid || null);
           setPages([]);
         } catch (error) {
-          console.error("Failed to create global section:", error);
+          renderToast({
+            content: "Failed to create global section",
+            intent: "danger",
+            id: "create-global-section-error",
+          });
         }
       } else {
         setChildrenUid(config.childrenUid || null);
@@ -127,7 +132,11 @@ const LeftSidebarGlobalSectionsContent = ({
         setNewPageInput("");
         setAutocompleteKey((prev) => prev + 1);
       } catch (error) {
-        console.error("Failed to add page:", error);
+        renderToast({
+          content: "Failed to add page",
+          intent: "danger",
+          id: "add-page-error",
+        });
       }
     },
     [childrenUid, pages],
@@ -138,7 +147,11 @@ const LeftSidebarGlobalSectionsContent = ({
       await deleteBlock(page.uid);
       setPages((prev) => prev.filter((p) => p.uid !== page.uid));
     } catch (error) {
-      console.error("Failed to remove page:", error);
+      renderToast({
+        content: "Failed to remove page",
+        intent: "danger",
+        id: "remove-page-error",
+      });
     }
   }, []);
 
@@ -252,7 +265,11 @@ const LeftSidebarGlobalSectionsContent = ({
             {pages.length > 0 ? (
               <div className="space-y-1">
                 {pages.map((page) => (
-                  <PageItem key={page.uid} page={page} onRemove={removePage} />
+                  <PageItem
+                    key={page.uid}
+                    page={page}
+                    onRemove={() => void removePage(page)}
+                  />
                 ))}
               </div>
             ) : (

--- a/apps/roam/src/components/settings/LeftSidebarGlobalSettings.tsx
+++ b/apps/roam/src/components/settings/LeftSidebarGlobalSettings.tsx
@@ -63,6 +63,8 @@ const LeftSidebarGlobalSectionsContent = ({
       const existingGlobalSection = leftSidebar.children.find(
         (n) => n.text === globalSectionText,
       );
+      const config = getLeftSidebarGlobalSectionConfig(leftSidebar.children);
+      setGlobalSection(config);
 
       if (!existingGlobalSection) {
         try {
@@ -84,20 +86,12 @@ const LeftSidebarGlobalSectionsContent = ({
             },
           });
 
-          const config = getLeftSidebarGlobalSectionConfig(
-            leftSidebar.children,
-          );
-          setGlobalSection(config);
           setChildrenUid(childrenUid || null);
           setPages([]);
         } catch (error) {
           console.error("Failed to create global section:", error);
         }
       } else {
-        const config = getLeftSidebarGlobalSectionConfig(
-          existingGlobalSection.children,
-        );
-        setGlobalSection(config);
         setChildrenUid(config.childrenUid || null);
         setPages(config.children || []);
       }

--- a/apps/roam/src/components/settings/LeftSidebarPersonalSettings.tsx
+++ b/apps/roam/src/components/settings/LeftSidebarPersonalSettings.tsx
@@ -16,6 +16,7 @@ import getPageUidByPageTitle from "roamjs-components/queries/getPageUidByPageTit
 import { DISCOURSE_CONFIG_PAGE_TITLE } from "~/utils/renderNodeConfigPage";
 import getCurrentUserDisplayName from "roamjs-components/queries/getCurrentUserDisplayName";
 import { getLeftSidebarPersonalSectionConfig } from "~/utils/getLeftSidebarSettings";
+import { render as renderToast } from "roamjs-components/components/Toast";
 
 const SectionItem = React.memo(
   ({
@@ -147,7 +148,7 @@ const SectionItem = React.memo(
                   small
                   minimal
                   disabled={!childInput}
-                  onClick={handleAddChild}
+                  onClick={() => void handleAddChild()}
                   title="Add child"
                 />
               </div>
@@ -266,7 +267,11 @@ const LeftSidebarPersonalSectionsContent = ({
         setNewSectionInput("");
         setAutocompleteKey((prev) => prev + 1);
       } catch (error) {
-        console.error("Failed to add section:", error);
+        renderToast({
+          content: "Failed to add section",
+          intent: "danger",
+          id: "add-section-error",
+        });
       }
     },
     [personalSectionUid, sections],
@@ -279,7 +284,11 @@ const LeftSidebarPersonalSectionsContent = ({
 
         setSections((prev) => prev.filter((s) => s.uid !== section.uid));
       } catch (error) {
-        console.error("Failed to remove section:", error);
+        renderToast({
+          content: "Failed to remove section",
+          intent: "danger",
+          id: "remove-section-error",
+        });
       }
     },
     [],
@@ -349,7 +358,11 @@ const LeftSidebarPersonalSectionsContent = ({
 
         setExpandedChildLists((prev) => new Set([...prev, section.uid]));
       } catch (error) {
-        console.error("Failed to convert to complex section:", error);
+        renderToast({
+          content: "Failed to convert to complex section",
+          intent: "danger",
+          id: "convert-to-complex-section-error",
+        });
       }
     },
     [],
@@ -389,7 +402,11 @@ const LeftSidebarPersonalSectionsContent = ({
           }),
         );
       } catch (error) {
-        console.error("Failed to add child:", error);
+        renderToast({
+          content: "Failed to add child",
+          intent: "danger",
+          id: "add-child-error",
+        });
       }
     },
     [],
@@ -412,7 +429,11 @@ const LeftSidebarPersonalSectionsContent = ({
           }),
         );
       } catch (error) {
-        console.error("Failed to remove child:", error);
+        renderToast({
+          content: "Failed to remove child",
+          intent: "danger",
+          id: "remove-child-error",
+        });
       }
     },
     [],

--- a/apps/roam/src/components/settings/LeftSidebarPersonalSettings.tsx
+++ b/apps/roam/src/components/settings/LeftSidebarPersonalSettings.tsx
@@ -1,0 +1,544 @@
+import discourseConfigRef from "~/utils/discourseConfigRef";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import FlagPanel from "roamjs-components/components/ConfigPanels/FlagPanel";
+import AutocompleteInput from "roamjs-components/components/AutocompleteInput";
+import getAllPageNames from "roamjs-components/queries/getAllPageNames";
+import { Button, Dialog, Collapse, Tooltip } from "@blueprintjs/core";
+import createBlock from "roamjs-components/writes/createBlock";
+import deleteBlock from "roamjs-components/writes/deleteBlock";
+import type { RoamBasicNode } from "roamjs-components/types";
+import NumberPanel from "roamjs-components/components/ConfigPanels/NumberPanel";
+import TextPanel from "roamjs-components/components/ConfigPanels/TextPanel";
+import { LeftSidebarPersonalSectionConfig } from "~/utils/getLeftSidebarSettings";
+import { extractRef, getSubTree } from "roamjs-components/util";
+import getTextByBlockUid from "roamjs-components/queries/getTextByBlockUid";
+import getPageUidByPageTitle from "roamjs-components/queries/getPageUidByPageTitle";
+import { DISCOURSE_CONFIG_PAGE_TITLE } from "~/utils/renderNodeConfigPage";
+import getCurrentUserDisplayName from "roamjs-components/queries/getCurrentUserDisplayName";
+import { getLeftSidebarPersonalSectionConfig } from "~/utils/getLeftSidebarSettings";
+
+const SectionItem = React.memo(
+  ({
+    section,
+    expandedChildLists,
+    convertToComplexSection,
+    setSettingsDialogSectionUid,
+    removeSection,
+    toggleChildrenList,
+    addChildToSection,
+    removeChild,
+    pageNames,
+  }: {
+    section: LeftSidebarPersonalSectionConfig;
+    expandedChildLists: Set<string>;
+    convertToComplexSection: (
+      section: LeftSidebarPersonalSectionConfig,
+    ) => void;
+    setSettingsDialogSectionUid: (uid: string | null) => void;
+    removeSection: (section: LeftSidebarPersonalSectionConfig) => void;
+    toggleChildrenList: (uid: string) => void;
+    addChildToSection: (
+      section: LeftSidebarPersonalSectionConfig,
+      childrenUid: string,
+      childName: string,
+    ) => Promise<void>;
+    removeChild: (
+      section: LeftSidebarPersonalSectionConfig,
+      child: RoamBasicNode,
+    ) => Promise<void>;
+    pageNames: string[];
+  }) => {
+    const ref = extractRef(section.text);
+    const blockText = getTextByBlockUid(ref);
+    const originalName = blockText || section.text;
+    const alias = section.settings?.alias?.value;
+    const [childInput, setChildInput] = useState("");
+    const [childInputKey, setChildInputKey] = useState(0);
+    const isExpanded = expandedChildLists.has(section.uid);
+
+    const handleAddChild = useCallback(async () => {
+      if (childInput && section.childrenUid) {
+        await addChildToSection(section, section.childrenUid, childInput);
+        setChildInput("");
+        setChildInputKey((prev) => prev + 1);
+      }
+    }, [childInput, section, addChildToSection]);
+
+    return (
+      <div key={section.uid} className="rounded-md border p-3 hover:bg-gray-50">
+        {/* Header Row */}
+        <div className="flex items-end justify-between">
+          <div className="flex flex-grow gap-2">
+            {!section.sectionWithoutSettingsAndChildren && (
+              <Button
+                icon={isExpanded ? "chevron-down" : "chevron-right"}
+                minimal
+                small
+                onClick={() => toggleChildrenList(section.uid)}
+              />
+            )}
+            <div className="flex-1 truncate">
+              {alias ? (
+                <Tooltip content={originalName} placement="top">
+                  <span className="font-medium">{alias}</span>
+                </Tooltip>
+              ) : (
+                <span className="font-medium">{originalName}</span>
+              )}
+            </div>
+          </div>
+          <div className="flex justify-end gap-1">
+            {section.sectionWithoutSettingsAndChildren ? (
+              <Button
+                icon="settings"
+                small
+                minimal
+                title="Convert to section with settings"
+                onClick={() => convertToComplexSection(section)}
+              />
+            ) : (
+              <Button
+                icon="settings"
+                small
+                minimal
+                title="Edit section settings"
+                onClick={() => setSettingsDialogSectionUid(section.uid)}
+              />
+            )}
+            <Button
+              icon="trash"
+              minimal
+              small
+              intent="danger"
+              onClick={() => removeSection(section)}
+              title="Remove section"
+            />
+          </div>
+        </div>
+
+        {!section.sectionWithoutSettingsAndChildren && (
+          <Collapse isOpen={isExpanded}>
+            <div className="ml-6 mt-3">
+              {/* Add Child Input */}
+              <div
+                className="mb-2 flex items-center gap-2"
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && childInput) {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    void handleAddChild();
+                  }
+                }}
+              >
+                <AutocompleteInput
+                  key={childInputKey}
+                  value={childInput}
+                  setValue={setChildInput}
+                  placeholder="Add child page…"
+                  options={pageNames}
+                  maxItemsDisplayed={50}
+                />
+                <Button
+                  icon="plus"
+                  small
+                  minimal
+                  disabled={!childInput}
+                  onClick={handleAddChild}
+                  title="Add child"
+                />
+              </div>
+
+              {(section.children || []).length > 0 && (
+                <div className="space-y-1">
+                  {(section.children || []).map((child) => (
+                    <div
+                      key={child.uid}
+                      className="flex items-center justify-between rounded bg-gray-50 p-2 hover:bg-gray-100"
+                    >
+                      <span className="flex-grow">{child.text}</span>
+                      <Button
+                        icon="trash"
+                        minimal
+                        small
+                        intent="danger"
+                        onClick={() => void removeChild(section, child)}
+                        title="Remove child"
+                      />
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              {(!section.children || section.children.length === 0) && (
+                <div className="text-sm italic text-gray-400">
+                  No children added yet
+                </div>
+              )}
+            </div>
+          </Collapse>
+        )}
+      </div>
+    );
+  },
+);
+
+SectionItem.displayName = "SectionItem";
+
+const LeftSidebarPersonalSectionsContent = ({
+  leftSidebar,
+}: {
+  leftSidebar: RoamBasicNode;
+}) => {
+  const [sections, setSections] = useState<LeftSidebarPersonalSectionConfig[]>(
+    [],
+  );
+  const [personalSectionUid, setPersonalSectionUid] = useState<string | null>(
+    null,
+  );
+  const [newSectionInput, setNewSectionInput] = useState("");
+  const [autocompleteKey, setAutocompleteKey] = useState(0);
+  const [settingsDialogSectionUid, setSettingsDialogSectionUid] = useState<
+    string | null
+  >(null);
+  const [expandedChildLists, setExpandedChildLists] = useState<Set<string>>(
+    new Set(),
+  );
+
+  useEffect(() => {
+    const initialize = async () => {
+      const userName = getCurrentUserDisplayName();
+      const personalSectionText = userName + "/Personal-Section";
+
+      const personalSection = leftSidebar.children.find(
+        (n) => n.text === personalSectionText,
+      );
+
+      if (!personalSection) {
+        const newSectionUid = await createBlock({
+          parentUid: leftSidebar.uid,
+          order: 0,
+          node: {
+            text: personalSectionText,
+          },
+        });
+        setPersonalSectionUid(newSectionUid);
+        setSections([]);
+      } else {
+        setPersonalSectionUid(personalSection.uid);
+        const loadedSections = getLeftSidebarPersonalSectionConfig(
+          leftSidebar.children,
+        ).sections;
+        setSections(loadedSections);
+      }
+    };
+
+    void initialize();
+  }, [leftSidebar]);
+
+  const addSection = useCallback(
+    async (sectionName: string) => {
+      if (!sectionName || !personalSectionUid) return;
+      if (sections.some((s) => s.text === sectionName)) return;
+
+      try {
+        const newBlock = await createBlock({
+          parentUid: personalSectionUid,
+          order: "last",
+          node: { text: sectionName },
+        });
+
+        setSections((prev) => [
+          ...prev,
+          {
+            text: sectionName,
+            uid: newBlock,
+            sectionWithoutSettingsAndChildren: true,
+            settings: undefined,
+            children: undefined,
+            childrenUid: undefined,
+          } as LeftSidebarPersonalSectionConfig,
+        ]);
+
+        setNewSectionInput("");
+        setAutocompleteKey((prev) => prev + 1);
+      } catch (error) {
+        console.error("Failed to add section:", error);
+      }
+    },
+    [personalSectionUid, sections],
+  );
+
+  const removeSection = useCallback(
+    async (section: LeftSidebarPersonalSectionConfig) => {
+      try {
+        await deleteBlock(section.uid);
+
+        setSections((prev) => prev.filter((s) => s.uid !== section.uid));
+      } catch (error) {
+        console.error("Failed to remove section:", error);
+      }
+    },
+    [],
+  );
+
+  const toggleChildrenList = useCallback((sectionUid: string) => {
+    setExpandedChildLists((prev) => {
+      const next = new Set(prev);
+      if (next.has(sectionUid)) {
+        next.delete(sectionUid);
+      } else {
+        next.add(sectionUid);
+      }
+      return next;
+    });
+  }, []);
+
+  const convertToComplexSection = useCallback(
+    async (section: LeftSidebarPersonalSectionConfig) => {
+      try {
+        const settingsUid = await createBlock({
+          parentUid: section.uid,
+          order: 0,
+          node: {
+            text: "Settings",
+            children: [
+              { text: "Folded" },
+              { text: "Truncate-result?", children: [{ text: "75" }] },
+            ],
+          },
+        });
+
+        const childrenUid = await createBlock({
+          parentUid: section.uid,
+          order: 1,
+          node: { text: "Children" },
+        });
+
+        setSections((prev) =>
+          prev.map((s) => {
+            if (s.uid === section.uid) {
+              return {
+                ...s,
+                sectionWithoutSettingsAndChildren: false,
+                settings: {
+                  uid: settingsUid,
+                  folded: { uid: "", value: false },
+                  truncateResult: { uid: "", value: 75 },
+                  alias: { uid: "", value: "" },
+                },
+                childrenUid: childrenUid,
+                children: [],
+              };
+            }
+            return s;
+          }),
+        );
+
+        setExpandedChildLists((prev) => new Set([...prev, section.uid]));
+      } catch (error) {
+        console.error("Failed to convert to complex section:", error);
+      }
+    },
+    [],
+  );
+
+  const addChildToSection = useCallback(
+    async (
+      section: LeftSidebarPersonalSectionConfig,
+      childrenUid: string,
+      childName: string,
+    ) => {
+      if (!childName || !childrenUid) return;
+
+      try {
+        const newChild = await createBlock({
+          parentUid: childrenUid,
+          order: "last",
+          node: { text: childName },
+        });
+
+        setSections((prev) =>
+          prev.map((s) => {
+            if (s.uid === section.uid) {
+              return {
+                ...s,
+                children: [
+                  ...(s.children || []),
+                  {
+                    text: childName,
+                    uid: newChild,
+                    children: [],
+                  },
+                ],
+              };
+            }
+            return s;
+          }),
+        );
+      } catch (error) {
+        console.error("Failed to add child:", error);
+      }
+    },
+    [],
+  );
+
+  const removeChild = useCallback(
+    async (section: LeftSidebarPersonalSectionConfig, child: RoamBasicNode) => {
+      try {
+        await deleteBlock(child.uid);
+
+        setSections((prev) =>
+          prev.map((s) => {
+            if (s.uid === section.uid) {
+              return {
+                ...s,
+                children: s.children?.filter((c) => c.uid !== child.uid),
+              };
+            }
+            return s;
+          }),
+        );
+      } catch (error) {
+        console.error("Failed to remove child:", error);
+      }
+    },
+    [],
+  );
+
+  const handleNewSectionInputChange = useCallback((value: string) => {
+    setNewSectionInput(value);
+  }, []);
+
+  const activeDialogSection = useMemo(() => {
+    return sections.find((s) => s.uid === settingsDialogSectionUid) || null;
+  }, [sections, settingsDialogSectionUid]);
+
+  const pageNames = useMemo(() => getAllPageNames(), []);
+
+  if (!personalSectionUid) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-col gap-4 p-1">
+      <div className="mb-2">
+        <div className="mb-2 text-sm text-gray-600">
+          Add pages or create custom sections with settings and children
+        </div>
+        <div
+          className="flex items-center gap-2"
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && newSectionInput) {
+              e.preventDefault();
+              e.stopPropagation();
+              void addSection(newSectionInput);
+            }
+          }}
+        >
+          <AutocompleteInput
+            key={autocompleteKey}
+            value={newSectionInput}
+            setValue={handleNewSectionInputChange}
+            placeholder="Add section or page…"
+            options={pageNames}
+            maxItemsDisplayed={50}
+          />
+          <Button
+            icon="plus"
+            small
+            minimal
+            disabled={
+              !newSectionInput ||
+              sections.some((s) => s.text === newSectionInput)
+            }
+            onClick={() => void addSection(newSectionInput)}
+          />
+        </div>
+      </div>
+
+      <div className="mt-2 space-y-2">
+        {sections.map((section) => (
+          <SectionItem
+            key={section.uid}
+            section={section}
+            expandedChildLists={expandedChildLists}
+            convertToComplexSection={convertToComplexSection}
+            setSettingsDialogSectionUid={setSettingsDialogSectionUid}
+            removeSection={removeSection}
+            toggleChildrenList={toggleChildrenList}
+            addChildToSection={addChildToSection}
+            removeChild={removeChild}
+            pageNames={pageNames}
+          />
+        ))}
+      </div>
+
+      {activeDialogSection && activeDialogSection.settings && (
+        <Dialog
+          isOpen={true}
+          onClose={() => setSettingsDialogSectionUid(null)}
+          title={`Settings for "${activeDialogSection.text}"`}
+          style={{ width: "500px" }}
+        >
+          <div className="space-y-4 p-4">
+            <div className="space-y-3">
+              <FlagPanel
+                title="Folded"
+                description="Start with section collapsed"
+                order={0}
+                uid={activeDialogSection.settings.folded?.uid}
+                parentUid={activeDialogSection.settings.uid}
+                value={activeDialogSection.settings.folded?.value}
+              />
+              <NumberPanel
+                title="Truncate-result?"
+                description="Maximum characters to display"
+                order={1}
+                uid={activeDialogSection.settings.truncateResult?.uid}
+                parentUid={activeDialogSection.settings.uid}
+                value={activeDialogSection.settings.truncateResult?.value}
+              />
+              <TextPanel
+                title="Alias"
+                description="Display name for the section"
+                order={2}
+                uid={activeDialogSection.settings.alias?.uid}
+                parentUid={activeDialogSection.settings.uid}
+                value={activeDialogSection.settings.alias?.value}
+                onChange={(value: string) => {
+                  setSections((prev) =>
+                    prev.map((s) => {
+                      if (s.uid === activeDialogSection.uid && s.settings) {
+                        return {
+                          ...s,
+                          settings: {
+                            ...s.settings,
+                            alias: { ...s.settings.alias, value },
+                          },
+                        };
+                      }
+                      return s;
+                    }),
+                  );
+                }}
+              />
+            </div>
+          </div>
+        </Dialog>
+      )}
+    </div>
+  );
+};
+
+export const LeftSidebarPersonalSections = () => {
+  const configPageUid = getPageUidByPageTitle(DISCOURSE_CONFIG_PAGE_TITLE);
+  const settings = discourseConfigRef.tree;
+
+  const leftSidebar = getSubTree({
+    tree: settings,
+    parentUid: configPageUid,
+    key: "Left Sidebar",
+  });
+
+  return <LeftSidebarPersonalSectionsContent leftSidebar={leftSidebar} />;
+};

--- a/apps/roam/src/components/settings/LeftSidebarPersonalSettings.tsx
+++ b/apps/roam/src/components/settings/LeftSidebarPersonalSettings.tsx
@@ -74,7 +74,7 @@ const SectionItem = React.memo(
         }}
       >
         <div className="flex items-end justify-between">
-          <div className="flex flex-grow gap-2">
+          <div className="flex flex-grow items-center gap-2">
             {!section.sectionWithoutSettingsAndChildren && (
               <Button
                 icon={isExpanded ? "chevron-down" : "chevron-right"}

--- a/apps/roam/src/components/settings/LeftSidebarPersonalSettings.tsx
+++ b/apps/roam/src/components/settings/LeftSidebarPersonalSettings.tsx
@@ -66,7 +66,6 @@ const SectionItem = React.memo(
 
     return (
       <div key={section.uid} className="rounded-md border p-3 hover:bg-gray-50">
-        {/* Header Row */}
         <div className="flex items-end justify-between">
           <div className="flex flex-grow gap-2">
             {!section.sectionWithoutSettingsAndChildren && (
@@ -119,7 +118,6 @@ const SectionItem = React.memo(
         {!section.sectionWithoutSettingsAndChildren && (
           <Collapse isOpen={isExpanded}>
             <div className="ml-6 mt-3">
-              {/* Add Child Input */}
               <div
                 className="mb-2 flex items-center gap-2"
                 onKeyDown={(e) => {
@@ -299,13 +297,22 @@ const LeftSidebarPersonalSectionsContent = ({
         const settingsUid = await createBlock({
           parentUid: section.uid,
           order: 0,
-          node: {
-            text: "Settings",
-            children: [
-              { text: "Folded" },
-              { text: "Truncate-result?", children: [{ text: "75" }] },
-            ],
-          },
+          node: { text: "Settings" },
+        });
+        const foldedUid = await createBlock({
+          parentUid: settingsUid,
+          order: 0,
+          node: { text: "Folded" },
+        });
+        const truncateSettingUid = await createBlock({
+          parentUid: settingsUid,
+          order: 1,
+          node: { text: "Truncate-result?", children: [{ text: "75" }] },
+        });
+        const aliasUid = await createBlock({
+          parentUid: settingsUid,
+          order: 2,
+          node: { text: "Alias" },
         });
 
         const childrenUid = await createBlock({
@@ -322,11 +329,11 @@ const LeftSidebarPersonalSectionsContent = ({
                 sectionWithoutSettingsAndChildren: false,
                 settings: {
                   uid: settingsUid,
-                  folded: { uid: "", value: false },
-                  truncateResult: { uid: "", value: 75 },
-                  alias: { uid: "", value: "" },
+                  folded: { uid: foldedUid, value: false },
+                  truncateResult: { uid: truncateSettingUid, value: 75 },
+                  alias: { uid: aliasUid, value: "" },
                 },
-                childrenUid: childrenUid,
+                childrenUid,
                 children: [],
               };
             }

--- a/apps/roam/src/components/settings/LeftSidebarPersonalSettings.tsx
+++ b/apps/roam/src/components/settings/LeftSidebarPersonalSettings.tsx
@@ -134,7 +134,7 @@ const SectionItem = React.memo(
           });
         }
       },
-      [],
+      [setSections],
     );
 
     const addChildToSection = useCallback(
@@ -179,7 +179,7 @@ const SectionItem = React.memo(
           });
         }
       },
-      [],
+      [setSections],
     );
     const removeChild = useCallback(
       async (

--- a/apps/roam/src/components/settings/LeftSidebarPersonalSettings.tsx
+++ b/apps/roam/src/components/settings/LeftSidebarPersonalSettings.tsx
@@ -65,7 +65,13 @@ const SectionItem = React.memo(
     }, [childInput, section, addChildToSection]);
 
     return (
-      <div key={section.uid} className="rounded-md border p-3 hover:bg-gray-50">
+      <div
+        key={section.uid}
+        className="personal-section rounded-md p-3 hover:bg-gray-50"
+        style={{
+          border: "1px solid rgba(51, 51, 51, 0.2)",
+        }}
+      >
         <div className="flex items-end justify-between">
           <div className="flex flex-grow gap-2">
             {!section.sectionWithoutSettingsAndChildren && (
@@ -87,23 +93,23 @@ const SectionItem = React.memo(
             </div>
           </div>
           <div className="flex justify-end gap-1">
-            {section.sectionWithoutSettingsAndChildren ? (
-              <Button
-                icon="settings"
-                small
-                minimal
-                title="Convert to section with settings"
-                onClick={() => convertToComplexSection(section)}
-              />
-            ) : (
-              <Button
-                icon="settings"
-                small
-                minimal
-                title="Edit section settings"
-                onClick={() => setSettingsDialogSectionUid(section.uid)}
-              />
-            )}
+            <Button
+              icon={
+                section.sectionWithoutSettingsAndChildren ? "plus" : "settings"
+              }
+              small
+              minimal
+              title={
+                section.sectionWithoutSettingsAndChildren
+                  ? "Add children"
+                  : "Edit section settings"
+              }
+              onClick={() =>
+                section.sectionWithoutSettingsAndChildren
+                  ? convertToComplexSection(section)
+                  : setSettingsDialogSectionUid(section.uid)
+              }
+            />
             <Button
               icon="trash"
               minimal
@@ -491,11 +497,11 @@ const LeftSidebarPersonalSectionsContent = ({
             <div className="space-y-3">
               <FlagPanel
                 title="Folded"
-                description="Start with section collapsed"
+                description="If children are present, start with personal section collapsed in left sidebar"
                 order={0}
-                uid={activeDialogSection.settings.folded?.uid}
+                uid={activeDialogSection.settings.folded?.uid || ""}
                 parentUid={activeDialogSection.settings.uid}
-                value={activeDialogSection.settings.folded?.value}
+                disabled={!activeDialogSection.children?.length}
               />
               <NumberPanel
                 title="Truncate-result?"

--- a/apps/roam/src/components/settings/Settings.tsx
+++ b/apps/roam/src/components/settings/Settings.tsx
@@ -27,6 +27,8 @@ import refreshConfigTree from "~/utils/refreshConfigTree";
 import { FeedbackWidget } from "~/components/BirdEatsBugs";
 import SuggestiveModeSettings from "./SuggestiveModeSettings";
 import { getVersionWithDate } from "~/utils/getVersion";
+import { LeftSidebarPersonalSections } from "./LeftSidebarPersonalSettings";
+import { LeftSidebarGlobalSections } from "./LeftSidebarGlobalSettings";
 
 type SectionHeaderProps = {
   children: React.ReactNode;
@@ -147,6 +149,12 @@ export const SettingsDialog = ({
             className="overflow-y-auto"
             panel={<QuerySettings extensionAPI={extensionAPI} />}
           />
+          <Tab
+            id="left-sidebar-personal-settings"
+            title="Left Sidebar"
+            className="overflow-y-auto"
+            panel={<LeftSidebarPersonalSections />}
+          />
           <SectionHeader className="text-lg font-semibold text-neutral-dark">
             Global Settings
           </SectionHeader>
@@ -161,6 +169,12 @@ export const SettingsDialog = ({
             title="Export"
             className="overflow-y-auto"
             panel={<DiscourseGraphExport />}
+          />
+          <Tab
+            id="left-sidebar-global-settings"
+            title="Left Sidebar"
+            className="overflow-y-auto"
+            panel={<LeftSidebarGlobalSections />}
           />
           <Tab
             id="suggestive-mode-settings"

--- a/apps/roam/src/utils/discourseConfigRef.ts
+++ b/apps/roam/src/utils/discourseConfigRef.ts
@@ -21,6 +21,18 @@ const configTreeRef: {
   nodes: { [uid: string]: { text: string; children: RoamBasicNode[] } };
 } = { tree: [], nodes: {} };
 
+const listeners = new Set<() => void>();
+
+export const subscribe = (listener: () => void) => {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+};
+
+export const notify = () => {
+  listeners.forEach(listener => listener());
+};
+
+
 type FormattedConfigTree = {
   settingsUid: string;
   grammarUid: string;

--- a/apps/roam/src/utils/getLeftSidebarSettings.ts
+++ b/apps/roam/src/utils/getLeftSidebarSettings.ts
@@ -31,7 +31,7 @@ type LeftSidebarGlobalSectionSettings = {
   folded: BooleanSetting;
 };
 
-type LeftSidebarGlobalSectionConfig = {
+export type LeftSidebarGlobalSectionConfig = {
   uid: string;
   settings?: LeftSidebarGlobalSectionSettings;
   children: RoamBasicNode[];
@@ -39,6 +39,7 @@ type LeftSidebarGlobalSectionConfig = {
 };
 
 export type LeftSidebarConfig = {
+  uid: string;
   global: LeftSidebarGlobalSectionConfig;
   personal: {
     uid: string;
@@ -65,7 +66,7 @@ const getGlobalSectionSettings = (
   };
 };
 
-const getLeftSidebarGlobalSectionConfig = (
+export const getLeftSidebarGlobalSectionConfig = (
   leftSidebarChildren: RoamBasicNode[],
 ): LeftSidebarGlobalSectionConfig => {
   const globalSectionNode = getSubTree({
@@ -131,7 +132,7 @@ const getPersonalSectionSettings = (
   };
 };
 
-const getLeftSidebarPersonalSectionConfig = (
+export const getLeftSidebarPersonalSectionConfig = (
   leftSidebarChildren: RoamBasicNode[],
 ): { uid: string; sections: LeftSidebarPersonalSectionConfig[] } => {
   const userUid = window.roamAlphaAPI.user.uid();
@@ -192,10 +193,12 @@ export const getLeftSidebarSettings = (
   const leftSidebarNode = globalTree.find(
     (node) => node.text === "Left Sidebar",
   );
+  const leftSidebarUid = leftSidebarNode?.uid || "";
   const leftSidebarChildren = leftSidebarNode?.children || [];
   const global = getLeftSidebarGlobalSectionConfig(leftSidebarChildren);
   const personal = getLeftSidebarPersonalSectionConfig(leftSidebarChildren);
   return {
+    uid: leftSidebarUid,
     global,
     personal,
   };

--- a/apps/roam/src/utils/getLeftSidebarSettings.ts
+++ b/apps/roam/src/utils/getLeftSidebarSettings.ts
@@ -19,7 +19,6 @@ type LeftSidebarPersonalSectionSettings = {
 export type LeftSidebarPersonalSectionConfig = {
   uid: string;
   text: string;
-  sectionWithoutSettingsAndChildren: boolean;
   settings?: LeftSidebarPersonalSectionSettings;
   children?: RoamBasicNode[];
   childrenUid?: string;
@@ -157,27 +156,15 @@ export const getLeftSidebarPersonalSectionConfig = (
       const childrenNode = sectionNode.children?.find(
         (child) => child.text === "Children",
       );
-
-      const sectionWithoutSettingsAndChildren = !settingsNode && !childrenNode;
-
-      if (sectionWithoutSettingsAndChildren) {
-        return {
-          uid: sectionNode.uid,
-          text: sectionNode.text,
-          sectionWithoutSettingsAndChildren: true,
-        };
-      } else {
-        return {
-          uid: sectionNode.uid,
-          text: sectionNode.text,
-          settings: settingsNode
-            ? getPersonalSectionSettings(settingsNode)
-            : undefined,
-          children: childrenNode?.children || [],
-          childrenUid: childrenNode?.uid || "",
-          sectionWithoutSettingsAndChildren: false,
-        };
-      }
+      return {
+        uid: sectionNode.uid,
+        text: sectionNode.text,
+        settings: settingsNode
+          ? getPersonalSectionSettings(settingsNode)
+          : undefined,
+        children: childrenNode?.children || [],
+        childrenUid: childrenNode?.uid || "",
+      };
     },
   );
 


### PR DESCRIPTION
https://www.loom.com/share/6f453441c5eb418cb728a6e165387340?sid=3a9e642d-413e-4717-bc01-1cc1882486a6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added Left Sidebar settings to the Settings dialog with two tabs: Personal and Global.
  - Global: Create and manage a “Global Section,” toggle folded/collapsible, add/remove pages with autocomplete, and expand/collapse children.
  - Personal: Create a per-user “Personal Section,” add sections or pages, convert sections to advanced mode with settings and children, edit per-section options (folded, alias, truncate), and manage child items.

- UX Improvements
  - Real-time updates, duplicate prevention, keyboard add (Enter), tooltips, and clear loading/empty states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->