### PR TITLE
[ENG-1026] Fix default node tags and improve lint for node type setting

### DIFF
--- a/apps/obsidian/src/components/NodeTypeSettings.tsx
+++ b/apps/obsidian/src/components/NodeTypeSettings.tsx
@@ -8,7 +8,7 @@ import { ConfirmationModal } from "./ConfirmationModal";
 import { getTemplateFiles, getTemplatePluginInfo } from "~/utils/templates";
 
 const generateTagPlaceholder = (format: string, nodeName?: string): string => {
-  if (!format) return "Enter tag (e.g., clm-candidate or #clm-candidate)";
+  if (!format) return "Enter tag (e.g., clm-candidate)";
 
   // Extract the prefix before " - {content}" or " -{content}" or " -{content}" etc.
   const match = format.match(/^([A-Z]+)\s*-\s*\{content\}/i);

--- a/apps/obsidian/src/components/NodeTypeSettings.tsx
+++ b/apps/obsidian/src/components/NodeTypeSettings.tsx
@@ -360,7 +360,7 @@ const NodeTypeSettings = () => {
     const modal = new ConfirmationModal(plugin.app, {
       title: "Delete Node Type",
       message: `Are you sure you want to delete the node type "${nodeType.name}"?`,
-      onConfirm: () => handleDeleteNodeType(index),
+      onConfirm: () => void handleDeleteNodeType(index),
     });
     modal.open();
   };
@@ -581,7 +581,7 @@ const NodeTypeSettings = () => {
               Cancel
             </button>
             <button
-              onClick={handleSave}
+              onClick={() => void handleSave()}
               className="mod-cta"
               disabled={
                 Object.keys(errors).length > 0 ||

--- a/apps/obsidian/src/constants.ts
+++ b/apps/obsidian/src/constants.ts
@@ -13,14 +13,14 @@ export const DEFAULT_NODE_TYPES: Record<string, DiscourseNode> = {
     name: "Claim",
     format: "CLM - {content}",
     color: "#7DA13E",
-    tag: "#clm-candidate",
+    tag: "clm-candidate",
   },
   Evidence: {
     id: generateUid("node"),
     name: "Evidence",
     format: "EVD - {content}",
     color: "#DB134A",
-    tag: "#evd-candidate",
+    tag: "evd-candidate",
   },
 };
 export const DEFAULT_RELATION_TYPES: Record<string, DiscourseRelationType> = {


### PR DESCRIPTION
Since our validator will discard any tag setting with `#` in it, we want to make sure our default values also reflect this constraint