### PR TITLE
ENG-1056 - Add seminar promotion for Metagov x Future of Science event to homepage

### DIFF
--- a/apps/website/app/(home)/page.tsx
+++ b/apps/website/app/(home)/page.tsx
@@ -11,6 +11,7 @@ import { getLatestBlogs } from "~/(home)/blog/readBlogs";
 import { TeamPerson } from "~/components/TeamPerson";
 import { TEAM_MEMBERS } from "~/data/constants";
 
+// eslint-disable-next-line @typescript-eslint/naming-convention
 const Home = async () => {
   const blogs = await getLatestBlogs();
   return (

--- a/apps/website/app/(home)/page.tsx
+++ b/apps/website/app/(home)/page.tsx
@@ -11,8 +11,7 @@ import { getLatestBlogs } from "~/(home)/blog/readBlogs";
 import { TeamPerson } from "~/components/TeamPerson";
 import { TEAM_MEMBERS } from "~/data/constants";
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
-const Home = async () => {
+const Home = async (): Promise<JSX.Element> => {
   const blogs = await getLatestBlogs();
   return (
     <div>
@@ -435,6 +434,22 @@ const Home = async () => {
             </CardHeader>
             <CardContent>
               <div className="space-y-6">
+                <div>
+                  <h3 className="mb-2 text-xl font-semibold text-neutral-dark">
+                    Metagov x Future of Science Seminar: Interoperable LLM - and
+                    Human-Centered Research with Discourse Graphs with Matt
+                    Akamatsu
+                  </h3>
+                  <p className="mb-2 text-neutral-dark">
+                    November 19, 2025 | Zoom
+                  </p>
+                  <Link
+                    href="https://luma.com/jijn0d5k"
+                    className="text-primary transition-colors hover:text-primary/80"
+                  >
+                    Register for the talk →
+                  </Link>
+                </div>
                 <div>
                   <h3 className="mb-2 text-xl font-semibold text-neutral-dark">
                     IOSP &apos;25 Winter Workshop: Discourse Graphs

--- a/apps/website/app/(home)/page.tsx
+++ b/apps/website/app/(home)/page.tsx
@@ -11,7 +11,7 @@ import { getLatestBlogs } from "~/(home)/blog/readBlogs";
 import { TeamPerson } from "~/components/TeamPerson";
 import { TEAM_MEMBERS } from "~/data/constants";
 
-const Home = async (): Promise<JSX.Element> => {
+const Home = async () => {
   const blogs = await getLatestBlogs();
   return (
     <div>

--- a/apps/website/tsconfig.json
+++ b/apps/website/tsconfig.json
@@ -3,6 +3,9 @@
   "compilerOptions": {
     "baseUrl": ".",
     "rootDir": ".",
+    "declaration": false,
+    "declarationMap": false,
+    "types": ["react", "react-dom"],
     "paths": {
       "~/*": ["./app/*"]
     }

--- a/apps/website/tsconfig.json
+++ b/apps/website/tsconfig.json
@@ -3,9 +3,6 @@
   "compilerOptions": {
     "baseUrl": ".",
     "rootDir": ".",
-    "declaration": false,
-    "declarationMap": false,
-    "types": ["react", "react-dom"],
     "paths": {
       "~/*": ["./app/*"]
     }


### PR DESCRIPTION
<img width="1808" height="665" alt="image" src="https://github.com/user-attachments/assets/05ebf1d4-1f76-4098-b9be-9c6f2a5e608c" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Metagov x Future of Science Seminar event to the home page's Events section, including event date, location information, and a registration link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->