### PR TITLE
remove success banner for suggestive mode, send error email on fail, fix on load check if we need to initialize by default

### DIFF
--- a/apps/roam/src/index.ts
+++ b/apps/roam/src/index.ts
@@ -1,4 +1,4 @@
-import { addStyle } from "roamjs-components/dom";
+import { addStyle, getRoamUrl } from "roamjs-components/dom";
 import { render as renderToast } from "roamjs-components/components/Toast";
 import getCurrentUserUid from "roamjs-components/queries/getCurrentUserUid";
 import { runExtension } from "roamjs-components/util";
@@ -32,6 +32,7 @@ import {
   setSyncActivity,
 } from "./utils/syncDgNodesToSupabase";
 import { initPluginTimer } from "./utils/pluginTimer";
+import { createClient } from "@repo/database/lib/client";
 
 const initPostHog = () => {
   posthog.init("phc_SNMmBqwNfcEpNduQ41dBUjtGNEUEKAy6jTn63Fzsrax", {
@@ -126,7 +127,18 @@ export default runExtension(async (onloadArgs) => {
   document.addEventListener("input", discourseNodeSearchTriggerListener);
   document.addEventListener("selectionchange", nodeCreationPopoverListener);
 
-  await initializeSupabaseSync();
+  const supabase = createClient();
+  if (supabase) {
+    const { data } = await supabase
+      .from("Space")
+      .select("url")
+      .eq("url", getRoamUrl())
+      .maybeSingle();
+
+    if (data) {
+      initializeSupabaseSync();
+    }
+  }
 
   const { extensionAPI } = onloadArgs;
   window.roamjs.extension.queryBuilder = {

--- a/apps/roam/src/utils/syncDgNodesToSupabase.ts
+++ b/apps/roam/src/utils/syncDgNodesToSupabase.ts
@@ -70,12 +70,13 @@ export const endSyncTask = async (
           intent: "danger",
           timeout: 5000,
         });
-        sendErrorEmail({
-          error: new Error("Discourse node embeddings sync failed"),
-          type: "Sync Failed",
-          context: { status },
-        }).catch(() => {});
       }
+      sendErrorEmail({
+        error: new Error("Failed to complete discourse node embeddings sync"),
+        type: "Sync Failed",
+        context: { status },
+      }).catch(() => {});
+
       return;
     } else if (showToast) {
       if (status === "failed") {
@@ -85,11 +86,6 @@ export const endSyncTask = async (
           intent: "danger",
           timeout: 5000,
         });
-        sendErrorEmail({
-          error: new Error("Discourse node embeddings sync failed"),
-          type: "Sync Failed",
-          context: { status },
-        }).catch(() => {});
       }
     }
   } catch (error) {
@@ -101,12 +97,12 @@ export const endSyncTask = async (
         intent: "danger",
         timeout: 5000,
       });
-      sendErrorEmail({
-        error: new Error("Failed to complete discourse node embeddings sync"),
-        type: "Sync Failed",
-        context: { status },
-      }).catch(() => {});
     }
+    sendErrorEmail({
+      error: new Error("Failed to complete discourse node embeddings sync"),
+      type: "Sync Failed",
+      context: { status },
+    }).catch(() => {});
   }
 };
 

--- a/apps/roam/src/utils/syncDgNodesToSupabase.ts
+++ b/apps/roam/src/utils/syncDgNodesToSupabase.ts
@@ -18,10 +18,10 @@ import {
 } from "./conceptConversion";
 import { fetchEmbeddingsForNodes } from "./upsertNodesAsContentWithEmbeddings";
 import { convertRoamNodeToLocalContent } from "./upsertNodesAsContentWithEmbeddings";
-import { render as renderToast } from "roamjs-components/components/Toast";
 import { createClient, type DGSupabaseClient } from "@repo/database/lib/client";
 import type { Json, CompositeTypes, Enums } from "@repo/database/dbTypes";
-
+import { render as renderToast } from "roamjs-components/components/Toast";
+import sendErrorEmail from "~/utils/sendErrorEmail";
 type LocalContentDataInput = Partial<CompositeTypes<"content_local_input">>;
 type AccountLocalInput = CompositeTypes<"account_local_input">;
 
@@ -63,40 +63,50 @@ export const endSyncTask = async (
     });
     if (error) {
       console.error("endSyncTask: Error calling end_sync_task:", error);
-      if (showToast)
+      if (showToast) {
         renderToast({
           id: "discourse-embedding-error",
           content: "Failed to complete discourse node embeddings sync",
           intent: "danger",
           timeout: 5000,
         });
+        sendErrorEmail({
+          error: new Error("Discourse node embeddings sync failed"),
+          type: "Sync Failed",
+          context: { status },
+        }).catch(() => {});
+      }
       return;
     } else if (showToast) {
-      if (status === "complete") {
-        renderToast({
-          id: "discourse-embedding-complete",
-          content: "Successfully completed discourse node embeddings sync",
-          intent: "success",
-          timeout: 4000,
-        });
-      } else if (status === "failed") {
+      if (status === "failed") {
         renderToast({
           id: "discourse-embedding-failed",
           content: "Discourse node embeddings sync failed",
           intent: "danger",
           timeout: 5000,
         });
+        sendErrorEmail({
+          error: new Error("Discourse node embeddings sync failed"),
+          type: "Sync Failed",
+          context: { status },
+        }).catch(() => {});
       }
     }
   } catch (error) {
     console.error("endSyncTask: Error calling end_sync_task:", error);
-    if (showToast)
+    if (showToast) {
       renderToast({
         id: "discourse-embedding-error",
         content: "Failed to complete discourse node embeddings sync",
         intent: "danger",
         timeout: 5000,
       });
+      sendErrorEmail({
+        error: new Error("Failed to complete discourse node embeddings sync"),
+        type: "Sync Failed",
+        context: { status },
+      }).catch(() => {});
+    }
   }
 };
 
@@ -468,13 +478,13 @@ export const createOrUpdateDiscourseEmbedding = async (showToast = false) => {
   }
 };
 
-export const initializeSupabaseSync = async () => {
-  const supabase = createClient();
-  if (supabase === null) {
-    doSync = false;
-  } else {
-    doSync = true;
-    // eslint-disable-next-line @typescript-eslint/no-misused-promises
-    activeTimeout = setTimeout(createOrUpdateDiscourseEmbedding, 100, true);
+export const initializeSupabaseSync = (): void => {
+  if (activeTimeout !== null) {
+    clearTimeout(activeTimeout);
+    activeTimeout = null;
   }
+
+  doSync = true;
+  // eslint-disable-next-line @typescript-eslint/no-misused-promises
+  activeTimeout = setTimeout(createOrUpdateDiscourseEmbedding, 100, true);
 };


### PR DESCRIPTION
While reviewing ENG-298 I missed to point out logic that was removed from `initializeSupabaseSync` was actually needed. So currently if we load the main plugin to any graph it automatically starts syncing even if the graph has "_Opted-in_" to do so. 

Before this sync the logic was, on load check supabase if this graph's url exist and if it doesn't don't sync. We removed this check and now we sync by default. 

In this PR I am adding the logic again for `initializeSupabaseSync` callsite in `index.ts`. Now the new intended flow is:

- On load check if the url exist in supabase, if it does initialize
- If it doesn't we don't initialize and wait for user to do it manually, which they do by going to settings and clicking on the button. Then we start the sync process in the same and all future sessions of this graph 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes & Improvements**
  * Enhanced error notifications: Sync operation failures now automatically generate both in-app toast alerts and email notifications to inform users of any issues.
  * Refined sync initialization with conditional activation logic to improve reliability and system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->