### PR TITLE
ENG-984 Add DiscourseContextOverlay support in ResultsTable

### DIFF
--- a/apps/roam/src/components/results-view/ResultsTable.tsx
+++ b/apps/roam/src/components/results-view/ResultsTable.tsx
@@ -5,12 +5,7 @@ import React, {
   useState,
   useCallback,
 } from "react";
-import {
-  Button,
-  HTMLTable,
-  Icon,
-  IconName,
-} from "@blueprintjs/core";
+import { Button, HTMLTable, Icon, IconName } from "@blueprintjs/core";
 import { IconNames } from "@blueprintjs/icons";
 import { Column, Result } from "~/utils/types";
 import type { FilterData, Sorts, Views } from "~/utils/parseResultSettings";
@@ -25,7 +20,6 @@ import setInputSettings from "roamjs-components/util/setInputSettings";
 import toCellValue from "~/utils/toCellValue";
 import { ContextContent } from "~/components/DiscourseContext";
 import DiscourseContextOverlay from "~/components/DiscourseContextOverlay";
-import nanoid from "nanoid";
 import { CONTEXT_OVERLAY_SUGGESTION } from "~/utils/predefinedSelections";
 
 const EXTRA_ROW_TYPES = ["context", "discourse"] as const;
@@ -224,11 +218,15 @@ const ResultRow = ({
           : { text: value };
       const actionUid = r[`${key}-uid`];
 
-      if (action === "discourse" && value === CONTEXT_OVERLAY_SUGGESTION) {
+      if (
+        action === "discourse" &&
+        value === CONTEXT_OVERLAY_SUGGESTION &&
+        actionUid
+      ) {
         return (
           <DiscourseContextOverlay
             uid={actionUid}
-            id={`discourse-overlay-${actionUid}-${nanoid()}`}
+            id={`discourse-overlay-${parentUid}-${actionUid}`}
           />
         );
       }

--- a/apps/roam/src/components/results-view/ResultsTable.tsx
+++ b/apps/roam/src/components/results-view/ResultsTable.tsx
@@ -24,6 +24,9 @@ import openBlockInSidebar from "roamjs-components/writes/openBlockInSidebar";
 import setInputSettings from "roamjs-components/util/setInputSettings";
 import toCellValue from "~/utils/toCellValue";
 import { ContextContent } from "~/components/DiscourseContext";
+import DiscourseContextOverlay from "~/components/DiscourseContextOverlay";
+import nanoid from "nanoid";
+import { CONTEXT_OVERLAY_SUGGESTION } from "~/utils/predefinedSelections";
 
 const EXTRA_ROW_TYPES = ["context", "discourse"] as const;
 type ExtraRowType = (typeof EXTRA_ROW_TYPES)[number] | null;
@@ -211,7 +214,7 @@ const ResultRow = ({
   const cell = (key: string) => {
     const value = toCellValue({
       value: r[`${key}-display`] || r[key] || "",
-      uid: (r[`${key}-uid`] as string) || "",
+      uid: r[`${key}-uid`] || "",
     });
     const action = r[`${key}-action`];
     if (typeof action === "string") {
@@ -219,6 +222,16 @@ const ResultRow = ({
         value.toUpperCase().replace(/\s/g, "_") in IconNames
           ? { icon: value as IconName, minimal: true }
           : { text: value };
+      const actionUid = r[`${key}-uid`];
+
+      if (action === "discourse" && value === CONTEXT_OVERLAY_SUGGESTION) {
+        return (
+          <DiscourseContextOverlay
+            uid={actionUid}
+            id={`discourse-overlay-${actionUid}-${nanoid()}`}
+          />
+        );
+      }
       return (
         <Button
           {...buttonProps}
@@ -227,7 +240,7 @@ const ResultRow = ({
               new CustomEvent("roamjs:query-builder:action", {
                 detail: {
                   action,
-                  uid: r[`${key}-uid`],
+                  uid: actionUid,
                   val: r["text"],
                   onRefresh,
                   queryUid: parentUid,

--- a/apps/roam/src/utils/predefinedSelections.ts
+++ b/apps/roam/src/utils/predefinedSelections.ts
@@ -242,6 +242,8 @@ const LEAF_SUGGESTIONS: SelectionSuggestion[] = CREATE_DATE_SUGGESTIONS.concat(
   .concat(EDIT_BY_SUGGESTIONS);
 // .concat(ATTR_SUGGESTIONS);
 
+export const CONTEXT_OVERLAY_SUGGESTION = "overlay";
+
 const predefinedSelections: PredefinedSelection[] = [
   {
     test: CREATE_DATE_TEST,
@@ -522,6 +524,7 @@ const predefinedSelections: PredefinedSelection[] = [
               { text: "flows" },
               { text: "graph" },
               { text: "layout" }, // replace with { text: "search-around" }, not supported yet
+              { text: CONTEXT_OVERLAY_SUGGESTION },
             ],
           },
         ],


### PR DESCRIPTION
simple v0 with the popup but this is the only way to async query the discourse relations/references to get the values.
`action:discourse:overlay`
<img width="1726" height="1008" alt="image" src="https://github.com/user-attachments/assets/c451eec3-a1a1-4bff-bd82-b00e92459031" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an "overlay" suggestion option for discourse-related actions, allowing users to view and interact with context overlays alongside other interaction options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->