### PR TITLE
ENG-924 start supabase before creating local env

### DIFF
--- a/packages/database/scripts/createEnv.mts
+++ b/packages/database/scripts/createEnv.mts
@@ -29,6 +29,9 @@ const getVercelToken = () => {
 };
 
 const makeLocalEnv = () => {
+  execSync("supabase start", {
+    cwd: projectRoot, stdio: "inherit"
+  });
   const stdout = execSync("supabase status -o env", {
     encoding: "utf8",
   });


### PR DESCRIPTION
I forgot to start supabase before generating the local environment. This make `turbo dev` fail if `SUPABASE_USE_DB=local`.

https://linear.app/discourse-graphs/issue/ENG-924/start-supabase-before-creating-local-env