### PR TITLE
ENG-1004 add a buffer, so we do not miss any change

### DIFF
--- a/apps/roam/src/utils/syncDgNodesToSupabase.ts
+++ b/apps/roam/src/utils/syncDgNodesToSupabase.ts
@@ -422,7 +422,8 @@ export const createOrUpdateDiscourseEmbedding = async (showToast = false) => {
     }
     claimed = true;
     const allUsers = await getAllUsers();
-    const time = (lastUpdateTime || DEFAULT_TIME).toISOString();
+    const sinceTime = (lastUpdateTime || DEFAULT_TIME).valueOf() - 1000; // add a one-second buffer
+    const time = new Date(sinceTime).toISOString();
     const { allDgNodeTypes, dgNodeTypesWithSettings } = getDgNodeTypes();
 
     const allNodeInstances = await getAllDiscourseNodesSince(


### PR DESCRIPTION
As described in [ENG-976](https://linear.app/discourse-graphs/issue/ENG-976/repair-sync-function), some roam changes happen after start of query. and if we query for changes starting at start of query, some will be skipped. The full solution would be [ENG-999](https://linear.app/discourse-graphs/issue/ENG-999/allow-sync-table-to-know-latest-timestamp-handled), but we can have a short-term fix with a simple time buffer.