### PR TITLE
ENG-1119 - Change add icon to settings icon

### DIFF
--- a/apps/roam/src/components/LeftSidebarView.tsx
+++ b/apps/roam/src/components/LeftSidebarView.tsx
@@ -387,7 +387,7 @@ const FavouritesPopover = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
           }
         >
           <span ref={menuTriggerRef} className="sidebar-title-button-add p-1">
-            <Icon icon="settings" iconSize={14} />
+            <Icon icon="settings" size={14} />
           </span>
         </Popover>
       </div>

--- a/apps/roam/src/components/LeftSidebarView.tsx
+++ b/apps/roam/src/components/LeftSidebarView.tsx
@@ -387,7 +387,7 @@ const FavouritesPopover = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
           }
         >
           <span ref={menuTriggerRef} className="sidebar-title-button-add p-1">
-            <Icon icon="plus" iconSize={14} />
+            <Icon icon="cog" iconSize={14} />
           </span>
         </Popover>
       </div>

--- a/apps/roam/src/components/LeftSidebarView.tsx
+++ b/apps/roam/src/components/LeftSidebarView.tsx
@@ -387,7 +387,7 @@ const FavouritesPopover = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
           }
         >
           <span ref={menuTriggerRef} className="sidebar-title-button-add p-1">
-            <Icon icon="cog" iconSize={14} />
+            <Icon icon="settings" iconSize={14} />
           </span>
         </Popover>
       </div>


### PR DESCRIPTION
Change the "add" icon to a "settings" icon in the left sidebar to clarify its function.

The previous "plus" icon caused user confusion by suggesting direct item addition, whereas the button actually opens settings. The "cog" icon more accurately represents that it leads to configuration.

Before
<img width="443" height="387" alt="image" src="https://github.com/user-attachments/assets/5ec9e7f5-c50a-4c2e-a62e-9bac01867099" />

After
<img width="467" height="371" alt="image" src="https://github.com/user-attachments/assets/02d834c5-8b5b-491d-acef-e366edf32030" />


---
Linear Issue: [ENG-1119](https://linear.app/discourse-graphs/issue/ENG-1119/change-add-icon-to-settings-icon-in-left-sidebar)

<a href="https://cursor.com/background-agent?bcId=bc-d3ad31a1-3f6f-4a17-b00b-ad8c11ddb30a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d3ad31a1-3f6f-4a17-b00b-ad8c11ddb30a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

