### PR TITLE
[ENG-869] Key figure

### DIFF
--- a/apps/obsidian/src/components/NodeTypeSettings.tsx
+++ b/apps/obsidian/src/components/NodeTypeSettings.tsx
@@ -32,7 +32,7 @@ type BaseFieldConfig = {
   label: string;
   description: string;
   required?: boolean;
-  type: "text" | "select" | "color";
+  type: "text" | "select" | "color" | "boolean";
   placeholder?: string;
   validate?: (
     value: string,
@@ -116,9 +116,31 @@ const FIELD_CONFIGS: Record<EditableFieldKey, BaseFieldConfig> = {
       return { isValid: true };
     },
   },
+  keyImage: {
+    key: "keyImage",
+    label: "Key image (first image from file)",
+    description:
+      "When enabled, canvas nodes of this type will show the first image from the linked file",
+    type: "boolean",
+    required: false,
+  },
 };
 
 const FIELD_CONFIG_ARRAY = Object.values(FIELD_CONFIGS);
+
+const BooleanField = ({
+  value,
+  onChange,
+}: {
+  value: boolean;
+  onChange: (value: boolean) => void;
+}) => (
+  <input
+    type="checkbox"
+    checked={!!value}
+    onChange={(e) => onChange((e.target as HTMLInputElement).checked)}
+  />
+);
 
 const TextField = ({
   fieldConfig,
@@ -297,12 +319,14 @@ const NodeTypeSettings = () => {
 
   const handleNodeTypeChange = (
     field: EditableFieldKey,
-    value: string,
+    value: string | boolean,
   ): void => {
     if (!editingNodeType) return;
 
     const updatedNodeType = { ...editingNodeType, [field]: value };
-    validateField(field, value, updatedNodeType);
+    if (typeof value === "string") {
+      validateField(field, value, updatedNodeType);
+    }
     setEditingNodeType(updatedNodeType);
     setHasUnsavedChanges(true);
   };
@@ -434,9 +458,9 @@ const NodeTypeSettings = () => {
   const renderField = (fieldConfig: BaseFieldConfig) => {
     if (!editingNodeType) return null;
 
-    const value = editingNodeType[fieldConfig.key] as string;
+    const value = editingNodeType[fieldConfig.key] as string | boolean;
     const error = errors[fieldConfig.key];
-    const handleChange = (newValue: string) =>
+    const handleChange = (newValue: string | boolean) =>
       handleNodeTypeChange(fieldConfig.key, newValue);
 
     return (
@@ -447,18 +471,24 @@ const NodeTypeSettings = () => {
       >
         {fieldConfig.key === "template" ? (
           <TemplateField
-            value={value}
+            value={value as string}
             error={error}
             onChange={handleChange}
             templateConfig={templateConfig}
             templateFiles={templateFiles}
           />
         ) : fieldConfig.type === "color" ? (
-          <ColorField value={value} error={error} onChange={handleChange} />
+          <ColorField
+            value={value as string}
+            error={error}
+            onChange={handleChange}
+          />
+        ) : fieldConfig.type === "boolean" ? (
+          <BooleanField value={value as boolean} onChange={handleChange} />
         ) : (
           <TextField
             fieldConfig={fieldConfig}
-            value={value}
+            value={value as string}
             error={error}
             onChange={handleChange}
             nodeType={editingNodeType}

--- a/apps/obsidian/src/components/canvas/ExistingNodeSearch.tsx
+++ b/apps/obsidian/src/components/canvas/ExistingNodeSearch.tsx
@@ -10,6 +10,7 @@ import {
   getFrontmatterForFile,
 } from "./shapes/discourseNodeShapeUtils";
 import { DiscourseNode } from "~/types";
+import { calcDiscourseNodeSize } from "~/utils/calcDiscourseNodeSize";
 
 export const ExistingNodeSearch = ({
   plugin,
@@ -72,15 +73,13 @@ export const ExistingNodeSearch = ({
             }
           }
 
-          // Compute initial dimensions based on whether we have an image
-          const paddingY = 2 * 8; // p-2 = 0.5rem = 8px
-          const titleHeight = 20; // approx
-          const subtitleHeight = 16; // approx
-          const maxImageHeight = 160;
-          const baseHeight = 100;
-          const initialHeight = preloadedImageSrc
-            ? paddingY + maxImageHeight + titleHeight + subtitleHeight + 4
-            : baseHeight;
+          // Calculate optimal dimensions using dynamic measurement
+          const { w, h } = await calcDiscourseNodeSize({
+            title: file.basename,
+            nodeTypeId: fmNodeTypeId ?? "",
+            imageSrc: preloadedImageSrc,
+            plugin,
+          });
 
           const id = createShapeId();
           editor.createShape({
@@ -89,12 +88,12 @@ export const ExistingNodeSearch = ({
             x: pagePoint.x - Math.random() * 100,
             y: pagePoint.y - Math.random() * 100,
             props: {
-              w: 200,
-              h: initialHeight,
+              w,
+              h,
               src,
               title: file.basename,
               nodeTypeId: fmNodeTypeId ?? "",
-              ...(preloadedImageSrc ? { imageSrc: preloadedImageSrc } : {}),
+              imageSrc: preloadedImageSrc,
             },
           });
           editor.markHistoryStoppingPoint("add existing discourse node");

--- a/apps/obsidian/src/components/canvas/shapes/DiscourseNodeShape.tsx
+++ b/apps/obsidian/src/components/canvas/shapes/DiscourseNodeShape.tsx
@@ -11,6 +11,7 @@ import DiscourseGraphPlugin from "~/index";
 import {
   getFrontmatterForFile,
   FrontmatterRecord,
+  getFirstImageSrcForFile,
 } from "./discourseNodeShapeUtils";
 import { resolveLinkedFileFromSrc } from "~/components/canvas/stores/assetStore";
 import { getNodeTypeById } from "~/utils/typeUtils";
@@ -25,6 +26,7 @@ export type DiscourseNodeShape = TLBaseShape<
     // Cached display data
     title: string;
     nodeTypeId: string;
+    imageSrc?: string;
   }
 >;
 
@@ -44,6 +46,7 @@ export class DiscourseNodeUtil extends BaseBoxShapeUtil<DiscourseNodeShape> {
     src: T.string.nullable(),
     title: T.string.optional(),
     nodeTypeId: T.string.nullable().optional(),
+    imageSrc: T.string.optional(),
   };
 
   getDefaultProps(): DiscourseNodeShape["props"] {
@@ -53,6 +56,7 @@ export class DiscourseNodeUtil extends BaseBoxShapeUtil<DiscourseNodeShape> {
       src: null,
       title: "",
       nodeTypeId: "",
+      imageSrc: undefined,
     };
   }
 
@@ -158,6 +162,51 @@ const discourseNodeContent = memo(
               },
             });
           }
+          // Load key image if enabled on node type
+          if (nodeType?.keyImage) {
+            const imageSrc = await getFirstImageSrcForFile(app, linkedFile);
+
+            if (imageSrc && imageSrc !== shape.props.imageSrc) {
+              editor.updateShape<DiscourseNodeShape>({
+                id: shape.id,
+                type: "discourse-node",
+                props: {
+                  ...shape.props,
+                  imageSrc,
+                },
+              });
+            }
+          } else if (shape.props.imageSrc) {
+            // Clear image if node type no longer has key image enabled
+            editor.updateShape<DiscourseNodeShape>({
+              id: shape.id,
+              type: "discourse-node",
+              props: {
+                ...shape.props,
+                imageSrc: undefined,
+              },
+            });
+          }
+
+          const paddingY = 2 * 8; // p-2 = 0.5rem = 8px
+          const titleHeight = 20; // approx
+          const subtitleHeight = 16; // approx
+          const maxImageHeight = 160;
+          const baseHeight = 100;
+          const hasImage = !!shape.props.imageSrc;
+          const targetHeight = hasImage
+            ? paddingY + maxImageHeight + titleHeight + subtitleHeight + 4
+            : baseHeight;
+          if (Math.abs((shape.props.h || 0) - targetHeight) > 1) {
+            editor.updateShape<DiscourseNodeShape>({
+              id: shape.id,
+              type: "discourse-node",
+              props: {
+                ...shape.props,
+                h: targetHeight,
+              },
+            });
+          }
         } catch (error) {
           console.error("Error loading node data", error);
           return;
@@ -169,17 +218,35 @@ const discourseNodeContent = memo(
       return () => {
         return;
       };
-    }, [src, shape.id, shape.props, editor, app, canvasFile, plugin]);
+    }, [
+      src,
+      shape.id,
+      shape.props,
+      editor,
+      app,
+      canvasFile,
+      plugin,
+      nodeType?.keyImage,
+    ]);
 
     return (
       <div
         style={{
           backgroundColor: nodeType?.color ?? "",
         }}
-        className="box-border flex h-full w-full flex-col items-start justify-center rounded-md border-2 p-2"
+        className="box-border flex h-full w-full flex-col items-start justify-start rounded-md border-2 p-2"
       >
-        <h1 className="m-0 text-base">{title || "..."}</h1>
+        <h1 className="m-1 text-base">{title || "..."}</h1>
         <p className="m-0 text-sm opacity-80">{nodeType?.name || ""}</p>
+        {shape.props.imageSrc ? (
+          <img
+            src={shape.props.imageSrc}
+            loading="lazy"
+            decoding="async"
+            draggable="false"
+            className="max-h-[160px] w-full object-cover"
+          />
+        ) : null}
       </div>
     );
   },

--- a/apps/obsidian/src/components/canvas/shapes/DiscourseNodeShape.tsx
+++ b/apps/obsidian/src/components/canvas/shapes/DiscourseNodeShape.tsx
@@ -213,7 +213,7 @@ const discourseNodeContent = memo(
               imageSrc: currentImageSrc,
               plugin,
             });
-
+            // Only update dimensions if they differ significantly (>1px)
             if (
               Math.abs((shape.props.w || 0) - w) > 1 ||
               Math.abs((shape.props.h || 0) - h) > 1

--- a/apps/obsidian/src/components/canvas/shapes/DiscourseNodeShape.tsx
+++ b/apps/obsidian/src/components/canvas/shapes/DiscourseNodeShape.tsx
@@ -260,6 +260,9 @@ const discourseNodeContent = memo(
         style={{
           backgroundColor: nodeType?.color ?? "",
         }}
+        // NOTE: These Tailwind classes (p-2, border-2, rounded-md, m-1, text-base, m-0, text-sm)
+        // correspond to constants in nodeConstants.ts. If you change these classes, update the
+        // constants and the measureNodeText function to keep measurements accurate.
         className="box-border flex h-full w-full flex-col items-start justify-start rounded-md border-2 p-2"
       >
         <h1 className="m-1 text-base">{title || "..."}</h1>

--- a/apps/obsidian/src/components/canvas/shapes/DiscourseNodeShape.tsx
+++ b/apps/obsidian/src/components/canvas/shapes/DiscourseNodeShape.tsx
@@ -176,11 +176,13 @@ const discourseNodeContent = memo(
             });
           }
 
+          let didImageChange = false;
           let currentImageSrc = shape.props.imageSrc;
           if (nodeType?.keyImage) {
             const imageSrc = await getFirstImageSrcForFile(app, linkedFile);
 
             if (imageSrc && imageSrc !== shape.props.imageSrc) {
+              didImageChange = true;
               currentImageSrc = imageSrc;
               editor.updateShape<DiscourseNodeShape>({
                 id: shape.id,
@@ -192,6 +194,7 @@ const discourseNodeContent = memo(
               });
             }
           } else if (shape.props.imageSrc) {
+            didImageChange = true;
             currentImageSrc = undefined;
             editor.updateShape<DiscourseNodeShape>({
               id: shape.id,
@@ -203,26 +206,28 @@ const discourseNodeContent = memo(
             });
           }
 
-          const { w, h } = await calcDiscourseNodeSize({
-            title: linkedFile.basename,
-            nodeTypeId: shape.props.nodeTypeId,
-            imageSrc: currentImageSrc,
-            plugin,
-          });
-
-          if (
-            Math.abs((shape.props.w || 0) - w) > 1 ||
-            Math.abs((shape.props.h || 0) - h) > 1
-          ) {
-            editor.updateShape<DiscourseNodeShape>({
-              id: shape.id,
-              type: "discourse-node",
-              props: {
-                ...shape.props,
-                w,
-                h,
-              },
+          if (didImageChange) {
+            const { w, h } = await calcDiscourseNodeSize({
+              title: linkedFile.basename,
+              nodeTypeId: shape.props.nodeTypeId,
+              imageSrc: currentImageSrc,
+              plugin,
             });
+
+            if (
+              Math.abs((shape.props.w || 0) - w) > 1 ||
+              Math.abs((shape.props.h || 0) - h) > 1
+            ) {
+              editor.updateShape<DiscourseNodeShape>({
+                id: shape.id,
+                type: "discourse-node",
+                props: {
+                  ...shape.props,
+                  w,
+                  h,
+                },
+              });
+            }
           }
         } catch (error) {
           console.error("Error loading node data", error);
@@ -260,13 +265,15 @@ const discourseNodeContent = memo(
         <h1 className="m-1 text-base">{title || "..."}</h1>
         <p className="m-0 text-sm opacity-80">{nodeType?.name || ""}</p>
         {shape.props.imageSrc ? (
-          <img
-            src={shape.props.imageSrc}
-            loading="lazy"
-            decoding="async"
-            draggable="false"
-            className="h-auto w-full object-cover"
-          />
+          <div className="mt-2 flex min-h-0 w-full flex-1 items-center justify-center overflow-hidden">
+            <img
+              src={shape.props.imageSrc}
+              loading="lazy"
+              decoding="async"
+              draggable="false"
+              className="max-h-full max-w-full object-contain"
+            />
+          </div>
         ) : null}
       </div>
     );

--- a/apps/obsidian/src/components/canvas/shapes/discourseNodeShapeUtils.ts
+++ b/apps/obsidian/src/components/canvas/shapes/discourseNodeShapeUtils.ts
@@ -16,3 +16,66 @@ export const getNodeTypeIdFromFrontmatter = (
   if (!frontmatter) return null;
   return (frontmatter as { nodeTypeId?: string })?.nodeTypeId ?? null;
 };
+
+// Extracts the first image reference from a file in document order.
+// Supports both internal vault embeds/links and external URLs.
+export const getFirstImageSrcForFile = async (
+  app: App,
+  file: TFile,
+): Promise<string | null> => {
+  try {
+    const content = await app.vault.cachedRead(file);
+
+    const imageRegex = /!\[([^\]]*)\]\(([^)]+)\)|!\[\[([^\]]+)\]\]/g;
+    let match;
+    const normalizeLinkTarget = (s: string) => {
+      // Strip optional markdown title: ![alt](url "title")
+      const withoutTitle = s.replace(/\s+"[^"]*"\s*$/, "");
+      // Unwrap angle brackets: ![alt](<path with spaces>)
+      const unwrapped = withoutTitle.replace(/^<(.+)>$/, "$1");
+      // Drop Obsidian alias and header fragments
+      return unwrapped.split("|")?.[0]?.split("#")?.[0]?.trim();
+    };
+
+    while ((match = imageRegex.exec(content)) !== null) {
+      if (match[2]) {
+        const target = match[2].trim();
+
+        // External URL - return directly
+        if (/^https?:\/\//i.test(target)) {
+          return target;
+        }
+
+        // Internal path - resolve to vault file
+        const normalized = normalizeLinkTarget(target);
+        const tfile = app.metadataCache.getFirstLinkpathDest(
+          normalized ?? target,
+          file.path,
+        );
+        if (
+          tfile &&
+          /^(png|jpe?g|gif|webp|svg|bmp|tiff?)$/i.test(tfile.extension)
+        ) {
+          return app.vault.getResourcePath(tfile);
+        }
+      } else if (match[3]) {
+        // Wiki-style embed: ![[path]]
+        const target = match[3].trim();
+        const normalized = normalizeLinkTarget(target);
+        const tfile = app.metadataCache.getFirstLinkpathDest(
+          normalized ?? target,
+          file.path,
+        );
+        if (
+          tfile &&
+          /^(png|jpe?g|gif|webp|svg|bmp|tiff?)$/i.test(tfile.extension)
+        ) {
+          return app.vault.getResourcePath(tfile);
+        }
+      }
+    }
+  } catch (e) {
+    console.warn("getFirstImageSrcForFile: failed to extract image", e);
+  }
+  return null;
+};

--- a/apps/obsidian/src/components/canvas/shapes/nodeConstants.ts
+++ b/apps/obsidian/src/components/canvas/shapes/nodeConstants.ts
@@ -7,10 +7,8 @@ export const DEFAULT_NODE_WIDTH = 200;
 export const MIN_NODE_WIDTH = 160;
 export const MAX_NODE_WIDTH = 400;
 
-// Padding: p-2 = 0.5rem = 8px on each side = 16px total vertical
-export const BASE_PADDING = 20;
+export const BASE_PADDING = 16;
 
-// Font sizes matching Tailwind classes
 export const TITLE_FONT_SIZE = 16; // text-base
 export const SUBTITLE_FONT_SIZE = 14; // text-sm
 

--- a/apps/obsidian/src/components/canvas/shapes/nodeConstants.ts
+++ b/apps/obsidian/src/components/canvas/shapes/nodeConstants.ts
@@ -1,0 +1,32 @@
+/**
+ * Constants for Discourse Node styling and sizing.
+ * These values match the Tailwind classes used in DiscourseNodeShape component.
+ */
+
+export const DEFAULT_NODE_WIDTH = 200;
+export const MIN_NODE_WIDTH = 160;
+export const MAX_NODE_WIDTH = 400;
+
+// Padding: p-2 = 0.5rem = 8px on each side = 16px total vertical
+export const BASE_PADDING = 20;
+
+// Font sizes matching Tailwind classes
+export const TITLE_FONT_SIZE = 16; // text-base
+export const SUBTITLE_FONT_SIZE = 14; // text-sm
+
+// Line height for text rendering
+export const LINE_HEIGHT = 1.5;
+
+// Font family - use system font stack similar to Tailwind
+export const FONT_FAMILY =
+  'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif';
+
+// Maximum height for key images
+export const MAX_IMAGE_HEIGHT = 250;
+
+// Gap between image and text
+export const IMAGE_GAP = 4;
+
+// Base height for nodes without images (estimated)
+export const BASE_HEIGHT_NO_IMAGE = 100;
+

--- a/apps/obsidian/src/components/canvas/shapes/nodeConstants.ts
+++ b/apps/obsidian/src/components/canvas/shapes/nodeConstants.ts
@@ -1,19 +1,34 @@
 /**
  * Constants for Discourse Node styling and sizing.
  * These values match the Tailwind classes used in DiscourseNodeShape component.
+ * 
+ * IMPORTANT: If you change these values, you must also update:
+ * - The Tailwind classes in DiscourseNodeShape.tsx (line ~263)
+ * - The measurement function in measureNodeText.ts
  */
 
 export const DEFAULT_NODE_WIDTH = 200;
 export const MIN_NODE_WIDTH = 160;
 export const MAX_NODE_WIDTH = 400;
 
+// Container styles (matches: p-2 border-2 rounded-md)
+export const CONTAINER_PADDING = "0.5rem"; // p-2 = 0.5rem = 8px
+export const CONTAINER_BORDER_WIDTH = "2px"; // border-2
+export const CONTAINER_BORDER_RADIUS = "0.375rem"; // rounded-md = 6px
+
+// Title styles (matches: m-1 text-base)
+export const TITLE_MARGIN = "0.25rem"; // m-1 = 0.25rem = 4px
+export const TITLE_FONT_SIZE = "1rem"; // text-base = 1rem = 16px
+export const TITLE_LINE_HEIGHT = 1.5;
+export const TITLE_FONT_WEIGHT = "600"; // font-semibold
+
+// Subtitle styles (matches: m-0 text-sm)
+export const SUBTITLE_MARGIN = "0"; // m-0
+export const SUBTITLE_FONT_SIZE = "0.875rem"; // text-sm = 0.875rem = 14px
+export const SUBTITLE_LINE_HEIGHT = 1.25;
+
+// Legacy exports for backward compatibility
 export const BASE_PADDING = 16;
-
-export const TITLE_FONT_SIZE = 16; // text-base
-export const SUBTITLE_FONT_SIZE = 14; // text-sm
-
-// Line height for text rendering
-export const LINE_HEIGHT = 1.5;
 
 // Font family - use system font stack similar to Tailwind
 export const FONT_FAMILY =

--- a/apps/obsidian/src/types.ts
+++ b/apps/obsidian/src/types.ts
@@ -9,6 +9,7 @@ export type DiscourseNode = {
   shortcut?: string;
   color?: string;
   tag?: string;
+  keyImage?: boolean;
 };
 
 export type DiscourseRelationType = {

--- a/apps/obsidian/src/utils/calcDiscourseNodeSize.ts
+++ b/apps/obsidian/src/utils/calcDiscourseNodeSize.ts
@@ -17,10 +17,7 @@ type CalcNodeSizeParams = {
 
 /**
  * Calculate the optimal dimensions for a discourse node shape.
- * Uses actual DOM text measurement and image dimensions for accuracy.
- *
- * This matches Roam's approach of measuring actual rendered content
- * rather than using hardcoded estimates.
+ * Uses actual DOM text measurement and image dimensions for accuracy. Matching Roam's approach.
  */
 export const calcDiscourseNodeSize = async ({
   title,
@@ -28,31 +25,28 @@ export const calcDiscourseNodeSize = async ({
   imageSrc,
   plugin,
 }: CalcNodeSizeParams): Promise<{ w: number; h: number }> => {
-  // Get node type to check if key images are enabled
   const nodeType = getNodeTypeById(plugin, nodeTypeId);
   const nodeTypeName = nodeType?.name || "";
 
-  // Measure text dimensions (title + subtitle)
   const { w, h: textHeight } = measureNodeText({
     title,
     subtitle: nodeTypeName,
   });
 
-  // If no image or key images not enabled, return text-only dimensions
   if (!imageSrc || !nodeType?.keyImage) {
     return { w, h: textHeight };
   }
 
-  // Load image to get actual dimensions
   try {
     const { width: imgWidth, height: imgHeight } = await loadImage(imageSrc);
     const aspectRatio = imgWidth / imgHeight;
 
-    // Calculate effective width (accounting for padding)
-    // Use the measured text width as the base
     const effectiveWidth = w + BASE_PADDING;
 
-    const imageHeight = Math.min(effectiveWidth / aspectRatio, MAX_IMAGE_HEIGHT);
+    const imageHeight = Math.min(
+      effectiveWidth / aspectRatio,
+      MAX_IMAGE_HEIGHT,
+    );
 
     let finalWidth = w;
     if (imageHeight === MAX_IMAGE_HEIGHT) {
@@ -63,12 +57,10 @@ export const calcDiscourseNodeSize = async ({
       }
     }
 
-    // Total height: padding + image + gap + text
     const totalHeight = BASE_PADDING + imageHeight + IMAGE_GAP + textHeight;
 
     return { w: finalWidth, h: totalHeight };
   } catch (error) {
-    // If image fails to load, fall back to text-only dimensions
     console.warn("calcDiscourseNodeSize: failed to load image", error);
     return { w, h: textHeight };
   }

--- a/apps/obsidian/src/utils/calcDiscourseNodeSize.ts
+++ b/apps/obsidian/src/utils/calcDiscourseNodeSize.ts
@@ -1,0 +1,76 @@
+import type DiscourseGraphPlugin from "~/index";
+import { measureNodeText } from "./measureNodeText";
+import { loadImage } from "./loadImage";
+import {
+  BASE_PADDING,
+  MAX_IMAGE_HEIGHT,
+  IMAGE_GAP,
+} from "~/components/canvas/shapes/nodeConstants";
+import { getNodeTypeById } from "./typeUtils";
+
+type CalcNodeSizeParams = {
+  title: string;
+  nodeTypeId: string;
+  imageSrc?: string;
+  plugin: DiscourseGraphPlugin;
+};
+
+/**
+ * Calculate the optimal dimensions for a discourse node shape.
+ * Uses actual DOM text measurement and image dimensions for accuracy.
+ *
+ * This matches Roam's approach of measuring actual rendered content
+ * rather than using hardcoded estimates.
+ */
+export const calcDiscourseNodeSize = async ({
+  title,
+  nodeTypeId,
+  imageSrc,
+  plugin,
+}: CalcNodeSizeParams): Promise<{ w: number; h: number }> => {
+  // Get node type to check if key images are enabled
+  const nodeType = getNodeTypeById(plugin, nodeTypeId);
+  const nodeTypeName = nodeType?.name || "";
+
+  // Measure text dimensions (title + subtitle)
+  const { w, h: textHeight } = measureNodeText({
+    title,
+    subtitle: nodeTypeName,
+  });
+
+  // If no image or key images not enabled, return text-only dimensions
+  if (!imageSrc || !nodeType?.keyImage) {
+    return { w, h: textHeight };
+  }
+
+  // Load image to get actual dimensions
+  try {
+    const { width: imgWidth, height: imgHeight } = await loadImage(imageSrc);
+    const aspectRatio = imgWidth / imgHeight;
+
+    // Calculate effective width (accounting for padding)
+    // Use the measured text width as the base
+    const effectiveWidth = w + BASE_PADDING;
+
+    const imageHeight = Math.min(effectiveWidth / aspectRatio, MAX_IMAGE_HEIGHT);
+
+    let finalWidth = w;
+    if (imageHeight === MAX_IMAGE_HEIGHT) {
+      const imageWidth = MAX_IMAGE_HEIGHT * aspectRatio;
+      const minWidthForImage = imageWidth + BASE_PADDING;
+      if (minWidthForImage > w) {
+        finalWidth = minWidthForImage;
+      }
+    }
+
+    // Total height: padding + image + gap + text
+    const totalHeight = BASE_PADDING + imageHeight + IMAGE_GAP + textHeight;
+
+    return { w: finalWidth, h: totalHeight };
+  } catch (error) {
+    // If image fails to load, fall back to text-only dimensions
+    console.warn("calcDiscourseNodeSize: failed to load image", error);
+    return { w, h: textHeight };
+  }
+};
+

--- a/apps/obsidian/src/utils/loadImage.ts
+++ b/apps/obsidian/src/utils/loadImage.ts
@@ -1,0 +1,41 @@
+/**
+ * Load an image and return its natural dimensions.
+ * Supports both vault resource paths (app://...) and external URLs (https://...).
+ * 
+ * Note: This works with Obsidian's resource paths returned by app.vault.getResourcePath()
+ * which are special app:// protocol URLs handled by Obsidian's Electron environment.
+ */
+export const loadImage = (
+  url: string,
+): Promise<{ width: number; height: number }> => {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    let resolved = false;
+
+    const timeoutId = setTimeout(() => {
+      if (!resolved) {
+        resolved = true;
+        reject(new Error("Failed to load image: timeout"));
+      }
+    }, 10000);
+
+    img.onload = () => {
+      if (!resolved) {
+        resolved = true;
+        clearTimeout(timeoutId);
+        resolve({ width: img.naturalWidth, height: img.naturalHeight });
+      }
+    };
+
+    img.onerror = () => {
+      if (!resolved) {
+        resolved = true;
+        clearTimeout(timeoutId);
+        reject(new Error("Failed to load image"));
+      }
+    };
+
+    img.src = url;
+  });
+};
+

--- a/apps/obsidian/src/utils/measureNodeText.ts
+++ b/apps/obsidian/src/utils/measureNodeText.ts
@@ -1,15 +1,29 @@
 import {
   MIN_NODE_WIDTH,
   MAX_NODE_WIDTH,
+  CONTAINER_PADDING,
+  CONTAINER_BORDER_WIDTH,
+  CONTAINER_BORDER_RADIUS,
+  TITLE_MARGIN,
+  TITLE_FONT_SIZE,
+  TITLE_LINE_HEIGHT,
+  TITLE_FONT_WEIGHT,
+  SUBTITLE_MARGIN,
+  SUBTITLE_FONT_SIZE,
+  SUBTITLE_LINE_HEIGHT,
 } from "~/components/canvas/shapes/nodeConstants";
 
 /**
  * Measure the dimensions needed for a discourse node's text content.
  * This renders the actual DOM structure that appears in the component,
  * matching the Tailwind classes and layout exactly.
- * 
+ *
  * Width is dynamic (fit-content) with a max constraint, matching Roam's behavior.
- * 
+ *
+ * IMPORTANT: The styles used here must match DiscourseNodeShape.tsx.
+ * If you change styles in nodeConstants.ts, both this function and the component
+ * will automatically stay in sync.
+ *
  * Structure matches DiscourseNodeShape.tsx:
  * - Container: p-2 border-2 rounded-md (box-border flex-col)
  * - Title (h1): m-1 text-base
@@ -27,7 +41,7 @@ export const measureNodeText = ({
   container.style.setProperty("position", "absolute");
   container.style.setProperty("visibility", "hidden");
   container.style.setProperty("pointer-events", "none");
-  
+
   // Match the actual component classes and styles
   // className="box-border flex h-full w-full flex-col items-start justify-start rounded-md border-2 p-2"
   container.style.setProperty("box-sizing", "border-box");
@@ -39,28 +53,34 @@ export const measureNodeText = ({
   container.style.setProperty("width", "fit-content");
   container.style.setProperty("min-width", `${MIN_NODE_WIDTH}px`);
   container.style.setProperty("max-width", `${MAX_NODE_WIDTH}px`);
-  container.style.setProperty("padding", "0.5rem"); // p-2
-  container.style.setProperty("border", "2px solid transparent"); // border-2
-  container.style.setProperty("border-radius", "0.375rem"); // rounded-md
+  container.style.setProperty("padding", CONTAINER_PADDING as string);
+  container.style.setProperty(
+    "border",
+    `${CONTAINER_BORDER_WIDTH} solid transparent`,
+  );
+  container.style.setProperty(
+    "border-radius",
+    CONTAINER_BORDER_RADIUS as string,
+  );
 
   // Create title element: <h1 className="m-1 text-base">
   const titleEl = document.createElement("h1");
-  titleEl.style.setProperty("margin", "0.25rem"); // m-1
-  titleEl.style.setProperty("font-size", "1rem"); // text-base (16px)
-  titleEl.style.setProperty("line-height", "1.5");
-  titleEl.style.setProperty("font-weight", "600");
+  titleEl.style.setProperty("margin", TITLE_MARGIN as string);
+  titleEl.style.setProperty("font-size", TITLE_FONT_SIZE as string);
+  titleEl.style.setProperty("line-height", String(TITLE_LINE_HEIGHT));
+  titleEl.style.setProperty("font-weight", TITLE_FONT_WEIGHT as string);
   titleEl.textContent = title || "...";
-  
+
   // Create subtitle element: <p className="m-0 text-sm opacity-80">
   const subtitleEl = document.createElement("p");
-  subtitleEl.style.setProperty("margin", "0"); // m-0
-  subtitleEl.style.setProperty("font-size", "0.875rem"); // text-sm (14px)
-  subtitleEl.style.setProperty("line-height", "1.25");
+  subtitleEl.style.setProperty("margin", SUBTITLE_MARGIN as string);
+  subtitleEl.style.setProperty("font-size", SUBTITLE_FONT_SIZE as string);
+  subtitleEl.style.setProperty("line-height", String(SUBTITLE_LINE_HEIGHT));
   subtitleEl.textContent = subtitle || "";
 
   container.appendChild(titleEl);
   container.appendChild(subtitleEl);
-  
+
   // Append to body, measure, and remove
   document.body.appendChild(container);
   const rect = container.getBoundingClientRect();

--- a/apps/obsidian/src/utils/measureNodeText.ts
+++ b/apps/obsidian/src/utils/measureNodeText.ts
@@ -1,0 +1,74 @@
+import {
+  MIN_NODE_WIDTH,
+  MAX_NODE_WIDTH,
+} from "~/components/canvas/shapes/nodeConstants";
+
+/**
+ * Measure the dimensions needed for a discourse node's text content.
+ * This renders the actual DOM structure that appears in the component,
+ * matching the Tailwind classes and layout exactly.
+ * 
+ * Width is dynamic (fit-content) with a max constraint, matching Roam's behavior.
+ * 
+ * Structure matches DiscourseNodeShape.tsx:
+ * - Container: p-2 border-2 rounded-md (box-border flex-col)
+ * - Title (h1): m-1 text-base
+ * - Subtitle (p): m-0 text-sm
+ */
+export const measureNodeText = ({
+  title,
+  subtitle,
+}: {
+  title: string;
+  subtitle: string;
+}): { w: number; h: number } => {
+  // Create a container matching the actual component structure
+  const container = document.createElement("div");
+  container.style.setProperty("position", "absolute");
+  container.style.setProperty("visibility", "hidden");
+  container.style.setProperty("pointer-events", "none");
+  
+  // Match the actual component classes and styles
+  // className="box-border flex h-full w-full flex-col items-start justify-start rounded-md border-2 p-2"
+  container.style.setProperty("box-sizing", "border-box");
+  container.style.setProperty("display", "flex");
+  container.style.setProperty("flex-direction", "column");
+  container.style.setProperty("align-items", "flex-start");
+  container.style.setProperty("justify-content", "flex-start");
+  // Dynamic width with constraints - matches Roam's approach
+  container.style.setProperty("width", "fit-content");
+  container.style.setProperty("min-width", `${MIN_NODE_WIDTH}px`);
+  container.style.setProperty("max-width", `${MAX_NODE_WIDTH}px`);
+  container.style.setProperty("padding", "0.5rem"); // p-2
+  container.style.setProperty("border", "2px solid transparent"); // border-2
+  container.style.setProperty("border-radius", "0.375rem"); // rounded-md
+
+  // Create title element: <h1 className="m-1 text-base">
+  const titleEl = document.createElement("h1");
+  titleEl.style.setProperty("margin", "0.25rem"); // m-1
+  titleEl.style.setProperty("font-size", "1rem"); // text-base (16px)
+  titleEl.style.setProperty("line-height", "1.5");
+  titleEl.style.setProperty("font-weight", "600");
+  titleEl.textContent = title || "...";
+  
+  // Create subtitle element: <p className="m-0 text-sm opacity-80">
+  const subtitleEl = document.createElement("p");
+  subtitleEl.style.setProperty("margin", "0"); // m-0
+  subtitleEl.style.setProperty("font-size", "0.875rem"); // text-sm (14px)
+  subtitleEl.style.setProperty("line-height", "1.25");
+  subtitleEl.textContent = subtitle || "";
+
+  container.appendChild(titleEl);
+  container.appendChild(subtitleEl);
+  
+  // Append to body, measure, and remove
+  document.body.appendChild(container);
+  const rect = container.getBoundingClientRect();
+  document.body.removeChild(container);
+
+  return {
+    w: rect.width,
+    h: rect.height,
+  };
+};
+


### PR DESCRIPTION
https://www.loom.com/share/11478ad987614ae4bdee0c0c61504fa8


Old PR comments can be found here: https://github.com/DiscourseGraphs/discourse-graph/pull/490
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a boolean "key image" option to node-type settings.
  * Canvas nodes can preload and display a key image from linked files.
  * Node dimensions are now calculated dynamically from title, type and image.
  * Nodes auto-resize (and respect manual resizing) to better fit text and images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->