### PR TITLE
ENG-1088 An affordance to delete reified relations

### DIFF
--- a/apps/roam/src/components/DiscourseContext.tsx
+++ b/apps/roam/src/components/DiscourseContext.tsx
@@ -269,9 +269,7 @@ const ContextTab = ({
       // TODO - always save settings, but maybe separate from root `parentUid`?
       preventSavingSettings
       parentUid={parentUid}
-      results={Object.values(results).map(
-        ({ target, complement, id, ...a }) => a as Result,
-      )}
+      results={Object.values(results).map(({ target, ...a }) => a as Result)}
       columns={columns}
       onRefresh={onRefresh}
       header={

--- a/apps/roam/src/components/results-view/ResultsTable.tsx
+++ b/apps/roam/src/components/results-view/ResultsTable.tsx
@@ -24,7 +24,6 @@ import DiscourseContextOverlay from "~/components/DiscourseContextOverlay";
 import { CONTEXT_OVERLAY_SUGGESTION } from "~/utils/predefinedSelections";
 import { getSetting } from "~/utils/extensionSettings";
 import { strictQueryForReifiedBlocks } from "~/utils/createReifiedBlock";
-import formatDistanceStrictWithOptions from "date-fns/esm/fp/formatDistanceStrictWithOptions/index.js";
 
 const EXTRA_ROW_TYPES = ["context", "discourse"] as const;
 type ExtraRowType = (typeof EXTRA_ROW_TYPES)[number] | null;
@@ -372,15 +371,19 @@ const ResultRow = ({
               ) : (
                 cell(key)
               )}
-              {useReifiedRel && r["ctxTargetUid"] !== undefined && (
-                <Button
-                  minimal
-                  icon="delete"
-                  className="float-right"
-                  title="Delete relation"
-                  onClick={onDelete}
-                ></Button>
-              )}
+              {useReifiedRel &&
+                typeof r["ctxTargetUid"] === "string" &&
+                typeof r["id"] === "string" &&
+                typeof r["complement"] === "number" &&
+                i === columns.length - 1 && (
+                  <Button
+                    minimal
+                    icon="delete"
+                    className="float-right"
+                    title="Delete relation"
+                    onClick={onDelete}
+                  ></Button>
+                )}
               {i < columns.length - 1 && (
                 <div
                   style={{

--- a/apps/roam/src/components/results-view/ResultsTable.tsx
+++ b/apps/roam/src/components/results-view/ResultsTable.tsx
@@ -274,6 +274,7 @@ const ResultRow = ({
       destinationUid: r["complement"] === 1 ? r["ctxTargetUid"] : r["uid"],
       hasSchema: r["id"],
     } as Record<string, string>;
+    // types got checked as a condition for displaying the button
     strictQueryForReifiedBlocks(data)
       .then((blockUid) => {
         if (blockUid === null) {

--- a/apps/roam/src/utils/createReifiedBlock.ts
+++ b/apps/roam/src/utils/createReifiedBlock.ts
@@ -6,7 +6,7 @@ export const DISCOURSE_GRAPH_PROP_NAME = "discourse-graph";
 
 const SANE_ROLE_NAME_RE = new RegExp(/^[\w\-]*$/);
 
-const strictQueryForReifiedBlocks = async (
+export const strictQueryForReifiedBlocks = async (
   parameterUids: Record<string, string>,
 ): Promise<string | null> => {
   const paramsAsSeq = Object.entries(parameterUids);

--- a/apps/roam/src/utils/getDiscourseContextResults.ts
+++ b/apps/roam/src/utils/getDiscourseContextResults.ts
@@ -76,7 +76,8 @@ const executeQueries = async (
   onResult?: onResult,
 ) => {
   const promises = queryConfigs.map(async ({ relation, queryPromise }) => {
-    const results = await queryPromise();
+    let results = await queryPromise();
+    results = results.map((r) => ({ ...r, ctxTargetUid: targetUid }));
     if (onResult) {
       const groupedResult = {
         label: relation.text,


### PR DESCRIPTION
https://linear.app/discourse-graphs/issue/ENG-1088/an-affordance-to-delete-reified-relations

This implements a "Delete relation" button near each discourse context search result (and in some cases query builder search results.) This is only visible if reified relations are on.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added delete functionality for reified relations in results. A delete button now appears for each relation entry when the reified relations setting is enabled, allowing users to remove relations directly from the results view.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->