### PR TITLE
ENG-955 create add node tag button on image hover

### DIFF
--- a/apps/roam/src/utils/initializeObserversAndListeners.ts
+++ b/apps/roam/src/utils/initializeObserversAndListeners.ts
@@ -46,6 +46,7 @@ import {
   findBlockElementFromSelection,
 } from "~/utils/renderTextSelectionPopup";
 import { renderNodeTagPopupButton } from "./renderNodeTagPopup";
+import { renderImageToolsMenu } from "./renderImageToolsMenu";
 import { formatHexColor } from "~/components/settings/DiscourseNodeCanvasSettings";
 import { getSetting } from "./extensionSettings";
 import { mountLeftSidebar } from "~/components/LeftSidebarView";
@@ -181,6 +182,16 @@ export const initObservers = async ({
     callback: (el) => {
       const div = el as HTMLDivElement;
       renderGraphOverviewExport(div);
+    },
+  });
+
+  const imageMenuObserver = createHTMLObserver({
+    tag: "IMG",
+    className: "rm-inline-img",
+    callback: (img: HTMLElement) => {
+      if (img instanceof HTMLImageElement) {
+        renderImageToolsMenu(img);
+      }
     },
   });
 
@@ -382,6 +393,7 @@ export const initObservers = async ({
       graphOverviewExportObserver,
       nodeTagPopupButtonObserver,
       leftSidebarObserver,
+      imageMenuObserver,
     ].filter((o): o is MutationObserver => !!o),
     listeners: {
       pageActionListener,

--- a/apps/roam/src/utils/initializeObserversAndListeners.ts
+++ b/apps/roam/src/utils/initializeObserversAndListeners.ts
@@ -190,7 +190,7 @@ export const initObservers = async ({
     className: "rm-inline-img",
     callback: (img: HTMLElement) => {
       if (img instanceof HTMLImageElement) {
-        renderImageToolsMenu(img);
+        renderImageToolsMenu(img, onloadArgs.extensionAPI);
       }
     },
   });

--- a/apps/roam/src/utils/renderImageToolsMenu.tsx
+++ b/apps/roam/src/utils/renderImageToolsMenu.tsx
@@ -1,0 +1,185 @@
+import React, { useCallback, useMemo } from "react";
+import ReactDOM from "react-dom";
+import {
+  Button,
+  Menu,
+  MenuItem,
+  Popover,
+  Position,
+  IconName,
+} from "@blueprintjs/core";
+import getUids from "roamjs-components/dom/getUids";
+import getTextByBlockUid from "roamjs-components/queries/getTextByBlockUid";
+import updateBlock from "roamjs-components/writes/updateBlock";
+import getDiscourseNodes from "./getDiscourseNodes";
+import { formatHexColor } from "~/components/settings/DiscourseNodeCanvasSettings";
+
+type ImageToolsMenuProps = {
+  onClose: () => void;
+  blockUid: string;
+};
+
+const ImageToolsMenu = ({
+  onClose,
+  blockUid,
+}: ImageToolsMenuProps): JSX.Element => {
+  const [isPopoverOpen, setIsPopoverOpen] = React.useState(false);
+
+  const userDiscourseNodes = useMemo(
+    () => getDiscourseNodes().filter((n) => n.backedBy === "user"),
+    [],
+  );
+
+  const discourseNodes = userDiscourseNodes.filter((n) => n.tag);
+
+  const handleAddTag = useCallback(
+    async (tag: string): Promise<void> => {
+      setIsPopoverOpen(false);
+      const currentText = getTextByBlockUid(blockUid);
+      const cleanTag = tag.replace(/^#/, "");
+      const textToInsert = ` #${cleanTag}`;
+      await updateBlock({ text: currentText + textToInsert, uid: blockUid });
+      onClose();
+    },
+    [blockUid, onClose],
+  );
+
+  const handleEditBlock = useCallback((): void => {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    void window.roamAlphaAPI.ui.setBlockFocusAndSelection({
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      location: { "block-uid": blockUid, "window-id": "main-window" },
+    });
+    onClose();
+  }, [blockUid, onClose]);
+
+  return (
+    <div
+      className="flex gap-1 rounded border border-gray-200 bg-white p-1 shadow-sm"
+      onClick={(e) => e.stopPropagation()}
+      onMouseDown={(e) => e.stopPropagation()}
+    >
+      <Popover
+        content={
+          <Menu>
+            {discourseNodes.map((item) => {
+              const nodeColor =
+                formatHexColor(item?.canvasSettings?.color) || "#000";
+              return (
+                <MenuItem
+                  key={item.text}
+                  text={item.text}
+                  icon={
+                    <div
+                      className="mr-2 h-4 w-4 select-none rounded-full"
+                      style={{
+                        backgroundColor: nodeColor,
+                        border: "none",
+                        outline: "none",
+                      }}
+                    />
+                  }
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    void handleAddTag(item.tag || "");
+                  }}
+                />
+              );
+            })}
+          </Menu>
+        }
+        position={Position.BOTTOM}
+        interactionKind="click"
+        isOpen={isPopoverOpen}
+        onInteraction={(nextOpenState) => setIsPopoverOpen(nextOpenState)}
+      >
+        <Button icon={"label" as IconName} minimal small title="Add Node Tag" />
+      </Popover>
+
+      <Button
+        icon={"edit" as IconName}
+        minimal
+        small
+        title="Edit Block"
+        onClick={(e) => {
+          e.stopPropagation();
+          handleEditBlock();
+        }}
+      />
+    </div>
+  );
+};
+
+const isMenuAlreadyRendered = (imageElement: HTMLImageElement): boolean => {
+  return (
+    imageElement.parentElement?.getAttribute("data-image-menu-rendered") ===
+    "true"
+  );
+};
+
+const getBlockUidFromImage = (
+  imageElement: HTMLImageElement,
+): string | undefined => {
+  const blockInputElement = imageElement.closest(".rm-block__input");
+  return blockInputElement
+    ? getUids(blockInputElement as HTMLDivElement).blockUid
+    : undefined;
+};
+
+const getImageWrapper = (
+  imageElement: HTMLImageElement,
+): HTMLElement | null => {
+  return (
+    (imageElement.closest(".rm-inline-img__resize") as HTMLElement) ||
+    (imageElement.closest(".rm-inline-img") as HTMLElement) ||
+    imageElement.parentElement
+  );
+};
+
+const setupWrapperForMenu = (wrapper: HTMLElement): void => {
+  wrapper.setAttribute("data-image-menu-rendered", "true");
+  wrapper.classList.add("relative");
+};
+
+const createMenuContainer = (): HTMLDivElement => {
+  const menuContainer = document.createElement("div");
+  menuContainer.className = "absolute bottom-1 right-1 z-[100] hidden";
+  return menuContainer;
+};
+
+const attachHoverListeners = (
+  wrapper: HTMLElement,
+  menuContainer: HTMLDivElement,
+): void => {
+  wrapper.addEventListener("mouseenter", () => {
+    menuContainer.classList.remove("hidden");
+    menuContainer.classList.add("block");
+  });
+  wrapper.addEventListener("mouseleave", () => {
+    menuContainer.classList.remove("block");
+    menuContainer.classList.add("hidden");
+  });
+};
+
+
+export const renderImageToolsMenu = (imageElement: HTMLImageElement): void => {
+  if (isMenuAlreadyRendered(imageElement)) return;
+
+  const blockUid = getBlockUidFromImage(imageElement);
+  if (!blockUid) return;
+
+  const wrapper = getImageWrapper(imageElement);
+  if (!wrapper) return;
+
+  setupWrapperForMenu(wrapper);
+
+  const menuContainer = createMenuContainer();
+  wrapper.appendChild(menuContainer);
+  attachHoverListeners(wrapper, menuContainer);
+
+  // eslint-disable-next-line react/no-deprecated
+  ReactDOM.render(
+    <ImageToolsMenu onClose={() => {}} blockUid={blockUid} />,
+    menuContainer,
+  );
+};

--- a/apps/roam/src/utils/renderImageToolsMenu.tsx
+++ b/apps/roam/src/utils/renderImageToolsMenu.tsx
@@ -1,57 +1,30 @@
-import React, { useCallback, useMemo } from "react";
+import React, { useCallback } from "react";
 import ReactDOM from "react-dom";
-import {
-  Button,
-  Menu,
-  MenuItem,
-  Popover,
-  Position,
-  IconName,
-} from "@blueprintjs/core";
+import { Button, IconName } from "@blueprintjs/core";
 import getUids from "roamjs-components/dom/getUids";
-import getTextByBlockUid from "roamjs-components/queries/getTextByBlockUid";
-import updateBlock from "roamjs-components/writes/updateBlock";
-import getDiscourseNodes from "./getDiscourseNodes";
-import { formatHexColor } from "~/components/settings/DiscourseNodeCanvasSettings";
+import NodeMenu from "~/components/DiscourseNodeMenu";
+import { OnloadArgs } from "roamjs-components/types";
 
 type ImageToolsMenuProps = {
-  onClose: () => void;
   blockUid: string;
+  extensionAPI: OnloadArgs["extensionAPI"];
 };
 
 const ImageToolsMenu = ({
-  onClose,
   blockUid,
+  extensionAPI,
 }: ImageToolsMenuProps): JSX.Element => {
-  const [isPopoverOpen, setIsPopoverOpen] = React.useState(false);
-
-  const userDiscourseNodes = useMemo(
-    () => getDiscourseNodes().filter((n) => n.backedBy === "user"),
-    [],
-  );
-
-  const discourseNodes = userDiscourseNodes.filter((n) => n.tag);
-
-  const handleAddTag = useCallback(
-    async (tag: string): Promise<void> => {
-      setIsPopoverOpen(false);
-      const currentText = getTextByBlockUid(blockUid);
-      const cleanTag = tag.replace(/^#/, "");
-      const textToInsert = ` #${cleanTag}`;
-      await updateBlock({ text: currentText + textToInsert, uid: blockUid });
-      onClose();
-    },
-    [blockUid, onClose],
-  );
-
   const handleEditBlock = useCallback((): void => {
     // eslint-disable-next-line @typescript-eslint/naming-convention
     void window.roamAlphaAPI.ui.setBlockFocusAndSelection({
       // eslint-disable-next-line @typescript-eslint/naming-convention
       location: { "block-uid": blockUid, "window-id": "main-window" },
     });
-    onClose();
-  }, [blockUid, onClose]);
+  }, [blockUid]);
+
+  const trigger = (
+    <Button icon={"label" as IconName} minimal small title="Add Node Tag" />
+  );
 
   return (
     <div
@@ -59,42 +32,13 @@ const ImageToolsMenu = ({
       onClick={(e) => e.stopPropagation()}
       onMouseDown={(e) => e.stopPropagation()}
     >
-      <Popover
-        content={
-          <Menu>
-            {discourseNodes.map((item) => {
-              const nodeColor =
-                formatHexColor(item?.canvasSettings?.color) || "#000";
-              return (
-                <MenuItem
-                  key={item.text}
-                  text={item.text}
-                  icon={
-                    <div
-                      className="mr-2 h-4 w-4 select-none rounded-full"
-                      style={{
-                        backgroundColor: nodeColor,
-                        border: "none",
-                        outline: "none",
-                      }}
-                    />
-                  }
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    void handleAddTag(item.tag || "");
-                  }}
-                />
-              );
-            })}
-          </Menu>
-        }
-        position={Position.BOTTOM}
-        interactionKind="click"
-        isOpen={isPopoverOpen}
-        onInteraction={(nextOpenState) => setIsPopoverOpen(nextOpenState)}
-      >
-        <Button icon={"label" as IconName} minimal small title="Add Node Tag" />
-      </Popover>
+      <NodeMenu
+        onClose={() => {}}
+        blockUid={blockUid}
+        extensionAPI={extensionAPI}
+        trigger={trigger}
+        isShift={false}
+      />
 
       <Button
         icon={"edit" as IconName}
@@ -161,8 +105,10 @@ const attachHoverListeners = (
   });
 };
 
-
-export const renderImageToolsMenu = (imageElement: HTMLImageElement): void => {
+export const renderImageToolsMenu = (
+  imageElement: HTMLImageElement,
+  extensionAPI: OnloadArgs["extensionAPI"],
+): void => {
   if (isMenuAlreadyRendered(imageElement)) return;
 
   const blockUid = getBlockUidFromImage(imageElement);
@@ -179,7 +125,7 @@ export const renderImageToolsMenu = (imageElement: HTMLImageElement): void => {
 
   // eslint-disable-next-line react/no-deprecated
   ReactDOM.render(
-    <ImageToolsMenu onClose={() => {}} blockUid={blockUid} />,
+    <ImageToolsMenu blockUid={blockUid} extensionAPI={extensionAPI} />,
     menuContainer,
   );
 };

--- a/apps/roam/src/utils/renderImageToolsMenu.tsx
+++ b/apps/roam/src/utils/renderImageToolsMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useState } from "react";
 import ReactDOM from "react-dom";
 import { Button, IconName } from "@blueprintjs/core";
 import getUids from "roamjs-components/dom/getUids";
@@ -14,6 +14,8 @@ const ImageToolsMenu = ({
   blockUid,
   extensionAPI,
 }: ImageToolsMenuProps): JSX.Element => {
+  const [menuKey, setMenuKey] = useState(0);
+
   const handleEditBlock = useCallback((): void => {
     // eslint-disable-next-line @typescript-eslint/naming-convention
     void window.roamAlphaAPI.ui.setBlockFocusAndSelection({
@@ -21,6 +23,10 @@ const ImageToolsMenu = ({
       location: { "block-uid": blockUid, "window-id": "main-window" },
     });
   }, [blockUid]);
+
+  const handleMenuClose = useCallback(() => {
+    setMenuKey((prev) => prev + 1);
+  }, []);
 
   const trigger = (
     <Button icon={"label" as IconName} minimal small title="Add Node Tag" />
@@ -33,7 +39,8 @@ const ImageToolsMenu = ({
       onMouseDown={(e) => e.stopPropagation()}
     >
       <NodeMenu
-        onClose={() => {}}
+        key={menuKey}
+        onClose={handleMenuClose}
         blockUid={blockUid}
         extensionAPI={extensionAPI}
         trigger={trigger}


### PR DESCRIPTION
https://www.loom.com/share/ad6efb370bfc402bb68f312fee6e7147

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Image tools menu: hover over images to access a contextual menu showing related discourse nodes, quick tag insertion, and an Edit Block action to focus referenced blocks.

* **Improvements**
  * Node menu handling made more robust when inline editing elements are absent, improving stability of tag insertion and menu interactions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->