### PR TITLE
ENG-1130 Enable parent node drag drop

### DIFF
--- a/apps/roam/src/components/canvas/Clipboard.tsx
+++ b/apps/roam/src/components/canvas/Clipboard.tsx
@@ -933,11 +933,20 @@ const ClipboardPageSection = ({
                   return (
                     <div key={group.uid} className="space-y-1">
                       <div
-                        className="group flex cursor-pointer items-center gap-2 rounded bg-white p-2 hover:bg-gray-50"
+                        className="group flex cursor-pointer items-center gap-2 rounded bg-white p-2 hover:bg-gray-50 active:cursor-grabbing"
+                        style={{ cursor: "grab" }}
+                        data-clipboard-node-uid={group.uid}
+                        data-clipboard-node-text={group.text}
                         onClick={(e) => {
                           e.stopPropagation();
+                          // Don't toggle if we just completed a drag operation
+                          if (rHasDragged.current) {
+                            return;
+                          }
                           toggleCollapse(group.uid);
                         }}
+                        onPointerDown={handlePointerDown}
+                        onPointerUp={handlePointerUp}
                       >
                         <div className="flex items-center gap-2">
                           <div className="flex items-center gap-1">


### PR DESCRIPTION
Enable drag and drop for parent node list items in the clipboard to allow users to drag the entire node when duplicates are present.

---
Linear Issue: [ENG-1130](https://linear.app/discourse-graphs/issue/ENG-1130/enable-drag-and-drop-for-parent-node-list-items-in-clipboard)

<a href="https://cursor.com/background-agent?bcId=bc-d71a42d8-da44-4ca0-8bd5-3f7c429b6b32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d71a42d8-da44-4ca0-8bd5-3f7c429b6b32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Clipboard items now support drag-and-drop interactions with intuitive visual cursor feedback (grab and grabbing states).
  * Added pointer event handling for seamless dragging of clipboard entries and duplicate item blocks.
  * Improved interaction logic that intelligently differentiates between drag operations and click-based navigation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->