### PR TITLE
ENG-947  dragging and/or clicking on section header crashes the sidebar

### DIFF
--- a/apps/roam/src/components/LeftSidebarView.tsx
+++ b/apps/roam/src/components/LeftSidebarView.tsx
@@ -218,11 +218,9 @@ const PersonalSectionItem = ({
         <div className="flex w-full items-center justify-between">
           <div
             className="flex items-center"
-            onClick={(e: React.MouseEvent) => {
+            onClick={() => {
               if ((section.children?.length || 0) > 0) {
                 handleChevronClick();
-              } else {
-                void openTarget(e, section.text);
               }
             }}
           >
@@ -574,6 +572,11 @@ const FavouritesPopover = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
 const LeftSidebarView = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
   const initialConfig = useConfig();
   const [config, setConfig] = useState(initialConfig);
+
+  useEffect(() => {
+    setConfig(initialConfig);
+  }, [initialConfig]);
+
   return (
     <>
       <FavouritesPopover onloadArgs={onloadArgs} />

--- a/apps/roam/src/components/LeftSidebarView.tsx
+++ b/apps/roam/src/components/LeftSidebarView.tsx
@@ -450,7 +450,7 @@ export const useConfig = () => {
       unsubscribe();
     };
   }, []);
-  return config;
+  return { config, setConfig };
 };
 
 export const refreshAndNotify = () => {
@@ -570,12 +570,7 @@ const FavouritesPopover = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
 };
 
 const LeftSidebarView = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
-  const initialConfig = useConfig();
-  const [config, setConfig] = useState(initialConfig);
-
-  useEffect(() => {
-    setConfig(initialConfig);
-  }, [initialConfig]);
+  const { config, setConfig } = useConfig();
 
   return (
     <>
@@ -602,7 +597,7 @@ export const mountLeftSidebar = (
     }
     root = document.createElement("div");
     root.id = id;
-    root.className = "starred-pages overflow-scroll";
+    root.className = "starred-pages";
     root.onmousedown = (e) => e.stopPropagation();
     wrapper.appendChild(root);
   } else {

--- a/apps/roam/src/components/LeftSidebarView.tsx
+++ b/apps/roam/src/components/LeftSidebarView.tsx
@@ -601,7 +601,7 @@ export const mountLeftSidebar = (
     root.onmousedown = (e) => e.stopPropagation();
     wrapper.appendChild(root);
   } else {
-    root.className = "starred-pages overflow-scroll";
+    root.className = "starred-pages";
   }
   ReactDOM.render(<LeftSidebarView onloadArgs={onloadArgs} />, root);
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sidebar configuration now stays in sync when initial settings change, preventing stale layouts.
  * Clicking a section title without sub-items no longer triggers unintended navigation.
  * Chevron actions only apply when a section has sub-items, reducing accidental clicks.

* **Refactor**
  * Simplified sidebar item click logic to make interactions more predictable and consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->