### PR TITLE
ENG-890 | ENG-891 - Ship pre populated tags and adjust tag placeholder

### DIFF
--- a/apps/roam/src/components/settings/NodeConfig.tsx
+++ b/apps/roam/src/components/settings/NodeConfig.tsx
@@ -141,6 +141,19 @@ const useDebouncedRoamUpdater = <
   return { value, handleChange, handleBlur };
 };
 
+const generateTagPlaceholder = (node: DiscourseNode): string => {
+  // Extract first reference from format like [[CLM]], [[QUE]], [[EVD]]
+  const referenceMatch = node.format.match(/\[\[([A-Z]+)\]\]/);
+
+  if (referenceMatch) {
+    const reference = referenceMatch[1].toLowerCase();
+    return `#${reference.slice(0, 3)}-candidate`; // [[EVD]] - {content} = #evd-candidate
+  }
+
+  const nodeTextPrefix = node.text.toLowerCase().slice(0, 3);
+  return `${nodeTextPrefix}-candidate`; // Evidence = #evi-candidate
+};
+
 const NodeConfig = ({
   node,
   onloadArgs,
@@ -288,7 +301,7 @@ const NodeConfig = ({
                 onChange={handleTagChange}
                 onBlur={handleTagBlur}
                 error={tagError}
-                placeholder={`#${node.text.toLowerCase()}`}
+                placeholder={generateTagPlaceholder(node)}
               />
             </div>
           }

--- a/apps/roam/src/components/settings/NodeConfig.tsx
+++ b/apps/roam/src/components/settings/NodeConfig.tsx
@@ -151,7 +151,7 @@ const generateTagPlaceholder = (node: DiscourseNode): string => {
   }
 
   const nodeTextPrefix = node.text.toLowerCase().slice(0, 3);
-  return `${nodeTextPrefix}-candidate`; // Evidence = #evi-candidate
+  return `#${nodeTextPrefix}-candidate`; // Evidence = #evi-candidate
 };
 
 const NodeConfig = ({

--- a/apps/roam/src/data/defaultDiscourseNodes.ts
+++ b/apps/roam/src/data/defaultDiscourseNodes.ts
@@ -6,6 +6,7 @@ const INITIAL_NODE_VALUES: Partial<DiscourseNode>[] = [
     format: "[[CLM]] - {content}",
     text: "Claim",
     shortcut: "C",
+    tag: "#clm-candidate",
     graphOverview: true,
     canvasSettings: {
       color: "7DA13E",
@@ -26,6 +27,7 @@ const INITIAL_NODE_VALUES: Partial<DiscourseNode>[] = [
     format: "[[EVD]] - {content} - {Source}",
     text: "Evidence",
     shortcut: "E",
+    tag: "#evd-candidate",
     graphOverview: true,
     canvasSettings: {
       color: "DB134A",


### PR DESCRIPTION
### Prepopulated tags
Evidence: `#evd-candidate`
Claim: `#clm-candidate`

### Placeholders
- Grab the first reference in format, use it's first 3 letters (evd-candidate)
- If no reference exists (Source, for example), fallback to the node label, use it's first 3 letters (sou-candidate)


## Summary by CodeRabbit

* **New Features**
  * Tag input now shows a smart, auto-generated placeholder based on the node’s reference or its text, improving guidance and reducing manual typing.
  * Default nodes include prefilled candidate tags (e.g., for CLM and EVD), streamlining initial setup and promoting consistent tagging.
  * These updates are purely UI-facing (placeholders and defaults) and do not alter saved data or validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->