### PR TITLE
Set node summoning menu default trigger to @

### DIFF
--- a/apps/roam/src/components/DiscourseNodeSearchMenu.tsx
+++ b/apps/roam/src/components/DiscourseNodeSearchMenu.tsx
@@ -536,7 +536,7 @@ export const NodeSearchMenuTriggerSetting = ({
 }) => {
   const extensionAPI = onloadArgs.extensionAPI;
   const [nodeSearchTrigger, setNodeSearchTrigger] = useState<string>(
-    extensionAPI.settings.get("node-search-trigger") as string,
+    (extensionAPI.settings.get("node-search-trigger") as string) || "@",
   );
 
   const handleNodeSearchTriggerChange = (

--- a/apps/roam/src/components/DiscourseNodeSearchMenu.tsx
+++ b/apps/roam/src/components/DiscourseNodeSearchMenu.tsx
@@ -25,6 +25,7 @@ import getDiscourseNodes, { DiscourseNode } from "~/utils/getDiscourseNodes";
 import getDiscourseNodeFormatExpression from "~/utils/getDiscourseNodeFormatExpression";
 import { escapeCljString } from "~/utils/formatUtils";
 import { Result } from "~/utils/types";
+import { getSetting } from "~/utils/extensionSettings";
 
 type Props = {
   textarea: HTMLTextAreaElement;
@@ -536,7 +537,7 @@ export const NodeSearchMenuTriggerSetting = ({
 }) => {
   const extensionAPI = onloadArgs.extensionAPI;
   const [nodeSearchTrigger, setNodeSearchTrigger] = useState<string>(
-    (extensionAPI.settings.get("node-search-trigger") as string) || "@",
+    getSetting("node-search-trigger", "@"),
   );
 
   const handleNodeSearchTriggerChange = (

--- a/apps/roam/src/utils/initializeObserversAndListeners.ts
+++ b/apps/roam/src/utils/initializeObserversAndListeners.ts
@@ -45,6 +45,7 @@ import {
 } from "~/utils/renderTextSelectionPopup";
 import { renderNodeTagPopupButton } from "./renderNodeTagPopup";
 import { formatHexColor } from "~/components/settings/DiscourseNodeCanvasSettings";
+import { getSetting } from "./extensionSettings";
 
 const debounce = (fn: () => void, delay = 250) => {
   let timeout: number;
@@ -230,9 +231,7 @@ export const initObservers = async ({
     }
   };
 
-  const customTrigger = (onloadArgs.extensionAPI.settings.get(
-    "node-search-trigger",
-  ) as string) || "@";
+  const customTrigger = getSetting("node-search-trigger", "@");
 
   const discourseNodeSearchTriggerListener = (e: Event) => {
     const evt = e as KeyboardEvent;

--- a/apps/roam/src/utils/initializeObserversAndListeners.ts
+++ b/apps/roam/src/utils/initializeObserversAndListeners.ts
@@ -230,9 +230,9 @@ export const initObservers = async ({
     }
   };
 
-  const customTrigger = onloadArgs.extensionAPI.settings.get(
+  const customTrigger = (onloadArgs.extensionAPI.settings.get(
     "node-search-trigger",
-  ) as string;
+  ) as string) || "@";
 
   const discourseNodeSearchTriggerListener = (e: Event) => {
     const evt = e as KeyboardEvent;


### PR DESCRIPTION
Set the node summoning menu default trigger to '@' to improve discoverability and align with existing default setting patterns.

---
Linear Issue: [ENG-459](https://linear.app/discourse-graphs/issue/ENG-459/set-node-summoning-menu-default-trigger-to)

<a href="https://cursor.com/background-agent?bcId=bc-95da97cb-6f58-4097-81fb-02a47e47f0fa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-95da97cb-6f58-4097-81fb-02a47e47f0fa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures the node search trigger reliably defaults to “@” when no user setting is defined, preventing missing-trigger issues.

* **Refactor**
  * Centralized retrieval of the node search trigger setting to improve consistency and maintainability across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->