### PR TITLE
[ENG-1071] Fix styling for tldraw buttons in tldraw obsidian

### DIFF
--- a/apps/obsidian/src/styles/style.css
+++ b/apps/obsidian/src/styles/style.css
@@ -2320,7 +2320,8 @@ it from receiving any pointer events or affecting the cursor. */
 
 /* ----------------------- Kbd ---------------------- */
 
-.tlui-kbd {
+/* Override Obsidian's kbd styles - kbd.tlui-kbd is more specific than kbd */
+kbd.tlui-kbd {
 	font-family: inherit;
 	font-size: 11px;
 	line-height: 11px;
@@ -2332,6 +2333,7 @@ it from receiving any pointer events or affecting the cursor. */
 	align-self: bottom;
 	color: currentColor;
 	margin-left: var(--space-4);
+	background-color: var(--color-low) !important;
 }
 
 .tlui-kbd > span {


### PR DESCRIPTION
Light mode:
<img width="228" height="391" alt="image" src="https://github.com/user-attachments/assets/064574ff-4a07-422d-9c04-aafbf71e5283" />
Dark mode:
<img width="340" height="645" alt="Screenshot 2025-12-11 at 20 40 56" src="https://github.com/user-attachments/assets/fb93c80a-c217-4387-b230-7a8eed8441ce" />

change:
- higher level of specificity in css selectors, also setting the background color to be responsive to the mode.
