### PR TITLE
ENG-954 Re-add focus removal after node tag creation

### DIFF
--- a/apps/roam/src/components/CreateNodeDialog.tsx
+++ b/apps/roam/src/components/CreateNodeDialog.tsx
@@ -116,6 +116,11 @@ const CreateNodeDialog = ({
       ),
     });
     setLoading(false);
+    
+    // Remove focus from the block by simulating a click on the document
+    // This changes the UI from block editing to not block editing
+    document.body.click();
+    
     onClose();
   };
 

--- a/apps/roam/src/components/CreateNodeDialog.tsx
+++ b/apps/roam/src/components/CreateNodeDialog.tsx
@@ -116,11 +116,6 @@ const CreateNodeDialog = ({
       ),
     });
     setLoading(false);
-    
-    // Remove focus from the block by simulating a click on the document
-    // This changes the UI from block editing to not block editing
-    document.body.click();
-    
     onClose();
   };
 

--- a/apps/roam/src/components/DiscourseNodeMenu.tsx
+++ b/apps/roam/src/components/DiscourseNodeMenu.tsx
@@ -113,10 +113,6 @@ const NodeMenu = ({
         const tag = menuItem.getAttribute("data-tag") || "";
         if (!tag) return;
 
-        // Remove focus from the block to ensure updateBlock works properly
-        // This changes the UI from block editing to not block editing
-        document.body.click();
-
         const addTagToBlock = () => {
           const currentText = textarea.value;
           const cursorPos = textarea.selectionStart;
@@ -134,6 +130,9 @@ const NodeMenu = ({
         };
         // timeout required to ensure the block is updated
         setTimeout(() => void addTagToBlock(), 100);
+
+        // Remove focus from the block so user can see tag css immediately
+        document.body.click();
       }
       onClose();
     },

--- a/apps/roam/src/components/DiscourseNodeMenu.tsx
+++ b/apps/roam/src/components/DiscourseNodeMenu.tsx
@@ -113,6 +113,10 @@ const NodeMenu = ({
         const tag = menuItem.getAttribute("data-tag") || "";
         if (!tag) return;
 
+        // Remove focus from the block to ensure updateBlock works properly
+        // This changes the UI from block editing to not block editing
+        document.body.click();
+
         const addTagToBlock = () => {
           const currentText = textarea.value;
           const cursorPos = textarea.selectionStart;


### PR DESCRIPTION
Re-add `document.body.click()` to remove focus after node tag creation in Roam.

This restores the expected UI behavior where the app exits block editing mode after a node tag (candidate node) is created, addressing a regression introduced by the removal of `document.click` in ENG-931.

---
Linear Issue: [ENG-954](https://linear.app/discourse-graphs/issue/ENG-954/re-add-remove-focus-after-node-tag-creation)

<a href="https://cursor.com/background-agent?bcId=bc-b6147879-5f6b-4b4b-84ba-67843d23ffad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b6147879-5f6b-4b4b-84ba-67843d23ffad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tags now display with correct styling immediately after creation in the Node Menu, improving visual feedback during tag operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->