### PR TITLE
ENG-1069: Move existing shortcuts to new global shortcuts

### DIFF
--- a/apps/roam/src/components/LeftSidebarView.tsx
+++ b/apps/roam/src/components/LeftSidebarView.tsx
@@ -414,7 +414,7 @@ const migrateFavorites = async () => {
 
   const config = getFormattedConfigTree().leftSidebar;
 
-  if ((config.favoritesMigrated as BooleanSetting).value) return;
+  if (config.favoritesMigrated.value) return;
 
   let leftSidebarUid = config.uid;
   if (leftSidebarUid) {

--- a/apps/roam/src/components/LeftSidebarView.tsx
+++ b/apps/roam/src/components/LeftSidebarView.tsx
@@ -38,6 +38,8 @@ import { Dispatch, SetStateAction } from "react";
 import { SettingsDialog } from "./settings/Settings";
 import { OnloadArgs } from "roamjs-components/types";
 import renderOverlay from "roamjs-components/util/renderOverlay";
+import getBasicTreeByParentUid from "roamjs-components/queries/getBasicTreeByParentUid";
+import { DISCOURSE_CONFIG_PAGE_TITLE } from "~/utils/renderNodeConfigPage";
 
 const parseReference = (text: string) => {
   const extracted = extractRef(text);
@@ -405,20 +407,109 @@ const LeftSidebarView = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
   );
 };
 
-export const mountLeftSidebar = (
+const migrateFavorites = async (starredPagesContainer: Element) => {
+  const configPageUid = getPageUidByPageTitle(DISCOURSE_CONFIG_PAGE_TITLE);
+  if (!configPageUid) return;
+
+  const config = getFormattedConfigTree().leftSidebar;
+
+  if (config.favoritesMigrated.value) return;
+
+  let leftSidebarUid = config.uid;
+  if (leftSidebarUid) {
+    const leftSidebarTree = getBasicTreeByParentUid(leftSidebarUid);
+    const hasAnyPersonalSection = leftSidebarTree.some((node) =>
+      node.text.endsWith("/Personal-Section"),
+    );
+    if (hasAnyPersonalSection) {
+      await createBlock({
+        parentUid: leftSidebarUid,
+        node: { text: "Favorites Migrated" },
+      });
+      refreshConfigTree();
+      return;
+    }
+  }
+
+  const titles = Array.from(starredPagesContainer.querySelectorAll(".page"))
+    .map((el) => el.textContent || "")
+    .filter((t) => t);
+
+  if (!leftSidebarUid) {
+    const tree = getBasicTreeByParentUid(configPageUid);
+    const found = tree.find((n) => n.text === "Left Sidebar");
+    if (found) {
+      leftSidebarUid = found.uid;
+    } else {
+      leftSidebarUid = await createBlock({
+        parentUid: configPageUid,
+        node: { text: "Left Sidebar" },
+      });
+    }
+  }
+
+  let globalSectionUid = config.global.uid;
+  if (!globalSectionUid) {
+    const tree = getBasicTreeByParentUid(leftSidebarUid);
+    const found = tree.find((n) => n.text === "Global-Section");
+    if (found) {
+      globalSectionUid = found.uid;
+    } else {
+      globalSectionUid = await createBlock({
+        parentUid: leftSidebarUid,
+        node: { text: "Global-Section" },
+      });
+    }
+  }
+
+  let childrenUid = config.global.childrenUid;
+  if (!childrenUid) {
+    const tree = getBasicTreeByParentUid(globalSectionUid);
+    const found = tree.find((n) => n.text === "Children");
+    if (found) {
+      childrenUid = found.uid;
+    } else {
+      childrenUid = await createBlock({
+        parentUid: globalSectionUid,
+        node: { text: "Children" },
+      });
+    }
+  }
+
+  const childrenTree = getBasicTreeByParentUid(childrenUid);
+  const existingTitles = new Set(childrenTree.map((c) => c.text));
+  const newTitles = titles.filter((t) => !existingTitles.has(t));
+
+  if (newTitles.length > 0) {
+    await Promise.all(
+      newTitles.map((text) =>
+        createBlock({ parentUid: childrenUid, node: { text } }),
+      ),
+    );
+    refreshAndNotify();
+  }
+
+  await createBlock({
+    parentUid: leftSidebarUid,
+    node: { text: "Favorites Migrated" },
+  });
+  refreshConfigTree();
+};
+
+export const mountLeftSidebar = async (
   wrapper: HTMLElement,
   onloadArgs: OnloadArgs,
-): void => {
+): Promise<void> => {
   if (!wrapper) return;
-  wrapper.innerHTML = "";
 
   const id = "dg-left-sidebar-root";
   let root = wrapper.querySelector(`#${id}`) as HTMLDivElement;
   if (!root) {
     const existingStarred = wrapper.querySelector(".starred-pages");
     if (existingStarred) {
-      existingStarred.remove();
+      await migrateFavorites(existingStarred);
     }
+    wrapper.innerHTML = "";
     root = document.createElement("div");
     root.id = id;
     root.className = "starred-pages";

--- a/apps/roam/src/components/settings/LeftSidebarGlobalSettings.tsx
+++ b/apps/roam/src/components/settings/LeftSidebarGlobalSettings.tsx
@@ -225,17 +225,6 @@ const LeftSidebarGlobalSectionsContent = ({
     setNewPageInput(value);
   }, []);
 
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent) => {
-      if (e.key === "Enter" && newPageInput) {
-        e.preventDefault();
-        e.stopPropagation();
-        void addPage(newPageInput);
-      }
-    },
-    [newPageInput, addPage],
-  );
-
   const toggleChildren = useCallback(() => {
     setIsExpanded((prev) => !prev);
   }, []);
@@ -305,10 +294,7 @@ const LeftSidebarGlobalSectionsContent = ({
             <div className="mb-2 text-sm text-gray-600">
               Add pages that will appear for all users
             </div>
-            <div
-              className="mb-3 flex items-center gap-2"
-              onKeyDown={handleKeyDown}
-            >
+            <div className="mb-3 flex items-center gap-2">
               <AutocompleteInput
                 key={autocompleteKey}
                 value={newPageInput}
@@ -316,6 +302,8 @@ const LeftSidebarGlobalSectionsContent = ({
                 placeholder="Add page…"
                 options={pageNames}
                 maxItemsDisplayed={50}
+                autoFocus
+                onConfirm={() => void addPage(newPageInput)}
               />
               <Button
                 icon="plus"

--- a/apps/roam/src/components/settings/LeftSidebarPersonalSettings.tsx
+++ b/apps/roam/src/components/settings/LeftSidebarPersonalSettings.tsx
@@ -346,16 +346,7 @@ const SectionItem = memo(
         {!sectionWithoutSettingsAndChildren && (
           <Collapse isOpen={isExpanded}>
             <div className="ml-6 mt-3">
-              <div
-                className="mb-2 flex items-center gap-2"
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" && childInput) {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    void handleAddChild();
-                  }
-                }}
-              >
+              <div className="mb-2 flex items-center gap-2">
                 <AutocompleteInput
                   key={childInputKey}
                   value={childInput}
@@ -363,6 +354,8 @@ const SectionItem = memo(
                   placeholder="Add child page…"
                   options={pageNames}
                   maxItemsDisplayed={50}
+                  autoFocus
+                  onConfirm={() => void handleAddChild()}
                 />
                 <Button
                   icon="plus"
@@ -443,7 +436,6 @@ const LeftSidebarPersonalSectionsContent = ({
     null,
   );
   const [newSectionInput, setNewSectionInput] = useState("");
-  const [autocompleteKey, setAutocompleteKey] = useState(0);
   const [settingsDialogSectionUid, setSettingsDialogSectionUid] = useState<
     string | null
   >(null);
@@ -503,7 +495,6 @@ const LeftSidebarPersonalSectionsContent = ({
         ]);
 
         setNewSectionInput("");
-        setAutocompleteKey((prev) => prev + 1);
         refreshAndNotify();
       } catch (error) {
         renderToast({
@@ -565,21 +556,18 @@ const LeftSidebarPersonalSectionsContent = ({
         <div className="mb-2 text-sm text-gray-600">
           Add pages or create custom sections with settings and children
         </div>
-        <div
-          className="flex items-center gap-2"
-          onKeyDown={(e) => {
-            if (e.key === "Enter" && newSectionInput) {
-              e.preventDefault();
-              e.stopPropagation();
-              void addSection(newSectionInput);
-            }
-          }}
-        >
+        <div className="flex items-center gap-2">
           <InputGroup
-            key={autocompleteKey}
             value={newSectionInput}
             onChange={(e) => handleNewSectionInputChange(e.target.value)}
             placeholder="Add section …"
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && newSectionInput) {
+                e.preventDefault();
+                e.stopPropagation();
+                void addSection(newSectionInput);
+              }
+            }}
           />
           <Button
             icon="plus"

--- a/apps/roam/src/utils/getLeftSidebarSettings.ts
+++ b/apps/roam/src/utils/getLeftSidebarSettings.ts
@@ -36,6 +36,7 @@ export type LeftSidebarGlobalSectionConfig = {
 
 export type LeftSidebarConfig = {
   uid: string;
+  favoritesMigrated: BooleanSetting;
   global: LeftSidebarGlobalSectionConfig;
   personal: {
     uid: string;
@@ -170,8 +171,13 @@ export const getLeftSidebarSettings = (
   const leftSidebarChildren = leftSidebarNode?.children || [];
   const global = getLeftSidebarGlobalSectionConfig(leftSidebarChildren);
   const personal = getLeftSidebarPersonalSectionConfig(leftSidebarChildren);
+  const favoritesMigrated = getUidAndBooleanSetting({
+    tree: leftSidebarChildren,
+    text: "Favorites Migrated",
+  });
   return {
     uid: leftSidebarUid,
+    favoritesMigrated,
     global,
     personal,
   };

--- a/apps/roam/src/utils/initializeObserversAndListeners.ts
+++ b/apps/roam/src/utils/initializeObserversAndListeners.ts
@@ -243,15 +243,17 @@ export const initObservers = async ({
     useBody: true,
     className: "starred-pages-wrapper",
     callback: (el) => {
-      const isLeftSidebarEnabled = getUidAndBooleanSetting({
-        tree: configTree,
-        text: "(BETA) Left Sidebar",
-      }).value;
-      const container = el as HTMLDivElement;
-      if (isLeftSidebarEnabled) {
-        container.style.padding = "0";
-        void mountLeftSidebar(container, onloadArgs);
-      }
+      void (async () => {
+        const isLeftSidebarEnabled = getUidAndBooleanSetting({
+          tree: configTree,
+          text: "(BETA) Left Sidebar",
+        }).value;
+        const container = el as HTMLDivElement;
+        if (isLeftSidebarEnabled) {
+          container.style.padding = "0";
+          await mountLeftSidebar(container, onloadArgs);
+        }
+      })();
     },
   });
 

--- a/apps/roam/src/utils/initializeObserversAndListeners.ts
+++ b/apps/roam/src/utils/initializeObserversAndListeners.ts
@@ -250,7 +250,7 @@ export const initObservers = async ({
       const container = el as HTMLDivElement;
       if (isLeftSidebarEnabled) {
         container.style.padding = "0";
-        mountLeftSidebar(container, onloadArgs);
+        void mountLeftSidebar(container, onloadArgs);
       }
     },
   });


### PR DESCRIPTION
## Solution

Implemented one-time migration that extracts starred pages from Roam's native `.starred-pages` DOM and adds them to Left Sidebar $\to$ Global-Section $\to$ Children in the graph configuration.

## Cases Handled

1.  **Fresh Install (New Graph)**
    * **Condition:** No "Favorites Migrated" flag, no Personal-Section exists
    * **Action:** Extract starred pages $\to$ Add to Global-Section $\to$ Set flag
    * **Result:** User's favorites preserved in new sidebar

2.  **Existing Install (Collaborative Graph)**
    * **Condition:** Any user has `{userId}/Personal-Section` under Left Sidebar
    * **Action:** Skip extraction, set "Favorites Migrated" flag
    * **Result:** No migration runs, existing configuration untouched

3.  **Fresh Install, Multiple Sessions**
    * **Condition:** Migration ran in previous session, graph reopened
    * **Action:** Check "Favorites Migrated" flag $\to$ early return
    * **Result:** No duplicate migration

4.  **Multi-User Graph (Late Joiner)**
    * **Condition:** User B joins after User A already configured plugin
    * **Action:** Detects User A's Personal-Section exists $\to$ skip migration
    * **Result:** No interference with existing setup

## Key Design Decisions

* **Graph-level flag:** "Favorites Migrated" stored under Left Sidebar (not per-user) ensures migration happens once per graph
* **Personal-Section heuristic:** Check for `*/Personal-Section` pattern to detect if plugin already in use by any user
* **Cache refresh:** Call `refreshConfigTree()` after creating flag to prevent duplicate blocks in same session
* **Performance:** Flag check is $O(1)$, expensive tree traversal only runs once per graph lifetime

## Technical Notes

* Migration runs in `mountLeftSidebar` before DOM is cleared
* Uses `getUidAndBooleanSetting` pattern consistent with existing config flags
* Async operation with proper `await` chains to ensure flag is created before subsequent calls

https://www.loom.com/share/fc639adb1f4341d68403a19094b6dd8c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Starred pages now automatically migrate into the Left Sidebar with duplicate title deduplication.
  * Added a migration status setting so the app tracks when migration has completed.

* **Bug Fixes / Reliability**
  * Sidebar mounting now runs migration reliably during startup so migrated favorites appear consistently without user action.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->