### PR TITLE
ENG-1047 Repair setBlockProps

### DIFF
--- a/apps/roam/src/utils/setBlockProps.ts
+++ b/apps/roam/src/utils/setBlockProps.ts
@@ -1,4 +1,4 @@
-import { type json, getRawBlockProps } from "./getBlockProps";
+import { type json, getRawBlockProps, normalizeProps } from "./getBlockProps";
 import getPageUidByPageTitle from "roamjs-components/queries/getPageUidByPageTitle";
 
 export const deNormalizeProps = (props: json): json =>
@@ -24,7 +24,8 @@ const setBlockProps = (
   newProps: Record<string, json>,
   denormalize: boolean = false,
 ) => {
-  const baseProps = getRawBlockProps(uid);
+  const rawBaseProps = getRawBlockProps(uid);
+  const baseProps = denormalize ? rawBaseProps : normalizeProps(rawBaseProps);
   if (typeof baseProps === "object" && !Array.isArray(baseProps)) {
     const props = {
       ...(baseProps || {}),


### PR DESCRIPTION
https://linear.app/discourse-graphs/issue/ENG-1047/repair-setblockprops
Problem: If I setBlockProp repeatedly, the old values get repeated with increased `:` nesting.
Eg: (Having put getBlockProps and setBlockProps in the index)
```
window.roamjs.extension.queryBuilder.getBlockProps('DFPKL0i51')
-> {}
window.roamjs.extension.queryBuilder.setBlockProps('DFPKL0i51', {a:1})
-> {a: 1}
window.roamjs.extension.queryBuilder.setBlockProps('DFPKL0i51', {a:2})
-> {:a: 1, a: 2}
window.roamjs.extension.queryBuilder.setBlockProps('DFPKL0i51', {a:3})
-> {::a: 1, :a: 2, a: 3}
window.roamjs.extension.queryBuilder.getBlockProps('DFPKL0i51')
-> {a: 3}
```

The way getBlockProps is programmed makes this invisible, but it is visible when pulling the props.
Solution: In the not-denormalized case, make sure to normalize the incoming old props before updating.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved block property handling with conditional normalization logic to ensure consistent and correct behavior when setting block properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->