### PR TITLE
eng-1144: DiscourseContext UI disappears

### DIFF
--- a/apps/roam/src/components/DiscourseContext.tsx
+++ b/apps/roam/src/components/DiscourseContext.tsx
@@ -228,7 +228,7 @@ const ContextTab = ({
   r: DiscourseContextResults[number];
   groupByTarget: boolean;
   setGroupByTarget: (b: boolean) => void;
-  onRefresh: () => void;
+  onRefresh: (ignoreCache?: boolean) => void;
 }) => {
   const [subTabId, setSubTabId] = useState(0);
 
@@ -345,14 +345,17 @@ export const ContextContent = ({ uid, results }: Props) => {
     }));
   }, []);
 
-  const onRefresh = useCallback(() => {
-    setRawQueryResults({});
-    getDiscourseContextResults({
-      uid,
-      onResult: addLabels,
-      ignoreCache: true,
-    }).finally(() => setLoading(false));
-  }, [uid, setRawQueryResults, setLoading, addLabels]);
+  const onRefresh = useCallback(
+    (ignoreCache = true) => {
+      setRawQueryResults({});
+      void getDiscourseContextResults({
+        uid,
+        onResult: addLabels,
+        ignoreCache,
+      }).finally(() => setLoading(false));
+    },
+    [uid, setRawQueryResults, setLoading, addLabels],
+  );
 
   const delayedRefresh = () => {
     window.setTimeout(onRefresh, 250);
@@ -360,7 +363,7 @@ export const ContextContent = ({ uid, results }: Props) => {
 
   useEffect(() => {
     if (!results) {
-      onRefresh();
+      onRefresh(false);
     } else {
       results.forEach(addLabels);
       setLoading(false);

--- a/apps/roam/src/components/results-view/ResultsTable.tsx
+++ b/apps/roam/src/components/results-view/ResultsTable.tsx
@@ -188,7 +188,7 @@ type ResultRowProps = {
   parentUid: string;
   ctrlClick?: (e: Result) => void;
   views: { column: string; mode: string; value: string }[];
-  onRefresh: () => void;
+  onRefresh: (ignoreCache?: boolean) => void;
 };
 
 const ResultRow = ({
@@ -391,7 +391,7 @@ const ResultsTable = ({
   setFilters: (f: FilterData) => void;
   preventSavingSettings?: boolean;
   views: Views;
-  onRefresh: () => void;
+  onRefresh: (ignoreCache?: boolean) => void;
   allResults: Result[];
   showInterface?: boolean;
 }) => {

--- a/apps/roam/src/components/results-view/ResultsView.tsx
+++ b/apps/roam/src/components/results-view/ResultsView.tsx
@@ -38,7 +38,7 @@ import Charts from "./Charts";
 import Timeline from "./Timeline";
 import Kanban from "./Kanban";
 import MenuItemSelect from "roamjs-components/components/MenuItemSelect";
-import { RoamBasicNode } from "roamjs-components/types";
+import type { RoamBasicNode } from "roamjs-components/types/native";
 import { render as renderToast } from "roamjs-components/components/Toast";
 import { Column, Result } from "~/utils/types";
 import updateBlock from "roamjs-components/writes/updateBlock";
@@ -238,7 +238,7 @@ type ResultsViewComponent = (props: {
   preventSavingSettings?: boolean;
   onEdit?: () => void;
   onDeleteQuery?: () => void;
-  onRefresh: (loadInBackground?: boolean) => void;
+  onRefresh: (ignoreCache?: boolean) => void;
   globalFiltersData?: Record<string, Filters>;
   globalPageSize?: number;
   isEditBlock?: boolean;
@@ -1369,7 +1369,7 @@ const ResultsView: ResultsViewComponent = ({
                 <Kanban
                   data={allProcessedResults}
                   layout={layout}
-                  onQuery={() => onRefresh(true)}
+                  onQuery={() => onRefresh()}
                   resultKeys={columns}
                   parentUid={parentUid}
                   views={views}

--- a/apps/roam/src/utils/getDiscourseContextResults.ts
+++ b/apps/roam/src/utils/getDiscourseContextResults.ts
@@ -13,7 +13,7 @@ const CACHE_TIMEOUT = 1000 * 60 * 5;
 
 type BuildQueryConfig = {
   args: {
-    ignoreCache?: true;
+    ignoreCache?: boolean;
   };
   targetUid: string;
   fireQueryContext: {

--- a/apps/roam/src/utils/getDiscourseContextResults.ts
+++ b/apps/roam/src/utils/getDiscourseContextResults.ts
@@ -176,7 +176,7 @@ const getDiscourseContextResults = async ({
   uid: string;
   nodes?: ReturnType<typeof getDiscourseNodes>;
   relations?: ReturnType<typeof getDiscourseRelations>;
-  ignoreCache?: true;
+  ignoreCache?: boolean;
   onResult?: onResult;
 }) => {
   const args = { ignoreCache };


### PR DESCRIPTION
Distinguish the onRefresh and forceRefresh function. 
The cache bypass was not consistent, leading to too many calls.
* Deleted a seemingly unused `loadInBackground` argument in the `onRefresh` signature
* updateCount variable so we both benefit from caching and can break it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved refresh and cache-control interfaces so components can request fresh or cached data more explicitly.
  * Coordinated refresh timing tightened to deliver more consistent contextual results across views (including Kanban and results lists).
  * Minor UI markup cleanup in results table for more stable rendering.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->