### PR TITLE
ENG-1107 Update drag and drop image for nodes in discourse toolbar

### DIFF
--- a/apps/roam/src/components/canvas/DiscourseNodeUtil.tsx
+++ b/apps/roam/src/components/canvas/DiscourseNodeUtil.tsx
@@ -33,7 +33,6 @@ import createDiscourseNode from "~/utils/createDiscourseNode";
 import { DiscourseNode } from "~/utils/getDiscourseNodes";
 import { isPageUid } from "./Tldraw";
 import LabelDialog from "./LabelDialog";
-import { colord } from "colord";
 import { discourseContext } from "./Tldraw";
 import getDiscourseContextResults from "~/utils/getDiscourseContextResults";
 import calcCanvasNodeSizeAndImg from "~/utils/calcCanvasNodeSizeAndImg";
@@ -46,7 +45,7 @@ import {
 } from "~/data/userSettings";
 import { getSetting } from "~/utils/extensionSettings";
 import DiscourseContextOverlay from "~/components/DiscourseContextOverlay";
-import getPleasingColors from "@repo/utils/getPleasingColors";
+import { getDiscourseNodeColors } from "~/utils/getDiscourseNodeColors";
 
 // TODO REPLACE WITH TLDRAW DEFAULTS
 // https://github.com/tldraw/tldraw/pull/1580/files
@@ -58,7 +57,7 @@ const TEXT_PROPS = {
   padding: "0px",
   maxWidth: "auto",
 };
-const FONT_SIZES: Record<TLDefaultSizeStyle, number> = {
+export const FONT_SIZES: Record<TLDefaultSizeStyle, number> = {
   m: 25,
   l: 38,
   xl: 48,
@@ -343,26 +342,7 @@ export class BaseDiscourseNodeUtil extends ShapeUtil<DiscourseNodeShape> {
   }
 
   getColors() {
-    const {
-      canvasSettings: { color: setColor = "" } = {},
-      index: discourseNodeIndex = -1,
-    } = discourseContext.nodes[this.type] || {};
-    const paletteColor =
-      COLOR_ARRAY[
-        discourseNodeIndex >= 0 && discourseNodeIndex < COLOR_ARRAY.length - 1
-          ? discourseNodeIndex
-          : 0
-      ];
-    const formattedTextColor =
-      setColor && !setColor.startsWith("#") ? `#${setColor}` : setColor;
-
-    const canvasSelectedColor = formattedTextColor
-      ? formattedTextColor
-      : COLOR_PALETTE[paletteColor];
-    const pleasingColors = getPleasingColors(colord(canvasSelectedColor));
-    const backgroundColor = pleasingColors.background;
-    const textColor = pleasingColors.text;
-    return { backgroundColor, textColor };
+    return getDiscourseNodeColors({ nodeType: this.type });
   }
 
   async toSvg(shape: DiscourseNodeShape): Promise<JSX.Element> {

--- a/apps/roam/src/components/canvas/DiscourseToolPanel.tsx
+++ b/apps/roam/src/components/canvas/DiscourseToolPanel.tsx
@@ -216,11 +216,6 @@ const DiscourseGraphPanel = ({
 
       if (!item) return;
 
-      // Relations should not be draggable, only clickable
-      if (item.type === "relation") {
-        return;
-      }
-
       const startPosition = new Vec(e.clientX, e.clientY);
 
       dragState.set({
@@ -229,8 +224,12 @@ const DiscourseGraphPanel = ({
         startPosition,
       });
 
-      target.addEventListener("pointermove", handlePointerMove);
-      document.addEventListener("keydown", handleKeyDown);
+      // Relations should not be draggable, only clickable
+      // So we don't add the pointermove listener for relations
+      if (item.type !== "relation") {
+        target.addEventListener("pointermove", handlePointerMove);
+        document.addEventListener("keydown", handleKeyDown);
+      }
     };
 
     const handleKeyDown = (e: KeyboardEvent) => {

--- a/apps/roam/src/components/canvas/DiscourseToolPanel.tsx
+++ b/apps/roam/src/components/canvas/DiscourseToolPanel.tsx
@@ -177,9 +177,8 @@ const DiscourseGraphPanel = ({
         case "dragging": {
           // When dragging ends, create the shape at the drop position
           const pagePoint = editor.screenToPage(current.currentPosition);
-          const zoomLevel = editor.getZoomLevel();
-          const offsetX = DEFAULT_WIDTH / 2 / zoomLevel;
-          const offsetY = DEFAULT_HEIGHT / 2 / zoomLevel;
+          const offsetX = DEFAULT_WIDTH / 2;
+          const offsetY = DEFAULT_HEIGHT / 2;
 
           if (current.item.type === "node") {
             const shapeId = createShapeId();
@@ -264,6 +263,7 @@ const DiscourseGraphPanel = ({
     0.5,
     useValue("clipboardZoomLevel", () => editor.getZoomLevel(), [editor]),
   );
+
   // Drag preview management
   useQuickReactor(
     "drag-image-style",
@@ -293,7 +293,7 @@ const DiscourseGraphPanel = ({
             panelContainerRect.height,
           );
 
-          const zoomLevel = editor.getZoomLevel();
+          const zoomLevel = Math.max(0.5, editor.getZoomLevel());
           const height = DEFAULT_HEIGHT * zoomLevel;
           const width = DEFAULT_WIDTH * zoomLevel;
           const isInside = Box.ContainsPoint(box, current.currentPosition);
@@ -431,7 +431,7 @@ const DiscourseGraphPanel = ({
               maxWidth: "",
               fontFamily: FONT_FAMILIES.sans,
               fontSize: `${FONT_SIZES.s * zoomLevel}px`,
-              padding: `${40 * zoomLevel}px`,
+              padding: `0px`,
             }}
           >
             {state.item.text}

--- a/apps/roam/src/components/canvas/Tldraw.tsx
+++ b/apps/roam/src/components/canvas/Tldraw.tsx
@@ -114,8 +114,8 @@ export const discourseContext: DiscourseContextType = {
   lastActions: [],
 };
 
-const DEFAULT_WIDTH = 160;
-const DEFAULT_HEIGHT = 64;
+export const DEFAULT_WIDTH = 160;
+export const DEFAULT_HEIGHT = 64;
 export const MAX_WIDTH = "400px";
 
 export const isPageUid = (uid: string) =>

--- a/apps/roam/src/utils/getDiscourseNodeColors.ts
+++ b/apps/roam/src/utils/getDiscourseNodeColors.ts
@@ -24,7 +24,7 @@ export const getDiscourseNodeColors = ({
 
   const paletteColor =
     COLOR_ARRAY[
-      discourseNodeIndex >= 0 && discourseNodeIndex < COLOR_ARRAY.length - 1
+      discourseNodeIndex >= 0 && discourseNodeIndex < COLOR_ARRAY.length
         ? discourseNodeIndex
         : 0
     ];

--- a/apps/roam/src/utils/getDiscourseNodeColors.ts
+++ b/apps/roam/src/utils/getDiscourseNodeColors.ts
@@ -1,0 +1,41 @@
+import { colord } from "colord";
+import getPleasingColors from "@repo/utils/getPleasingColors";
+import {
+  COLOR_ARRAY,
+  COLOR_PALETTE,
+} from "~/components/canvas/DiscourseNodeUtil";
+import getDiscourseNodes, { DiscourseNode } from "./getDiscourseNodes";
+
+type GetDiscourseNodeColorsParams = {
+  nodeType?: string;
+  discourseNodes?: DiscourseNode[];
+};
+
+export const getDiscourseNodeColors = ({
+  nodeType,
+  discourseNodes = getDiscourseNodes(),
+}: GetDiscourseNodeColorsParams): {
+  backgroundColor: string;
+  textColor: string;
+} => {
+  const discourseNodeIndex =
+    discourseNodes.findIndex((node) => node.type === nodeType) ?? -1;
+  const color = discourseNodes[discourseNodeIndex]?.canvasSettings?.color ?? "";
+
+  const paletteColor =
+    COLOR_ARRAY[
+      discourseNodeIndex >= 0 && discourseNodeIndex < COLOR_ARRAY.length - 1
+        ? discourseNodeIndex
+        : 0
+    ];
+  const formattedTextColor =
+    color && !color.startsWith("#") ? `#${color}` : color;
+
+  const canvasSelectedColor = formattedTextColor
+    ? formattedTextColor
+    : COLOR_PALETTE[paletteColor];
+  const pleasingColors = getPleasingColors(colord(canvasSelectedColor));
+  const backgroundColor = pleasingColors.background;
+  const textColor = pleasingColors.text;
+  return { backgroundColor, textColor };
+};


### PR DESCRIPTION
Before
<img width="996" height="533" alt="image" src="https://github.com/user-attachments/assets/20a635a8-4da8-41b2-8e7d-5706fdf64ef4" />

After
<img width="424" height="288" alt="image" src="https://github.com/user-attachments/assets/ff87534a-e0a4-4595-b216-d5966cba3952" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Relations are no longer draggable; only nodes can be dragged.
  * Dropped items now center correctly on the canvas.

* **Improvements**
  * Drag previews now scale intelligently with zoom level for improved visibility.
  * Enhanced color consistency in drag-and-drop UI elements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->