### PR TITLE
ENG-1145 multiple-errors-running-migrate-all-relations

### DIFF
--- a/apps/roam/src/components/Export.tsx
+++ b/apps/roam/src/components/Export.tsx
@@ -199,7 +199,7 @@ const ExportDialog: ExportDialogComponent = ({
       if (response.status === 401) {
         setGitHubAccessToken(null);
         setError("Authentication failed. Please log in again.");
-        setSetting("oauth-github", "");
+        await setSetting("oauth-github", "");
         return { status: 401 };
       }
       return { status: response.status };
@@ -222,7 +222,7 @@ const ExportDialog: ExportDialogComponent = ({
   const addToSelectedCanvas = async (pageUid: string) => {
     if (typeof results !== "object") return;
 
-    let props: Record<string, unknown> = getBlockProps(pageUid);
+    const props: Record<string, unknown> = getBlockProps(pageUid);
 
     const PADDING_BETWEEN_SHAPES = 20;
     const COMMON_BOUNDS_XOFFSET = 250;
@@ -309,10 +309,10 @@ const ExportDialog: ExportDialogComponent = ({
       let minY = Number.MAX_SAFE_INTEGER;
 
       shapes.forEach((shape) => {
-        let rightX = shape.x + shape.w;
-        let leftX = shape.x;
-        let topY = shape.y;
-        let bottomY = shape.y - shape.h;
+        const rightX = shape.x + shape.w;
+        const leftX = shape.x;
+        const topY = shape.y;
+        const bottomY = shape.y - shape.h;
 
         if (rightX > maxX) maxX = rightX;
         if (leftX < minX) minX = leftX;

--- a/apps/roam/src/components/ExportGithub.tsx
+++ b/apps/roam/src/components/ExportGithub.tsx
@@ -11,7 +11,6 @@ import MenuItemSelect from "roamjs-components/components/MenuItemSelect";
 import apiGet from "roamjs-components/util/apiGet";
 import apiPost from "roamjs-components/util/apiPost";
 import { getNodeEnv } from "roamjs-components/util/env";
-import getExtensionApi from "roamjs-components/util/extensionApiContext";
 import { setSetting } from "~/utils/extensionSettings";
 
 type UserReposResponse = {

--- a/apps/roam/src/components/ExportGithub.tsx
+++ b/apps/roam/src/components/ExportGithub.tsx
@@ -59,11 +59,11 @@ export const ExportGithub = ({
   const isDev = useMemo(() => getNodeEnv() === "development", []);
   const setRepo = (repo: string) => {
     setSelectedRepo(repo);
-    void setSetting("selected-repo", repo).catch();
+    void setSetting("selected-repo", repo).catch(() => undefined);
   };
 
-  const handleReceivedAccessToken = (token: string) => {
-    void setSetting("oauth-github", token).catch();
+  const handleReceivedAccessToken = (token: string): void => {
+    void setSetting("oauth-github", token).catch(() => undefined);
     setGitHubAccessToken(token);
     setClickedInstall(false);
     authWindow.current?.close();
@@ -92,7 +92,7 @@ export const ExportGithub = ({
 
       if (e.message === "Bad credentials") {
         setGitHubAccessToken(null);
-        void setSetting("oauth-github", "").catch();
+        void setSetting("oauth-github", "").catch(() => undefined);
       }
       return false;
     }

--- a/apps/roam/src/components/ExportGithub.tsx
+++ b/apps/roam/src/components/ExportGithub.tsx
@@ -59,11 +59,11 @@ export const ExportGithub = ({
   const isDev = useMemo(() => getNodeEnv() === "development", []);
   const setRepo = (repo: string) => {
     setSelectedRepo(repo);
-    setSetting("selected-repo", repo);
+    void setSetting("selected-repo", repo).catch();
   };
 
   const handleReceivedAccessToken = (token: string) => {
-    setSetting("oauth-github", token);
+    void setSetting("oauth-github", token).catch();
     setGitHubAccessToken(token);
     setClickedInstall(false);
     authWindow.current?.close();
@@ -92,7 +92,7 @@ export const ExportGithub = ({
 
       if (e.message === "Bad credentials") {
         setGitHubAccessToken(null);
-        setSetting("oauth-github", "");
+        void setSetting("oauth-github", "").catch();
       }
       return false;
     }

--- a/apps/roam/src/components/settings/AdminPanel.tsx
+++ b/apps/roam/src/components/settings/AdminPanel.tsx
@@ -254,7 +254,7 @@ const MigrationTab = (): React.ReactElement => {
   const [useOngoing, setOngoing] = useState<boolean>(false);
   const [useDryRun, setDryRun] = useState<boolean>(false);
   const [enabled, setEnabled] = useState<boolean>(
-    getSetting("use-reified-relations"),
+    getSetting("use-reified-relations", false),
   );
   const doMigrateRelations = async () => {
     setOngoing(true);
@@ -336,7 +336,7 @@ const FeatureFlagsTab = (): React.ReactElement => {
         onChange={(e) => {
           const target = e.target as HTMLInputElement;
           setUseReifiedRelations(target.checked);
-          setSetting("use-reified-relations", target.checked);
+          void setSetting("use-reified-relations", target.checked).catch();
         }}
         labelElement={
           <>

--- a/apps/roam/src/components/settings/AdminPanel.tsx
+++ b/apps/roam/src/components/settings/AdminPanel.tsx
@@ -250,10 +250,12 @@ const NodeListTab = (): React.ReactElement => {
 
 const MigrationTab = (): React.ReactElement => {
   let initial = true;
-  const enabled = getSetting("use-reified-relations");
   const [useMigrationResults, setMigrationResults] = useState<string>("");
   const [useOngoing, setOngoing] = useState<boolean>(false);
   const [useDryRun, setDryRun] = useState<boolean>(false);
+  const [enabled, setEnabled] = useState<boolean>(
+    getSetting("use-reified-relations"),
+  );
   const doMigrateRelations = async () => {
     setOngoing(true);
     try {
@@ -271,6 +273,7 @@ const MigrationTab = (): React.ReactElement => {
         `Migration failed: ${(e as Error).message ?? "see console for details"}`,
       );
     } finally {
+      setEnabled(true);
       setOngoing(false);
     }
   };

--- a/apps/roam/src/components/settings/AdminPanel.tsx
+++ b/apps/roam/src/components/settings/AdminPanel.tsx
@@ -336,7 +336,9 @@ const FeatureFlagsTab = (): React.ReactElement => {
         onChange={(e) => {
           const target = e.target as HTMLInputElement;
           setUseReifiedRelations(target.checked);
-          void setSetting("use-reified-relations", target.checked).catch();
+          void setSetting("use-reified-relations", target.checked).catch(
+            () => undefined,
+          );
         }}
         labelElement={
           <>

--- a/apps/roam/src/components/settings/DiscourseRelationConfigPanel.tsx
+++ b/apps/roam/src/components/settings/DiscourseRelationConfigPanel.tsx
@@ -913,7 +913,7 @@ export const RelationEditPanel = ({
                 void setSetting(
                   "discourse-relation-copy",
                   JSON.stringify(elementsRef.current[tab]),
-                ).catch();
+                ).catch(() => undefined);
                 renderToast({
                   id: "relation-copy",
                   content: "Copied Relation",

--- a/apps/roam/src/components/settings/DiscourseRelationConfigPanel.tsx
+++ b/apps/roam/src/components/settings/DiscourseRelationConfigPanel.tsx
@@ -910,10 +910,10 @@ export const RelationEditPanel = ({
               disabled={loading}
               onClick={() => {
                 saveCyToElementRef(tab);
-                setSetting(
+                void setSetting(
                   "discourse-relation-copy",
                   JSON.stringify(elementsRef.current[tab]),
-                );
+                ).catch();
                 renderToast({
                   id: "relation-copy",
                   content: "Copied Relation",

--- a/apps/roam/src/components/settings/HomePersonalSettings.tsx
+++ b/apps/roam/src/components/settings/HomePersonalSettings.tsx
@@ -218,7 +218,7 @@ const HomePersonalSettings = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
           void setSetting(
             DISCOURSE_CONTEXT_OVERLAY_IN_CANVAS_KEY,
             target.checked,
-          ).catch();
+          ).catch(() => undefined);
         }}
         labelElement={
           <>
@@ -235,7 +235,9 @@ const HomePersonalSettings = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
         defaultChecked={getSetting(STREAMLINE_STYLING_KEY, false)}
         onChange={(e) => {
           const target = e.target as HTMLInputElement;
-          void setSetting(STREAMLINE_STYLING_KEY, target.checked).catch();
+          void setSetting(STREAMLINE_STYLING_KEY, target.checked).catch(
+            () => undefined,
+          );
 
           // Load or unload the streamline styling
           const existingStyleElement =

--- a/apps/roam/src/components/settings/HomePersonalSettings.tsx
+++ b/apps/roam/src/components/settings/HomePersonalSettings.tsx
@@ -215,7 +215,10 @@ const HomePersonalSettings = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
         )}
         onChange={(e) => {
           const target = e.target as HTMLInputElement;
-          setSetting(DISCOURSE_CONTEXT_OVERLAY_IN_CANVAS_KEY, target.checked);
+          void setSetting(
+            DISCOURSE_CONTEXT_OVERLAY_IN_CANVAS_KEY,
+            target.checked,
+          ).catch();
         }}
         labelElement={
           <>
@@ -232,7 +235,7 @@ const HomePersonalSettings = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
         defaultChecked={getSetting(STREAMLINE_STYLING_KEY, false)}
         onChange={(e) => {
           const target = e.target as HTMLInputElement;
-          setSetting(STREAMLINE_STYLING_KEY, target.checked);
+          void setSetting(STREAMLINE_STYLING_KEY, target.checked).catch();
 
           // Load or unload the streamline styling
           const existingStyleElement =

--- a/apps/roam/src/utils/extensionSettings.ts
+++ b/apps/roam/src/utils/extensionSettings.ts
@@ -1,6 +1,6 @@
 import getExtensionAPI from "roamjs-components/util/extensionApiContext";
 
-export function getSetting<T>(key: string, defaultValue?: T): T {
+export const getSetting = <T>(key: string, defaultValue?: T): T => {
   const extensionAPI = getExtensionAPI();
   const value = extensionAPI.settings.get(key);
 
@@ -8,9 +8,9 @@ export function getSetting<T>(key: string, defaultValue?: T): T {
     return value as T;
   }
   return defaultValue as T;
-}
+};
 
-export function setSetting<T>(key: string, value: T): void {
+export const setSetting = async <T>(key: string, value: T): Promise<void> => {
   const extensionAPI = getExtensionAPI();
-  extensionAPI.settings.set(key, value);
-}
+  await extensionAPI.settings.set(key, value);
+};

--- a/apps/roam/src/utils/migrateRelations.ts
+++ b/apps/roam/src/utils/migrateRelations.ts
@@ -2,7 +2,7 @@ import getRelationData from "./getRelationData";
 import getBlockProps from "./getBlockProps";
 import type { json } from "./getBlockProps";
 import setBlockProps from "./setBlockProps";
-import { getSetting } from "./extensionSettings";
+import { getSetting, setSetting } from "./extensionSettings";
 import {
   createReifiedRelation,
   DISCOURSE_GRAPH_PROP_NAME,
@@ -13,50 +13,56 @@ const MIGRATION_PROP_NAME = "relation-migration";
 const migrateRelations = async (dryRun = false): Promise<number> => {
   const authorized = getSetting("use-reified-relations");
   if (!authorized) return 0;
-  const processed = new Set<string>();
-  const relationData = await getRelationData();
   let numProcessed = 0;
-  for (const rel of relationData) {
-    const key = `${rel.source}:${rel.relUid}:${rel.target}`;
-    if (processed.has(key)) continue;
-    processed.add(key);
-    if (!dryRun) {
-      const uid = (await createReifiedRelation({
-        sourceUid: rel.source,
-        destinationUid: rel.target,
-        relationBlockUid: rel.relUid,
-      }))!;
-      const sourceProps = getBlockProps(rel.source);
-      const dgDataOrig = sourceProps[DISCOURSE_GRAPH_PROP_NAME];
-      const dgData: Record<string, json> =
-        dgDataOrig !== null &&
-        typeof dgDataOrig === "object" &&
-        !Array.isArray(dgDataOrig)
-          ? dgDataOrig
-          : {};
-      const migrationDataOrig = dgData[MIGRATION_PROP_NAME];
-      let migrationData: Record<string, json> =
-        migrationDataOrig !== null &&
-        typeof migrationDataOrig === "object" &&
-        !Array.isArray(migrationDataOrig)
-          ? migrationDataOrig
-          : {};
-      if (migrationData[uid] !== undefined) {
-        console.debug(`reprocessed ${key}`);
+  await setSetting("use-reified-relations", false); // so queries use patterns
+  try {
+    const processed = new Set<string>();
+    const relationData = await getRelationData();
+    for (const rel of relationData) {
+      const key = `${rel.source}:${rel.relUid}:${rel.target}`;
+      if (processed.has(key)) continue;
+      processed.add(key);
+      if (!dryRun) {
+        const uid = (await createReifiedRelation({
+          sourceUid: rel.source,
+          destinationUid: rel.target,
+          relationBlockUid: rel.relUid,
+        }))!;
+        const sourceProps = getBlockProps(rel.source);
+        const dgDataOrig = sourceProps[DISCOURSE_GRAPH_PROP_NAME];
+        const dgData: Record<string, json> =
+          dgDataOrig !== null &&
+          typeof dgDataOrig === "object" &&
+          !Array.isArray(dgDataOrig)
+            ? dgDataOrig
+            : {};
+        const migrationDataOrig = dgData[MIGRATION_PROP_NAME];
+        let migrationData: Record<string, json> =
+          migrationDataOrig !== null &&
+          typeof migrationDataOrig === "object" &&
+          !Array.isArray(migrationDataOrig)
+            ? migrationDataOrig
+            : {};
+        if (migrationData[uid] !== undefined) {
+          console.debug(`reprocessed ${key}`);
+        }
+        // clean up old migration entries
+        migrationData = Object.fromEntries(
+          Object.entries(migrationData).filter(
+            ([uid]) =>
+              window.roamAlphaAPI.q(
+                `[:find ?p :where [?p :block/uid "${uid}"]]`,
+              ).length > 0,
+          ),
+        );
+        migrationData[uid] = new Date().valueOf();
+        dgData[MIGRATION_PROP_NAME] = migrationData;
+        setBlockProps(rel.source, { [DISCOURSE_GRAPH_PROP_NAME]: dgData });
       }
-      // clean up old migration entries
-      migrationData = Object.fromEntries(
-        Object.entries(migrationData).filter(
-          ([uid]) =>
-            window.roamAlphaAPI.q(`[:find ?p :where [?p :block/uid "${uid}"]]`)
-              .length > 0,
-        ),
-      );
-      migrationData[uid] = new Date().valueOf();
-      dgData[MIGRATION_PROP_NAME] = migrationData;
-      setBlockProps(rel.source, { [DISCOURSE_GRAPH_PROP_NAME]: dgData });
+      numProcessed++;
     }
-    numProcessed++;
+  } finally {
+    await setSetting("use-reified-relations", true);
   }
   return numProcessed;
 };


### PR DESCRIPTION
https://linear.app/discourse-graphs/issue/ENG-1145/multiple-errors-running-migrate-all-relations
There are two issues: One is that the migration code is run when reified relations are active, and hence use the reified relations instead of the patterns as basis. Wrap the migration in a change of setting, which happens to be async (made changes accordingly)
The other issue is hammering the server: the check-for-duplicate query is short enough, and likely to be used often enough, that it's worth not using the server for it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GitHub export authentication handling to avoid stuck states on auth errors.

* **Refactor**
  * Migration UI reliably re-enables controls after processing.
  * Reified-relations flow simplified and now runs by default.
  * Internal shape/coordinate computations made immutable for safety.

* **Chores**
  * Settings persistence and feature toggles use non-blocking calls that suppress unhandled promise rejections.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->