### PR TITLE
ENG-861 - Update canvas node click behavior

### DIFF
--- a/apps/roam/src/components/canvas/Tldraw.tsx
+++ b/apps/roam/src/components/canvas/Tldraw.tsx
@@ -656,11 +656,11 @@ const TldrawCanvas = ({ title }: { title: string }) => {
                 // navigate / open in sidebar
                 const validModifier = e.shiftKey || e.ctrlKey; // || e.metaKey;
                 if (!(e.name === "pointer_up" && validModifier)) return;
-                if (app.getSelectedShapes().length) return; // User is positioning selected shape
-                const shape = app.getShapeAtPoint(
-                  app.inputs.currentPagePoint,
-                ) as DiscourseNodeShape;
-                if (!shape) return;
+                
+                // Get shape at mouse coordinates instead of requiring selection
+                const pagePoint = app.screenToPage(e.point);
+                const shape = app.getShapeAtPoint(pagePoint) as DiscourseNodeShape;
+                if (!shape || !isDiscourseNodeShape(shape)) return;
                 const shapeUid = shape.props.uid;
 
                 if (!isLiveBlock(shapeUid)) {

--- a/apps/roam/src/components/canvas/Tldraw.tsx
+++ b/apps/roam/src/components/canvas/Tldraw.tsx
@@ -674,6 +674,7 @@ const TldrawCanvas = ({ title }: { title: string }) => {
                 if (e.shiftKey) {
                   if (app.getSelectedShapes().length > 1) return; // User is selecting multiple shapes
                   void openBlockInSidebar(shapeUid);
+                  app.selectNone();
                 }
 
                 if (

--- a/apps/roam/src/components/canvas/Tldraw.tsx
+++ b/apps/roam/src/components/canvas/Tldraw.tsx
@@ -656,11 +656,10 @@ const TldrawCanvas = ({ title }: { title: string }) => {
                 // navigate / open in sidebar
                 const validModifier = e.shiftKey || e.ctrlKey; // || e.metaKey;
                 if (!(e.name === "pointer_up" && validModifier)) return;
-                
-                // Get shape at mouse coordinates instead of requiring selection
-                const pagePoint = app.screenToPage(e.point);
-                const shape = app.getShapeAtPoint(pagePoint) as DiscourseNodeShape;
-                if (!shape || !isDiscourseNodeShape(shape)) return;
+                const shape = app.getShapeAtPoint(
+                  app.inputs.currentPagePoint,
+                ) as DiscourseNodeShape;
+                if (!shape) return;
                 const shapeUid = shape.props.uid;
 
                 if (!isLiveBlock(shapeUid)) {
@@ -672,7 +671,10 @@ const TldrawCanvas = ({ title }: { title: string }) => {
                   });
                 }
 
-                if (e.shiftKey) openBlockInSidebar(shapeUid);
+                if (e.shiftKey) {
+                  if (app.getSelectedShapes().length > 1) return; // User is selecting multiple shapes
+                  void openBlockInSidebar(shapeUid);
+                }
 
                 if (
                   e.ctrlKey


### PR DESCRIPTION
Allow shift click on Canvas nodes without prior selection to fix ENG-861.

Previously, shift clicking on a Canvas node only worked if the node was already selected.  It will now work if no nodes are selected.

If a node is selected and a user shift clicks a different node, it will not open in sidebar, as tldraw uses this to allow for multiple selections.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Using Shift with exactly one selected shape now opens the block in the sidebar and then clears the selection for smoother flow.
  * Prevents sidebar opening when multiple shapes are selected; action triggers only with a single selection.
  * Refines modifier-based interactions on the canvas for more consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->