### PR TITLE
ENG-1115 - add command to toggle discourse context overlay from command

### DIFF
--- a/apps/roam/src/components/DiscourseContextOverlay.tsx
+++ b/apps/roam/src/components/DiscourseContextOverlay.tsx
@@ -93,6 +93,8 @@ type DiscourseContextOverlayBaseProps = {
 type DiscourseContextOverlayProps = DiscourseContextOverlayBaseProps &
   ({ tag: string; uid?: never } | { tag?: never; uid: string });
 
+const ICON_SIZE = 16;
+
 const DiscourseContextOverlay = ({
   tag,
   id,
@@ -169,6 +171,7 @@ const DiscourseContextOverlay = ({
               icon={"diagram-tree"}
               color={iconColor}
               style={{ opacity: `${Number(opacity) / 100}` }}
+              size={ICON_SIZE}
             />
             <span
               className={`mr-1 leading-none opacity-${opacity}`}
@@ -180,6 +183,7 @@ const DiscourseContextOverlay = ({
               icon={"link"}
               color={iconColor}
               style={{ opacity: `${Number(opacity) / 100}` }}
+              size={ICON_SIZE}
             />
             <span
               className={`leading-none opacity-${opacity}`}
@@ -209,15 +213,20 @@ const Wrapper = ({ parent, tag }: { parent: HTMLElement; tag: string }) => {
     <Button
       small
       id={id}
+      className={`roamjs-discourse-context-overlay`}
+      style={{
+        minHeight: "initial",
+        paddingTop: ".25rem",
+        paddingBottom: ".25rem",
+      }}
       minimal
-      className={"roamjs-discourse-context-overlay"}
       disabled={true}
     >
       <div className="flex items-center gap-1.5">
-        <Icon icon={"diagram-tree"} />
-        <span className="mr-1">-</span>
-        <Icon icon={"link"} />
-        <span>-</span>
+        <Icon icon={"diagram-tree"} size={ICON_SIZE} />
+        <span className={`mr-1 leading-none`}>-</span>
+        <Icon icon={"link"} size={ICON_SIZE} />
+        <span className={`leading-none`}>-</span>
       </div>
     </Button>
   );

--- a/apps/roam/src/utils/initializeObserversAndListeners.ts
+++ b/apps/roam/src/utils/initializeObserversAndListeners.ts
@@ -23,7 +23,8 @@ import {
   addPageRefObserver,
   getPageRefObserversSize,
   previewPageRefHandler,
-  overlayPageRefHandler,
+  getOverlayHandler,
+  onPageRefObserverChange,
   getSuggestiveOverlayHandler,
 } from "~/utils/pageRefObserverHandlers";
 import getDiscourseNodes from "~/utils/getDiscourseNodes";
@@ -186,7 +187,8 @@ export const initObservers = async ({
   if (onloadArgs.extensionAPI.settings.get("page-preview"))
     addPageRefObserver(previewPageRefHandler);
   if (onloadArgs.extensionAPI.settings.get("discourse-context-overlay")) {
-    addPageRefObserver((s) => overlayPageRefHandler(s, onloadArgs));
+    const overlayHandler = getOverlayHandler(onloadArgs);
+    onPageRefObserverChange(overlayHandler)(true);
   }
   if (!!getPageRefObserversSize()) enablePageRefObserver();
 

--- a/apps/roam/src/utils/registerCommandPaletteCommands.ts
+++ b/apps/roam/src/utils/registerCommandPaletteCommands.ts
@@ -138,17 +138,26 @@ export const registerCommandPaletteCommands = (onloadArgs: OnloadArgs) => {
 
   const renderSettingsPopup = () => renderSettings({ onloadArgs });
 
-  const toggleDiscourseContextOverlay = () => {
+  const toggleDiscourseContextOverlay = async () => {
     const currentValue =
       (extensionAPI.settings.get("discourse-context-overlay") as boolean) ??
       false;
     const newValue = !currentValue;
-    void extensionAPI.settings.set("discourse-context-overlay", newValue);
+    try {
+      await extensionAPI.settings.set("discourse-context-overlay", newValue);
+    } catch (error) {
+      const e = error as Error;
+      renderToast({
+        id: "discourse-context-overlay-toggle-error",
+        content: `Failed to toggle discourse context overlay: ${e.message}`,
+      });
+      return;
+    }
     const overlayHandler = getOverlayHandler(onloadArgs);
     onPageRefObserverChange(overlayHandler)(newValue);
     renderToast({
       id: "discourse-context-overlay-toggle",
-      content: `Discourse context overlay ${newValue ? "enabled" : "disabled"}`,
+      content: `Discourse Context Overlay ${newValue ? "enabled" : "disabled"}`,
     });
   };
 

--- a/apps/roam/src/utils/registerCommandPaletteCommands.ts
+++ b/apps/roam/src/utils/registerCommandPaletteCommands.ts
@@ -12,6 +12,10 @@ import getDiscourseNodes from "./getDiscourseNodes";
 import fireQuery from "./fireQuery";
 import { excludeDefaultNodes } from "~/utils/getDiscourseNodes";
 import { render as renderSettings } from "~/components/settings/Settings";
+import {
+  getOverlayHandler,
+  onPageRefObserverChange,
+} from "./pageRefObserverHandlers";
 
 export const registerCommandPaletteCommands = (onloadArgs: OnloadArgs) => {
   const { extensionAPI } = onloadArgs;
@@ -134,6 +138,20 @@ export const registerCommandPaletteCommands = (onloadArgs: OnloadArgs) => {
 
   const renderSettingsPopup = () => renderSettings({ onloadArgs });
 
+  const toggleDiscourseContextOverlay = () => {
+    const currentValue =
+      (extensionAPI.settings.get("discourse-context-overlay") as boolean) ??
+      false;
+    const newValue = !currentValue;
+    void extensionAPI.settings.set("discourse-context-overlay", newValue);
+    const overlayHandler = getOverlayHandler(onloadArgs);
+    onPageRefObserverChange(overlayHandler)(newValue);
+    renderToast({
+      id: "discourse-context-overlay-toggle",
+      content: `Discourse Context Overlay ${newValue ? "enabled" : "disabled"}`,
+    });
+  };
+
   const addCommand = (label: string, callback: () => void) => {
     return extensionAPI.ui.commandPalette.addCommand({
       label,
@@ -141,11 +159,15 @@ export const registerCommandPaletteCommands = (onloadArgs: OnloadArgs) => {
     });
   };
 
-  // Roam organizes commands by alphabetically
-  addCommand("DG: Export - Current Page", exportCurrentPage);
-  addCommand("DG: Export - Discourse Graph", exportDiscourseGraph);
-  addCommand("DG: Open - Discourse Settings", renderSettingsPopup);
-  addCommand("DG: Open - Query Drawer", openQueryDrawerWithArgs);
-  addCommand("DG: Query Block - Create", createQueryBlock);
-  addCommand("DG: Query Block - Refresh", refreshCurrentQueryBuilder);
+  // Roam organizes commands alphabetically
+  void addCommand("DG: Export - Current Page", exportCurrentPage);
+  void addCommand("DG: Export - Discourse Graph", exportDiscourseGraph);
+  void addCommand("DG: Open - Discourse Settings", renderSettingsPopup);
+  void addCommand("DG: Open - Query Drawer", openQueryDrawerWithArgs);
+  void addCommand(
+    "DG: Toggle - Discourse Context Overlay",
+    toggleDiscourseContextOverlay,
+  );
+  void addCommand("DG: Query Block - Create", createQueryBlock);
+  void addCommand("DG: Query Block - Refresh", refreshCurrentQueryBuilder);
 };

--- a/apps/roam/src/utils/registerCommandPaletteCommands.ts
+++ b/apps/roam/src/utils/registerCommandPaletteCommands.ts
@@ -148,7 +148,7 @@ export const registerCommandPaletteCommands = (onloadArgs: OnloadArgs) => {
     onPageRefObserverChange(overlayHandler)(newValue);
     renderToast({
       id: "discourse-context-overlay-toggle",
-      content: `Discourse Context Overlay ${newValue ? "enabled" : "disabled"}`,
+      content: `Discourse context overlay ${newValue ? "enabled" : "disabled"}`,
     });
   };
 
@@ -160,14 +160,14 @@ export const registerCommandPaletteCommands = (onloadArgs: OnloadArgs) => {
   };
 
   // Roam organizes commands alphabetically
-  void addCommand("DG: Export - Current Page", exportCurrentPage);
-  void addCommand("DG: Export - Discourse Graph", exportDiscourseGraph);
-  void addCommand("DG: Open - Discourse Settings", renderSettingsPopup);
-  void addCommand("DG: Open - Query Drawer", openQueryDrawerWithArgs);
+  void addCommand("DG: Export - Current page", exportCurrentPage);
+  void addCommand("DG: Export - Discourse graph", exportDiscourseGraph);
+  void addCommand("DG: Open - Discourse settings", renderSettingsPopup);
+  void addCommand("DG: Open - Query drawer", openQueryDrawerWithArgs);
   void addCommand(
-    "DG: Toggle - Discourse Context Overlay",
+    "DG: Toggle - Discourse context overlay",
     toggleDiscourseContextOverlay,
   );
-  void addCommand("DG: Query Block - Create", createQueryBlock);
-  void addCommand("DG: Query Block - Refresh", refreshCurrentQueryBuilder);
+  void addCommand("DG: Query block - Create", createQueryBlock);
+  void addCommand("DG: Query block - Refresh", refreshCurrentQueryBuilder);
 };

--- a/apps/roam/src/utils/registerCommandPaletteCommands.ts
+++ b/apps/roam/src/utils/registerCommandPaletteCommands.ts
@@ -157,7 +157,7 @@ export const registerCommandPaletteCommands = (onloadArgs: OnloadArgs) => {
     onPageRefObserverChange(overlayHandler)(newValue);
     renderToast({
       id: "discourse-context-overlay-toggle",
-      content: `Discourse Context Overlay ${newValue ? "enabled" : "disabled"}`,
+      content: `Discourse context overlay ${newValue ? "enabled" : "disabled"}`,
     });
   };
 


### PR DESCRIPTION
https://www.loom.com/share/4b185d42af5147a785e9139b44139df9

Suggestion to reduce the icon/font size to remove line layout shift: [FEE-624: Discourse context overlay / suggestive mode icon causes layout shift](https://linear.app/discourse-graphs/issue/FEE-624/discourse-context-overlay-suggestive-mode-icon-causes-layout-shift)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a command to toggle the Discourse Context Overlay feature on and off via the command palette.
  * Settings are now persisted when toggling the overlay.

* **Bug Fixes**
  * Fixed duplicate overlays appearing on page references.

* **Style**
  * Refined overlay UI with consistent icon sizing and improved spacing alignment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->