### PR TITLE
ENG-1012 Update Query Builder Relation Conditions to Use Reified Relation Triples

### DIFF
--- a/apps/roam/package.json
+++ b/apps/roam/package.json
@@ -68,7 +68,7 @@
     "react-draggable": "4.4.5",
     "react-in-viewport": "1.0.0-alpha.20",
     "react-vertical-timeline-component": "3.5.2",
-    "roamjs-components": "0.85.4",
+    "roamjs-components": "0.85.6",
     "tldraw": "2.3.0",
     "use-sync-external-store": "1.5.0",
     "xregexp": "^5.0.0",

--- a/apps/roam/src/utils/createReifiedBlock.ts
+++ b/apps/roam/src/utils/createReifiedBlock.ts
@@ -5,10 +5,19 @@ import { getSetting } from "~/utils/extensionSettings";
 
 export const DISCOURSE_GRAPH_PROP_NAME = "discourse-graph";
 
+const SANE_ROLE_NAME_RE = new RegExp(/^[a-zA-Z][a-zA-Z0-9_-]*$/);
+
 const strictQueryForReifiedBlocks = async (
   parameterUids: Record<string, string>,
 ): Promise<string | null> => {
   const paramsAsSeq = Object.entries(parameterUids);
+  // sanitize parameter names
+  if (
+    Object.keys(parameterUids).filter((k) => !k.match(SANE_ROLE_NAME_RE)).length
+  )
+    throw new Error(
+      `invalid parameter names in ${Object.keys(parameterUids).join(", "),}`
+    );
   const query = `[:find ?u ?d
   :in $ ${paramsAsSeq.map(([k]) => "?" + k).join(" ")}
   :where [?s :block/uid ?u] [?s :block/props ?p] [(get ?p :${DISCOURSE_GRAPH_PROP_NAME}) ?d]

--- a/apps/roam/src/utils/createReifiedBlock.ts
+++ b/apps/roam/src/utils/createReifiedBlock.ts
@@ -5,13 +5,13 @@ import { getSetting } from "~/utils/extensionSettings";
 
 export const DISCOURSE_GRAPH_PROP_NAME = "discourse-graph";
 
-const SANE_ROLE_NAME_RE = new RegExp(/^[a-zA-Z][a-zA-Z0-9_-]*$/);
+const SANE_ROLE_NAME_RE = new RegExp(/^[\w\-]*$/);
 
 const strictQueryForReifiedBlocks = async (
   parameterUids: Record<string, string>,
 ): Promise<string | null> => {
   const paramsAsSeq = Object.entries(parameterUids);
-  // sanitize parameter names
+  // validate parameter names
   if (
     Object.keys(parameterUids).filter((k) => !k.match(SANE_ROLE_NAME_RE)).length
   )
@@ -81,7 +81,7 @@ const createReifiedBlock = async ({
 const RELATION_PAGE_TITLE = "roam/js/discourse-graph/relations";
 let relationPageUid: string | undefined = undefined;
 
-export const getOrCreateRelationPageUid = async (): Promise<string> => {
+const getOrCreateRelationPageUid = async (): Promise<string> => {
   if (relationPageUid === undefined) {
     relationPageUid = getPageUidByPageTitle(RELATION_PAGE_TITLE);
     if (relationPageUid === "") {

--- a/apps/roam/src/utils/createReifiedBlock.ts
+++ b/apps/roam/src/utils/createReifiedBlock.ts
@@ -72,7 +72,7 @@ const createReifiedBlock = async ({
 const RELATION_PAGE_TITLE = "roam/js/discourse-graph/relations";
 let relationPageUid: string | undefined = undefined;
 
-const getRelationPageUid = async (): Promise<string> => {
+export const getOrCreateRelationPageUid = async (): Promise<string> => {
   if (relationPageUid === undefined) {
     relationPageUid = getPageUidByPageTitle(RELATION_PAGE_TITLE);
     if (relationPageUid === "") {
@@ -82,8 +82,16 @@ const getRelationPageUid = async (): Promise<string> => {
   return relationPageUid;
 };
 
+export const getExistingRelationPageUid = (): string | undefined => {
+  if (relationPageUid === undefined) {
+    const uid = getPageUidByPageTitle(RELATION_PAGE_TITLE);
+    if (uid !== "") relationPageUid = uid;
+  }
+  return relationPageUid;
+};
+
 export const countReifiedRelations = async (): Promise<number> => {
-  const pageUid = await getRelationPageUid();
+  const pageUid = getExistingRelationPageUid();
   if (pageUid === undefined) return 0;
   const r = await window.roamAlphaAPI.data.async.q(
     `[:find (count ?c) :where [?p :block/children ?c] [?p :block/uid "${pageUid}"]]`,
@@ -103,7 +111,7 @@ export const createReifiedRelation = async ({
   const authorized = getSetting("use-reified-relations");
   if (authorized) {
     return await createReifiedBlock({
-      destinationBlockUid: await getRelationPageUid(),
+      destinationBlockUid: await getOrCreateRelationPageUid(),
       schemaUid: relationBlockUid,
       parameterUids: {
         sourceUid,

--- a/apps/roam/src/utils/createReifiedBlock.ts
+++ b/apps/roam/src/utils/createReifiedBlock.ts
@@ -16,7 +16,7 @@ const strictQueryForReifiedBlocks = async (
     Object.keys(parameterUids).filter((k) => !k.match(SANE_ROLE_NAME_RE)).length
   )
     throw new Error(
-      `invalid parameter names in ${Object.keys(parameterUids).join(", "),}`
+      `invalid parameter names in ${Object.keys(parameterUids).join(", ")}`,
     );
   const query = `[:find ?u ?d
   :in $ ${paramsAsSeq.map(([k]) => "?" + k).join(" ")}

--- a/apps/roam/src/utils/registerDiscourseDatalogTranslators.ts
+++ b/apps/roam/src/utils/registerDiscourseDatalogTranslators.ts
@@ -447,18 +447,6 @@ const registerDiscourseDatalogTranslators = () => {
                 fn: "get",
                 arguments: [
                   { type: "variable", value: "reldata" },
-                  { type: "constant", value: ":hasSchema" },
-                ],
-                binding: {
-                  type: "bind-scalar",
-                  variable: { type: "variable", value: "relSchema" },
-                },
-              },
-              {
-                type: "fn-expr",
-                fn: "get",
-                arguments: [
-                  { type: "variable", value: "reldata" },
                   { type: "constant", value: ":sourceUid" },
                 ],
                 binding: {
@@ -476,6 +464,18 @@ const registerDiscourseDatalogTranslators = () => {
                 binding: {
                   type: "bind-scalar",
                   variable: { type: "variable", value: "relTarget" },
+                },
+              },
+              {
+                type: "fn-expr",
+                fn: "get",
+                arguments: [
+                  { type: "variable", value: "reldata" },
+                  { type: "constant", value: ":hasSchema" },
+                ],
+                binding: {
+                  type: "bind-scalar",
+                  variable: { type: "variable", value: "relSchema" },
                 },
               },
             ];
@@ -580,32 +580,36 @@ const registerDiscourseDatalogTranslators = () => {
                 clauses: [forwardClause, reverseClause],
               });
             } else {
-              const forwardRelationClauses = filteredRelations
+              let forwardRelationIds = filteredRelations
                 .filter((r) => r.forward)
-                .map(
-                  (r) =>
-                    ({
-                      type: "pred-expr",
-                      pred: "=",
-                      arguments: [
-                        { type: "variable", value: "relSchema" },
-                        { type: "constant", value: `"${r.id}"` },
-                      ],
-                    }) as DatalogClause,
-                );
-              const reverseRelationClauses = filteredRelations
+                .map((r) => r.id);
+              forwardRelationIds = [...new Set(forwardRelationIds)];
+              const forwardRelationClauses = forwardRelationIds.map(
+                (id) =>
+                  ({
+                    type: "pred-expr",
+                    pred: "=",
+                    arguments: [
+                      { type: "variable", value: "relSchema" },
+                      { type: "constant", value: `"${id}"` },
+                    ],
+                  }) as DatalogClause,
+              );
+              let reverseRelationIds = filteredRelations
                 .filter((r) => !r.forward)
-                .map(
-                  (r) =>
-                    ({
-                      type: "pred-expr",
-                      pred: "=",
-                      arguments: [
-                        { type: "variable", value: "relSchema" },
-                        { type: "constant", value: `"${r.id}"` },
-                      ],
-                    }) as DatalogClause,
-                );
+                .map((r) => r.id);
+              reverseRelationIds = [...new Set(reverseRelationIds)];
+              const reverseRelationClauses = reverseRelationIds.map(
+                (id) =>
+                  ({
+                    type: "pred-expr",
+                    pred: "=",
+                    arguments: [
+                      { type: "variable", value: "relSchema" },
+                      { type: "constant", value: `"${id}"` },
+                    ],
+                  }) as DatalogClause,
+              );
               if (
                 forwardRelationClauses.length &&
                 reverseRelationClauses.length

--- a/apps/roam/src/utils/registerDiscourseDatalogTranslators.ts
+++ b/apps/roam/src/utils/registerDiscourseDatalogTranslators.ts
@@ -573,7 +573,6 @@ const registerDiscourseDatalogTranslators = () => {
             const typeOfTarget = typeOfValue(target);
             const clauses: DatalogClause[] = [...relClauseBasis];
 
-            // todo: It could be a title or a node type.
             if (
               !(
                 typeOfSource <= ValueType.nodeType ||

--- a/apps/roam/src/utils/registerDiscourseDatalogTranslators.ts
+++ b/apps/roam/src/utils/registerDiscourseDatalogTranslators.ts
@@ -423,7 +423,6 @@ const registerDiscourseDatalogTranslators = () => {
           });
           if (!filteredRelations.length && !ANY_RELATION_REGEX.test(label))
             return [];
-          console.log("source", source, "target", target);
           const typeOfValue = (value: string): ValueType => {
             const possibleNodeType = nodeTypeByLabel[value?.toLowerCase()];
             if (possibleNodeType) {
@@ -575,12 +574,6 @@ const registerDiscourseDatalogTranslators = () => {
             const clauses: DatalogClause[] = [...relClauseBasis];
 
             // todo: It could be a title or a node type.
-            console.log(
-              "typeOfSource",
-              typeOfSource,
-              "typeOfTarget",
-              typeOfTarget,
-            );
             if (
               !(
                 typeOfSource <= ValueType.nodeType ||
@@ -603,12 +596,6 @@ const registerDiscourseDatalogTranslators = () => {
                 ),
               )
               .filter((x) => x !== undefined);
-            console.log(
-              "sourceTriples",
-              sourceTriples,
-              "targetTriples",
-              targetTriples,
-            );
             if (typeOfSource === ValueType.uid) {
               if (sourceTriples.length)
                 clauses.push(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -279,8 +279,8 @@ importers:
         specifier: 3.5.2
         version: 3.5.2(react@18.2.0)
       roamjs-components:
-        specifier: 0.85.4
-        version: 0.85.4(8b55b1f14ffbf718c26dbfa3a20c2d6b)
+        specifier: 0.85.6
+        version: 0.85.6(8b55b1f14ffbf718c26dbfa3a20c2d6b)
       tldraw:
         specifier: 2.3.0
         version: 2.3.0(patch_hash=53157a9866fb748b22a548ab8d9aca2a557f98c0487b201b01f0a4ca89c71708)(@types/react-dom@18.2.17)(@types/react@18.2.21)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -7963,8 +7963,8 @@ packages:
     deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
-  roamjs-components@0.85.4:
-    resolution: {integrity: sha512-1jKcPg3HXrX3+D6XEjf21IZVQ7IMPfdJHr3zffVX88zQLS4VmqeF0hcv95oAnts4NRRjrWu/kyG3apXwq6BFHw==}
+  roamjs-components@0.85.6:
+    resolution: {integrity: sha512-uE4QcwmbBZbLuq5fuYV8iSywDAb+VYw9IyS1rfiweUQxO+BttyAYNhGoCN/O2k3Bow0dhnFKTzPkFLElW6htmg==}
     engines: {node: '>=16.0.0', npm: '>=7.0.0'}
     hasBin: true
     peerDependencies:
@@ -18126,7 +18126,7 @@ snapshots:
     dependencies:
       glob: 7.2.3
 
-  roamjs-components@0.85.4(8b55b1f14ffbf718c26dbfa3a20c2d6b):
+  roamjs-components@0.85.6(8b55b1f14ffbf718c26dbfa3a20c2d6b):
     dependencies:
       '@blueprintjs/core': 3.50.4(patch_hash=51c5847e0a73a1be0cc263036ff64d8fada46f3b65831ed938dbca5eecf3edc0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@blueprintjs/datetime': 3.23.14(react-dom@18.2.0(react@18.2.0))(react@18.2.0)


### PR DESCRIPTION
https://linear.app/discourse-graphs/issue/ENG-1012/update-query-builder-relation-conditions-to-use-reified-relation

Update query builder relation conditions.

Notes: 
Right now, we use one of two query paths, according to the `use-reified-relations` setting. 
I had to make changes to the optimizer. (Otherwise queries with or-clause would just fail, or even crash.)
Performance is clearly better than before but a bit less than hoped for.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Admin panel redesigned with tabbed interface: "Node list" and "Experiments" sections for improved organization.
  * Experiment settings now toggleable via checkbox with persistent storage.
  * Reified relations support for managing complex node relationships with deduplication control.
  * Relation migration utility to transform existing relation data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->