### PR TITLE
[ENG-877] Initial Implementation node tags for Obsidian

### DIFF
--- a/apps/obsidian/src/utils/colorUtils.ts
+++ b/apps/obsidian/src/utils/colorUtils.ts
@@ -17,59 +17,30 @@ const COLOR_PALETTE: Record<string, string> = {
   yellow: "#ffc078",
 };
 
-const COLOR_ARRAY = [
-  "yellow",
-  "white",
-  "violet",
-  "red",
-  "orange",
-  "lightViolet",
-  "lightRed",
-  "lightGreen",
-  "lightBlue",
-  "grey",
-  "green",
-  "blue",
-  "black",
-];
-
-/**
- * Format hex color to ensure it starts with #
- */
-export const formatHexColor = (color: string): string => {
-  if (!color) return "";
-  const COLOR_TEST = /^[0-9a-f]{6}$/i;
-  const COLOR_TEST_WITH_HASH = /^#[0-9a-f]{6}$/i;
-  if (color.startsWith("#")) {
-    return COLOR_TEST_WITH_HASH.test(color) ? color : "";
-  } else if (COLOR_TEST.test(color)) {
-    return "#" + color;
-  }
-  return "";
-};
-
+const COLOR_ARRAY = Object.keys(COLOR_PALETTE);
 /**
  * Calculate contrast color (black or white) based on background color
  * Simplified version of contrast-color logic
  */
+// TODO switch to colord - https://linear.app/discourse-graphs/issue/ENG-836/button-like-css-styling-for-node-tag
 export const getContrastColor = (bgColor: string): string => {
   // Remove # if present
   const hex = bgColor.replace("#", "");
-  
+
   // Ensure we have a valid hex string
   if (hex.length !== 6) return "#000000";
-  
+
   // Convert to RGB
   const r = parseInt(hex.substring(0, 2), 16);
   const g = parseInt(hex.substring(2, 4), 16);
   const b = parseInt(hex.substring(4, 6), 16);
-  
+
   // Check for NaN values
   if (isNaN(r) || isNaN(g) || isNaN(b)) return "#000000";
-  
+
   // Calculate luminance
   const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
-  
+
   // Return black for light backgrounds, white for dark backgrounds
   return luminance > 0.5 ? "#000000" : "#ffffff";
 };
@@ -77,27 +48,38 @@ export const getContrastColor = (bgColor: string): string => {
 /**
  * Get colors for a discourse node type
  */
-export const getDiscourseNodeColors = (nodeType: DiscourseNode, nodeIndex: number): { backgroundColor: string; textColor: string } => {
+export const getNodeTagColors = (
+  nodeType: DiscourseNode,
+  nodeIndex: number,
+): { backgroundColor: string; textColor: string } => {
   // Use custom color from node type if available
-  const customColor = nodeType.color ? formatHexColor(nodeType.color) : "";
-  
+  const customColor = nodeType.color || "";
+
   // Fall back to palette color based on index
-  const safeIndex = nodeIndex >= 0 && nodeIndex < COLOR_ARRAY.length ? nodeIndex : 0;
+  const safeIndex =
+    nodeIndex >= 0 && nodeIndex < COLOR_ARRAY.length ? nodeIndex : 0;
   const paletteColorKey = COLOR_ARRAY[safeIndex];
-  const paletteColor = paletteColorKey ? COLOR_PALETTE[paletteColorKey] : COLOR_PALETTE.blue;
-  
+  const paletteColor = paletteColorKey
+    ? COLOR_PALETTE[paletteColorKey]
+    : COLOR_PALETTE.blue;
+
   const backgroundColor = customColor || paletteColor || "#4263eb";
   const textColor = getContrastColor(backgroundColor);
-  
+
   return { backgroundColor, textColor };
 };
 
 /**
  * Get all discourse node colors for CSS variable generation
  */
-export const getAllDiscourseNodeColors = (nodeTypes: DiscourseNode[]): Array<{ nodeType: DiscourseNode; colors: { backgroundColor: string; textColor: string } }> => {
+export const getAllDiscourseNodeColors = (
+  nodeTypes: DiscourseNode[],
+): Array<{
+  nodeType: DiscourseNode;
+  colors: { backgroundColor: string; textColor: string };
+}> => {
   return nodeTypes.map((nodeType, index) => ({
     nodeType,
-    colors: getDiscourseNodeColors(nodeType, index),
+    colors: getNodeTagColors(nodeType, index),
   }));
 };

--- a/apps/obsidian/src/utils/colorUtils.ts
+++ b/apps/obsidian/src/utils/colorUtils.ts
@@ -1,0 +1,103 @@
+import { DiscourseNode } from "~/types";
+
+// Color palette similar to Roam's implementation
+const COLOR_PALETTE: Record<string, string> = {
+  black: "#1d1d1d",
+  blue: "#4263eb",
+  green: "#099268",
+  grey: "#adb5bd",
+  lightBlue: "#4dabf7",
+  lightGreen: "#40c057",
+  lightRed: "#ff8787",
+  lightViolet: "#e599f7",
+  orange: "#f76707",
+  red: "#e03131",
+  violet: "#ae3ec9",
+  white: "#ffffff",
+  yellow: "#ffc078",
+};
+
+const COLOR_ARRAY = [
+  "yellow",
+  "white",
+  "violet",
+  "red",
+  "orange",
+  "lightViolet",
+  "lightRed",
+  "lightGreen",
+  "lightBlue",
+  "grey",
+  "green",
+  "blue",
+  "black",
+];
+
+/**
+ * Format hex color to ensure it starts with #
+ */
+export const formatHexColor = (color: string): string => {
+  if (!color) return "";
+  const COLOR_TEST = /^[0-9a-f]{6}$/i;
+  const COLOR_TEST_WITH_HASH = /^#[0-9a-f]{6}$/i;
+  if (color.startsWith("#")) {
+    return COLOR_TEST_WITH_HASH.test(color) ? color : "";
+  } else if (COLOR_TEST.test(color)) {
+    return "#" + color;
+  }
+  return "";
+};
+
+/**
+ * Calculate contrast color (black or white) based on background color
+ * Simplified version of contrast-color logic
+ */
+export const getContrastColor = (bgColor: string): string => {
+  // Remove # if present
+  const hex = bgColor.replace("#", "");
+  
+  // Ensure we have a valid hex string
+  if (hex.length !== 6) return "#000000";
+  
+  // Convert to RGB
+  const r = parseInt(hex.substring(0, 2), 16);
+  const g = parseInt(hex.substring(2, 4), 16);
+  const b = parseInt(hex.substring(4, 6), 16);
+  
+  // Check for NaN values
+  if (isNaN(r) || isNaN(g) || isNaN(b)) return "#000000";
+  
+  // Calculate luminance
+  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+  
+  // Return black for light backgrounds, white for dark backgrounds
+  return luminance > 0.5 ? "#000000" : "#ffffff";
+};
+
+/**
+ * Get colors for a discourse node type
+ */
+export const getDiscourseNodeColors = (nodeType: DiscourseNode, nodeIndex: number): { backgroundColor: string; textColor: string } => {
+  // Use custom color from node type if available
+  const customColor = nodeType.color ? formatHexColor(nodeType.color) : "";
+  
+  // Fall back to palette color based on index
+  const safeIndex = nodeIndex >= 0 && nodeIndex < COLOR_ARRAY.length ? nodeIndex : 0;
+  const paletteColorKey = COLOR_ARRAY[safeIndex];
+  const paletteColor = paletteColorKey ? COLOR_PALETTE[paletteColorKey] : COLOR_PALETTE.blue;
+  
+  const backgroundColor = customColor || paletteColor || "#4263eb";
+  const textColor = getContrastColor(backgroundColor);
+  
+  return { backgroundColor, textColor };
+};
+
+/**
+ * Get all discourse node colors for CSS variable generation
+ */
+export const getAllDiscourseNodeColors = (nodeTypes: DiscourseNode[]): Array<{ nodeType: DiscourseNode; colors: { backgroundColor: string; textColor: string } }> => {
+  return nodeTypes.map((nodeType, index) => ({
+    nodeType,
+    colors: getDiscourseNodeColors(nodeType, index),
+  }));
+};

--- a/apps/obsidian/src/utils/colorUtils.ts
+++ b/apps/obsidian/src/utils/colorUtils.ts
@@ -18,44 +18,30 @@ const COLOR_PALETTE: Record<string, string> = {
 };
 
 const COLOR_ARRAY = Object.keys(COLOR_PALETTE);
-/**
- * Calculate contrast color (black or white) based on background color
- * Simplified version of contrast-color logic
- */
+
 // TODO switch to colord - https://linear.app/discourse-graphs/issue/ENG-836/button-like-css-styling-for-node-tag
 export const getContrastColor = (bgColor: string): string => {
-  // Remove # if present
   const hex = bgColor.replace("#", "");
 
-  // Ensure we have a valid hex string
   if (hex.length !== 6) return "#000000";
 
-  // Convert to RGB
   const r = parseInt(hex.substring(0, 2), 16);
   const g = parseInt(hex.substring(2, 4), 16);
   const b = parseInt(hex.substring(4, 6), 16);
 
-  // Check for NaN values
   if (isNaN(r) || isNaN(g) || isNaN(b)) return "#000000";
 
-  // Calculate luminance
   const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
 
-  // Return black for light backgrounds, white for dark backgrounds
   return luminance > 0.5 ? "#000000" : "#ffffff";
 };
 
-/**
- * Get colors for a discourse node type
- */
 export const getNodeTagColors = (
   nodeType: DiscourseNode,
   nodeIndex: number,
 ): { backgroundColor: string; textColor: string } => {
-  // Use custom color from node type if available
   const customColor = nodeType.color || "";
 
-  // Fall back to palette color based on index
   const safeIndex =
     nodeIndex >= 0 && nodeIndex < COLOR_ARRAY.length ? nodeIndex : 0;
   const paletteColorKey = COLOR_ARRAY[safeIndex];
@@ -69,9 +55,7 @@ export const getNodeTagColors = (
   return { backgroundColor, textColor };
 };
 
-/**
- * Get all discourse node colors for CSS variable generation
- */
+
 export const getAllDiscourseNodeColors = (
   nodeTypes: DiscourseNode[],
 ): Array<{

--- a/apps/obsidian/src/utils/tagNodeHandler.ts
+++ b/apps/obsidian/src/utils/tagNodeHandler.ts
@@ -100,7 +100,7 @@ export class TagNodeHandler {
           mutation.target instanceof HTMLElement
         ) {
           const target = mutation.target;
-          if (this.hasTagClass(target)) {
+          if (hasTagClass(target)) {
             this.processElement(target);
           }
         }
@@ -115,16 +115,7 @@ export class TagNodeHandler {
     return (
       element.classList.contains("cm-line") ||
       element.querySelector('[class*="cm-tag-"]') !== null ||
-      this.hasTagClass(element)
-    );
-  }
-
-  /**
-   * Check if element has cm-tag-* class
-   */
-  private hasTagClass(element: HTMLElement): boolean {
-    return Array.from(element.classList).some((cls) =>
-      cls.startsWith("cm-tag-"),
+      hasTagClass(element)
     );
   }
 
@@ -233,7 +224,7 @@ export class TagNodeHandler {
   ): void {
     const extractedData = this.extractContentUpToTag(tagElement);
     if (!extractedData) {
-      new Notice("Could not extract content", 3000);
+      new Notice("Could not create discourse node", 3000);
       return;
     }
 
@@ -283,7 +274,7 @@ export class TagNodeHandler {
 
       const extractedData = this.extractContentUpToTag(tagElement);
       if (!extractedData) {
-        new Notice("Could not determine content range for replacement", 3000);
+        new Notice("Could not create discourse node", 3000);
         return;
       }
 
@@ -304,13 +295,13 @@ export class TagNodeHandler {
       }
 
       if (lineNumber === -1) {
-        new Notice("Could not find matching line in editor", 3000);
+        new Notice("Could not replace tag with discourse node", 3000);
         return;
       }
 
       const actualLineText = allLines[lineNumber];
       if (!actualLineText) {
-        new Notice("Could not find matching line in editor", 3000);
+        new Notice("Could not replace tag with discourse node", 3000);
         return;
       }
       const tagStartPos = actualLineText.indexOf(tagWithHash);
@@ -363,8 +354,6 @@ export class TagNodeHandler {
         top: ${rect.top - TOOLTIP_OFFSET}px;
         left: ${rect.left + rect.width / 2}px;
         transform: translateX(-50%);
-        background: var(--background-primary);
-        border: 1px solid var(--background-modifier-border);
         border-radius: 6px;
         padding: 6px;
         z-index: 9999;
@@ -556,3 +545,10 @@ export class TagNodeHandler {
     return activeView?.editor || null;
   }
 }
+
+/**
+ * Check if element has cm-tag-* class
+ */
+export const hasTagClass = (element: HTMLElement): boolean => {
+  return Array.from(element.classList).some((cls) => cls.startsWith("cm-tag-"));
+};

--- a/apps/obsidian/src/utils/tagNodeHandler.ts
+++ b/apps/obsidian/src/utils/tagNodeHandler.ts
@@ -1,0 +1,446 @@
+import { App, Editor, Notice, MarkdownView } from "obsidian";
+import { DiscourseNode } from "~/types";
+import type DiscourseGraphPlugin from "~/index";
+import { CreateNodeModal } from "~/components/CreateNodeModal";
+import { createDiscourseNodeFile, formatNodeName } from "./createNode";
+import { getDiscourseNodeColors } from "./colorUtils";
+
+export class TagNodeHandler {
+  private plugin: DiscourseGraphPlugin;
+  private app: App;
+  private registeredEventHandlers: (() => void)[] = [];
+  private tagObserver: MutationObserver | null = null;
+
+  constructor(plugin: DiscourseGraphPlugin) {
+    this.plugin = plugin;
+    this.app = plugin.app;
+  }
+
+  /**
+   * Create a MutationObserver to watch for discourse node tags
+   */
+  private createTagObserver(): MutationObserver {
+    return new MutationObserver((mutations) => {
+      mutations.forEach((mutation) => {
+        // Only process nodes that are likely to contain tags
+        if (mutation.type === 'childList') {
+          mutation.addedNodes.forEach((node) => {
+            if (node instanceof HTMLElement) {
+              if (node.classList.contains('cm-line') || 
+                  node.querySelector('[class*="cm-tag-"]') ||
+                  Array.from(node.classList).some(cls => cls.startsWith('cm-tag-'))) {
+                this.processElement(node);
+              }
+            }
+          });
+        }
+        
+        // Only watch class changes on elements that might be tags
+        if (mutation.type === 'attributes' && 
+            mutation.attributeName === 'class' && 
+            mutation.target instanceof HTMLElement) {
+          const target = mutation.target;
+          const classList = Array.from(target.classList);
+          
+          // Only process if it has or gained a cm-tag-* class
+          if (classList.some(cls => cls.startsWith('cm-tag-'))) {
+            this.processElement(target);
+          }
+        }
+      });
+    });
+  }
+
+  /**
+   * Process an element and its children for discourse node tags
+   */
+  private processElement(element: HTMLElement) {
+    this.plugin.settings.nodeTypes.forEach((nodeType) => {
+      const nodeTypeName = nodeType.name.toLowerCase();
+      const tagSelector = `.cm-tag-${nodeTypeName}`;
+      
+      // Check if the element itself matches
+      if (element.matches(tagSelector)) {
+        this.applyDiscourseTagStyling(element, nodeType);
+      }
+      
+      // Check all children
+      const childTags = element.querySelectorAll(tagSelector);
+      childTags.forEach((tagEl) => {
+        if (tagEl instanceof HTMLElement) {
+          this.applyDiscourseTagStyling(tagEl, nodeType);
+        }
+      });
+    });
+  }
+
+  /**
+   * Apply colors and hover functionality to a discourse tag
+   */
+  private applyDiscourseTagStyling(tagElement: HTMLElement, nodeType: DiscourseNode) {
+    const alreadyProcessed = tagElement.dataset.discourseTagProcessed === 'true';
+
+    const nodeIndex = this.plugin.settings.nodeTypes.findIndex((nt) => nt.id === nodeType.id);
+    const colors = getDiscourseNodeColors(nodeType, nodeIndex);
+
+    tagElement.style.backgroundColor = colors.backgroundColor;
+    tagElement.style.color = colors.textColor;
+    tagElement.style.cursor = "pointer";
+
+    if (!alreadyProcessed) {
+      const editor = this.getActiveEditor();
+      if (editor) {
+        this.addHoverFunctionality(tagElement, nodeType, editor);
+      }
+    }
+  }
+
+  /**
+   * Get the active editor (helper method)
+   */
+  private getActiveEditor(): Editor | null {
+    const activeView = this.app.workspace.getActiveViewOfType(MarkdownView);
+    return activeView?.editor || null;
+  }
+  /**
+   * Extract content from the line up to the clicked tag using simple text approach
+   */
+  private extractContentUpToTag(tagElement: HTMLElement): { contentUpToTag: string; tagName: string } | null {
+    const lineDiv = tagElement.closest('.cm-line');
+    if (!lineDiv) return null;
+    
+    const fullLineText = lineDiv.textContent || '';
+    
+    const tagClasses = Array.from(tagElement.classList);
+    const tagClass = tagClasses.find(cls => cls.startsWith('cm-tag-'));
+    if (!tagClass) return null;
+    
+    const tagName = tagClass.replace('cm-tag-', '');
+    const tagWithHash = `#${tagName}`;
+    
+    const tagIndex = fullLineText.indexOf(tagWithHash);
+    if (tagIndex === -1) return null;
+    
+    const contentUpToTag = fullLineText.substring(0, tagIndex).trim();
+
+    return {
+      contentUpToTag,
+      tagName
+    };
+  }
+
+
+
+  /**
+   * Handle tag click to create discourse node
+   */
+  private handleTagClick(tagElement: HTMLElement, nodeType: DiscourseNode, editor: Editor): void {
+    const extractedData = this.extractContentUpToTag(tagElement);
+    if (!extractedData) {
+      new Notice("Could not extract content", 3000);
+      return;
+    }
+
+    const cleanText = extractedData.contentUpToTag.replace(/#\w+/g, '').trim();
+    
+    new CreateNodeModal(this.app, {
+      nodeTypes: this.plugin.settings.nodeTypes,
+      plugin: this.plugin,
+      initialTitle: cleanText,
+      initialNodeType: nodeType,
+      onNodeCreate: async (selectedNodeType, title) => {
+        await this.createNodeAndReplace({
+          nodeType: selectedNodeType,
+          title,
+          editor,
+          tagElement,
+        });
+      },
+    }).open();
+  }
+
+  /**
+   * Create the discourse node and replace the content up to the tag
+   */
+  private async createNodeAndReplace(params: {
+    nodeType: DiscourseNode;
+    title: string;
+    editor: Editor;
+    tagElement: HTMLElement;
+  }): Promise<void> {
+    const { nodeType, title, editor, tagElement } = params;
+    try {
+      // Create the discourse node file
+      const formattedNodeName = formatNodeName(title, nodeType);
+      if (!formattedNodeName) {
+        new Notice("Failed to format node name", 3000);
+        return;
+      }
+
+      const newFile = await createDiscourseNodeFile({
+        plugin: this.plugin,
+        formattedNodeName,
+        nodeType,
+      });
+
+      if (!newFile) {
+        new Notice("Failed to create discourse node file", 3000);
+        return;
+      }
+
+      const extractedData = this.extractContentUpToTag(tagElement);
+      if (!extractedData) {
+        new Notice("Could not determine content range for replacement", 3000);
+        return;
+      }
+      
+      const { contentUpToTag, tagName } = extractedData;
+      const tagWithHash = `#${tagName}`;
+      
+      // Find the actual line in editor that matches our DOM content
+      const allLines = editor.getValue().split('\n');
+      let lineNumber = -1;
+      for (let i = 0; i < allLines.length; i++) {
+        if (allLines[i]?.includes(tagWithHash) && allLines[i]?.includes(contentUpToTag.substring(0, 10))) {
+          lineNumber = i;
+          break;
+        }
+      }
+      
+      if (lineNumber === -1) {
+        new Notice("Could not find matching line in editor", 3000);
+        return;
+      }
+      
+      const actualLineText = allLines[lineNumber]; 
+      if (!actualLineText) {
+        new Notice("Could not find matching line in editor", 3000);
+        return;
+      }
+      const tagStartPos = actualLineText.indexOf(tagWithHash);
+      const tagEndPos = tagStartPos + tagWithHash.length;
+      
+      const linkText = `[[${formattedNodeName}]]`;
+      const contentAfterTag = actualLineText.substring(tagEndPos);
+      
+      editor.replaceRange(
+        linkText + contentAfterTag,
+        { line: lineNumber, ch: 0 },
+        { line: lineNumber, ch: actualLineText.length }
+      );
+    } catch (error) {
+      console.error("Error creating discourse node from tag:", error);
+      new Notice(
+        `Error creating discourse node: ${error instanceof Error ? error.message : String(error)}`,
+        5000,
+      );
+    }
+  }
+
+  /**
+   * Add hover functionality with "Create [NodeType]" button
+   */
+  private addHoverFunctionality(tagElement: HTMLElement, nodeType: DiscourseNode, editor: Editor) {
+    // Mark as processed to avoid duplicate handlers
+    if (tagElement.dataset.discourseTagProcessed === 'true') return;
+    tagElement.dataset.discourseTagProcessed = 'true';
+    
+    let hoverTooltip: HTMLElement | null = null;
+    let hoverTimeout: number | null = null;
+    
+    const showTooltip = () => {
+      if (hoverTooltip) return;
+      const rect = tagElement.getBoundingClientRect();
+      
+      hoverTooltip = document.createElement('div');
+      hoverTooltip.className = 'discourse-tag-popover';
+      hoverTooltip.style.cssText = `
+        position: fixed;
+        top: ${rect.top - 40}px;
+        left: ${rect.left + rect.width / 2}px;
+        transform: translateX(-50%);
+        background: var(--background-primary);
+        border: 1px solid var(--background-modifier-border);
+        border-radius: 6px;
+        padding: 6px;
+        box-shadow: 0 4px 16px rgba(0,0,0,0.15);
+        z-index: 9999;
+        white-space: nowrap;
+        font-size: 12px;
+        pointer-events: auto;
+      `;
+      
+      const createButton = document.createElement('button');
+      createButton.textContent = `Create ${nodeType.name}`;
+      createButton.className = 'mod-cta dg-create-node-button';
+      
+      createButton.addEventListener('click', (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        
+        this.handleTagClick(tagElement, nodeType, editor);
+        
+        hideTooltip();
+      });
+      
+      hoverTooltip.appendChild(createButton);
+      
+      document.body.appendChild(hoverTooltip);
+      
+      hoverTooltip.addEventListener('mouseenter', () => {
+        if (hoverTimeout) {
+          clearTimeout(hoverTimeout);
+          hoverTimeout = null;
+        }
+      });
+      
+      hoverTooltip.addEventListener('mouseleave', () => {
+        void setTimeout(hideTooltip, 100);
+      });
+    };
+    
+    const hideTooltip = () => {
+      if (hoverTooltip) {
+        hoverTooltip.remove();
+        hoverTooltip = null;
+      }
+    };
+    
+    tagElement.addEventListener('mouseenter', () => {
+      if (hoverTimeout) {
+        clearTimeout(hoverTimeout);
+      }
+      hoverTimeout = window.setTimeout(showTooltip, 200);
+    });
+    
+    tagElement.addEventListener('mouseleave', (e) => {
+      if (hoverTimeout) {
+        clearTimeout(hoverTimeout);
+        hoverTimeout = null;
+      }
+      
+      const relatedTarget = e.relatedTarget as HTMLElement;
+      if (!relatedTarget || !hoverTooltip?.contains(relatedTarget)) {
+        void setTimeout(hideTooltip, 100);
+      }
+    });
+    
+    const cleanup = () => {
+      if (hoverTimeout) {
+        clearTimeout(hoverTimeout);
+      }
+      hideTooltip();
+    };
+    
+    (tagElement as HTMLElement & { __discourseTagCleanup?: () => void }).__discourseTagCleanup = cleanup;
+  }
+  
+  
+
+  /**
+   * Process existing tags in the current view (for initial setup)
+   */
+  private processTagsInView() {
+    const activeView = this.app.workspace.getActiveViewOfType(MarkdownView);
+    if (!activeView) return;
+
+    this.processElement(activeView.contentEl);
+  }
+
+  /**
+   * Refresh discourse tag colors when node types change
+   */
+  public refreshColors() {
+    this.processTagsInView();
+  }
+
+  /**
+   * Initialize the tag node handler
+   */
+  public initialize() {
+    // Create and start the tag observer (similar to Roam's approach)
+    this.tagObserver = this.createTagObserver();
+    
+    // Start observing the workspace
+    this.startObserving();
+    
+    // Process existing tags in the current view
+    this.processTagsInView();
+    
+    // Re-start observing when the active view changes
+    const activeLeafChangeHandler = () => {
+      void setTimeout(() => {
+        this.stopObserving();
+        this.startObserving();
+        this.processTagsInView();
+      }, 100);
+    };
+    
+    this.app.workspace.on('active-leaf-change', activeLeafChangeHandler);
+    this.registeredEventHandlers.push(() => {
+      this.app.workspace.off('active-leaf-change', activeLeafChangeHandler);
+    });
+  }
+
+  /**
+   * Start observing the current active view for tag changes
+   */
+  private startObserving() {
+    if (!this.tagObserver) return;
+    
+    const activeView = this.app.workspace.getActiveViewOfType(MarkdownView);
+    if (!activeView) return;
+    
+    const targetElement = activeView.contentEl;
+    if (targetElement) {
+      this.tagObserver.observe(targetElement, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+        attributeFilter: ['class']
+      });
+    }
+  }
+
+  /**
+   * Stop observing
+   */
+  private stopObserving() {
+    if (this.tagObserver) {
+      this.tagObserver.disconnect();
+    }
+  }
+
+  /**
+   * Cleanup event handlers and tooltips
+   */
+  public cleanup() {
+    this.registeredEventHandlers.forEach(cleanup => cleanup());
+    this.registeredEventHandlers = [];
+    
+    // Stop and cleanup the tag observer
+    this.stopObserving();
+    this.tagObserver = null;
+    
+    // Clean up any remaining tooltips
+    const tooltips = document.querySelectorAll('.discourse-tag-popover');
+    tooltips.forEach(tooltip => tooltip.remove());
+    
+    // Clean up processed tags
+    const processedTags = document.querySelectorAll('[data-discourse-tag-processed="true"]');
+    processedTags.forEach(tag => {
+      const tagWithCleanup = tag as HTMLElement & { __discourseTagCleanup?: () => void };
+      const cleanup = tagWithCleanup.__discourseTagCleanup;
+      if (typeof cleanup === 'function') {
+        cleanup();
+      }
+      tag.removeAttribute('data-discourse-tag-processed');
+      
+      // Reset styles for the tag element
+      const htmlTag = tag as HTMLElement;
+      htmlTag.style.backgroundColor = '';
+      htmlTag.style.color = '';
+      htmlTag.style.cursor = '';
+    });
+  }
+}

--- a/apps/obsidian/src/utils/tagNodeHandler.ts
+++ b/apps/obsidian/src/utils/tagNodeHandler.ts
@@ -367,7 +367,6 @@ export class TagNodeHandler {
         border: 1px solid var(--background-modifier-border);
         border-radius: 6px;
         padding: 6px;
-        box-shadow: 0 4px 16px rgba(0,0,0,0.15);
         z-index: 9999;
         white-space: nowrap;
         font-size: 12px;

--- a/apps/obsidian/src/utils/tagNodeHandler.ts
+++ b/apps/obsidian/src/utils/tagNodeHandler.ts
@@ -308,7 +308,10 @@ export class TagNodeHandler {
       const allLines = editor.getValue().split("\n");
       let lineNumber = -1;
       for (let i = 0; i < allLines.length; i++) {
-        if (allLines[i]?.includes(fullLineContent)) {
+        if (
+          allLines[i]?.includes(fullLineContent) &&
+          allLines[i]?.includes(tagElement.textContent ?? "")
+        ) {
           lineNumber = i;
           break;
         }

--- a/apps/obsidian/styles.css
+++ b/apps/obsidian/styles.css
@@ -17,3 +17,20 @@
 .dg-h4 {
   @apply text-lg font-bold mb-2;
 }
+
+.dg-create-node-button {
+  background: var(--interactive-accent);
+  color: var(--text-on-accent);
+  border: none;
+  border-radius: 4px;
+  padding: 6px 12px;
+  font-size: 11px;
+  cursor: pointer;
+  font-weight: 500;
+  white-space: nowrap;
+  transition: background-color 0.2s ease;
+}
+
+.dg-create-node-button:hover {
+  background: var(--interactive-accent-hover);
+}


### PR DESCRIPTION
https://www.loom.com/share/ce7628cb337942fd86338e12d6a8f7ef


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Discourse tags in Markdown are auto-styled with distinct background/text colors per node type for better readability.
  - Hovering a discourse tag shows a tooltip with a “Create [NodeType]” button.
  - Clicking “Create” opens a modal to create the node and replaces the tag with a link to the new item.
  - Works dynamically as you edit and across view changes.

- Style
  - Added styling for the “Create Node” button with hover effects for clearer, more consistent UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->