### PR TITLE
[ENG-1072] Error "Folder already exists" when create new canvas

### DIFF
--- a/apps/obsidian/src/components/GeneralSettings.tsx
+++ b/apps/obsidian/src/components/GeneralSettings.tsx
@@ -191,13 +191,19 @@ const GeneralSettings = () => {
   }, []);
 
   const handleSave = async () => {
-    plugin.settings.showIdsInFrontmatter = showIdsInFrontmatter;
-    plugin.settings.nodesFolderPath = nodesFolderPath.trim();
-    plugin.settings.canvasFolderPath = canvasFolderPath.trim();
-    plugin.settings.canvasAttachmentsFolderPath =
+    const trimmedNodesFolderPath = nodesFolderPath.trim();
+    const trimmedCanvasFolderPath = canvasFolderPath.trim();
+    const trimmedCanvasAttachmentsFolderPath =
       canvasAttachmentsFolderPath.trim();
+    plugin.settings.showIdsInFrontmatter = showIdsInFrontmatter;
+    plugin.settings.nodesFolderPath = trimmedNodesFolderPath;
+    plugin.settings.canvasFolderPath = trimmedCanvasFolderPath;
+    plugin.settings.canvasAttachmentsFolderPath =
+      trimmedCanvasAttachmentsFolderPath;
     plugin.settings.nodeTagHotkey = nodeTagHotkey || "";
-
+    setNodesFolderPath(trimmedNodesFolderPath);
+    setCanvasFolderPath(trimmedCanvasFolderPath);
+    setCanvasAttachmentsFolderPath(trimmedCanvasAttachmentsFolderPath);
     await plugin.saveSettings();
     new Notice("General settings saved");
     setHasUnsavedChanges(false);

--- a/apps/obsidian/src/components/GeneralSettings.tsx
+++ b/apps/obsidian/src/components/GeneralSettings.tsx
@@ -192,10 +192,12 @@ const GeneralSettings = () => {
 
   const handleSave = async () => {
     plugin.settings.showIdsInFrontmatter = showIdsInFrontmatter;
-    plugin.settings.nodesFolderPath = nodesFolderPath;
-    plugin.settings.canvasFolderPath = canvasFolderPath;
-    plugin.settings.canvasAttachmentsFolderPath = canvasAttachmentsFolderPath;
+    plugin.settings.nodesFolderPath = nodesFolderPath.trim();
+    plugin.settings.canvasFolderPath = canvasFolderPath.trim();
+    plugin.settings.canvasAttachmentsFolderPath =
+      canvasAttachmentsFolderPath.trim();
     plugin.settings.nodeTagHotkey = nodeTagHotkey || "";
+
     await plugin.saveSettings();
     new Notice("General settings saved");
     setHasUnsavedChanges(false);

--- a/apps/obsidian/src/utils/file.ts
+++ b/apps/obsidian/src/utils/file.ts
@@ -2,13 +2,14 @@ import { TAbstractFile, TFolder, Vault, normalizePath } from "obsidian";
 
 export const checkAndCreateFolder = async (folderpath: string, vault: Vault) => {
   if (!folderpath) return;
+  const normalizedPath = normalizePath(folderpath);
 
-  const abstractItem = vault.getAbstractFileByPath(folderpath);
+  const abstractItem = vault.getAbstractFileByPath(normalizedPath);
   if (abstractItem instanceof TFolder) return;
   if (abstractItem instanceof TAbstractFile) {
-    throw new Error(`${folderpath} exists as a file`);
+    throw new Error(`${normalizedPath} exists as a file`);
   }
-  await vault.createFolder(folderpath);
+  await vault.createFolder(normalizedPath);
 };
 
 export const getNewUniqueFilepath = ({


### PR DESCRIPTION
The error was caused by Obsidian internally normalize the folder path when we call `vault.createFolder()`. eg: if we have `Discourse Canvas/` saved, then when normalized we have `Discourse Canvas`, which already exists. I made sure to normalize the name in both Saving and Creating step -> remove the error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved folder path handling in General Settings to automatically trim whitespace and normalize path formatting for configuration folders, ensuring cleaner and more reliable settings storage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->