### PR TITLE
ENG-1122 Replace or-clause with or-join-clause to fix variable binding in datalog queries

### DIFF
--- a/apps/roam/src/utils/conditionToDatalog.ts
+++ b/apps/roam/src/utils/conditionToDatalog.ts
@@ -446,7 +446,7 @@ const translator: Record<string, Translator> = {
       if (currentUserMatch) {
         return [
           {
-            type: "or-clause",
+            type: "or-join-clause",
             clauses: [
               {
                 type: "data-pattern",
@@ -465,6 +465,7 @@ const translator: Record<string, Translator> = {
                 ],
               },
             ],
+            variables: [{ type: "variable", value: `${source}-String` }],
           },
           {
             type: "pred-expr",
@@ -481,7 +482,7 @@ const translator: Record<string, Translator> = {
         const rePattern = regexRePatternValue(target);
         return [
           {
-            type: "or-clause",
+            type: "or-join-clause",
             clauses: [
               {
                 type: "data-pattern",
@@ -500,6 +501,7 @@ const translator: Record<string, Translator> = {
                 ],
               },
             ],
+            variables: [{ type: "variable", value: `${source}-String` }],
           },
           {
             type: "fn-expr",
@@ -528,7 +530,7 @@ const translator: Record<string, Translator> = {
 
       return [
         {
-          type: "or-clause",
+          type: "or-join-clause",
           clauses: [
             {
               type: "data-pattern",
@@ -547,6 +549,7 @@ const translator: Record<string, Translator> = {
               ],
             },
           ],
+          variables: [{ type: "variable", value: `${source}-String` }],
         },
         {
           type: "pred-expr",


### PR DESCRIPTION
https://linear.app/discourse-graphs/issue/ENG-1122/some-queries-now-broken
A new error is due to an or-clause being pushed after the variable it uses. This can be solved by replacing the or-clause by an or-join-clause; then the optimizer knows about the variables and takes them into account.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal condition handling structure for enhanced data consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->