### PR TITLE
ENG-1139 - Sort clipboard nodes alphabetically

### DIFF
--- a/apps/roam/src/components/canvas/Clipboard.tsx
+++ b/apps/roam/src/components/canvas/Clipboard.tsx
@@ -529,12 +529,7 @@ const ClipboardPageSection = ({
       };
     });
 
-    return groups.sort((a, b) => {
-      if (a.isDuplicate !== b.isDuplicate) {
-        return a.isDuplicate ? -1 : 1;
-      }
-      return a.text.localeCompare(b.text);
-    });
+    return groups.sort((a, b) => a.text.localeCompare(b.text));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [discourseNodes, findShapesByUid, storeVersion]);
 


### PR DESCRIPTION
Remove sorting logic that prioritized duplicate nodes in the clipboard to maintain a stable alphabetical order.

Previously, nodes with multiple instances (duplicates) were moved to the top of the list, causing a jarring reorder when instances were added to the canvas. This change ensures nodes remain in their alphabetical position regardless of instance count.

---
Linear Issue: [ENG-1139](https://linear.app/discourse-graphs/issue/ENG-1139/sort-nodes-alphabetically-in-clipboard)

<a href="https://cursor.com/background-agent?bcId=bc-83baf95f-23a1-41e1-8495-7e4422ee4f48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-83baf95f-23a1-41e1-8495-7e4422ee4f48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

