### PR TITLE
ENG-1118 - Correct spelling of favourites in sidebar

### DIFF
--- a/apps/roam/src/components/LeftSidebarView.tsx
+++ b/apps/roam/src/components/LeftSidebarView.tsx
@@ -284,7 +284,7 @@ export const refreshAndNotify = () => {
   notify();
 };
 
-const FavouritesPopover = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
+const FavoritesPopover = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const menuTriggerRef = useRef<HTMLSpanElement | null>(null);
 
@@ -352,7 +352,7 @@ const FavouritesPopover = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
         <span className="flex items-baseline">
           <Icon icon="star" iconSize={14} />
           <div style={{ width: 8 }}></div>
-          FAVOURITES
+          FAVORITES
         </span>
         <Popover
           interactionKind={PopoverInteractionKind.CLICK}
@@ -400,7 +400,7 @@ const LeftSidebarView = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
 
   return (
     <>
-      <FavouritesPopover onloadArgs={onloadArgs} />
+      <FavoritesPopover onloadArgs={onloadArgs} />
       <GlobalSection config={config.global} />
       <PersonalSections config={config} />
     </>


### PR DESCRIPTION
Remove "U" from "FAVOURITES" in the sidebar and rename the corresponding component for consistency.

---
Linear Issue: [ENG-1118](https://linear.app/discourse-graphs/issue/ENG-1118/remove-u-in-favourites-from-sidebar)

<a href="https://cursor.com/background-agent?bcId=bc-5a5122c7-b65b-4c4e-b60f-f89a1ea01eea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5a5122c7-b65b-4c4e-b60f-f89a1ea01eea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

