### PR TITLE
ENG-904 - Added isACandidateCallback to registerDiscourseDatalogTranslators for handling discourse node candidates.

### DIFF
--- a/apps/roam/src/utils/compileDatalog.ts
+++ b/apps/roam/src/utils/compileDatalog.ts
@@ -6,7 +6,8 @@ import type {
 
 const indent = (n: number) => "".padStart(n * 2, " ");
 
-const toVar = (v = "undefined") => v.replace(/[\s"()[\]{}/\\^@,~`]/g, "");
+export const toVar = (v = "undefined") =>
+  v.replace(/[\s"()[\]{}/\\^@,~`]/g, "");
 
 const compileDatalog = (
   d: DatalogClause | DatalogArgument | DatalogBinding,

--- a/apps/roam/src/utils/conditionToDatalog.ts
+++ b/apps/roam/src/utils/conditionToDatalog.ts
@@ -29,7 +29,7 @@ const regexRePatternValue = (str: string) => {
     ? `"(?i)${str.slice(1, -2).replace(/\\/g, "\\\\")}"`
     : `"${str.slice(1, -1).replace(/\\/g, "\\\\")}"`;
 };
-const getTitleDatalog = ({
+export const getTitleDatalog = ({
   source,
   target,
   uid,

--- a/apps/roam/src/utils/registerDiscourseDatalogTranslators.ts
+++ b/apps/roam/src/utils/registerDiscourseDatalogTranslators.ts
@@ -120,7 +120,7 @@ const registerDiscourseDatalogTranslators = () => {
                     value: `${source}-${toVar(node.tag)}-ref`,
                   },
                   { type: "constant" as const, value: ":node/title" },
-                  { type: "constant" as const, value: `"${node.tag}"` },
+                  { type: "constant" as const, value: `"${toVar(node.tag)}"` },
                 ],
               },
               {
@@ -154,7 +154,7 @@ const registerDiscourseDatalogTranslators = () => {
             value: `${source}-${toVar(targetNode.tag)}-ref`,
           },
           { type: "constant" as const, value: ":node/title" },
-          { type: "constant" as const, value: `"${targetNode.tag}"` },
+          { type: "constant" as const, value: `"${toVar(targetNode.tag)}"` },
         ],
       },
       {

--- a/apps/roam/src/utils/registerDiscourseDatalogTranslators.ts
+++ b/apps/roam/src/utils/registerDiscourseDatalogTranslators.ts
@@ -137,7 +137,7 @@ const registerDiscourseDatalogTranslators = () => {
       ];
     }
 
-    const targetNodeTag = nodeByTypeOrText[target].tag;
+    const targetNodeTag = nodeByTypeOrText[target]?.tag;
     if (!targetNodeTag) return [];
     const variableRef = `${toVar(targetNodeTag)}-ref`;
 


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved candidate detection for discourse nodes using tags, yielding more relevant suggestions and query results.
  * Supports targeting either “any discourse node” or specific tagged nodes for broader, smarter discovery.

* **Chores**
  * Internal utility adjustments to support the above behavior (no change to existing user workflows).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->