### PR TITLE
[ENG-997] High priority small fixes

### DIFF
--- a/apps/obsidian/src/components/canvas/ExistingNodeSearch.tsx
+++ b/apps/obsidian/src/components/canvas/ExistingNodeSearch.tsx
@@ -66,6 +66,7 @@ export const ExistingNodeSearch = ({
           });
           editor.markHistoryStoppingPoint("add existing discourse node");
           editor.setSelectedShapes([id]);
+          editor.setCurrentTool("select");
         } catch (error) {
           console.error("Error in handleSelect:", error);
         }

--- a/apps/obsidian/src/components/canvas/TldrawView.tsx
+++ b/apps/obsidian/src/components/canvas/TldrawView.tsx
@@ -14,6 +14,7 @@ export class TldrawView extends TextFileView {
   private reactRoot?: Root;
   private store: TLStore | null = null;
   private assetStore: ObsidianTLAssetStore | null = null;
+  private canvasUuid: string | null = null;
   private onUnloadCallbacks: (() => void)[] = [];
 
   constructor(leaf: WorkspaceLeaf, plugin: DiscourseGraphPlugin) {
@@ -108,6 +109,11 @@ export class TldrawView extends TextFileView {
         console.warn("Invalid tldraw data format - missing raw field");
         return;
       }
+      if (data.meta?.uuid) {
+        this.canvasUuid = data.meta.uuid;
+      } else {
+        this.canvasUuid = window.crypto.randomUUID();
+      }
 
       if (!this.file) {
         console.warn("TldrawView not initialized: missing file");
@@ -142,6 +148,8 @@ export class TldrawView extends TextFileView {
       throw new Error("TldrawView not initialized: missing assetStore");
     if (!this.store)
       throw new Error("TldrawView not initialized: missing store");
+    if (!this.canvasUuid)
+      throw new Error("TldrawView not initialized: missing canvas UUID");
 
     if (!this.assetStore) {
       console.warn("Asset store is not set");
@@ -155,6 +163,7 @@ export class TldrawView extends TextFileView {
             store={store}
             file={this.file}
             assetStore={this.assetStore}
+            canvasUuid={this.canvasUuid}
           />
         </PluginProvider>
       </React.StrictMode>,

--- a/apps/obsidian/src/components/canvas/TldrawViewComponent.tsx
+++ b/apps/obsidian/src/components/canvas/TldrawViewComponent.tsx
@@ -131,8 +131,26 @@ export const TldrawPreviewComponent = ({
         ),
       );
 
-      if (!verifyMatch || verifyMatch[1]?.trim() !== stringifiedData.trim()) {
-        throw new Error("Failed to verify saved TLDraw data");
+      if (!verifyMatch) {
+        throw new Error(
+          "Failed to verify saved TLDraw data: Could not find data block",
+        );
+      }
+
+      try {
+        const savedData: unknown = JSON.parse(verifyMatch[1]?.trim() ?? "{}");
+        const expectedData: unknown = JSON.parse(
+          stringifiedData?.trim() ?? "{}",
+        );
+
+        if (JSON.stringify(savedData) !== JSON.stringify(expectedData)) {
+          throw new Error(
+            "Failed to verify saved TLDraw data: Content mismatch",
+          );
+        }
+      } catch (error) {
+        console.error("Verification error:", error);
+        throw new Error(`Failed to verify saved TLDraw data: ${String(error)}`);
       }
 
       lastSavedDataRef.current = stringifiedData;

--- a/apps/obsidian/src/components/canvas/TldrawViewComponent.tsx
+++ b/apps/obsidian/src/components/canvas/TldrawViewComponent.tsx
@@ -366,7 +366,7 @@ export const TldrawPreviewComponent = ({
                     <TldrawUiMenuItem
                       id="discourse-node"
                       icon="discourseNodeIcon"
-                      label="Discourse Node"
+                      label="Discourse Graph"
                       onSelect={() => {
                         if (editorRef.current) {
                           editorRef.current.setCurrentTool("discourse-node");

--- a/apps/obsidian/src/components/canvas/shapes/DiscourseRelationShape.tsx
+++ b/apps/obsidian/src/components/canvas/shapes/DiscourseRelationShape.tsx
@@ -1134,7 +1134,7 @@ export class DiscourseRelationUtil extends ShapeUtil<DiscourseRelationShape> {
       }
 
       // Add the bidirectional relation to frontmatter
-      await addRelationToFrontmatter({
+      const { alreadyExisted } = await addRelationToFrontmatter({
         app: this.options.app,
         plugin: this.options.plugin,
         sourceFile,
@@ -1147,7 +1147,7 @@ export class DiscourseRelationUtil extends ShapeUtil<DiscourseRelationShape> {
         (rt) => rt.id === shape.props.relationTypeId,
       );
 
-      if (relationType) {
+      if (relationType && !alreadyExisted) {
         showToast({
           severity: "success",
           title: "Relation Created",

--- a/apps/obsidian/src/components/canvas/utils/frontmatterUtils.ts
+++ b/apps/obsidian/src/components/canvas/utils/frontmatterUtils.ts
@@ -4,6 +4,8 @@ import type DiscourseGraphPlugin from "~/index";
 /**
  * Adds bidirectional relation links to the frontmatter of both files.
  * This follows the same pattern as RelationshipSection.tsx
+ * 
+ * @returns Object indicating whether the relation already existed
  */
 export const addRelationToFrontmatter = async ({
   app,
@@ -17,21 +19,26 @@ export const addRelationToFrontmatter = async ({
   sourceFile: TFile;
   targetFile: TFile;
   relationTypeId: string;
-}): Promise<void> => {
+}): Promise<{ alreadyExisted: boolean }> => {
   const relationType = plugin.settings.relationTypes.find(
     (r) => r.id === relationTypeId,
   );
 
   if (!relationType) {
     console.error(`Relation type ${relationTypeId} not found`);
-    return;
+    return { alreadyExisted: false };
   }
 
   try {
+    let sourceToTargetExisted = false;
+    let targetToSourceExisted = false;
+
     const appendLinkToFrontmatter = async (
       fileToMutate: TFile,
       targetFile: TFile,
-    ) => {
+    ): Promise<boolean> => {
+      let linkAlreadyExists = false;
+
       await app.fileManager.processFrontMatter(
         fileToMutate,
         (fm: FrontMatterCache) => {
@@ -69,13 +76,27 @@ export const addRelationToFrontmatter = async ({
 
           if (!normalizedExistingLinks.includes(normalizedLinkToAdd)) {
             fm[relationType.id] = [...existingLinks, linkToAdd];
+            linkAlreadyExists = false;
+          } else {
+            linkAlreadyExists = true;
           }
         },
       );
+
+      return linkAlreadyExists;
     };
 
-    await appendLinkToFrontmatter(sourceFile, targetFile);
-    await appendLinkToFrontmatter(targetFile, sourceFile);
+    sourceToTargetExisted = await appendLinkToFrontmatter(
+      sourceFile,
+      targetFile,
+    );
+    targetToSourceExisted = await appendLinkToFrontmatter(
+      targetFile,
+      sourceFile,
+    );
+
+    // Consider the relation as "already existed" if both directions existed
+    return { alreadyExisted: sourceToTargetExisted && targetToSourceExisted };
   } catch (error) {
     console.error("Failed to add relation to frontmatter:", error);
     throw error;

--- a/apps/obsidian/src/components/canvas/utils/frontmatterUtils.ts
+++ b/apps/obsidian/src/components/canvas/utils/frontmatterUtils.ts
@@ -74,12 +74,11 @@ export const addRelationToFrontmatter = async ({
           const normalizedExistingLinks = existingLinks.map(normalizeLink);
           const normalizedLinkToAdd = normalizeLink(linkToAdd);
 
-          if (!normalizedExistingLinks.includes(normalizedLinkToAdd)) {
-            fm[relationType.id] = [...existingLinks, linkToAdd];
-            linkAlreadyExists = false;
-          } else {
-            linkAlreadyExists = true;
-          }
+         linkAlreadyExists =
+           normalizedExistingLinks.includes(normalizedLinkToAdd);
+         if (!linkAlreadyExists) {
+           fm[relationType.id] = [...existingLinks, linkToAdd];
+         }
         },
       );
 

--- a/apps/obsidian/src/components/canvas/utils/nodeCreationFlow.ts
+++ b/apps/obsidian/src/components/canvas/utils/nodeCreationFlow.ts
@@ -59,6 +59,7 @@ export const openCreateDiscourseNodeAt = (args: CreateNodeAtArgs): void => {
           `create discourse node ${selectedNodeType.id}`,
         );
         tldrawEditor.setSelectedShapes([shapeId]);
+        tldrawEditor.setCurrentTool("select");
       } catch (error) {
         console.error("Error creating discourse node:", error);
         showToast({


### PR DESCRIPTION
# Changes in this file
1. On hover now the tool say "Discourse Graph" instead of "Discourse Node"

<img width="201" height="99" alt="image" src="https://github.com/user-attachments/assets/8d88dae8-d0f8-4850-a4e6-6c8af4cb17be" />
Linear link: [FEE-569: "dg nodes" is strange label given that it also gives access to dg relations](https://linear.app/discourse-graphs/issue/FEE-569/dg-nodes-is-strange-label-given-that-it-also-gives-access-to-dg)

2. Don't create toast if the relation already exists
[FEE-570: strange for toast to say "created relation..." if relation already exists](https://linear.app/discourse-graphs/issue/FEE-570/strange-for-toast-to-say-created-relation-if-relation-already-exists)

3. Default back to Select tool once a new Discourse Node is added to canvas

https://www.loom.com/share/1f56f80d19cf4168a9012399dbc390d8

Linear link: [FEE-567: when i search for and add node on obsidian tldraw canvas, want to default back to select cursor](https://linear.app/discourse-graphs/issue/FEE-567/when-i-search-for-and-add-node-on-obsidian-tldraw-canvas-want-to)

4. Data corruption

https://www.loom.com/share/21f090dcccf14657a7bf946f6b9cf764

Linear link: [ENG-998: Content deleted on canvas when pasting an image.](https://linear.app/discourse-graphs/issue/ENG-998/content-deleted-on-canvas-when-pasting-an-image)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed file content appending logic to prevent data corruption.
  * Corrected editor tool state after creating or selecting nodes.
  * Improved duplicate relation handling to suppress redundant success notifications.

* **UI Improvements**
  * Updated toolbar label from "Discourse Node" to "Discourse Graph".

* **Improvements**
  * Enhanced error messages with more descriptive diagnostics for data verification failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->