### PR TITLE
ENG-970 Persist search filter UI in query builder

### DIFF
--- a/apps/roam/src/components/results-view/ResultsView.tsx
+++ b/apps/roam/src/components/results-view/ResultsView.tsx
@@ -382,7 +382,7 @@ const ResultsView: ResultsViewComponent = ({
   const [isEditLayout, setIsEditLayout] = useState(false);
   const [isEditColumnSort, setIsEditColumnSort] = useState(false);
   const [isEditColumnFilter, setIsEditColumnFilter] = useState(false);
-  const [isEditSearchFilter, setIsEditSearchFilter] = useState(false);
+  const [isEditSearchFilter, setIsEditSearchFilter] = useState(settings.showSearchFilter);
 
   const [layout, setLayout] = useState(settings.layout);
   const layoutMode = useMemo(
@@ -1091,7 +1091,17 @@ const ResultsView: ResultsViewComponent = ({
                       className={searchFilter ? "roamjs-item-dirty" : ""}
                       onClick={() => {
                         setMoreMenuOpen(false);
-                        setIsEditSearchFilter((prevState) => !prevState);
+                        setIsEditSearchFilter((prevState) => {
+                          const newState = !prevState;
+                          if (!preventSavingSettings) {
+                            setInputSetting({
+                              blockUid: settings.resultNodeUid,
+                              key: "showSearchFilter",
+                              value: newState ? "show" : "hide",
+                            });
+                          }
+                          return newState;
+                        });
                       }}
                     />
                     <MenuItem

--- a/apps/roam/src/components/results-view/ResultsView.tsx
+++ b/apps/roam/src/components/results-view/ResultsView.tsx
@@ -440,7 +440,6 @@ const ResultsView: ResultsViewComponent = ({
     (view) => VIEWS[view.mode]?.value === true,
   );
 
-  console.log("showSearchFilter", showSearchFilter);
   return (
     <div
       className={`roamjs-query-results-view relative w-full mode-${layout.mode}`}

--- a/apps/roam/src/components/results-view/ResultsView.tsx
+++ b/apps/roam/src/components/results-view/ResultsView.tsx
@@ -324,6 +324,9 @@ const ResultsView: ResultsViewComponent = ({
   const [views, setViews] = useState(settings.views);
   const [columnFilters, setColumnFilters] = useState(settings.columnFilters);
   const [searchFilter, setSearchFilter] = useState(settings.searchFilter);
+  const [showSearchFilter, setShowSearchFilter] = useState(
+    settings.showSearchFilter,
+  );
   const [showInterface, setShowInterface] = useState(settings.showInterface);
   const [revealMenuIcons, setRevealMenuIcons] = useState(false);
   const [showInputs, setShowInputs] = useState(settings.showInputs);
@@ -348,6 +351,7 @@ const ResultsView: ResultsViewComponent = ({
       page,
       pageSize,
       searchFilter,
+      showSearchFilter,
       showInterface,
     });
   }, [
@@ -358,6 +362,8 @@ const ResultsView: ResultsViewComponent = ({
     pageSize,
     random.count,
     searchFilter,
+    showSearchFilter,
+    showInterface,
     columnFilters,
   ]);
 
@@ -382,7 +388,6 @@ const ResultsView: ResultsViewComponent = ({
   const [isEditLayout, setIsEditLayout] = useState(false);
   const [isEditColumnSort, setIsEditColumnSort] = useState(false);
   const [isEditColumnFilter, setIsEditColumnFilter] = useState(false);
-  const [isEditSearchFilter, setIsEditSearchFilter] = useState(settings.showSearchFilter);
 
   const [layout, setLayout] = useState(settings.layout);
   const layoutMode = useMemo(
@@ -391,11 +396,18 @@ const ResultsView: ResultsViewComponent = ({
   );
   const isMenuIconDirty = useMemo(
     () =>
-      searchFilter ||
+      (searchFilter && !showSearchFilter) ||
       columnFilters.length ||
       random.count ||
       (activeSort.length && layout.mode !== "table"), // indicator is on ResultHeader
-    [searchFilter, columnFilters, random, activeSort, layout.mode],
+    [
+      searchFilter,
+      showSearchFilter,
+      columnFilters,
+      random,
+      activeSort,
+      layout.mode,
+    ],
   );
   const onViewChange = (view: (typeof views)[number], i: number) => {
     const newViews = views.map((v, j) => (i === j ? view : v));
@@ -428,6 +440,7 @@ const ResultsView: ResultsViewComponent = ({
     (view) => VIEWS[view.mode]?.value === true,
   );
 
+  console.log("showSearchFilter", showSearchFilter);
   return (
     <div
       className={`roamjs-query-results-view relative w-full mode-${layout.mode}`}
@@ -490,7 +503,7 @@ const ResultsView: ResultsViewComponent = ({
         </div>
       )}
 
-      {isEditSearchFilter && (
+      {showSearchFilter && (
         <div
           className="w-full p-4"
           style={{
@@ -1086,22 +1099,23 @@ const ResultsView: ResultsViewComponent = ({
                       }}
                     />
                     <MenuItem
-                      icon={isEditSearchFilter ? "zoom-out" : "search"}
-                      text={isEditSearchFilter ? "Hide Search" : "Search"}
-                      className={searchFilter ? "roamjs-item-dirty" : ""}
+                      icon={showSearchFilter ? "zoom-out" : "search"}
+                      text={showSearchFilter ? "Hide Search" : "Search"}
+                      className={
+                        searchFilter && !showSearchFilter
+                          ? "roamjs-item-dirty"
+                          : ""
+                      }
                       onClick={() => {
                         setMoreMenuOpen(false);
-                        setIsEditSearchFilter((prevState) => {
-                          const newState = !prevState;
-                          if (!preventSavingSettings) {
-                            setInputSetting({
-                              blockUid: settings.resultNodeUid,
-                              key: "showSearchFilter",
-                              value: newState ? "show" : "hide",
-                            });
-                          }
-                          return newState;
-                        });
+                        setShowSearchFilter((s) => !s);
+                        if (!preventSavingSettings) {
+                          setInputSetting({
+                            blockUid: settings.resultNodeUid,
+                            key: "showSearchFilter",
+                            value: showSearchFilter ? "hide" : "show",
+                          });
+                        }
                       }}
                     />
                     <MenuItem

--- a/apps/roam/src/utils/parseResultSettings.ts
+++ b/apps/roam/src/utils/parseResultSettings.ts
@@ -171,6 +171,10 @@ const parseResultSettings = (
     tree: resultNode.children,
     key: "showInputs",
   });
+  const showSearchFilterNode = getSubTree({
+    tree: resultNode.children,
+    key: "showSearchFilter",
+  });
   const showAliasNode = getSubTree({
     tree: resultNode.children,
     key: "showAlias",
@@ -215,6 +219,7 @@ const parseResultSettings = (
     page: 1, // TODO save in roam data
     inputs,
     showInputs: showInputsNode.children[0]?.text === "show",
+    showSearchFilter: showSearchFilterNode.children[0]?.text === "show",
     showAlias: showAliasNode.children[0]?.text === "show",
     alias,
   };


### PR DESCRIPTION
Make the search filter UI persistent in query results to remember its visibility state across sessions.

---
Linear Issue: [ENG-970](https://linear.app/discourse-graphs/issue/ENG-970/make-the-search-ui-persistent-in-queries)

<a href="https://cursor.com/background-agent?bcId=bc-efc19607-b86c-4c8c-aa6e-f3c12efe1f6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-efc19607-b86c-4c8c-aa6e-f3c12efe1f6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search filter visibility is now persistent and user-configurable. Users can toggle the search filter panel on/off, and preferences are automatically saved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->