### PR TITLE
ENG-1102 Create reified relation via canvas

### DIFF
--- a/apps/roam/src/components/canvas/DiscourseRelationShape/DiscourseRelationUtil.tsx
+++ b/apps/roam/src/components/canvas/DiscourseRelationShape/DiscourseRelationUtil.tsx
@@ -546,7 +546,7 @@ export const createAllRelationShapeUtils = (
           await createReifiedRelation({
             sourceUid: (source.props as DiscourseNodeShape["props"]).uid,
             destinationUid: (target.props as DiscourseNodeShape["props"]).uid,
-            relationBlockUid: arrow.type,
+            relationBlockUid: relation.id,
           });
         } else {
           const { triples, label: relationLabel } = relation;


### PR DESCRIPTION
This is a basic implementation of creation of reified relation through the canvas.
What is not handled yet: 
1. I think in this context I do not have to worry about inverse relations, is that accurate?
2. Should we destroy the relation if the user undoes the relation?
(In that case we should actually check if the relation preexisted, this is not simple.)
Is there a hook for undo actions?
Or is this out of scope?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a feature flag to control relation creation behavior. When enabled, relations are created using a new alternative method; when disabled, the original block-based approach continues. This provides flexibility for relation handling while maintaining complete backward compatibility with all existing data and workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->