### PR TITLE
ENG-1128 Remove "Add Or Edit" from Favorites setting menu

### DIFF
--- a/apps/roam/src/components/LeftSidebarView.tsx
+++ b/apps/roam/src/components/LeftSidebarView.tsx
@@ -13,7 +13,6 @@ import {
   Popover,
   Menu,
   MenuItem,
-  MenuDivider,
   Divider,
   Position,
   PopoverInteractionKind,
@@ -368,7 +367,6 @@ const FavoritesPopover = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
           minimal
           content={
             <Menu>
-              <MenuDivider title="Add Or Edit" />
               <MenuItem
                 text="Global Section"
                 onClick={() => {


### PR DESCRIPTION
Remove "Add Or Edit" from Favorites setting menu because it was redundant and misleading.

---
Linear Issue: [ENG-1128](https://linear.app/discourse-graphs/issue/ENG-1128/remove-add-or-edit-from-favorites-setting-menu)

<a href="https://cursor.com/background-agent?bcId=bc-0d1d1901-e75b-4fb2-abb5-a91341460d8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0d1d1901-e75b-4fb2-abb5-a91341460d8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

