### PR TITLE
ENG-490 - removing duplicates from expected inputs in Inputs.tsx and fireQuery.ts

### DIFF
--- a/apps/roam/src/components/results-view/Inputs.tsx
+++ b/apps/roam/src/components/results-view/Inputs.tsx
@@ -178,7 +178,8 @@ export const Inputs = ({
                 ),
         )
         .filter((t) => /^:in /.test(t))
-        .map((t) => t.substring(4));
+        .map((t) => t.substring(4))
+        .filter((value, index, array) => array.indexOf(value) === index); // Remove duplicates
     };
 
     const newInputs = getExpectedInputs().map((key) => {

--- a/apps/roam/src/utils/fireQuery.ts
+++ b/apps/roam/src/utils/fireQuery.ts
@@ -192,7 +192,8 @@ export const getDatalogQuery = ({
   const expectedInputs = getConditionTargets(conditions)
     .filter((c) => /^:in /.test(c))
     .map((c) => c.substring(4))
-    .filter((c) => !!inputs[c]);
+    .filter((c) => !!inputs[c])
+    .filter((value, index, array) => array.indexOf(value) === index); // Remove duplicates
   const whereClauses = optimizeQuery(
     getWhereClauses({ conditions, returnNode }),
     new Set([]),


### PR DESCRIPTION
<img width="800" height="610" alt="image" src="https://github.com/user-attachments/assets/10789b35-1b4b-4c85-9df4-0814266f084c" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Deduplicates expected input variables extracted from conditions to avoid duplicate inputs and :in parameters.
> 
> - **Query Inputs Deduplication**
>   - In `apps/roam/src/components/results-view/Inputs.tsx`, de-duplicate expected input keys parsed from conditions before creating inputs.
>   - In `apps/roam/src/utils/fireQuery.ts`, de-duplicate expected input keys used to build the `:in` parameter list for the Datalog query.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4dd49d51980fb58a23979a69c0661073a29fadd4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Bug Fixes
  * Eliminates duplicate input prompts in the results view.
  * Ensures each input is included only once when running queries, reducing confusion and mismatches.

* Improvements
  * Streamlined input handling for a cleaner setup experience.
  * More predictable query results due to deduplicated inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->