### PR TITLE
ENG-1101 Create reified relation via suggestion mode

### DIFF
--- a/apps/roam/src/components/SuggestionsBody.tsx
+++ b/apps/roam/src/components/SuggestionsBody.tsx
@@ -29,6 +29,7 @@ import { type RelationDetails } from "~/utils/hyde";
 import { getFormattedConfigTree } from "~/utils/discourseConfigRef";
 import { render as renderToast } from "roamjs-components/components/Toast";
 import { getSetting } from "~/utils/extensionSettings";
+import { USE_REIFIED_RELATIONS } from "~/data/userSettings";
 import { createReifiedRelation } from "~/utils/createReifiedBlock";
 
 export type DiscourseData = {
@@ -308,7 +309,7 @@ const SuggestionsBody = ({
   };
 
   const handleCreateBlock = async (node: SuggestedNode) => {
-    if (getSetting("use-reified-relations")) {
+    if (getSetting<boolean>(USE_REIFIED_RELATIONS, false)) {
       if (discourseNode === false) {
         renderToast({
           id: "suggestions-create-block-error",

--- a/apps/roam/src/components/SuggestionsBody.tsx
+++ b/apps/roam/src/components/SuggestionsBody.tsx
@@ -19,9 +19,7 @@ import { performHydeSearch } from "../utils/hyde";
 import { createBlock } from "roamjs-components/writes";
 import getDiscourseContextResults from "~/utils/getDiscourseContextResults";
 import getPageUidByPageTitle from "roamjs-components/queries/getPageUidByPageTitle";
-import findDiscourseNode, {
-  findDiscourseNodeByTitleAndUid,
-} from "~/utils/findDiscourseNode";
+import findDiscourseNode from "~/utils/findDiscourseNode";
 import getDiscourseRelations from "~/utils/getDiscourseRelations";
 import getDiscourseNodes from "~/utils/getDiscourseNodes";
 import normalizePageTitle from "roamjs-components/queries/normalizePageTitle";
@@ -319,25 +317,11 @@ const SuggestionsBody = ({
         });
         return;
       }
-      const selectedNodeType = findDiscourseNodeByTitleAndUid({
-        uid: node.uid,
-        title: node.text,
-      });
-      if (selectedNodeType === false) {
-        renderToast({
-          id: "suggestions-create-block-error",
-          content: "Could not identify type of target",
-          intent: "danger",
-          timeout: 5000,
-        });
-        return;
-      }
       const relevantRelns = validRelations.filter(
         (rel) =>
-          (rel.source === selectedNodeType.type &&
+          (rel.source === node.type &&
             rel.destination === discourseNode.type) ||
-          (rel.destination === selectedNodeType.type &&
-            rel.source === discourseNode.type),
+          (rel.destination === node.type && rel.source === discourseNode.type),
       );
       if (relevantRelns.length) {
         if (relevantRelns.length > 1) {
@@ -347,7 +331,7 @@ const SuggestionsBody = ({
         }
         const rel = relevantRelns[0];
         try {
-          if (rel.destination === selectedNodeType.type)
+          if (rel.destination === node.type)
             await createReifiedRelation({
               sourceUid: tagUid,
               destinationUid: node.uid,

--- a/apps/roam/src/components/SuggestionsBody.tsx
+++ b/apps/roam/src/components/SuggestionsBody.tsx
@@ -309,10 +309,6 @@ const SuggestionsBody = ({
 
   const handleCreateBlock = async (node: SuggestedNode) => {
     if (getSetting("use-reified-relations")) {
-      const selectedNodeType = findDiscourseNodeByTitleAndUid({
-        uid: node.uid,
-        title: node.title as string,
-      });
       if (discourseNode === false) {
         renderToast({
           id: "suggestions-create-block-error",
@@ -322,6 +318,10 @@ const SuggestionsBody = ({
         });
         return;
       }
+      const selectedNodeType = findDiscourseNodeByTitleAndUid({
+        uid: node.uid,
+        title: node.text,
+      });
       if (selectedNodeType === false) {
         renderToast({
           id: "suggestions-create-block-error",
@@ -345,18 +345,29 @@ const SuggestionsBody = ({
           console.warn("Picking an arbitrary relation");
         }
         const rel = relevantRelns[0];
-        if (rel.destination === selectedNodeType.type)
-          await createReifiedRelation({
-            sourceUid: tagUid,
-            destinationUid: node.uid,
-            relationBlockUid: rel.id,
+        try {
+          if (rel.destination === selectedNodeType.type)
+            await createReifiedRelation({
+              sourceUid: tagUid,
+              destinationUid: node.uid,
+              relationBlockUid: rel.id,
+            });
+          else
+            await createReifiedRelation({
+              sourceUid: node.uid,
+              destinationUid: tagUid,
+              relationBlockUid: rel.id,
+            });
+        } catch (error) {
+          console.error("Failed to create reified relation:", error);
+          renderToast({
+            id: "suggestions-create-block-error",
+            content: "Failed to create relation",
+            intent: "danger",
+            timeout: 5000,
           });
-        else
-          await createReifiedRelation({
-            sourceUid: node.uid,
-            destinationUid: tagUid,
-            relationBlockUid: rel.id,
-          });
+          return;
+        }
       } else {
         renderToast({
           id: "suggestions-create-block-error",


### PR DESCRIPTION
https://linear.app/discourse-graphs/issue/ENG-1101/create-reified-relation-via-suggestion-mode

Create a reified relation from the suggestion mode.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a toggleable setting for block creation workflows. When enabled, an alternative creation flow with validation and relation processing is used; when disabled, the original method is preserved. Enhanced error notifications improve user feedback.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->