### PR TITLE
ENG-453 - filter out empty branches in OR queries

### DIFF
--- a/apps/roam/src/utils/conditionToDatalog.ts
+++ b/apps/roam/src/utils/conditionToDatalog.ts
@@ -990,10 +990,17 @@ export const getConditionLabels = () =>
 
 const conditionToDatalog: ConditionToDatalog = (con) => {
   if (con.type === "or" || con.type === "not or") {
-    const clauses: DatalogAndClause[] = con.conditions.map((branch) => ({
+    const allClauses: DatalogAndClause[] = con.conditions.map((branch) => ({
       type: "and-clause",
       clauses: branch.flatMap((c) => conditionToDatalog(c)),
     }));
+
+    // Filter out empty branches (e.g., from ignored "is a" conditions with non-existent targets)
+    const clauses = allClauses.filter((c) => c.clauses.length > 0);
+
+    // If all branches are empty, return empty array
+    if (clauses.length === 0) return [];
+
     const variableSet: Record<string, number> = {};
     clauses.forEach((c) => {
       const gathered = gatherDatalogVariablesFromClause(c);


### PR DESCRIPTION
This specifically targets when a branch references `is a` `someNode` where `someNode` doesn't exists.

<img width="1102" height="508" alt="image" src="https://github.com/user-attachments/assets/4743a40e-23f5-4fd9-a465-dd34f096b4b9" />
<img width="356" height="558" alt="image" src="https://github.com/user-attachments/assets/b78a3515-74c6-47d2-832a-72fac6fce66a" />


Previous behavior was to silently error (console.error), returning no results.
<img width="785" height="179" alt="image" src="https://github.com/user-attachments/assets/680ae517-0bab-4ff0-8854-1871251459e0" />





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved reliability of advanced filters when using OR conditions. The app now correctly ignores empty or invalid branches (e.g., references to non-existent items) without causing unexpected empty results.
  - More consistent query outcomes when some filter criteria are omitted or become invalid, reducing edge-case failures and improving result accuracy.
  - Enhanced stability in complex searches by ensuring only meaningful conditions are evaluated, minimizing unexpected behavior in filtered views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->