### PR TITLE
 ENG-914 Add DiscourseSuggestionsPanel and panel manager

### DIFF
--- a/apps/roam/src/components/DiscourseSuggestionsPanel.tsx
+++ b/apps/roam/src/components/DiscourseSuggestionsPanel.tsx
@@ -40,50 +40,22 @@ export const DiscourseSuggestionsPanel = ({
 
   return (
     <Card
-      data-dg-block-uid={blockUid}
-      style={{
-        backgroundColor: "#fff",
-        display: "flex",
-        flexDirection: "column",
-        padding: "8px",
-      }}
+      data-dg-block-uid={`${blockUid}`}
       onMouseEnter={() => toggleHighlight(true)}
       onMouseLeave={() => toggleHighlight(false)}
-      className="discourse-suggestions-panel"
+      className="discourse-suggestions-panel flex flex-col bg-white p-2"
     >
-      <Navbar
-        style={{
-          borderBottom: "1px solid #d8e1e8",
-          boxShadow: "none",
-          paddingRight: 0,
-          display: "flex",
-          flexWrap: "nowrap",
-          alignItems: "center",
-        }}
-      >
-        <Navbar.Group align={Alignment.LEFT} style={{ flex: 1, minWidth: 0 }}>
-          <Navbar.Heading
-            className="truncate"
-            style={{
-              fontSize: "13px",
-              margin: 0,
-              fontWeight: 600,
-              cursor: "pointer",
-            }}
-            onClick={() => setIsOpen((prev) => !prev)}
-          >
+      <Navbar className="flex flex-nowrap items-center pl-2 pr-0 shadow-none">
+        <Navbar.Group
+          align={Alignment.LEFT}
+          className="min-w-0 flex-1 cursor-pointer"
+          onClick={() => setIsOpen((prev) => !prev)}
+        >
+          <Navbar.Heading className="cursor-pointer truncate text-base font-semibold">
             {tag}
           </Navbar.Heading>
         </Navbar.Group>
-        <Navbar.Group
-          align={Alignment.RIGHT}
-          style={{
-            marginRight: "5px",
-            flexShrink: 0,
-            display: "flex",
-            gap: "4px",
-          }}
-        >
+        <Navbar.Group align={Alignment.RIGHT} className="flex-0">
           <Button
             icon={isOpen ? "chevron-up" : "chevron-down"}
             minimal
@@ -105,10 +77,7 @@ export const DiscourseSuggestionsPanel = ({
         keepChildrenMounted={true}
         transitionDuration={150}
       >
-        <div
-          className={Classes.CARD}
-          style={{ flexGrow: 1, overflowY: "auto", padding: "6px" }}
-        >
+        <div className="flex-grow overflow-y-auto p-2">
           {/* TODO: Replace with actual body*/}
           <div>Body placeholder</div>
         </div>

--- a/apps/roam/src/components/DiscourseSuggestionsPanel.tsx
+++ b/apps/roam/src/components/DiscourseSuggestionsPanel.tsx
@@ -12,6 +12,7 @@ export const DiscourseSuggestionsPanel = ({
   tag,
   blockUid,
   onClose,
+  // TODO: Will be used to pass setting to body renderer
   shouldGrabFromReferencedPages,
   shouldGrabParentChildContext,
 }: {
@@ -27,7 +28,12 @@ export const DiscourseSuggestionsPanel = ({
     (on: boolean) => {
       document
         .querySelectorAll(`[data-dg-block-uid="${blockUid}"]`)
-        .forEach((el) => el.classList.toggle("dg-highlight", on));
+        .forEach((el) =>
+          el.classList.toggle(
+            "suggestive-mode-overlay-highlight-on-panel-hover",
+            on,
+          ),
+        );
     },
     [blockUid],
   );

--- a/apps/roam/src/components/DiscourseSuggestionsPanel.tsx
+++ b/apps/roam/src/components/DiscourseSuggestionsPanel.tsx
@@ -1,0 +1,112 @@
+import {
+  Alignment,
+  Card,
+  Classes,
+  Button,
+  Navbar,
+  Collapse,
+} from "@blueprintjs/core";
+import React, { useState, useCallback } from "react";
+
+export const DiscourseSuggestionsPanel = ({
+  tag,
+  blockUid,
+  onClose,
+  shouldGrabFromReferencedPages,
+  shouldGrabParentChildContext,
+}: {
+  tag: string;
+  blockUid: string;
+  onClose: () => void;
+  shouldGrabFromReferencedPages: boolean;
+  shouldGrabParentChildContext: boolean;
+}) => {
+  const [isOpen, setIsOpen] = useState(true);
+
+  const toggleHighlight = useCallback(
+    (on: boolean) => {
+      document
+        .querySelectorAll(`[data-dg-block-uid="${blockUid}"]`)
+        .forEach((el) => el.classList.toggle("dg-highlight", on));
+    },
+    [blockUid],
+  );
+
+  return (
+    <Card
+      data-dg-block-uid={blockUid}
+      style={{
+        backgroundColor: "#fff",
+        display: "flex",
+        flexDirection: "column",
+        padding: "8px",
+      }}
+      onMouseEnter={() => toggleHighlight(true)}
+      onMouseLeave={() => toggleHighlight(false)}
+      className="discourse-suggestions-panel"
+    >
+      <Navbar
+        style={{
+          borderBottom: "1px solid #d8e1e8",
+          boxShadow: "none",
+          paddingRight: 0,
+          display: "flex",
+          flexWrap: "nowrap",
+          alignItems: "center",
+        }}
+      >
+        <Navbar.Group align={Alignment.LEFT} style={{ flex: 1, minWidth: 0 }}>
+          <Navbar.Heading
+            className="truncate"
+            style={{
+              fontSize: "13px",
+              margin: 0,
+              fontWeight: 600,
+              cursor: "pointer",
+            }}
+            onClick={() => setIsOpen((prev) => !prev)}
+          >
+            {tag}
+          </Navbar.Heading>
+        </Navbar.Group>
+        <Navbar.Group
+          align={Alignment.RIGHT}
+          style={{
+            marginRight: "5px",
+            flexShrink: 0,
+            display: "flex",
+            gap: "4px",
+          }}
+        >
+          <Button
+            icon={isOpen ? "chevron-up" : "chevron-down"}
+            minimal
+            small
+            onClick={() => setIsOpen((prev) => !prev)}
+            title={isOpen ? "Collapse" : "Expand"}
+          />
+          <Button
+            icon="cross"
+            minimal={true}
+            title="Close Panel"
+            onClick={onClose}
+            small={true}
+          />
+        </Navbar.Group>
+      </Navbar>
+      <Collapse
+        isOpen={isOpen}
+        keepChildrenMounted={true}
+        transitionDuration={150}
+      >
+        <div
+          className={Classes.CARD}
+          style={{ flexGrow: 1, overflowY: "auto", padding: "6px" }}
+        >
+          {/* TODO: Replace with actual body*/}
+          <div>Body placeholder</div>
+        </div>
+      </Collapse>
+    </Card>
+  );
+};

--- a/apps/roam/src/components/PanelManager.tsx
+++ b/apps/roam/src/components/PanelManager.tsx
@@ -297,7 +297,9 @@ const clearBlockHighlight = (blockUid: string): void => {
     const nodes = document.querySelectorAll(
       `[data-dg-block-uid="${blockUid}"]`,
     );
-    nodes.forEach((el) => el.classList.remove("dg-highlight"));
+    nodes.forEach((el) =>
+      el.classList.remove("suggestive-mode-overlay-highlight-on-panel-hover"),
+    );
   } catch {
     // no-op
   }

--- a/apps/roam/src/components/PanelManager.tsx
+++ b/apps/roam/src/components/PanelManager.tsx
@@ -143,6 +143,10 @@ export const PanelContainer = (): React.ReactElement => {
     if (articleWrapper) {
       articleWrapper.style.flex = isMinimized ? "1 1 auto" : "1 1 60%";
     }
+    if (containerMount) {
+      containerMount.style.flex = isMinimized ? "0 0 auto" : "0 0 40%";
+      containerMount.style.width = isMinimized ? "auto" : "";
+    }
   }, [isMinimized]);
 
   const handleMinimize = useCallback(() => setIsMinimized(true), []);
@@ -170,8 +174,8 @@ export const PanelContainer = (): React.ReactElement => {
       style={{
         display: "flex",
         flexDirection: "column",
-        flex: isMinimized ? "0 0 auto" : "0 0 40%",
-        width: isMinimized ? "auto" : undefined,
+        width: "100%",
+        height: "100%",
       }}
     >
       {!isMinimized ? (
@@ -258,29 +262,6 @@ const cssEscape = (value: string): string =>
   window.CSS && window.CSS.escape
     ? window.CSS.escape(value)
     : value.replace(/[^a-zA-Z0-9_-]/g, (c: string) => `\\${c}`);
-
-const updateOverlayToggleButtons = (tag: string, isOpen: boolean): void => {
-  const selector = `button[data-dg-role="panel-toggle"][data-dg-tag="${cssEscape(tag)}"]`;
-  const buttons = Array.from(document.querySelectorAll(selector));
-  buttons.forEach((btn) => {
-    const buttonEl = btn as HTMLButtonElement;
-    buttonEl.dataset.dgPanelOpen = isOpen ? "true" : "false";
-    if (isOpen) buttonEl.classList.add("bp3-intent-primary");
-    else buttonEl.classList.remove("bp3-intent-primary");
-    buttonEl.title = isOpen
-      ? "Close suggestions panel"
-      : "Open suggestions panel";
-    const icon = buttonEl.querySelector(".bp3-icon");
-    if (icon) {
-      icon.classList.remove(
-        isOpen ? "bp3-icon-panel-stats" : "bp3-icon-panel-table",
-      );
-      icon.classList.add(
-        isOpen ? "bp3-icon-panel-table" : "bp3-icon-panel-stats",
-      );
-    }
-  });
-};
 
 const clearBlockHighlight = (blockUid: string): void => {
   try {
@@ -436,7 +417,6 @@ export const panelManager: PanelManager = {
       element: null,
     });
     this.notify();
-    updateOverlayToggleButtons(tag, true);
     notifySubscribers(tag, true);
   },
 
@@ -446,7 +426,6 @@ export const panelManager: PanelManager = {
 
     openPanels.delete(tag);
     this.notify();
-    updateOverlayToggleButtons(tag, false);
     clearBlockHighlight(state.blockUid);
     notifySubscribers(tag, false);
 
@@ -461,7 +440,6 @@ export const panelManager: PanelManager = {
     this.notify();
 
     entries.forEach(([tag, state]) => {
-      updateOverlayToggleButtons(tag, false);
       clearBlockHighlight(state.blockUid);
       notifySubscribers(tag, false);
     });

--- a/apps/roam/src/components/PanelManager.tsx
+++ b/apps/roam/src/components/PanelManager.tsx
@@ -1,0 +1,477 @@
+import React, { useEffect, useState, useRef, useCallback } from "react";
+import ReactDOM from "react-dom";
+import { Navbar, Alignment, Button } from "@blueprintjs/core";
+import { OnloadArgs } from "roamjs-components/types/native";
+import ExtensionApiContextProvider from "roamjs-components/components/ExtensionApiContext";
+import { DiscourseSuggestionsPanel } from "./DiscourseSuggestionsPanel";
+
+const SPACING_PREFIX = "rm-spacing--";
+const initialSpacingByWrapper = new WeakMap<HTMLElement, string | null>();
+
+type PanelState = {
+  blockUid: string;
+  onloadArgs: OnloadArgs;
+  element: HTMLElement | null;
+};
+type PanelEntry = [string, PanelState];
+
+let globalIsMinimized = false;
+const openPanels: Map<string, PanelState> = new Map();
+
+const panelSubscribers = new Map<string, Set<(isOpen: boolean) => void>>();
+
+const notifySubscribers = (tag: string, isOpen: boolean): void => {
+  const subscribers = panelSubscribers.get(tag);
+  if (subscribers) {
+    subscribers.forEach((callback) => callback(isOpen));
+  }
+};
+
+export const subscribeToPanelState = (
+  tag: string,
+  callback: (isOpen: boolean) => void,
+): (() => void) => {
+  if (!panelSubscribers.has(tag)) {
+    panelSubscribers.set(tag, new Set());
+  }
+  panelSubscribers.get(tag)!.add(callback);
+
+  callback(openPanels.has(tag));
+
+  return () => {
+    const subscribers = panelSubscribers.get(tag);
+    if (subscribers) {
+      subscribers.delete(callback);
+      if (subscribers.size === 0) {
+        panelSubscribers.delete(tag);
+      }
+    }
+  };
+};
+
+const getSpacingClass = (element: HTMLElement): string | null => {
+  for (const className of Array.from(element.classList)) {
+    if (className.startsWith(SPACING_PREFIX)) return className;
+  }
+  return null;
+};
+
+const setSpacingClass = (
+  element: HTMLElement,
+  spacingClass: string | null,
+): void => {
+  for (const className of Array.from(element.classList)) {
+    if (className.startsWith(SPACING_PREFIX))
+      element.classList.remove(className);
+  }
+  if (spacingClass) element.classList.add(spacingClass);
+};
+
+const selectOpenPanelsEntries = (): PanelEntry[] =>
+  Array.from(openPanels.entries());
+
+const subscribeToOpenPanels = (callback: () => void): (() => void) => {
+  const handler = (): void => callback();
+  panelManager.addListener("change", handler);
+  return () => panelManager.removeListener("change", handler);
+};
+
+const useExternalStore = <T,>(
+  selector: () => T,
+  subscribe: (callback: () => void) => () => void,
+): T => {
+  const [state, setState] = useState<T>(selector);
+
+  useEffect(() => {
+    const handleChange = (): void => setState(selector());
+    const unsubscribe = subscribe(handleChange);
+    handleChange();
+    return unsubscribe;
+  }, [selector, subscribe]);
+
+  return state;
+};
+
+export const PanelContainer = (): React.ReactElement => {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const panels = useExternalStore<PanelEntry[]>(
+    selectOpenPanelsEntries,
+    subscribeToOpenPanels,
+  );
+
+  const [isMinimized, setIsMinimized] = useState(globalIsMinimized);
+
+  useEffect(() => {
+    const roamBodyMain = document.querySelector<HTMLElement>(".roam-body-main");
+    const articleWrapper = roamBodyMain?.querySelector<HTMLElement>(
+      ".rm-article-wrapper",
+    );
+
+    if (roamBodyMain && articleWrapper && containerRef.current) {
+      roamBodyMain.style.display = "flex";
+      roamBodyMain.dataset.isSplit = "true";
+      articleWrapper.style.flex = "1 1 60%";
+
+      if (!initialSpacingByWrapper.has(articleWrapper)) {
+        initialSpacingByWrapper.set(
+          articleWrapper,
+          getSpacingClass(articleWrapper),
+        );
+      }
+      setSpacingClass(articleWrapper, "rm-spacing--full");
+    }
+
+    return () => {
+      if (roamBodyMain && articleWrapper) {
+        roamBodyMain.removeAttribute("data-is-split");
+        roamBodyMain.style.display = "";
+        articleWrapper.style.flex = "";
+        const initial = initialSpacingByWrapper.get(articleWrapper) ?? null;
+        setSpacingClass(articleWrapper, initial);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    globalIsMinimized = isMinimized;
+    const roamBodyMain = document.querySelector<HTMLElement>(".roam-body-main");
+    const articleWrapper = roamBodyMain?.querySelector<HTMLElement>(
+      ".rm-article-wrapper",
+    );
+
+    if (articleWrapper) {
+      articleWrapper.style.flex = isMinimized ? "1 1 auto" : "1 1 60%";
+    }
+  }, [isMinimized]);
+
+  const handleMinimize = useCallback(() => setIsMinimized(true), []);
+  const handleRestore = useCallback(() => setIsMinimized(false), []);
+  const handleCloseAll = useCallback(() => panelManager.closeAll(), []);
+  const getBooleanSetting = (
+    extensionAPI: unknown,
+    key: string,
+    defaultValue: boolean,
+  ): boolean => {
+    try {
+      const value = (
+        extensionAPI as { settings: { get: (k: string) => unknown } }
+      ).settings.get(key);
+      return value == null ? defaultValue : Boolean(value);
+    } catch {
+      return defaultValue;
+    }
+  };
+
+  return (
+    <div
+      ref={containerRef}
+      id="discourse-graph-suggestions-root"
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        flex: isMinimized ? "0 0 auto" : "0 0 40%",
+        width: isMinimized ? "auto" : undefined,
+      }}
+    >
+      {!isMinimized ? (
+        <div
+          id="discourse-graph-panels-container"
+          className="flex flex-1 flex-col gap-2 overflow-y-auto bg-transparent"
+        >
+          <div id="discourse-suggestions-header">
+            <Navbar className="flex items-center rounded-t shadow-none">
+              <Navbar.Group
+                align={Alignment.LEFT}
+                className="flex-grow overflow-hidden"
+              >
+                <Navbar.Heading className="truncate bg-transparent text-[13px] font-semibold">
+                  Suggested Discourse nodes
+                </Navbar.Heading>
+              </Navbar.Group>
+              <Navbar.Group align={Alignment.RIGHT}>
+                <Button
+                  icon="minus"
+                  minimal
+                  small
+                  title="Minimize sidebar"
+                  onClick={handleMinimize}
+                />
+                <Button
+                  icon="cross"
+                  minimal
+                  small
+                  title="Close all open panels"
+                  onClick={handleCloseAll}
+                />
+              </Navbar.Group>
+            </Navbar>
+          </div>
+
+          {panels.map(([tag, state]) => (
+            <div
+              key={tag}
+              id={`discourse-panel-${tag.replace(/[^a-zA-Z0-9]/g, "-")}`}
+              className="m-2 flex-shrink-0 rounded bg-white shadow"
+            >
+              <ExtensionApiContextProvider {...state.onloadArgs}>
+                <DiscourseSuggestionsPanel
+                  tag={tag}
+                  blockUid={state.blockUid}
+                  onClose={() => panelManager.removePanel(tag)}
+                  shouldGrabFromReferencedPages={getBooleanSetting(
+                    state.onloadArgs.extensionAPI,
+                    "context-grab-from-referenced-pages",
+                    true,
+                  )}
+                  shouldGrabParentChildContext={getBooleanSetting(
+                    state.onloadArgs.extensionAPI,
+                    "context-grab-parent-child-context",
+                    true,
+                  )}
+                />
+              </ExtensionApiContextProvider>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div
+          id="discourse-suggestions-minimized"
+          className="m-2 flex w-fit items-center gap-1 rounded bg-white px-2 py-[6px] shadow-sm"
+        >
+          <Button
+            icon="panel-stats"
+            minimal
+            small
+            title="Restore sidebar"
+            onClick={handleRestore}
+          />
+        </div>
+      )}
+    </div>
+  );
+};
+
+let navigationObserver: MutationObserver | null = null;
+
+const cssEscape = (value: string): string =>
+  window.CSS && window.CSS.escape
+    ? window.CSS.escape(value)
+    : value.replace(/[^a-zA-Z0-9_-]/g, (c: string) => `\\${c}`);
+
+const updateOverlayToggleButtons = (tag: string, isOpen: boolean): void => {
+  const selector = `button[data-dg-role="panel-toggle"][data-dg-tag="${cssEscape(tag)}"]`;
+  const buttons = Array.from(document.querySelectorAll(selector));
+  buttons.forEach((btn) => {
+    const buttonEl = btn as HTMLButtonElement;
+    buttonEl.dataset.dgPanelOpen = isOpen ? "true" : "false";
+    if (isOpen) buttonEl.classList.add("bp3-intent-primary");
+    else buttonEl.classList.remove("bp3-intent-primary");
+    buttonEl.title = isOpen
+      ? "Close suggestions panel"
+      : "Open suggestions panel";
+    const icon = buttonEl.querySelector(".bp3-icon");
+    if (icon) {
+      icon.classList.remove(
+        isOpen ? "bp3-icon-panel-stats" : "bp3-icon-panel-table",
+      );
+      icon.classList.add(
+        isOpen ? "bp3-icon-panel-table" : "bp3-icon-panel-stats",
+      );
+    }
+  });
+};
+
+const clearBlockHighlight = (blockUid: string): void => {
+  try {
+    const nodes = document.querySelectorAll(
+      `[data-dg-block-uid="${blockUid}"]`,
+    );
+    nodes.forEach((el) => el.classList.remove("dg-highlight"));
+  } catch {
+    // no-op
+  }
+};
+
+let articleWrapperObserver: MutationObserver | null = null;
+const cleanupNavigationObserver = (): void => {
+  if (navigationObserver) {
+    navigationObserver.disconnect();
+    navigationObserver = null;
+  }
+};
+
+const cleanupArticleWrapperObserver = (): void => {
+  if (articleWrapperObserver) {
+    articleWrapperObserver.disconnect();
+    articleWrapperObserver = null;
+  }
+};
+
+const initializeNavigationObserver = (): void => {
+  if (navigationObserver) {
+    return;
+  }
+
+  const roamApp = document.querySelector(".roam-app");
+  if (!roamApp) return;
+
+  navigationObserver = new MutationObserver((): void => {
+    if (openPanels.size > 0) {
+      const isMountConnected = !!(
+        containerMount && document.body.contains(containerMount)
+      );
+      const panelRoot = document.getElementById(
+        "discourse-graph-suggestions-root",
+      );
+      if (!isMountConnected || !panelRoot) {
+        if (containerMount && !isMountConnected) {
+          containerMount = null;
+        }
+        mountPanelContainer();
+      }
+    }
+  });
+
+  navigationObserver.observe(roamApp, {
+    childList: true,
+    subtree: true,
+  });
+};
+
+const cleanupObservers = (): void => {
+  cleanupArticleWrapperObserver();
+  cleanupNavigationObserver();
+};
+
+if (typeof window !== "undefined") {
+  const handleUnload = (): void => {
+    cleanupObservers();
+    openPanels.clear();
+  };
+
+  window.addEventListener("beforeunload", handleUnload);
+  window.addEventListener("pagehide", handleUnload);
+}
+
+let containerMount: HTMLElement | null = null;
+
+export const mountPanelContainer = (): void => {
+  if (containerMount && !document.body.contains(containerMount)) {
+    containerMount = null;
+  }
+
+  if (containerMount) return;
+
+  const roamBodyMain = document.querySelector<HTMLElement>(".roam-body-main");
+  const articleWrapper = roamBodyMain?.querySelector<HTMLElement>(
+    ".rm-article-wrapper",
+  );
+
+  if (!roamBodyMain || !articleWrapper) return;
+
+  containerMount = document.createElement("div");
+  containerMount.setAttribute("data-dg-role", "panel-container-mount");
+  roamBodyMain.insertBefore(containerMount, articleWrapper);
+
+  ReactDOM.render(<PanelContainer />, containerMount);
+};
+
+const unmountPanelContainer = (): void => {
+  if (!containerMount) return;
+
+  ReactDOM.unmountComponentAtNode(containerMount);
+  containerMount.remove();
+  containerMount = null;
+};
+
+type PanelManager = {
+  listeners: Set<() => void>;
+  addListener: (event: "change", handler: () => void) => void;
+  removeListener: (event: "change", handler: () => void) => void;
+  notify: () => void;
+  toggle: (args: {
+    tag: string;
+    blockUid: string;
+    onloadArgs: OnloadArgs;
+  }) => void;
+  addPanel: (args: {
+    tag: string;
+    blockUid: string;
+    onloadArgs: OnloadArgs;
+  }) => void;
+  removePanel: (tag: string) => void;
+  closeAll: () => void;
+  isOpen: (tag: string) => boolean;
+};
+
+export const panelManager: PanelManager = {
+  listeners: new Set<() => void>(),
+
+  addListener(event: "change", handler: () => void): void {
+    this.listeners.add(handler);
+  },
+
+  removeListener(event: "change", handler: () => void): void {
+    this.listeners.delete(handler);
+  },
+
+  notify(): void {
+    this.listeners.forEach((handler) => handler());
+  },
+
+  toggle: ({ tag, blockUid, onloadArgs }): void => {
+    if (openPanels.has(tag)) {
+      panelManager.removePanel(tag);
+    } else {
+      panelManager.addPanel({ tag, blockUid, onloadArgs });
+    }
+  },
+
+  addPanel({ tag, blockUid, onloadArgs }): void {
+    mountPanelContainer();
+    openPanels.set(tag, {
+      blockUid,
+      onloadArgs,
+      element: null,
+    });
+    this.notify();
+    updateOverlayToggleButtons(tag, true);
+    notifySubscribers(tag, true);
+  },
+
+  removePanel(tag: string): void {
+    const state = openPanels.get(tag);
+    if (!state) return;
+
+    openPanels.delete(tag);
+    this.notify();
+    updateOverlayToggleButtons(tag, false);
+    clearBlockHighlight(state.blockUid);
+    notifySubscribers(tag, false);
+
+    if (openPanels.size === 0) {
+      unmountPanelContainer();
+    }
+  },
+
+  closeAll(): void {
+    const entries = Array.from(openPanels.entries());
+    openPanels.clear();
+    this.notify();
+
+    entries.forEach(([tag, state]) => {
+      updateOverlayToggleButtons(tag, false);
+      clearBlockHighlight(state.blockUid);
+      notifySubscribers(tag, false);
+    });
+
+    unmountPanelContainer();
+  },
+
+  isOpen: (tag: string): boolean => openPanels.has(tag),
+};
+
+if (typeof window !== "undefined") {
+  initializeNavigationObserver();
+}

--- a/apps/roam/src/components/SuggestiveModeOverlay.tsx
+++ b/apps/roam/src/components/SuggestiveModeOverlay.tsx
@@ -5,30 +5,7 @@ import useInViewport from "react-in-viewport/dist/es/lib/useInViewport";
 import { OnloadArgs } from "roamjs-components/types/native";
 import { getBlockUidFromTarget } from "roamjs-components/dom";
 import ExtensionApiContextProvider from "roamjs-components/components/ExtensionApiContext";
-
-// TODO: REMOVE THE STUB FUNCTIONS BELOW'
-
-const panelManager = {
-  isOpen: (tag: string) => false,
-  toggle: ({
-    tag,
-    blockUid,
-    onloadArgs,
-  }: {
-    tag: string;
-    blockUid: string;
-    onloadArgs: OnloadArgs;
-  }) => {},
-};
-
-const subscribeToPanelState = (
-  tag: string,
-  setIsPanelOpen: (isPanelOpen: boolean) => void,
-) => {
-  return () => {};
-};
-
-// END OF STUB FUNCTIONS
+import { panelManager, subscribeToPanelState } from "./PanelManager";
 
 const SuggestiveModeOverlay = ({
   tag,

--- a/apps/roam/src/components/SuggestiveModeOverlay.tsx
+++ b/apps/roam/src/components/SuggestiveModeOverlay.tsx
@@ -37,7 +37,10 @@ const SuggestiveModeOverlay = ({
           elem.closest(".suggestive-mode-overlay")
         )
           return;
-        elem.classList.toggle("dg-highlight", on);
+        elem.classList.toggle(
+          "suggestive-mode-overlay-highlight-on-panel-hover",
+          on,
+        );
       });
     },
     [blockUid],

--- a/apps/roam/src/components/SuggestiveModeOverlay.tsx
+++ b/apps/roam/src/components/SuggestiveModeOverlay.tsx
@@ -58,25 +58,18 @@ const SuggestiveModeOverlay = ({
 
   return (
     <div className="suggestive-mode-overlay flex max-w-3xl">
-      <Tooltip
-        content={
-          isPanelOpen ? "Close suggestions panel" : "Open suggestions panel"
-        }
-        hoverOpenDelay={200}
-      >
-        <Button
-          data-dg-role="panel-toggle"
-          data-dg-tag={tag}
-          data-dg-block-uid={blockUid}
-          icon={isPanelOpen ? "panel-table" : "panel-stats"}
-          minimal
-          small
-          intent={isPanelOpen ? "primary" : "none"}
-          onClick={handleTogglePanel}
-          onMouseEnter={() => toggleHighlight(true)}
-          onMouseLeave={() => toggleHighlight(false)}
-        />
-      </Tooltip>
+      <Button
+        data-dg-role="panel-toggle"
+        data-dg-tag={tag}
+        data-dg-block-uid={blockUid}
+        icon={isPanelOpen ? "panel-table" : "panel-stats"}
+        minimal
+        small
+        intent={isPanelOpen ? "primary" : "none"}
+        onClick={handleTogglePanel}
+        onMouseEnter={() => toggleHighlight(true)}
+        onMouseLeave={() => toggleHighlight(false)}
+      />
     </div>
   );
 };

--- a/apps/roam/src/styles/styles.css
+++ b/apps/roam/src/styles/styles.css
@@ -141,3 +141,8 @@
   background-color: #10161a;
   color: #f5f8fa;
 }
+
+.suggestive-mode-overlay-highlight-on-panel-hover {
+  box-shadow: 0 0 0 2px #137cbd !important;
+  border-radius: 4px;
+}

--- a/apps/roam/src/utils/suggestiveModeSidebarSizing.ts
+++ b/apps/roam/src/utils/suggestiveModeSidebarSizing.ts
@@ -1,0 +1,106 @@
+let articleWrapperObserver: MutationObserver | null = null;
+let globalIsMinimized = false;
+
+export const setGlobalIsMinimized = (value: boolean): void => {
+  globalIsMinimized = value;
+};
+
+export const getGlobalIsMinimized = (): boolean => globalIsMinimized;
+
+const BASE_SPACING_CLASSES = {
+  "rm-spacing--large": "1400px",
+  "rm-spacing--medium": "1000px",
+  "rm-spacing--small": "800px",
+  "rm-spacing--full": "2000px",
+};
+type SpacingClass = keyof typeof BASE_SPACING_CLASSES;
+
+const getSpacingClass = (
+  element: HTMLElement,
+): { className: SpacingClass; value: string } | null => {
+  for (const className of element.classList) {
+    if (className in BASE_SPACING_CLASSES) {
+      return {
+        className: className as SpacingClass,
+        value: BASE_SPACING_CLASSES[className as SpacingClass],
+      };
+    }
+  }
+  return null;
+};
+
+export const getRoamElements = (): {
+  roamBodyMain: HTMLElement | null;
+  articleWrapper: HTMLElement | null;
+} => {
+  const roamBodyMain = document.querySelector<HTMLElement>(".roam-body-main");
+  const articleWrapper =
+    roamBodyMain?.querySelector<HTMLElement>(".rm-article-wrapper") ?? null;
+  return { roamBodyMain: roamBodyMain ?? null, articleWrapper };
+};
+
+export const updateArticleWrapperPadding = (
+  articleWrapper: HTMLElement,
+): void => {
+  const { value } = getSpacingClass(articleWrapper) ?? { value: "800px" };
+  articleWrapper.style.setProperty("padding-left", "0px", "important");
+  articleWrapper.style.setProperty("padding-right", "0px", "important");
+  articleWrapper.style.setProperty("max-width", value, "important");
+};
+
+export const resetArticleWrapperPadding = (
+  articleWrapper: HTMLElement,
+): void => {
+  articleWrapper.style.removeProperty("padding-left");
+  articleWrapper.style.removeProperty("padding-right");
+  articleWrapper.style.removeProperty("max-width");
+};
+
+export const initializeArticleWrapperObserver = (): void => {
+  if (articleWrapperObserver) return;
+  const { articleWrapper } = getRoamElements();
+  if (!articleWrapper) return;
+
+  articleWrapperObserver = new MutationObserver((): void => {
+    const panelRoot = document.getElementById(
+      "discourse-graph-suggestions-root",
+    );
+
+    if (panelRoot && !getGlobalIsMinimized()) {
+      updateArticleWrapperPadding(articleWrapper);
+    } else {
+      resetArticleWrapperPadding(articleWrapper);
+    }
+  });
+  articleWrapperObserver.observe(articleWrapper, {
+    attributes: true,
+    attributeFilter: ["class"],
+  });
+};
+
+export const cleanupArticleWrapperObserver = (): void => {
+  if (articleWrapperObserver) {
+    articleWrapperObserver.disconnect();
+    articleWrapperObserver = null;
+  }
+};
+export const setupSplitView = (
+  roamBodyMain: HTMLElement,
+  articleWrapper: HTMLElement,
+): void => {
+  roamBodyMain.style.display = "flex";
+  roamBodyMain.dataset.isSplit = "true";
+  updateArticleWrapperPadding(articleWrapper);
+  cleanupArticleWrapperObserver();
+  initializeArticleWrapperObserver();
+};
+
+export const teardownSplitView = (
+  roamBodyMain: HTMLElement,
+  articleWrapper: HTMLElement,
+): void => {
+  roamBodyMain.removeAttribute("data-is-split");
+  roamBodyMain.style.display = "";
+  articleWrapper.style.flex = "";
+  resetArticleWrapperPadding(articleWrapper);
+};


### PR DESCRIPTION
<img width="1915" height="1262" alt="image" src="https://github.com/user-attachments/assets/4858c0d0-5621-45b7-a7af-5efbd85104b7" />


The change form the original pr is that it address the comments and the code structure, previously it was all imperative and now I am using a react component for the panel container. 

There is a todo which will be done in the next pr. Following are the feature:

## Panel Management
- **Open/close suggestion panels** for discourse nodes by clicking overlay buttons
- **Multiple panels** - View suggestions for multiple nodes simultaneously
- **Close all** - Single button to close all open panels at once
- **Per-panel close** - Each panel has its own close button

## Layout & Display
- **Side-by-side view** - Suggestions panel appears alongside main content (60/40 split)
- **Minimize/restore** - Collapse entire panel to small button in top-left corner to reclaim screen space
- **Automatic width adjustment** - Main content expands when panel is minimized
- **Persistent across navigation** - Panels stay open as you navigate between Roam pages

## Visual Feedback
- **Block highlighting** - Hover over panel toggle button to highlight related blocks
- **Button state indication** - Toggle buttons show blue when panel is open
- **Dynamic icons** - Button icons change between open (table) and closed (stats) states
- **Tooltips** - Helpful hover text on all interactive elements


## Robustness
- **Auto-recovery** - Panel remounts if DOM structure changes during navigation
- **Spacing protection** - Preserves proper layout when Roam's UI elements toggle
- **Clean teardown** - Restores original layout when all panels close


There are 2 bugs which I found and are fixed in pr #473 
- New panels get added to the top.
- If a panel is too big to fit into the default window we add a scroll but this make the header disappear.