### PR TITLE
[ENG-866] Make sure users can't move the entire relation arrow

### DIFF
--- a/apps/obsidian/src/components/canvas/shapes/DiscourseRelationShape.tsx
+++ b/apps/obsidian/src/components/canvas/shapes/DiscourseRelationShape.tsx
@@ -472,6 +472,62 @@ export class DiscourseRelationUtil extends ShapeUtil<DiscourseRelationShape> {
     const atTranslationStart = shapeAtTranslationStart.get(initialShape);
     if (!atTranslationStart) return;
 
+    const bindings = getArrowBindings(this.editor, shape);
+
+    // If both ends are bound, convert translation to bend changes instead of moving the arrow
+    if (bindings.start && bindings.end) {
+      const shapePageTransform = this.editor.getShapePageTransform(shape.id);
+      const pageDelta = Vec.Sub(
+        shapePageTransform.applyToPoint(shape),
+        atTranslationStart.pagePosition,
+      );
+
+      const initialBindings = getArrowBindings(this.editor, initialShape);
+      const { start: initialStart, end: initialEnd } =
+        getArrowTerminalsInArrowSpace(
+          this.editor,
+          initialShape,
+          initialBindings,
+        );
+
+      const delta = Vec.Sub(initialEnd, initialStart);
+      const v = Vec.Per(delta);
+      const med = Vec.Med(initialEnd, initialStart);
+
+      const initialPageTransform = this.editor.getShapePageTransform(
+        initialShape.id,
+      );
+      const arrowSpaceDelta = Vec.Rot(
+        pageDelta,
+        -initialPageTransform.rotation(),
+      );
+
+      const translatedMidpoint = Vec.Add(med, arrowSpaceDelta);
+      const A = Vec.Sub(med, v);
+      const B = Vec.Add(med, v);
+      const point = Vec.NearestPointOnLineSegment(
+        A,
+        B,
+        translatedMidpoint,
+        false,
+      );
+
+      // Calculate new bend based on distance from midpoint
+      let newBend = Vec.Dist(point, med);
+      if (Vec.Clockwise(point, initialEnd, med)) {
+        newBend *= -1;
+      }
+
+      return {
+        id: shape.id,
+        type: shape.type,
+        x: initialShape.x,
+        y: initialShape.y,
+        props: { bend: newBend },
+      };
+    }
+
+    // If not both ends are bound, use normal translation behavior
     const shapePageTransform = this.editor.getShapePageTransform(shape.id);
     const pageDelta = Vec.Sub(
       shapePageTransform.applyToPoint(shape),
@@ -539,6 +595,27 @@ export class DiscourseRelationUtil extends ShapeUtil<DiscourseRelationShape> {
       bindings,
     );
     const shapePageTransform = this.editor.getShapePageTransform(shape.id);
+
+    // If both ends are bound, we'll convert translation to bend changes
+    // So we don't need to update bindings or unbind
+    if (bindings.start && bindings.end) {
+      shapeAtTranslationStart.set(shape, {
+        pagePosition: shapePageTransform.applyToPoint(shape),
+        terminalBindings: mapObjectMapValues(
+          terminalsInArrowSpace,
+          (terminalName, point) => {
+            const binding = bindings[terminalName];
+            if (!binding) return null;
+            return {
+              binding,
+              shapePosition: point,
+              pagePosition: shapePageTransform.applyToPoint(point),
+            };
+          },
+        ),
+      });
+      return;
+    }
 
     // If at least one bound shape is in the selection, do nothing;
     // If no bound shapes are in the selection, unbind any bound shapes


### PR DESCRIPTION
https://www.loom.com/share/8b9748d5e8d149cb977216c0c6fda427 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced discourse relation handling: when both endpoints are bound, dragging now adjusts the curve bending instead of repositioning the endpoints. Single-bound or unbound relations maintain previous behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->