### PR TITLE
ENG-1014 Add Admin Feature Flag for “Reified Relation Triples” Flow

### DIFF
--- a/apps/roam/src/components/settings/AdminPanel.tsx
+++ b/apps/roam/src/components/settings/AdminPanel.tsx
@@ -236,7 +236,7 @@ const AdminPanel = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
                   Reified Relation Triples
                   <Description
                     description={
-                      "When ON, relations are read/written as sourceUid:relationBlockUid:destinationUid in [[roam/js/discourse-graph/relations]]."
+                      "When ON, relations are read/written as reifiedRelationUid in [[roam/js/discourse-graph/relations]]."
                     }
                   />
                 </>

--- a/apps/roam/src/components/settings/AdminPanel.tsx
+++ b/apps/roam/src/components/settings/AdminPanel.tsx
@@ -10,7 +10,6 @@ import {
   TabId,
   Tabs,
 } from "@blueprintjs/core";
-import { OnloadArgs } from "roamjs-components/types";
 import Description from "roamjs-components/components/Description";
 import { Select } from "@blueprintjs/select";
 import { getSetting, setSetting } from "~/utils/extensionSettings";
@@ -104,12 +103,7 @@ const NodeTable = ({ nodes }: { nodes: PConceptFull[] }) => {
   );
 };
 
-const AdminPanel = ({
-  onloadArgs,
-}: {
-  onloadArgs: OnloadArgs;
-}): React.ReactElement => {
-  const extensionAPI = onloadArgs.extensionAPI;
+const AdminPanel = (): React.ReactElement => {
   const [context, setContext] = useState<SupabaseContext | null>(null);
   const [supabase, setSupabase] = useState<DGSupabaseClient | null>(null);
   const [schemas, setSchemas] = useState<NodeSignature[]>([]);

--- a/apps/roam/src/components/settings/AdminPanel.tsx
+++ b/apps/roam/src/components/settings/AdminPanel.tsx
@@ -103,7 +103,11 @@ const NodeTable = ({ nodes }: { nodes: PConceptFull[] }) => {
   );
 };
 
-const AdminPanel = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
+const AdminPanel = ({
+  onloadArgs,
+}: {
+  onloadArgs: OnloadArgs;
+}): React.ReactElement => {
   const extensionAPI = onloadArgs.extensionAPI;
   const [context, setContext] = useState<SupabaseContext | null>(null);
   const [supabase, setSupabase] = useState<DGSupabaseClient | null>(null);

--- a/apps/roam/src/components/settings/AdminPanel.tsx
+++ b/apps/roam/src/components/settings/AdminPanel.tsx
@@ -13,6 +13,7 @@ import {
 import { OnloadArgs } from "roamjs-components/types";
 import Description from "roamjs-components/components/Description";
 import { Select } from "@blueprintjs/select";
+import { getSetting, setSetting } from "~/utils/extensionSettings";
 import {
   getSupabaseContext,
   getLoggedInClient,
@@ -119,6 +120,9 @@ const AdminPanel = ({
   const [loadingNodes, setLoadingNodes] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [selectedTabId, setSelectedTabId] = useState<TabId>("admin");
+  const [useReifiedRelations, setUseReifiedRelations] = useState<boolean>(
+    getSetting("use-reified-relations"),
+  );
 
   useEffect(() => {
     let ignore = false;
@@ -225,15 +229,11 @@ const AdminPanel = ({
         panel={
           <div className="flex flex-col gap-4 p-1">
             <Checkbox
-              defaultChecked={
-                extensionAPI.settings.get("use-reified-relations") as boolean
-              }
+              defaultChecked={useReifiedRelations}
               onChange={(e) => {
                 const target = e.target as HTMLInputElement;
-                void extensionAPI.settings.set(
-                  "use-reified-relations",
-                  target.checked,
-                );
+                setUseReifiedRelations(target.checked);
+                setSetting("use-reified-relations", target.checked);
               }}
               labelElement={
                 <>

--- a/apps/roam/src/components/settings/AdminPanel.tsx
+++ b/apps/roam/src/components/settings/AdminPanel.tsx
@@ -114,7 +114,7 @@ const AdminPanel = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
   const [loading, setLoading] = useState(true);
   const [loadingNodes, setLoadingNodes] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [selectedTabId, setSelectedTabId] = useState<TabId>("node-list");
+  const [selectedTabId, setSelectedTabId] = useState<TabId>("admin");
 
   useEffect(() => {
     let ignore = false;
@@ -216,6 +216,36 @@ const AdminPanel = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
       renderActiveTabPanelOnly={true}
     >
       <Tab
+        id="admin"
+        title="Admin"
+        panel={
+          <div className="flex flex-col gap-4 p-1">
+            <Checkbox
+              defaultChecked={
+                extensionAPI.settings.get("use-reified-relations") as boolean
+              }
+              onChange={(e) => {
+                const target = e.target as HTMLInputElement;
+                void extensionAPI.settings.set(
+                  "use-reified-relations",
+                  target.checked,
+                );
+              }}
+              labelElement={
+                <>
+                  Reified Relation Triples
+                  <Description
+                    description={
+                      "When ON, relations are read/written as sourceUid:relationBlockUid:destinationUid in [[roam/js/discourse-graph/relations]]."
+                    }
+                  />
+                </>
+              }
+            />
+          </div>
+        }
+      />
+      <Tab
         id="node-list"
         title="Node list"
         panel={
@@ -258,36 +288,6 @@ const AdminPanel = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
               <p>No node schemas found</p>
             )}
           </>
-        }
-      />
-      <Tab
-        id="experiments"
-        title="Experiments"
-        panel={
-          <div className="flex flex-col gap-4 p-1">
-            <Checkbox
-              defaultChecked={
-                extensionAPI.settings.get("use-reified-relations") as boolean
-              }
-              onChange={(e) => {
-                const target = e.target as HTMLInputElement;
-                extensionAPI.settings.set(
-                  "use-reified-relations",
-                  target.checked,
-                );
-              }}
-              labelElement={
-                <>
-                  Reified Relation Triples
-                  <Description
-                    description={
-                      "When ON, relations are read/written as sourceUid:relationBlockUid:destinationUid in [[roam/js/discourse-graph/relations]]."
-                    }
-                  />
-                </>
-              }
-            />
-          </div>
         }
       />
     </Tabs>

--- a/apps/roam/src/components/settings/Settings.tsx
+++ b/apps/roam/src/components/settings/Settings.tsx
@@ -78,7 +78,6 @@ export const SettingsDialog = ({
     selectedTabId ?? "discourse-graph-home-personal",
   );
 
-
   useEffect(() => {
     const handleKeyPress = (e: KeyboardEvent) => {
       if (e.ctrlKey && e.shiftKey && e.key === "A") {
@@ -230,7 +229,7 @@ export const SettingsDialog = ({
             id="secret-admin-panel"
             title="Secret Admin Panel"
             className="overflow-y-auto"
-            panel={<AdminPanel />}
+            panel={<AdminPanel onloadArgs={onloadArgs} />}
           />
         </Tabs>
       </div>

--- a/apps/roam/src/components/settings/Settings.tsx
+++ b/apps/roam/src/components/settings/Settings.tsx
@@ -229,7 +229,7 @@ export const SettingsDialog = ({
             id="secret-admin-panel"
             title="Secret Admin Panel"
             className="overflow-y-auto"
-            panel={<AdminPanel onloadArgs={onloadArgs} />}
+            panel={<AdminPanel />}
           />
         </Tabs>
       </div>


### PR DESCRIPTION
https://linear.app/discourse-graphs/issue/ENG-1014/add-admin-feature-flag-for-reified-relation-triples-flow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reorganized admin settings into a tabbed interface for improved navigation.
  * Added Admin tab with toggle for reified relations setting.
  * Node list functionality now in dedicated tab with schema selection control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->