### PR TITLE
ENG-967 Add webp support to tldraw canvas

### DIFF
--- a/apps/roam/src/components/canvas/Tldraw.tsx
+++ b/apps/roam/src/components/canvas/Tldraw.tsx
@@ -736,6 +736,7 @@ const InsideEditorAndUiContext = ({
     "image/png",
     "image/gif",
     "image/svg+xml",
+    "image/webp",
   ];
   const isImage = (ext: string) => ACCEPTED_IMG_TYPE.includes(ext);
   const isCustomArrowShape = (shape: TLShape) => {


### PR DESCRIPTION
Add `image/webp` to accepted image types to support WebP uploads in the TLDraw canvas.

---
Linear Issue: [ENG-967](https://linear.app/discourse-graphs/issue/ENG-967/support-file-type-imagewebp-in-canvas)

<a href="https://cursor.com/background-agent?bcId=bc-d244cc4e-2076-4136-9286-1ff294ea14ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d244cc4e-2076-4136-9286-1ff294ea14ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

