### PR TITLE
ENG-965 Fix tldraw image paste positioning bug

### DIFF
--- a/apps/roam/src/components/canvas/Tldraw.tsx
+++ b/apps/roam/src/components/canvas/Tldraw.tsx
@@ -801,11 +801,9 @@ const InsideEditorAndUiContext = ({
           },
         });
         editor.createAssets([asset]);
-        
-        const position = editor.inputs.shiftKey
-          ? editor.inputs.currentPagePoint
-          : editor.getViewportPageBounds().center;
-        
+
+        const position = editor.getViewportPageBounds().center;
+
         editor.createShape({
           type: "image",
           x: position.x - size.w / 2,

--- a/apps/roam/src/components/canvas/Tldraw.tsx
+++ b/apps/roam/src/components/canvas/Tldraw.tsx
@@ -801,11 +801,15 @@ const InsideEditorAndUiContext = ({
           },
         });
         editor.createAssets([asset]);
+        
+        const position = editor.inputs.shiftKey
+          ? editor.inputs.currentPagePoint
+          : editor.getViewportPageBounds().center;
+        
         editor.createShape({
           type: "image",
-          // Center the image in the editor
-          x: (window.innerWidth - size.w) / 2,
-          y: (window.innerHeight - size.h) / 2,
+          x: position.x - size.w / 2,
+          y: position.y - size.h / 2,
           props: { assetId, w: size.w, h: size.h },
         });
 


### PR DESCRIPTION
Fix image paste positioning to drop at viewport center or cursor, resolving ENG-965.

Previously, pasted images were centered relative to the entire window, forcing users to scroll to locate them. This change aligns image paste behavior with SVG paste and tldraw's standard, placing images at the current viewport center or at the cursor if the Shift key is held.

---
Linear Issue: [ENG-965](https://linear.app/discourse-graphs/issue/ENG-965/when-pasting-image-in-tldraw-canvas-roam-image-shows-up-in-center)

<a href="https://cursor.com/background-agent?bcId=bc-d2588108-24a0-4662-956d-2d8e306d7c22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d2588108-24a0-4662-956d-2d8e306d7c22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Smarter placement for newly added images on the canvas. Hold Shift while adding an image to drop it at the current page point (e.g., your cursor location). Without Shift, images are automatically centered within the visible viewport. This provides more control and predictability when arranging images, replacing the previous behavior that always centered images regardless of context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->