### PR TITLE
ENG-938 createEnv should use .env

### DIFF
--- a/packages/database/scripts/createEnv.mts
+++ b/packages/database/scripts/createEnv.mts
@@ -24,7 +24,6 @@ const projectIdOrName: string =
   "discourse-graph";
 
 const getVercelToken = () => {
-  dotenv.config();
   return process.env["VERCEL_TOKEN"];
 };
 
@@ -148,6 +147,7 @@ const main = async (variant: Variant) => {
 };
 
 if (fileURLToPath(import.meta.url) === process.argv[1]) {
+  dotenv.config();
   const variantS: string =
     (process.argv.length === 3
       ? process.argv[2]


### PR DESCRIPTION
https://linear.app/discourse-graphs/issue/ENG-938/createenv-should-use-env
The problem being solved is that, if `SUPABASE_USE_DB` is defined in `.env` instead of the environment, createEnv does not find it.