### PR TITLE
Eng 1062 optimize all relations

### DIFF
--- a/apps/roam/src/utils/__tests__/fireQuery.test.ts
+++ b/apps/roam/src/utils/__tests__/fireQuery.test.ts
@@ -66,6 +66,34 @@ describe("getDatalogQuery", () => {
     ]);
     expect(formatted).toMatchObject({ text: "A", uid: "u1", Created: "123" });
   });
+
+  it("adds internal find variables to the query output", async () => {
+    const built = getDatalogQuery({
+      conditions: [],
+      selections: [],
+      findVariables: [
+        { label: "relationUid", variable: "condition-relSchema" },
+        { label: "effectiveSource", variable: "?condition-relSource" },
+      ],
+    });
+
+    expect(built.query).toContain("?condition-relSchema");
+    expect(built.query).toContain("?condition-relSource");
+
+    const formatted = await built.formatResult([
+      { ":node/title": "A", ":block/uid": "u1" },
+      { ":block/uid": "u1" },
+      "rel-1",
+      "source-1",
+    ]);
+
+    expect(formatted).toMatchObject({
+      text: "A",
+      uid: "u1",
+      relationUid: "rel-1",
+      effectiveSource: "source-1",
+    });
+  });
 });
 
 describe("fireQuery", () => {

--- a/apps/roam/src/utils/__tests__/getDiscourseContextResults.test.ts
+++ b/apps/roam/src/utils/__tests__/getDiscourseContextResults.test.ts
@@ -1,0 +1,163 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { DiscourseNode } from "~/utils/getDiscourseNodes";
+import type { DiscourseRelation } from "~/utils/getDiscourseRelations";
+
+const mocks = vi.hoisted(() => ({
+  findDiscourseNode: vi.fn(),
+  fireQuery: vi.fn(),
+  generateUID: vi.fn(),
+  getSetting: vi.fn(),
+}));
+
+vi.mock("~/utils/deriveDiscourseNodeAttribute", () => ({
+  ANY_RELATION_NAME: "Has Any Relation To",
+  ANY_RELATION_REGEX: /Has Any Relation To/i,
+}));
+
+vi.mock("~/utils/extensionSettings", () => ({
+  getSetting: mocks.getSetting,
+}));
+
+vi.mock("~/utils/findDiscourseNode", () => ({
+  default: mocks.findDiscourseNode,
+}));
+
+vi.mock("~/utils/fireQuery", () => ({
+  default: mocks.fireQuery,
+}));
+
+vi.mock("~/utils/getDiscourseNodes", () => ({
+  default: () => [],
+}));
+
+vi.mock("~/utils/getDiscourseRelations", () => ({
+  default: () => [],
+}));
+
+import getDiscourseContextResults from "~/utils/getDiscourseContextResults";
+
+const makeNode = ({
+  type,
+  text,
+}: {
+  type: string;
+  text: string;
+}): DiscourseNode => ({
+  type,
+  text,
+  shortcut: "",
+  specification: [],
+  backedBy: "user",
+  canvasSettings: {},
+  format: "{content}",
+});
+
+describe("getDiscourseContextResults", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (globalThis as { window: unknown }).window = {
+      roamAlphaAPI: {
+        util: {
+          generateUID: mocks.generateUID,
+        },
+      },
+    };
+
+    mocks.generateUID.mockReturnValue("condition");
+    mocks.getSetting.mockReturnValue(true);
+    mocks.findDiscourseNode.mockReturnValue({ type: "CLM" });
+  });
+
+  it("regroups all-relation reified query results by relation direction", async () => {
+    const onResult = vi.fn();
+    const nodes: DiscourseNode[] = [
+      makeNode({ type: "CLM", text: "Claim" }),
+      makeNode({ type: "QUE", text: "Question" }),
+      makeNode({ type: "EVD", text: "Evidence" }),
+    ];
+    const relations: DiscourseRelation[] = [
+      {
+        id: "supports",
+        label: "Supports",
+        complement: "Supported By",
+        source: "CLM",
+        destination: "QUE",
+        triples: [],
+      },
+      {
+        id: "informs",
+        label: "Informs",
+        complement: "Informed By",
+        source: "EVD",
+        destination: "CLM",
+        triples: [],
+      },
+    ];
+
+    mocks.fireQuery.mockResolvedValue([
+      {
+        text: "Question A",
+        uid: "question-a",
+        relationUid: "supports",
+        effectiveSource: "claim-a",
+      },
+      {
+        text: "Evidence A",
+        uid: "evidence-a",
+        relationUid: "informs",
+        effectiveSource: "evidence-a",
+      },
+    ]);
+
+    const results = await getDiscourseContextResults({
+      uid: "claim-a",
+      nodes,
+      relations,
+      onResult,
+    });
+
+    expect(mocks.fireQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        returnNode: "Any",
+        selections: [],
+        findVariables: [
+          { label: "relationUid", variable: "condition-relSchema" },
+          { label: "effectiveSource", variable: "condition-relSource" },
+        ],
+      }),
+    );
+
+    expect(results[0]).toEqual({
+      label: "Supports",
+      results: {
+        "question-a": {
+          text: "Question A",
+          uid: "question-a",
+          relationUid: "supports",
+          effectiveSource: "claim-a",
+          target: "Question",
+          complement: 0,
+          id: "supports",
+          ctxTargetUid: "claim-a",
+        },
+      },
+    });
+    expect(results[1]).toEqual({
+      label: "Informed By",
+      results: {
+        "evidence-a": {
+          text: "Evidence A",
+          uid: "evidence-a",
+          relationUid: "informs",
+          effectiveSource: "evidence-a",
+          target: "Evidence",
+          complement: 1,
+          id: "informs",
+          ctxTargetUid: "claim-a",
+        },
+      },
+    });
+    expect(onResult).toHaveBeenNthCalledWith(1, results[0]);
+    expect(onResult).toHaveBeenNthCalledWith(2, results[1]);
+  });
+});

--- a/apps/roam/src/utils/__tests__/getDiscourseContextResults.test.ts
+++ b/apps/roam/src/utils/__tests__/getDiscourseContextResults.test.ts
@@ -68,7 +68,7 @@ describe("getDiscourseContextResults", () => {
     mocks.findDiscourseNode.mockReturnValue({ type: "CLM" });
   });
 
-  it("regroups all-relation reified query results by relation direction", async () => {
+  it("regroups all-relation reified query results by schema order", async () => {
     const onResult = vi.fn();
     const nodes: DiscourseNode[] = [
       makeNode({ type: "CLM", text: "Claim" }),
@@ -96,16 +96,16 @@ describe("getDiscourseContextResults", () => {
 
     mocks.fireQuery.mockResolvedValue([
       {
-        text: "Question A",
-        uid: "question-a",
-        relationUid: "supports",
-        effectiveSource: "claim-a",
-      },
-      {
         text: "Evidence A",
         uid: "evidence-a",
         relationUid: "informs",
         effectiveSource: "evidence-a",
+      },
+      {
+        text: "Question A",
+        uid: "question-a",
+        relationUid: "supports",
+        effectiveSource: "claim-a",
       },
     ]);
 

--- a/apps/roam/src/utils/deriveDiscourseNodeAttribute.ts
+++ b/apps/roam/src/utils/deriveDiscourseNodeAttribute.ts
@@ -6,7 +6,8 @@ import findDiscourseNode from "./findDiscourseNode";
 import getDiscourseNodes from "./getDiscourseNodes";
 import getDiscourseRelations from "./getDiscourseRelations";
 
-export const ANY_RELATION_REGEX = /Has Any Relation To/i;
+export const ANY_RELATION_NAME = "Has Any Relation To";
+export const ANY_RELATION_REGEX = RegExp(ANY_RELATION_NAME, "i");
 
 const evaluate = async (s: string) =>
   window.RoamLazy

--- a/apps/roam/src/utils/fireQuery.ts
+++ b/apps/roam/src/utils/fireQuery.ts
@@ -21,6 +21,10 @@ export type QueryArgs = {
   conditions: Condition[];
   selections: Selection[];
   inputs?: Record<string, string | number>;
+  findVariables?: {
+    label: string;
+    variable: string;
+  }[];
 };
 type RelationInQuery = {
   id: string;
@@ -39,6 +43,12 @@ export type FireQueryArgs = QueryArgs & {
 };
 
 type FireQuery = (query: FireQueryArgs) => Promise<QueryResult[]>;
+type DefinedSelection = {
+  mapper?: PredefinedSelection["mapper"];
+  pull: string;
+  label: string;
+  key: string;
+};
 
 const firstVariable = (
   clause: DatalogClause | DatalogAndClause,
@@ -200,6 +210,7 @@ export const getDatalogQuery = ({
   selections,
   returnNode = DEFAULT_RETURN_NODE,
   inputs = {},
+  findVariables = [],
 }: FireQueryArgs) => {
   const expectedInputs = getConditionTargets(conditions)
     .filter((c) => /^:in /.test(c))
@@ -211,12 +222,7 @@ export const getDatalogQuery = ({
     new Set([]),
   );
 
-  const defaultSelections: {
-    mapper: PredefinedSelection["mapper"];
-    pull: string;
-    label: string;
-    key: string;
-  }[] = [
+  const defaultSelections: DefinedSelection[] = [
     {
       mapper: (r) => {
         return {
@@ -237,26 +243,35 @@ export const getDatalogQuery = ({
       key: "",
     },
   ];
+  const userSelections: DefinedSelection[] = selections
+    .map((s) => ({
+      defined: predefinedSelections.find((p) => p.test.test(s.text)),
+      s,
+    }))
+    .filter(
+      (p): p is { defined: PredefinedSelection; s: Selection } => !!p.defined,
+    )
+    .map((p) => ({
+      mapper: p.defined.mapper,
+      pull: p.defined.pull({
+        where: whereClauses,
+        returnNode,
+        match: p.defined.test.exec(p.s.text),
+      }),
+      label: p.s.label || p.s.text,
+      key: p.s.text,
+    }))
+    .filter((p) => !!p.pull);
+  const internalFindVariables: DefinedSelection[] = findVariables.map(
+    ({ label, variable }) => ({
+      pull: variable.startsWith("?") ? variable : `?${variable}`,
+      label,
+      key: variable,
+    }),
+  );
   const definedSelections = defaultSelections.concat(
-    selections
-      .map((s) => ({
-        defined: predefinedSelections.find((p) => p.test.test(s.text)),
-        s,
-      }))
-      .filter(
-        (p): p is { defined: PredefinedSelection; s: Selection } => !!p.defined,
-      )
-      .map((p) => ({
-        mapper: p.defined.mapper,
-        pull: p.defined.pull({
-          where: whereClauses,
-          returnNode,
-          match: p.defined.test.exec(p.s.text),
-        }),
-        label: p.s.label || p.s.text,
-        key: p.s.text,
-      }))
-      .filter((p) => !!p.pull),
+    userSelections,
+    internalFindVariables,
   );
   const find = definedSelections.map((p) => p.pull).join("\n  ");
   const where = whereClauses.map((c) => compileDatalog(c, 1)).join("\n");
@@ -274,7 +289,9 @@ export const getDatalogQuery = ({
       definedSelections
         .map((c, i) => (prev: QueryResult) => {
           const pullResult = result[i];
-          return typeof pullResult === "object" && pullResult !== null
+          return c.mapper &&
+            typeof pullResult === "object" &&
+            pullResult !== null
             ? Promise.resolve(
                 c.mapper(pullResult as PullBlock, c.key, prev),
               ).then((output) => ({

--- a/apps/roam/src/utils/getDiscourseContextResults.ts
+++ b/apps/roam/src/utils/getDiscourseContextResults.ts
@@ -7,6 +7,9 @@ import getDiscourseRelations, {
   DiscourseRelation,
 } from "./getDiscourseRelations";
 import { Selection } from "./types";
+import { getSetting } from "./extensionSettings";
+import { ANY_RELATION_REGEX } from "./deriveDiscourseNodeAttribute";
+import { use } from "cytoscape";
 
 const resultCache: Record<string, Awaited<ReturnType<typeof fireQuery>>> = {};
 const CACHE_TIMEOUT = 1000 * 60 * 5;
@@ -55,6 +58,18 @@ const buildSelections = ({
       uid: window.roamAlphaAPI.util.generateUID(),
       label: "anchor",
       text: `node:${conditionUid}-Anchor`,
+    });
+  }
+  if (ANY_RELATION_REGEX.test(r.label)) {
+    selections.push({
+      uid: window.roamAlphaAPI.util.generateUID(),
+      label: "relationUid",
+      text: "hasSchema",
+    });
+    selections.push({
+      uid: window.roamAlphaAPI.util.generateUID(),
+      label: "effectiveSource",
+      text: "effectiveSource",
     });
   }
 
@@ -186,6 +201,10 @@ const getDiscourseContextResults = async ({
 
   const discourseNode = findDiscourseNode({ uid: targetUid });
   if (!discourseNode) return [];
+  const useReifiedRelations = getSetting<boolean>(
+    "use-reified-relations",
+    false,
+  );
   const nodeType = discourseNode?.type;
   const nodeTextByType = Object.fromEntries(
     nodes.map(({ type, text }) => [type, text]),
@@ -217,9 +236,24 @@ const getDiscourseContextResults = async ({
   });
 
   const relationsWithComplement = Array.from(uniqueRelations.values());
+  const queryRelations = useReifiedRelations
+    ? [
+        {
+          r: {
+            id: "null",
+            complement: "Has Any Relation To",
+            label: "Has Any Relation To",
+            triples: [],
+            source: "*",
+            destination: "*",
+          },
+          complement: false,
+        },
+      ]
+    : relationsWithComplement;
 
   const context = { nodes, relations };
-  const queryConfigs = relationsWithComplement.map((relation) =>
+  const queryConfigs = queryRelations.map((relation) =>
     buildQueryConfig({
       args,
       targetUid,
@@ -232,12 +266,40 @@ const getDiscourseContextResults = async ({
     }),
   );
 
-  const resultsWithRelation = await executeQueries(
+  let resultsWithRelation = await executeQueries(
     queryConfigs,
     targetUid,
     nodeTextByType,
     onResult,
   );
+  if (
+    useReifiedRelations &&
+    resultsWithRelation.length > 0 &&
+    resultsWithRelation[0].results.length > 0
+  ) {
+    const byRel: Record<string, Result[]> = {};
+    const results = resultsWithRelation[0].results;
+    resultsWithRelation = [];
+    for (const r of results) {
+      const relKey = `${r.relationUid}-${r.effectiveSource !== targetUid}`;
+      byRel[relKey] = byRel[relKey] || [];
+      byRel[relKey].push(r);
+    }
+    resultsWithRelation = Object.entries(byRel).map(([ruid, results]) => ({
+      relation: {
+        id: ruid,
+        label: ruid.endsWith("-false")
+          ? uniqueRelations.get(ruid)!.r.label
+          : uniqueRelations.get(ruid)!.r.complement,
+        isComplement: ruid.endsWith("-false"),
+        text: ruid.endsWith("-false")
+          ? uniqueRelations.get(ruid)!.r.label
+          : uniqueRelations.get(ruid)!.r.complement,
+        target: targetUid,
+      },
+      results,
+    }));
+  }
   const groupedResults = Object.fromEntries(
     resultsWithRelation.map((r) => [
       r.relation.text,

--- a/apps/roam/src/utils/getDiscourseContextResults.ts
+++ b/apps/roam/src/utils/getDiscourseContextResults.ts
@@ -9,7 +9,6 @@ import getDiscourseRelations, {
 import { Selection } from "./types";
 import { getSetting } from "./extensionSettings";
 import { ANY_RELATION_REGEX } from "./deriveDiscourseNodeAttribute";
-import { use } from "cytoscape";
 
 const resultCache: Record<string, Awaited<ReturnType<typeof fireQuery>>> = {};
 const CACHE_TIMEOUT = 1000 * 60 * 5;
@@ -281,7 +280,7 @@ const getDiscourseContextResults = async ({
     const results = resultsWithRelation[0].results;
     resultsWithRelation = [];
     for (const r of results) {
-      const relKey = `${r.relationUid}-${r.effectiveSource !== targetUid}`;
+      const relKey = `${r.relationUid as string}-${r.effectiveSource !== targetUid}`;
       byRel[relKey] = byRel[relKey] || [];
       byRel[relKey].push(r);
     }

--- a/apps/roam/src/utils/getDiscourseContextResults.ts
+++ b/apps/roam/src/utils/getDiscourseContextResults.ts
@@ -285,20 +285,29 @@ const getDiscourseContextResults = async ({
       byRel[relKey] = byRel[relKey] || [];
       byRel[relKey].push(r);
     }
-    resultsWithRelation = Object.entries(byRel).map(([ruid, results]) => ({
-      relation: {
-        id: ruid,
-        label: ruid.endsWith("-false")
-          ? uniqueRelations.get(ruid)!.r.label
-          : uniqueRelations.get(ruid)!.r.complement,
-        isComplement: ruid.endsWith("-false"),
-        text: ruid.endsWith("-false")
-          ? uniqueRelations.get(ruid)!.r.label
-          : uniqueRelations.get(ruid)!.r.complement,
-        target: targetUid,
-      },
-      results,
-    }));
+    resultsWithRelation = Object.entries(byRel)
+      .map(([ruid, results]) => {
+        const relation = uniqueRelations.get(ruid);
+        if (!relation) {
+          console.error("Relation with obsolete relation type:" + ruid);
+          return { relation, results };
+        }
+        return {
+          relation: {
+            id: ruid,
+            label: ruid.endsWith("-false")
+              ? relation.r.label
+              : relation.r.complement,
+            isComplement: ruid.endsWith("-false"),
+            text: ruid.endsWith("-false")
+              ? relation.r.label
+              : relation.r.complement,
+            target: targetUid,
+          },
+          results,
+        };
+      })
+      .filter((o) => !!o.relation);
   }
   const groupedResults = Object.fromEntries(
     resultsWithRelation.map((r) => [

--- a/apps/roam/src/utils/getDiscourseContextResults.ts
+++ b/apps/roam/src/utils/getDiscourseContextResults.ts
@@ -279,20 +279,29 @@ const getDiscourseContextResults = async ({
       byRel[relKey] = byRel[relKey] || [];
       byRel[relKey].push(r);
     }
-    resultsWithRelation = Object.entries(byRel).map(([ruid, results]) => ({
-      relation: {
-        id: ruid,
-        label: ruid.endsWith("-false")
-          ? uniqueRelations.get(ruid)!.r.label
-          : uniqueRelations.get(ruid)!.r.complement,
-        isComplement: ruid.endsWith("-false"),
-        text: ruid.endsWith("-false")
-          ? uniqueRelations.get(ruid)!.r.label
-          : uniqueRelations.get(ruid)!.r.complement,
-        target: targetUid,
-      },
-      results,
-    }));
+    resultsWithRelation = Object.entries(byRel)
+      .map(([ruid, results]) => {
+        const relation = uniqueRelations.get(ruid);
+        if (!relation) {
+          console.error("Relation with obsolete relation type:" + ruid);
+          return { relation, results };
+        }
+        return {
+          relation: {
+            id: ruid,
+            label: ruid.endsWith("-false")
+              ? relation.r.label
+              : relation.r.complement,
+            isComplement: ruid.endsWith("-false"),
+            text: ruid.endsWith("-false")
+              ? relation.r.label
+              : relation.r.complement,
+            target: targetUid,
+          },
+          results,
+        };
+      })
+      .filter((o) => !!o.relation);
   }
   const groupedResults = Object.fromEntries(
     resultsWithRelation.map((r) => [

--- a/apps/roam/src/utils/getDiscourseContextResults.ts
+++ b/apps/roam/src/utils/getDiscourseContextResults.ts
@@ -263,11 +263,14 @@ const getDiscourseContextResults = async ({
       complement: relation.complement,
     }),
   );
+  const postQueryOnResult = useReifiedRelations ? onResult : undefined;
+  onResult = postQueryOnResult ? undefined : onResult;
 
   let resultsWithRelation = await executeQueries(
     queryConfigs,
     targetUid,
     nodeTextByType,
+    onResult,
   );
   if (
     useReifiedRelations &&
@@ -338,7 +341,7 @@ const getDiscourseContextResults = async ({
       label,
       results,
     }));
-  if (onResult) asResultList.map((r) => onResult(r));
+  if (postQueryOnResult) asResultList.map((r) => postQueryOnResult(r));
   return asResultList;
 };
 

--- a/apps/roam/src/utils/getDiscourseContextResults.ts
+++ b/apps/roam/src/utils/getDiscourseContextResults.ts
@@ -290,7 +290,13 @@ const getDiscourseContextResults = async ({
       .map(([ruid, results]) => {
         const relation = uniqueRelations.get(ruid);
         if (!relation) {
-          console.error("Relation with obsolete relation type:" + ruid);
+          /*
+           * A stored reified relation can outlive its relation schema, or the
+           * schema can stop applying to this node type after source/destination
+           * settings change. Drop that stale result from discourse context
+           * instead of treating it as a runtime failure.
+           */
+          console.warn("Relation with obsolete relation type:" + ruid);
           return undefined;
         }
         const isComplement = relation.complement;

--- a/apps/roam/src/utils/getDiscourseContextResults.ts
+++ b/apps/roam/src/utils/getDiscourseContextResults.ts
@@ -7,6 +7,9 @@ import getDiscourseRelations, {
   DiscourseRelation,
 } from "./getDiscourseRelations";
 import { Selection } from "./types";
+import { getSetting } from "./extensionSettings";
+import { ANY_RELATION_REGEX } from "./deriveDiscourseNodeAttribute";
+import { use } from "cytoscape";
 
 const resultCache: Record<string, Awaited<ReturnType<typeof fireQuery>>> = {};
 const CACHE_TIMEOUT = 1000 * 60 * 5;
@@ -49,6 +52,18 @@ const buildSelections = ({
       uid: window.roamAlphaAPI.util.generateUID(),
       label: "context",
       text: `node:${conditionUid}-Context`,
+    });
+  }
+  if (ANY_RELATION_REGEX.test(r.label)) {
+    selections.push({
+      uid: window.roamAlphaAPI.util.generateUID(),
+      label: "relationUid",
+      text: "hasSchema",
+    });
+    selections.push({
+      uid: window.roamAlphaAPI.util.generateUID(),
+      label: "effectiveSource",
+      text: "effectiveSource",
     });
   }
 
@@ -180,6 +195,10 @@ const getDiscourseContextResults = async ({
 
   const discourseNode = findDiscourseNode({ uid: targetUid });
   if (!discourseNode) return [];
+  const useReifiedRelations = getSetting<boolean>(
+    "use-reified-relations",
+    false,
+  );
   const nodeType = discourseNode?.type;
   const nodeTextByType = Object.fromEntries(
     nodes.map(({ type, text }) => [type, text]),
@@ -211,9 +230,24 @@ const getDiscourseContextResults = async ({
   });
 
   const relationsWithComplement = Array.from(uniqueRelations.values());
+  const queryRelations = useReifiedRelations
+    ? [
+        {
+          r: {
+            id: "null",
+            complement: "Has Any Relation To",
+            label: "Has Any Relation To",
+            triples: [],
+            source: "*",
+            destination: "*",
+          },
+          complement: false,
+        },
+      ]
+    : relationsWithComplement;
 
   const context = { nodes, relations };
-  const queryConfigs = relationsWithComplement.map((relation) =>
+  const queryConfigs = queryRelations.map((relation) =>
     buildQueryConfig({
       args,
       targetUid,
@@ -226,12 +260,40 @@ const getDiscourseContextResults = async ({
     }),
   );
 
-  const resultsWithRelation = await executeQueries(
+  let resultsWithRelation = await executeQueries(
     queryConfigs,
     targetUid,
     nodeTextByType,
     onResult,
   );
+  if (
+    useReifiedRelations &&
+    resultsWithRelation.length > 0 &&
+    resultsWithRelation[0].results.length > 0
+  ) {
+    const byRel: Record<string, Result[]> = {};
+    const results = resultsWithRelation[0].results;
+    resultsWithRelation = [];
+    for (const r of results) {
+      const relKey = `${r.relationUid}-${r.effectiveSource !== targetUid}`;
+      byRel[relKey] = byRel[relKey] || [];
+      byRel[relKey].push(r);
+    }
+    resultsWithRelation = Object.entries(byRel).map(([ruid, results]) => ({
+      relation: {
+        id: ruid,
+        label: ruid.endsWith("-false")
+          ? uniqueRelations.get(ruid)!.r.label
+          : uniqueRelations.get(ruid)!.r.complement,
+        isComplement: ruid.endsWith("-false"),
+        text: ruid.endsWith("-false")
+          ? uniqueRelations.get(ruid)!.r.label
+          : uniqueRelations.get(ruid)!.r.complement,
+        target: targetUid,
+      },
+      results,
+    }));
+  }
   const groupedResults = Object.fromEntries(
     resultsWithRelation.map((r) => [
       r.relation.text,

--- a/apps/roam/src/utils/getDiscourseContextResults.ts
+++ b/apps/roam/src/utils/getDiscourseContextResults.ts
@@ -8,7 +8,10 @@ import getDiscourseRelations, {
 } from "./getDiscourseRelations";
 import { Selection } from "./types";
 import { getSetting } from "./extensionSettings";
-import { ANY_RELATION_REGEX } from "./deriveDiscourseNodeAttribute";
+import {
+  ANY_RELATION_NAME,
+  ANY_RELATION_REGEX,
+} from "./deriveDiscourseNodeAttribute";
 
 const resultCache: Record<string, Awaited<ReturnType<typeof fireQuery>>> = {};
 const CACHE_TIMEOUT = 1000 * 60 * 5;
@@ -233,10 +236,11 @@ const getDiscourseContextResults = async ({
   const queryRelations = useReifiedRelations
     ? [
         {
+          id: ANY_RELATION_ID,
           r: {
             id: ANY_RELATION_ID,
-            complement: "Has Any Relation To",
-            label: "Has Any Relation To",
+            complement: ANY_RELATION_NAME,
+            label: ANY_RELATION_NAME,
             triples: [],
             source: "*",
             destination: "*",

--- a/apps/roam/src/utils/getDiscourseContextResults.ts
+++ b/apps/roam/src/utils/getDiscourseContextResults.ts
@@ -9,7 +9,6 @@ import getDiscourseRelations, {
 import { Selection } from "./types";
 import { getSetting } from "./extensionSettings";
 import { ANY_RELATION_REGEX } from "./deriveDiscourseNodeAttribute";
-import { use } from "cytoscape";
 
 const resultCache: Record<string, Awaited<ReturnType<typeof fireQuery>>> = {};
 const CACHE_TIMEOUT = 1000 * 60 * 5;
@@ -275,7 +274,7 @@ const getDiscourseContextResults = async ({
     const results = resultsWithRelation[0].results;
     resultsWithRelation = [];
     for (const r of results) {
-      const relKey = `${r.relationUid}-${r.effectiveSource !== targetUid}`;
+      const relKey = `${r.relationUid as string}-${r.effectiveSource !== targetUid}`;
       byRel[relKey] = byRel[relKey] || [];
       byRel[relKey].push(r);
     }

--- a/apps/roam/src/utils/getDiscourseContextResults.ts
+++ b/apps/roam/src/utils/getDiscourseContextResults.ts
@@ -12,6 +12,7 @@ import { ANY_RELATION_REGEX } from "./deriveDiscourseNodeAttribute";
 
 const resultCache: Record<string, Awaited<ReturnType<typeof fireQuery>>> = {};
 const CACHE_TIMEOUT = 1000 * 60 * 5;
+const ANY_RELATION_ID = "any_relation";
 
 type BuildQueryConfig = {
   args: {
@@ -233,7 +234,7 @@ const getDiscourseContextResults = async ({
     ? [
         {
           r: {
-            id: "null",
+            id: ANY_RELATION_ID,
             complement: "Has Any Relation To",
             label: "Has Any Relation To",
             triples: [],
@@ -263,7 +264,6 @@ const getDiscourseContextResults = async ({
     queryConfigs,
     targetUid,
     nodeTextByType,
-    onResult,
   );
   if (
     useReifiedRelations &&
@@ -288,14 +288,16 @@ const getDiscourseContextResults = async ({
         return {
           relation: {
             id: ruid,
-            label: ruid.endsWith("-false")
+            label: ruid.endsWith("-true")
               ? relation.r.label
               : relation.r.complement,
-            isComplement: ruid.endsWith("-false"),
-            text: ruid.endsWith("-false")
+            isComplement: ruid.endsWith("-true"),
+            text: ruid.endsWith("-true")
               ? relation.r.label
               : relation.r.complement,
-            target: targetUid,
+            target: ruid.endsWith("-true")
+              ? relation.r.source
+              : relation.r.destination,
           },
           results,
         };
@@ -326,10 +328,14 @@ const getDiscourseContextResults = async ({
           }),
       ),
   );
-  return Object.entries(groupedResults).map(([label, results]) => ({
-    label,
-    results,
-  }));
+  const asResultList = Object.entries(groupedResults)
+    .filter(([, results]) => Object.keys(results).length > 0)
+    .map(([label, results]) => ({
+      label,
+      results,
+    }));
+  if (onResult) asResultList.map((r) => onResult(r));
+  return asResultList;
 };
 
 export default getDiscourseContextResults;

--- a/apps/roam/src/utils/getDiscourseContextResults.ts
+++ b/apps/roam/src/utils/getDiscourseContextResults.ts
@@ -57,19 +57,6 @@ const buildSelections = ({
       text: `node:${conditionUid}-Context`,
     });
   }
-  if (ANY_RELATION_REGEX.test(r.label)) {
-    selections.push({
-      uid: window.roamAlphaAPI.util.generateUID(),
-      label: "relationUid",
-      text: "hasSchema",
-    });
-    selections.push({
-      uid: window.roamAlphaAPI.util.generateUID(),
-      label: "effectiveSource",
-      text: "effectiveSource",
-    });
-  }
-
   return selections;
 };
 
@@ -148,7 +135,20 @@ const buildQueryConfig = ({
   const returnNode = nodeTextByType[target];
 
   const conditionUid = window.roamAlphaAPI.util.generateUID();
+  const isAllRelationsQuery = ANY_RELATION_REGEX.test(r.label);
   const selections = buildSelections({ r, conditionUid });
+  const findVariables = isAllRelationsQuery
+    ? [
+        {
+          label: "relationUid",
+          variable: `${conditionUid}-relSchema`,
+        },
+        {
+          label: "effectiveSource",
+          variable: `${conditionUid}-relSource`,
+        },
+      ]
+    : [];
   const { nodes, relations } = fireQueryContext;
   return {
     relation,
@@ -166,6 +166,7 @@ const buildQueryConfig = ({
           },
         ],
         selections,
+        findVariables,
         context: {
           relationsInQuery: [relation],
           customNodes: nodes,
@@ -290,26 +291,21 @@ const getDiscourseContextResults = async ({
         const relation = uniqueRelations.get(ruid);
         if (!relation) {
           console.error("Relation with obsolete relation type:" + ruid);
-          return { relation, results };
+          return undefined;
         }
+        const isComplement = relation.complement;
         return {
           relation: {
-            id: ruid,
-            label: ruid.endsWith("-true")
-              ? relation.r.label
-              : relation.r.complement,
-            isComplement: ruid.endsWith("-true"),
-            text: ruid.endsWith("-true")
-              ? relation.r.label
-              : relation.r.complement,
-            target: ruid.endsWith("-true")
-              ? relation.r.source
-              : relation.r.destination,
+            id: relation.id,
+            label: isComplement ? relation.r.complement : relation.r.label,
+            isComplement,
+            text: isComplement ? relation.r.complement : relation.r.label,
+            target: isComplement ? relation.r.source : relation.r.destination,
           },
           results,
         };
       })
-      .filter((o) => !!o.relation);
+      .filter((o): o is NonNullable<typeof o> => !!o);
   }
   const groupedResults = Object.fromEntries(
     resultsWithRelation.map((r) => [

--- a/apps/roam/src/utils/getDiscourseContextResults.ts
+++ b/apps/roam/src/utils/getDiscourseContextResults.ts
@@ -286,32 +286,35 @@ const getDiscourseContextResults = async ({
       byRel[relKey] = byRel[relKey] || [];
       byRel[relKey].push(r);
     }
-    resultsWithRelation = Object.entries(byRel)
-      .map(([ruid, results]) => {
-        const relation = uniqueRelations.get(ruid);
-        if (!relation) {
-          /*
-           * A stored reified relation can outlive its relation schema, or the
-           * schema can stop applying to this node type after source/destination
-           * settings change. Drop that stale result from discourse context
-           * instead of treating it as a runtime failure.
-           */
-          console.warn("Relation with obsolete relation type:" + ruid);
-          return undefined;
-        }
+    resultsWithRelation = Array.from(uniqueRelations.entries()).flatMap(
+      ([ruid, relation]) => {
+        const results = byRel[ruid];
+        if (!results?.length) return [];
+        delete byRel[ruid];
         const isComplement = relation.complement;
-        return {
-          relation: {
-            id: relation.id,
-            label: isComplement ? relation.r.complement : relation.r.label,
-            isComplement,
-            text: isComplement ? relation.r.complement : relation.r.label,
-            target: isComplement ? relation.r.source : relation.r.destination,
+        return [
+          {
+            relation: {
+              id: relation.id,
+              label: isComplement ? relation.r.complement : relation.r.label,
+              isComplement,
+              text: isComplement ? relation.r.complement : relation.r.label,
+              target: isComplement ? relation.r.source : relation.r.destination,
+            },
+            results,
           },
-          results,
-        };
-      })
-      .filter((o): o is NonNullable<typeof o> => !!o);
+        ];
+      },
+    );
+    Object.keys(byRel).forEach((ruid) => {
+      /*
+       * A stored reified relation can outlive its relation schema, or the
+       * schema can stop applying to this node type after source/destination
+       * settings change. Drop that stale result from discourse context
+       * instead of treating it as a runtime failure.
+       */
+      console.warn("Relation with obsolete relation type:" + ruid);
+    });
   }
   const groupedResults = Object.fromEntries(
     resultsWithRelation.map((r) => [

--- a/apps/roam/src/utils/predefinedSelections.ts
+++ b/apps/roam/src/utils/predefinedSelections.ts
@@ -30,6 +30,8 @@ const NODE_TEST = /^node:(\s*[^:]+\s*)(:.*)?$/i;
 const ACTION_TEST = /^action:\s*([^:]+)\s*(?::(.*))?$/i;
 const DATE_FORMAT_TEST = /^date-format\(([^,)]+),([^,)]+)\)$/i;
 const MILLISECONDS_IN_DAY = 1000 * 60 * 60 * 24;
+const HAS_SCHEMA_TEST = /^hasSchema$/;
+const EFFECTIVE_SOURCE_TEST = /^effectiveSource$/;
 
 const getArgValue = (key: string, result: QueryResult) => {
   if (/^today$/i.test(key)) return new Date();
@@ -286,6 +288,26 @@ const predefinedSelections: PredefinedSelection[] = [
     suggestions: EDIT_BY_SUGGESTIONS,
   },
   {
+    test: HAS_SCHEMA_TEST,
+    pull: ({ match, returnNode, where }) => {
+      return "?relSchema";
+    },
+    mapper: (r, key) => {
+      // not sure here?
+      return "?relSchema";
+    },
+  },
+  {
+    test: EFFECTIVE_SOURCE_TEST,
+    pull: ({ match, returnNode, where }) => {
+      return "?relSource";
+    },
+    mapper: (r, key) => {
+      // not sure here?
+      return "?relSource";
+    },
+  },
+  {
     test: NODE_TEST,
     pull: ({ match, returnNode, where }) => {
       const node = (match?.[1] || returnNode)?.trim();
@@ -367,9 +389,7 @@ const predefinedSelections: PredefinedSelection[] = [
           (c): c is QBClause => c.type === "clause" && c.target === selectedVar,
         );
         if (introducedCondition?.relation === "references") {
-          const sourceUid = result[
-            `${introducedCondition.source}-uid`
-          ] as string;
+          const sourceUid = result[`${introducedCondition.source}-uid`];
           if (sourceUid) {
             const blockText = getTextByBlockUid(sourceUid);
             await updateBlock({

--- a/apps/roam/src/utils/predefinedSelections.ts
+++ b/apps/roam/src/utils/predefinedSelections.ts
@@ -289,20 +289,20 @@ const predefinedSelections: PredefinedSelection[] = [
   },
   {
     test: HAS_SCHEMA_TEST,
-    pull: ({ match, returnNode, where }) => {
+    pull: () => {
       return "?relSchema";
     },
-    mapper: (r, key) => {
+    mapper: () => {
       // not sure here?
       return "?relSchema";
     },
   },
   {
     test: EFFECTIVE_SOURCE_TEST,
-    pull: ({ match, returnNode, where }) => {
+    pull: () => {
       return "?relSource";
     },
-    mapper: (r, key) => {
+    mapper: () => {
       // not sure here?
       return "?relSource";
     },

--- a/apps/roam/src/utils/predefinedSelections.ts
+++ b/apps/roam/src/utils/predefinedSelections.ts
@@ -30,8 +30,6 @@ const NODE_TEST = /^node:(\s*[^:]+\s*)(:.*)?$/i;
 const ACTION_TEST = /^action:\s*([^:]+)\s*(?::(.*))?$/i;
 const DATE_FORMAT_TEST = /^date-format\(([^,)]+),([^,)]+)\)$/i;
 const MILLISECONDS_IN_DAY = 1000 * 60 * 60 * 24;
-const HAS_SCHEMA_TEST = /^hasSchema$/;
-const EFFECTIVE_SOURCE_TEST = /^effectiveSource$/;
 
 const getArgValue = (key: string, result: QueryResult) => {
   if (/^today$/i.test(key)) return new Date();
@@ -286,26 +284,6 @@ const predefinedSelections: PredefinedSelection[] = [
       return getUserDisplayNameById(r?.[":edit/user"]?.[":db/id"]);
     },
     suggestions: EDIT_BY_SUGGESTIONS,
-  },
-  {
-    test: HAS_SCHEMA_TEST,
-    pull: () => {
-      return "?relSchema";
-    },
-    mapper: () => {
-      // not sure here?
-      return "?relSchema";
-    },
-  },
-  {
-    test: EFFECTIVE_SOURCE_TEST,
-    pull: () => {
-      return "?relSource";
-    },
-    mapper: () => {
-      // not sure here?
-      return "?relSource";
-    },
   },
   {
     test: NODE_TEST,

--- a/apps/roam/src/utils/registerDiscourseDatalogTranslators.ts
+++ b/apps/roam/src/utils/registerDiscourseDatalogTranslators.ts
@@ -816,6 +816,8 @@ const registerDiscourseDatalogTranslators = (snapshot?: SettingsSnapshot) => {
               [
                 { from: source, to: source },
                 { from: target, to: target },
+                { from: "relSchema", to: "relSchema" },
+                { from: "relSource", to: "relSource" },
                 { from: true, to: (v) => `${uid}-${v}` },
               ],
               clauses,

--- a/apps/roam/src/utils/registerDiscourseDatalogTranslators.ts
+++ b/apps/roam/src/utils/registerDiscourseDatalogTranslators.ts
@@ -819,8 +819,6 @@ const registerDiscourseDatalogTranslators = (snapshot?: SettingsSnapshot) => {
               [
                 { from: source, to: source },
                 { from: target, to: target },
-                { from: "relSchema", to: "relSchema" },
-                { from: "relSource", to: "relSource" },
                 { from: true, to: (v) => `${uid}-${v}` },
               ],
               clauses,

--- a/apps/roam/src/utils/registerDiscourseDatalogTranslators.ts
+++ b/apps/roam/src/utils/registerDiscourseDatalogTranslators.ts
@@ -8,7 +8,10 @@ import conditionToDatalog, {
   getTitleDatalog,
   registerDatalogTranslator,
 } from "./conditionToDatalog";
-import { ANY_RELATION_REGEX } from "./deriveDiscourseNodeAttribute";
+import {
+  ANY_RELATION_NAME,
+  ANY_RELATION_REGEX,
+} from "./deriveDiscourseNodeAttribute";
 import getDiscourseNodes, {
   excludeDefaultNodes,
   type DiscourseNode,
@@ -404,7 +407,7 @@ const registerDiscourseDatalogTranslators = (snapshot?: SettingsSnapshot) => {
   const relationLabels = new Set(
     discourseRelations.flatMap((d) => [d.label, d.complement].filter(Boolean)),
   );
-  relationLabels.add(ANY_RELATION_REGEX.source);
+  relationLabels.add(ANY_RELATION_NAME);
   relationLabels.forEach((label) => {
     unregisters.add(
       registerDatalogTranslator({


### PR DESCRIPTION
Use a pseudo-relation for a query for all relations. Rework the algorithm for grouping results, which means adding some selections. 

https://www.loom.com/share/ced1e4cf67ec4acdb97db690431ee9a0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for broader relation queries, including a new “any relation” mode.
  * Query results can now include extra fields for relation context and map them into richer output.

* **Bug Fixes**
  * Improved how discourse context results are grouped and returned, keeping related items together more reliably.
  * Made result mapping more robust when handling non-empty structured values.

* **Tests**
  * Added coverage for the new query variable handling and updated result grouping behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->