### PR TITLE
[ENG-870] Bug fix allow right click on canvas

### DIFF
--- a/apps/obsidian/src/components/canvas/TldrawViewComponent.tsx
+++ b/apps/obsidian/src/components/canvas/TldrawViewComponent.tsx
@@ -266,10 +266,35 @@ export const TldrawPreviewComponent = ({
     editorRef.current = editor;
     setIsEditorMounted(true);
 
+    // Handle right-click to ensure context menu opens
+    // Obsidian may intercept contextmenu events, so we manually dispatch one
     editor.on("event", (event) => {
       // Handle pointer events
       if (event.type !== "pointer") return;
       const e = event as TLPointerEventInfo;
+
+      // Handle right-click events - manually dispatch contextmenu for Radix UI
+      if (e.type === "pointer" && e.name === "right_click") {
+        // Use requestAnimationFrame to ensure this happens after tldraw's handling
+        requestAnimationFrame(() => {
+          const container = editor.getContainer();
+          const canvas = container?.querySelector(".tl-canvas") as HTMLElement;
+          if (canvas) {
+            // Get the screen point from the event
+            const screenPoint = editor.inputs.currentScreenPoint;
+            // Dispatch a contextmenu event that Radix UI can handle
+            const contextMenuEvent = new MouseEvent("contextmenu", {
+              bubbles: true,
+              cancelable: true,
+              clientX: screenPoint.x,
+              clientY: screenPoint.y,
+              button: 2,
+            });
+            canvas.dispatchEvent(contextMenuEvent);
+          }
+        });
+      }
+
       if (e.type === "pointer" && e.name === "pointer_down") {
         const currentTool = editor.getCurrentTool();
         const currentToolId = currentTool.id;

--- a/apps/obsidian/src/components/canvas/TldrawViewComponent.tsx
+++ b/apps/obsidian/src/components/canvas/TldrawViewComponent.tsx
@@ -265,17 +265,18 @@ export const TldrawPreviewComponent = ({
   const handleMount = (editor: Editor) => {
     editorRef.current = editor;
     setIsEditorMounted(true);
-    
+
     editor.on("event", (event) => {
       // Handle pointer events
       if (event.type !== "pointer") return;
       const e = event as TLPointerEventInfo;
 
       if (e.type === "pointer" && e.name === "right_click") {
-        requestAnimationFrame(() => {
-          const container = editor.getContainer();
-          const canvas = container?.querySelector(".tl-canvas") as HTMLElement;
-          if (canvas) {
+        const container = editor.getContainer();
+        const canvas = container?.querySelector(".tl-canvas") as HTMLElement;
+
+        if (canvas) {
+          setTimeout(() => {
             const contextMenuEvent = new MouseEvent("contextmenu", {
               bubbles: true,
               cancelable: true,
@@ -288,8 +289,8 @@ export const TldrawPreviewComponent = ({
               metaKey: e.metaKey,
             });
             canvas.dispatchEvent(contextMenuEvent);
-          }
-        });
+          }, 0);
+        }
       }
 
       if (e.type === "pointer" && e.name === "pointer_down") {

--- a/apps/obsidian/src/components/canvas/TldrawViewComponent.tsx
+++ b/apps/obsidian/src/components/canvas/TldrawViewComponent.tsx
@@ -265,9 +265,7 @@ export const TldrawPreviewComponent = ({
   const handleMount = (editor: Editor) => {
     editorRef.current = editor;
     setIsEditorMounted(true);
-
-    // Handle right-click to ensure context menu opens
-    // Obsidian may intercept contextmenu events, so we manually dispatch one
+    
     editor.on("event", (event) => {
       // Handle pointer events
       if (event.type !== "pointer") return;
@@ -275,20 +273,20 @@ export const TldrawPreviewComponent = ({
 
       // Handle right-click events - manually dispatch contextmenu for Radix UI
       if (e.type === "pointer" && e.name === "right_click") {
-        // Use requestAnimationFrame to ensure this happens after tldraw's handling
         requestAnimationFrame(() => {
           const container = editor.getContainer();
           const canvas = container?.querySelector(".tl-canvas") as HTMLElement;
           if (canvas) {
-            // Get the screen point from the event
-            const screenPoint = editor.inputs.currentScreenPoint;
-            // Dispatch a contextmenu event that Radix UI can handle
             const contextMenuEvent = new MouseEvent("contextmenu", {
               bubbles: true,
               cancelable: true,
-              clientX: screenPoint.x,
-              clientY: screenPoint.y,
+              clientX: e.point.x,
+              clientY: e.point.y,
               button: 2,
+              shiftKey: e.shiftKey,
+              ctrlKey: e.ctrlKey,
+              altKey: e.altKey,
+              metaKey: e.metaKey,
             });
             canvas.dispatchEvent(contextMenuEvent);
           }

--- a/apps/obsidian/src/components/canvas/TldrawViewComponent.tsx
+++ b/apps/obsidian/src/components/canvas/TldrawViewComponent.tsx
@@ -271,7 +271,6 @@ export const TldrawPreviewComponent = ({
       if (event.type !== "pointer") return;
       const e = event as TLPointerEventInfo;
 
-      // Handle right-click events - manually dispatch contextmenu for Radix UI
       if (e.type === "pointer" && e.name === "right_click") {
         requestAnimationFrame(() => {
           const container = editor.getContainer();


### PR DESCRIPTION
https://www.loom.com/share/aad654710f5a413fa819dadf9252dfbd
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored right-click context menu behavior in the canvas editor so native and Radix UI menus open correctly.
  * Improved auto-save resilience: saves are now debounced, guarded against concurrent writes, and include error handling that recovers and reloads if a save fails.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->