### PR TITLE
ENG-974 part 1 Do not re-embed a node with an existing embedding.

### DIFF
--- a/packages/database/src/dbTypes.ts
+++ b/packages/database/src/dbTypes.ts
@@ -1250,21 +1250,19 @@ export type Database = {
         Returns: {
           arity: number | null
           author_id: number | null
-          created: string | null
+          created: string
           description: string | null
-          epistemic_status:
-            | Database["public"]["Enums"]["EpistemicStatus"]
-            | null
-          id: number | null
-          is_schema: boolean | null
-          last_modified: string | null
-          literal_content: Json | null
-          name: string | null
-          reference_content: Json | null
-          refs: number[] | null
+          epistemic_status: Database["public"]["Enums"]["EpistemicStatus"]
+          id: number
+          is_schema: boolean
+          last_modified: string
+          literal_content: Json
+          name: string
+          reference_content: Json
+          refs: number[]
           represented_by_id: number | null
           schema_id: number | null
-          space_id: number | null
+          space_id: number
         }[]
       }
       concept_in_space: {
@@ -1384,19 +1382,21 @@ export type Database = {
         Returns: {
           arity: number | null
           author_id: number | null
-          created: string
+          created: string | null
           description: string | null
-          epistemic_status: Database["public"]["Enums"]["EpistemicStatus"]
-          id: number
-          is_schema: boolean
-          last_modified: string
-          literal_content: Json
-          name: string
-          reference_content: Json
-          refs: number[]
+          epistemic_status:
+            | Database["public"]["Enums"]["EpistemicStatus"]
+            | null
+          id: number | null
+          is_schema: boolean | null
+          last_modified: string | null
+          literal_content: Json | null
+          name: string | null
+          reference_content: Json | null
+          refs: number[] | null
           represented_by_id: number | null
           schema_id: number | null
-          space_id: number
+          space_id: number | null
         }[]
       }
       is_my_account: {

--- a/packages/database/supabase/migrations/20251017151558_update_content_text_delete_embeddings.sql
+++ b/packages/database/supabase/migrations/20251017151558_update_content_text_delete_embeddings.sql
@@ -1,0 +1,16 @@
+-- on update content text trigger
+CREATE OR REPLACE FUNCTION public.after_update_content_text_trigger ()
+RETURNS TRIGGER
+SET search_path = ''
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF OLD.text != NEW.text THEN
+        DELETE FROM public."ContentEmbedding_openai_text_embedding_3_small_1536" WHERE target_id = NEW.id;
+    END IF;
+    RETURN NEW;
+END;
+$$ ;
+
+CREATE TRIGGER on_update_text_trigger AFTER UPDATE ON public."Content"
+FOR EACH ROW EXECUTE FUNCTION public.after_update_content_text_trigger () ;


### PR DESCRIPTION
https://linear.app/discourse-graphs/issue/ENG-976/do-not-re-embed-a-node-with-an-existing-embedding

Instead of recomputing embeddings of all the changed nodes (where text may not have changed), just resend all updated nodes. A database trigger will delete the embedding if the text was changed.
Then, look for nodes missing embeddings, and upsert those separately. This also handles ENG-973, i.e. makes the system more resilient if the embedding step failed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Content embeddings now automatically refresh when text is updated.

* **Improvements**
  * Enhanced content synchronization with optimized batching for faster, more reliable data uploads.
  * Improved operational logging provides clearer visibility into sync status and helps identify issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->