### PR TITLE
ENG-1078 Vercel api URLs do not include https prefix

### DIFF
--- a/packages/database/scripts/createEnv.mts
+++ b/packages/database/scripts/createEnv.mts
@@ -84,8 +84,7 @@ const makeBranchEnv = async (vercel: Vercel, vercelToken: string) => {
     console.error(err);
     throw err;
   }
-
-  appendFileSync(".env.branch", `NEXT_API_ROOT="${url}/api"\n`);
+  appendFileSync(".env.branch", `NEXT_API_ROOT="https://${url}/api"\n`);
 };
 
 const makeProductionEnv = async (vercel: Vercel, vercelToken: string) => {
@@ -103,7 +102,7 @@ const makeProductionEnv = async (vercel: Vercel, vercelToken: string) => {
   execSync(
     `vercel -t ${vercelToken} env pull --environment production .env.production`,
   );
-  appendFileSync(".env.production", `NEXT_API_ROOT="${url}/api"\n`);
+  appendFileSync(".env.production", `NEXT_API_ROOT="https://${url}/api"\n`);
 };
 
 const main = async (variant: Variant) => {


### PR DESCRIPTION
https://linear.app/discourse-graphs/issue/ENG-1078/vercel-api-urls-do-not-include-https-prefix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Environment configuration now explicitly enforces HTTPS protocol for API connections across all deployment environments.
  * Minor formatting improvements to configuration scripts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->