### PR TITLE
ENG-978 Refactor table pagination and display controls

### DIFF
--- a/apps/roam/src/components/results-view/ResultsTable.tsx
+++ b/apps/roam/src/components/results-view/ResultsTable.tsx
@@ -10,7 +10,6 @@ import {
   HTMLTable,
   Icon,
   IconName,
-  InputGroup,
 } from "@blueprintjs/core";
 import { IconNames } from "@blueprintjs/icons";
 import { Column, Result } from "~/utils/types";
@@ -19,7 +18,6 @@ import Filter, { Filters } from "roamjs-components/components/Filter";
 import getRoamUrl from "roamjs-components/dom/getRoamUrl";
 import getPageTitleByPageUid from "roamjs-components/queries/getPageTitleByPageUid";
 import getSubTree from "roamjs-components/util/getSubTree";
-import setInputSetting from "roamjs-components/util/setInputSetting";
 import createBlock from "roamjs-components/writes/createBlock";
 import deleteBlock from "roamjs-components/writes/deleteBlock";
 import openBlockInSidebar from "roamjs-components/writes/openBlockInSidebar";
@@ -371,12 +369,6 @@ const ResultsTable = ({
   preventSavingSettings,
   onRefresh,
   views,
-  pageSize,
-  setPageSize,
-  pageSizeTimeoutRef,
-  page,
-  setPage,
-  allProcessedResults,
   allResults,
   showInterface,
 }: {
@@ -391,13 +383,7 @@ const ResultsTable = ({
   setFilters: (f: FilterData) => void;
   preventSavingSettings?: boolean;
   views: Views;
-  pageSize: number;
-  setPageSize: (p: number) => void;
-  pageSizeTimeoutRef: React.MutableRefObject<number>;
-  page: number;
-  setPage: (p: number) => void;
   onRefresh: () => void;
-  allProcessedResults: Result[];
   allResults: Result[];
   showInterface?: boolean;
 }) => {
@@ -701,90 +687,6 @@ const ResultsTable = ({
           </React.Fragment>
         ))}
       </tbody>
-      <tfoot style={!showInterface ? { display: "none" } : {}}>
-        <tr>
-          <td
-            colSpan={columns.length}
-            style={{ padding: 0, background: "#eeeeee80" }}
-          >
-            <div
-              className="flex items-center justify-between"
-              style={{ padding: 4 }}
-            >
-              <div
-                className="flex items-center gap-4"
-                style={{ paddingLeft: 4 }}
-              >
-                <span>Rows per page:</span>
-                <InputGroup
-                  defaultValue={pageSize.toString()}
-                  onChange={(e) => {
-                    clearTimeout(pageSizeTimeoutRef.current);
-                    pageSizeTimeoutRef.current = window.setTimeout(() => {
-                      setPageSize(Number(e.target.value));
-
-                      if (preventSavingSettings) return;
-                      setInputSetting({
-                        key: "size",
-                        value: e.target.value,
-                        blockUid: parentUid,
-                      });
-                    }, 1000);
-                  }}
-                  type="number"
-                  style={{
-                    width: 60,
-                    maxWidth: 60,
-                    marginRight: 32,
-                    marginLeft: 16,
-                  }}
-                />
-              </div>
-              <span>
-                <Button
-                  minimal
-                  icon={"double-chevron-left"}
-                  onClick={() => setPage(1)}
-                  disabled={page === 1}
-                  small
-                />
-                <Button
-                  minimal
-                  icon={"chevron-left"}
-                  onClick={() => setPage(page - 1)}
-                  disabled={page === 1}
-                  small
-                />
-                <span style={{ margin: "4px 0" }} className={"text-sm"}>
-                  {page}
-                </span>
-                <Button
-                  minimal
-                  icon={"chevron-right"}
-                  onClick={() => setPage(page + 1)}
-                  disabled={
-                    page === Math.ceil(allProcessedResults.length / pageSize) ||
-                    allProcessedResults.length === 0
-                  }
-                  small
-                />
-                <Button
-                  minimal
-                  icon={"double-chevron-right"}
-                  disabled={
-                    page === Math.ceil(allProcessedResults.length / pageSize) ||
-                    allProcessedResults.length === 0
-                  }
-                  onClick={() =>
-                    setPage(Math.ceil(allProcessedResults.length / pageSize))
-                  }
-                  small
-                />
-              </span>
-            </div>
-          </td>
-        </tr>
-      </tfoot>
     </HTMLTable>
   );
 };

--- a/apps/roam/src/components/results-view/ResultsView.tsx
+++ b/apps/roam/src/components/results-view/ResultsView.tsx
@@ -388,6 +388,7 @@ const ResultsView: ResultsViewComponent = ({
   const [isEditLayout, setIsEditLayout] = useState(false);
   const [isEditColumnSort, setIsEditColumnSort] = useState(false);
   const [isEditColumnFilter, setIsEditColumnFilter] = useState(false);
+  const [isEditPageSize, setIsEditPageSize] = useState(false);
 
   const [layout, setLayout] = useState(settings.layout);
   const layoutMode = useMemo(
@@ -583,6 +584,7 @@ const ResultsView: ResultsViewComponent = ({
               setIsEditColumnFilter(false);
               setIsEditViews(false);
               setIsEditColumnSort(false);
+              setIsEditPageSize(false);
             }}
             autoFocus={false}
             enforceFocus={false}
@@ -637,6 +639,46 @@ const ResultsView: ResultsViewComponent = ({
                       setInputSetting({
                         key: "random",
                         value: "0",
+                        blockUid: settings.resultNodeUid,
+                      });
+                    }}
+                    minimal
+                  />
+                </div>
+              ) : isEditPageSize ? (
+                <div className="relative p-4">
+                  <MenuHeading
+                    onClear={() => setIsEditPageSize(false)}
+                    text="Rows per page"
+                  />
+                  <InputGroup
+                    type={"number"}
+                    min={1}
+                    max={1000}
+                    value={pageSize.toString()}
+                    className="inline-block w-24 pr-2"
+                    onChange={(e) => {
+                      const value = Number(e.target.value);
+                      if (value > 0) {
+                        setPageSize(value);
+                        if (preventSavingSettings) return;
+                        void setInputSetting({
+                          key: "size",
+                          value: e.target.value,
+                          blockUid: settings.resultNodeUid,
+                        });
+                      }
+                    }}
+                  />
+                  <Button
+                    hidden={pageSize === 10}
+                    icon={"reset"}
+                    onClick={() => {
+                      setPageSize(10);
+                      if (preventSavingSettings) return;
+                      void setInputSetting({
+                        key: "size",
+                        value: "10",
                         blockUid: settings.resultNodeUid,
                       });
                     }}
@@ -1155,27 +1197,10 @@ const ResultsView: ResultsViewComponent = ({
                       onClick={() => setIsEditRandom(true)}
                     />
                     <MenuItem
-                      icon={"numerical"}
+                      icon={"numbered-list"}
                       text={"Rows per page"}
-                    >
-                      {[5, 10, 20, 50, 100].map((size) => (
-                        <MenuItem
-                          key={size}
-                          text={size.toString()}
-                          active={pageSize === size}
-                          onClick={() => {
-                            setPageSize(size);
-                            setMoreMenuOpen(false);
-                            if (preventSavingSettings) return;
-                            setInputSetting({
-                              key: "size",
-                              value: size.toString(),
-                              blockUid: settings.resultNodeUid,
-                            });
-                          }}
-                        />
-                      ))}
-                    </MenuItem>
+                      onClick={() => setIsEditPageSize(true)}
+                    />
                   </MenuItem>
                   <MenuItem
                     icon={"tag"}
@@ -1415,7 +1440,8 @@ const ResultsView: ResultsViewComponent = ({
                     icon={"chevron-right"}
                     onClick={() => setPage(page + 1)}
                     disabled={
-                      page === Math.ceil(allProcessedResults.length / pageSize) ||
+                      page ===
+                        Math.ceil(allProcessedResults.length / pageSize) ||
                       allProcessedResults.length === 0
                     }
                     small
@@ -1424,7 +1450,8 @@ const ResultsView: ResultsViewComponent = ({
                     minimal
                     icon={"double-chevron-right"}
                     disabled={
-                      page === Math.ceil(allProcessedResults.length / pageSize) ||
+                      page ===
+                        Math.ceil(allProcessedResults.length / pageSize) ||
                       allProcessedResults.length === 0
                     }
                     onClick={() =>

--- a/apps/roam/src/components/results-view/ResultsView.tsx
+++ b/apps/roam/src/components/results-view/ResultsView.tsx
@@ -1154,6 +1154,28 @@ const ResultsView: ResultsViewComponent = ({
                       className={random.count ? "roamjs-item-dirty" : ""}
                       onClick={() => setIsEditRandom(true)}
                     />
+                    <MenuItem
+                      icon={"numerical"}
+                      text={"Rows per page"}
+                    >
+                      {[5, 10, 20, 50, 100].map((size) => (
+                        <MenuItem
+                          key={size}
+                          text={size.toString()}
+                          active={pageSize === size}
+                          onClick={() => {
+                            setPageSize(size);
+                            setMoreMenuOpen(false);
+                            if (preventSavingSettings) return;
+                            setInputSetting({
+                              key: "size",
+                              value: size.toString(),
+                              blockUid: settings.resultNodeUid,
+                            });
+                          }}
+                        />
+                      ))}
+                    </MenuItem>
                   </MenuItem>
                   <MenuItem
                     icon={"tag"}
@@ -1292,13 +1314,7 @@ const ResultsView: ResultsViewComponent = ({
                   filters={filters}
                   setFilters={setFilters}
                   views={views}
-                  page={page}
-                  setPage={setPage}
-                  pageSize={pageSize}
-                  setPageSize={setPageSize}
-                  pageSizeTimeoutRef={pageSizeTimeoutRef}
                   onRefresh={onRefresh}
-                  allProcessedResults={allProcessedResults}
                   allResults={results}
                   showInterface={showInterface}
                 />
@@ -1375,6 +1391,47 @@ const ResultsView: ResultsViewComponent = ({
                     Showing {paginatedResults.length} of {results.length}{" "}
                     results
                   </i>
+                </span>
+                <span>
+                  <Button
+                    minimal
+                    icon={"double-chevron-left"}
+                    onClick={() => setPage(1)}
+                    disabled={page === 1}
+                    small
+                  />
+                  <Button
+                    minimal
+                    icon={"chevron-left"}
+                    onClick={() => setPage(page - 1)}
+                    disabled={page === 1}
+                    small
+                  />
+                  <span style={{ margin: "4px 0" }} className={"text-sm"}>
+                    {page}
+                  </span>
+                  <Button
+                    minimal
+                    icon={"chevron-right"}
+                    onClick={() => setPage(page + 1)}
+                    disabled={
+                      page === Math.ceil(allProcessedResults.length / pageSize) ||
+                      allProcessedResults.length === 0
+                    }
+                    small
+                  />
+                  <Button
+                    minimal
+                    icon={"double-chevron-right"}
+                    disabled={
+                      page === Math.ceil(allProcessedResults.length / pageSize) ||
+                      allProcessedResults.length === 0
+                    }
+                    onClick={() =>
+                      setPage(Math.ceil(allProcessedResults.length / pageSize))
+                    }
+                    small
+                  />
                 </span>
               </div>
               {showContent && <QueryUsed parentUid={parentUid} />}


### PR DESCRIPTION
Move "Rows per page" to the hamburger menu and consolidate pagination controls with the "Showing X of Y results" row to align with design requirements.

This change streamlines the table footer by combining pagination and result summary into a single row and moves the page size selector into the "More" menu, as specified in Linear issue ENG-978.

### BEFORE
<img width="1901" height="1101" alt="image" src="https://github.com/user-attachments/assets/8df724cd-45ac-4ab6-8da4-08253b5e5510" />

### AFTER
<img width="1892" height="1021" alt="image" src="https://github.com/user-attachments/assets/8ab222b7-5e69-4497-87da-a4230f0417cd" />

<img width="899" height="767" alt="image" src="https://github.com/user-attachments/assets/ca136d24-e5ed-4247-b920-9b575c02f40c" />
<img width="587" height="281" alt="image" src="https://github.com/user-attachments/assets/89d1cc72-86c2-4fa7-8049-25dd3919d923" />
<img width="602" height="303" alt="image" src="https://github.com/user-attachments/assets/87a273d5-ec81-4fdf-9970-e6f341e362c2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Rows per page" customization option in the results menu (range: 1-1000, default: 10)
  * Added pagination controls with first, previous, next, and last page navigation buttons
  * Added current page number display with automatic disabled states at boundaries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->