### PR TITLE
eng-1135 define internalError

### DIFF
--- a/apps/roam/src/components/CreateRelationDialog.tsx
+++ b/apps/roam/src/components/CreateRelationDialog.tsx
@@ -103,8 +103,8 @@ const CreateRelationDialog = ({
     if (selectedTargetType === false) {
       // should not happen at this point, since the pattern was vetted at input.
       internalError({
-        type: "create-relation-error",
-        error: "Create Relation dialog: Could not identify node downstream",
+        type: "Create Relation dialog",
+        error: "Could not identify node downstream",
       });
       return null;
     }
@@ -126,16 +126,16 @@ const CreateRelationDialog = ({
     if (candidateRelations.length === 0) {
       // also should not happen
       internalError({
-        type: "create-relation-error",
-        error: "Create Relation dialog: Could not find the relation",
+        type: "Create Relation dialog",
+        error: "Could not find the relation",
       });
       return null;
     }
     if (candidateRelations.length !== 1) {
       // This seems to happen... I need more data.
       internalError({
-        type: "create-relation-error",
-        error: `Create Relation dialog: Too many relations between ${selectedTargetType.type} and ${selectedSourceType.type}: ${candidateRelations.map((r) => r.id).join(",")}`,
+        type: "Create Relation dialog",
+        error: `Too many relations between ${selectedTargetType.type} and ${selectedSourceType.type}: ${candidateRelations.map((r) => r.id).join(",")}`,
       });
       return null;
     }
@@ -286,8 +286,8 @@ const prepareRelData = (
   if (!nodeSchema) {
     // should not happen at this point, since the pattern was vetted at input.
     internalError({
-      error: "Create Relation dialog: Could not identify node downstream",
-      type: "create-relation-error",
+      error: "Could not identify node downstream",
+      type: "Create Relation dialog",
     });
     return [];
   }

--- a/apps/roam/src/components/CreateRelationDialog.tsx
+++ b/apps/roam/src/components/CreateRelationDialog.tsx
@@ -104,8 +104,7 @@ const CreateRelationDialog = ({
       // should not happen at this point, since the pattern was vetted at input.
       internalError({
         type: "create-relation-error",
-        error:
-          "Create Relation dialog: Could not find identify node downstream",
+        error: "Create Relation dialog: Could not identify node downstream",
       });
       return null;
     }
@@ -287,7 +286,7 @@ const prepareRelData = (
   if (!nodeSchema) {
     // should not happen at this point, since the pattern was vetted at input.
     internalError({
-      error: "Create Relation dialog: Could not find identify node downstream",
+      error: "Create Relation dialog: Could not identify node downstream",
       type: "create-relation-error",
     });
     return [];

--- a/apps/roam/src/components/CreateRelationDialog.tsx
+++ b/apps/roam/src/components/CreateRelationDialog.tsx
@@ -20,6 +20,7 @@ import { createReifiedRelation } from "~/utils/createReifiedBlock";
 import { findDiscourseNodeByTitleAndUid } from "~/utils/findDiscourseNode";
 import { getDiscourseNodeFormatInnerExpression } from "~/utils/getDiscourseNodeFormatExpression";
 import type { DiscourseNode } from "~/utils/getDiscourseNodes";
+import type { Result } from "~/utils/types";
 import internalError from "~/utils/internalError";
 import getDiscourseNodes from "~/utils/getDiscourseNodes";
 

--- a/apps/roam/src/components/Export.tsx
+++ b/apps/roam/src/components/Export.tsx
@@ -54,7 +54,7 @@ import {
 import calcCanvasNodeSizeAndImg from "~/utils/calcCanvasNodeSizeAndImg";
 import { DiscourseNodeShape } from "~/components/canvas/DiscourseNodeUtil";
 import { MAX_WIDTH } from "~/components/canvas/Tldraw";
-import sendErrorEmail from "~/utils/sendErrorEmail";
+import internalError from "~/utils/internalError";
 import { getSetting, setSetting } from "~/utils/extensionSettings";
 
 const ExportProgress = ({ id }: { id: string }) => {
@@ -468,13 +468,12 @@ const ExportDialog: ExportDialogComponent = ({
         id: "query-builder-export-success",
       });
     } catch (e) {
-      const error = e as Error;
-      renderToast({
-        content: "Looks like there was an error. The team has been notified.",
-        intent: "danger",
-        id: "discourse-graphs-error",
+      internalError({
+        error: e as Error,
+        type: "export-error",
+        userMessage:
+          "Looks like there was an error. The team has been notified.",
       });
-      sendErrorEmail({ error, type: "Export Dialog Failed" }).catch(() => {});
     } finally {
       setLoading(false);
       onClose();
@@ -688,18 +687,13 @@ const ExportDialog: ExportDialogComponent = ({
                     setError(`Unsupported export type: ${exportType}`);
                   }
                 } catch (e) {
-                  const error = e as Error;
-                  renderToast({
-                    id: "export-error",
-                    content:
+                  internalError({
+                    error: e as Error,
+                    type: "export-error",
+                    userMessage:
                       "Looks like there was an error. The team has been notified.",
-                    intent: "danger",
-                  });
-                  sendErrorEmail({
-                    error,
-                    type: "Export Dialog Failed",
                     context: { activeExportType, filename, results },
-                  }).catch(() => {});
+                  });
                   setDialogOpen(true);
                   setError((e as Error).message);
                 } finally {

--- a/apps/roam/src/components/Export.tsx
+++ b/apps/roam/src/components/Export.tsx
@@ -470,7 +470,7 @@ const ExportDialog: ExportDialogComponent = ({
     } catch (e) {
       internalError({
         error: e as Error,
-        type: "export-error",
+        type: "Export Dialog Failed",
         userMessage:
           "Looks like there was an error. The team has been notified.",
       });
@@ -689,7 +689,7 @@ const ExportDialog: ExportDialogComponent = ({
                 } catch (e) {
                   internalError({
                     error: e as Error,
-                    type: "export-error",
+                    type: "Export Dialog Failed",
                     userMessage:
                       "Looks like there was an error. The team has been notified.",
                     context: {

--- a/apps/roam/src/components/Export.tsx
+++ b/apps/roam/src/components/Export.tsx
@@ -692,7 +692,16 @@ const ExportDialog: ExportDialogComponent = ({
                     type: "export-error",
                     userMessage:
                       "Looks like there was an error. The team has been notified.",
-                    context: { activeExportType, filename, results },
+                    context: {
+                      activeExportType,
+                      filename,
+                      resultsCount: Array.isArray(results)
+                        ? results.length
+                        : undefined,
+                      sampleUids: Array.isArray(results)
+                        ? results.slice(0, 10).map((r) => r.uid)
+                        : undefined,
+                    },
                   });
                   setDialogOpen(true);
                   setError((e as Error).message);

--- a/apps/roam/src/components/canvas/Clipboard.tsx
+++ b/apps/roam/src/components/canvas/Clipboard.tsx
@@ -141,8 +141,8 @@ export const ClipboardProvider = ({
         const userUid = getCurrentUserUid();
         if (!userUid) {
           internalError({
-            error: new Error("Canvas Clipboard: Missing current user UID"),
-            type: "canvas-clipboard-missing-uid",
+            error: new Error("Missing current user UID"),
+            type: "Canvas Clipboard: Missing current user UID",
             context: {
               canvasPageTitle,
             },
@@ -169,7 +169,7 @@ export const ClipboardProvider = ({
       } catch (error) {
         internalError({
           error,
-          type: "canvas-clipboard-initialization-error",
+          type: "Canvas Clipboard: Failed to initialize",
           context: { canvasPageTitle },
         });
       } finally {
@@ -190,7 +190,7 @@ export const ClipboardProvider = ({
     } catch (error) {
       internalError({
         error,
-        type: "canvas-clipboard-state-save-error",
+        type: "Canvas Clipboard: Failed to persist state",
         context: { clipboardBlockUid, pageCount: pages.length },
       });
     }
@@ -434,7 +434,7 @@ const ClipboardPageSection = ({
       } catch (error) {
         internalError({
           error,
-          type: "canvas-clipboard-discourse-node-error",
+          type: "Canvas Clipboard: Failed to fetch discourse nodes",
           context: { pageTitle: page.text },
         });
         setDiscourseNodes([]);
@@ -593,7 +593,7 @@ const ClipboardPageSection = ({
       if (!nodeType) {
         internalError({
           error: new Error("Canvas Clipboard: Node type not found"),
-          type: "canvas-clipboard-type-not-found",
+          type: "Canvas Clipboard: Node type not found",
           context: { uid: node.uid },
         });
         return;

--- a/apps/roam/src/components/canvas/DiscourseRelationShape/DiscourseRelationUtil.tsx
+++ b/apps/roam/src/components/canvas/DiscourseRelationShape/DiscourseRelationUtil.tsx
@@ -80,7 +80,7 @@ import getCurrentPageUid from "roamjs-components/dom/getCurrentPageUid";
 import getPageTitleByPageUid from "roamjs-components/queries/getPageTitleByPageUid";
 import { AddReferencedNodeType } from "./DiscourseRelationTool";
 import { dispatchToastEvent } from "~/components/canvas/ToastListener";
-import sendErrorEmail from "~/utils/sendErrorEmail";
+import internalError from "~/utils/internalError";
 
 const COLOR_ARRAY = Array.from(textShapeProps.color.values)
   .filter((c) => !["red", "green", "grey"].includes(c))
@@ -564,12 +564,10 @@ export const createAllRelationShapeUtils = (
               relationBlockUid: relation.id,
             });
           else {
-            void sendErrorEmail({
-              error: new Error(
-                "attempt to create a relation between non discourse nodes",
-              ),
-              type: "canvas-create-relation-non-dgn",
-            }).catch(() => undefined);
+            void internalError({
+              error: "attempt to create a relation between non discourse nodes",
+              type: "Canvas create relation",
+            });
           }
         } else {
           const { triples, label: relationLabel } = relation;

--- a/apps/roam/src/components/canvas/Tldraw.tsx
+++ b/apps/roam/src/components/canvas/Tldraw.tsx
@@ -86,7 +86,7 @@ import { createMigrations } from "./DiscourseRelationShape/discourseRelationMigr
 import ToastListener, { dispatchToastEvent } from "./ToastListener";
 import { CanvasDrawerPanel } from "./CanvasDrawer";
 import { ClipboardPanel, ClipboardProvider } from "./Clipboard";
-import sendErrorEmail from "~/utils/sendErrorEmail";
+import internalError from "~/utils/internalError";
 import { AUTO_CANVAS_RELATIONS_KEY } from "~/data/userSettings";
 import { getSetting } from "~/utils/extensionSettings";
 import { isPluginTimerReady, waitForPluginTimer } from "~/utils/pluginTimer";
@@ -516,16 +516,14 @@ const TldrawCanvas = ({ title }: { title: string }) => {
         error.stack = e.detail.stack;
       }
 
-      sendErrorEmail({
+      internalError({
         error,
-        type: "Tldraw Error",
+        type: "tldraw-error",
         context: {
           title: title,
           lastActions: lastActionsRef.current,
         },
-      }).catch(() => {});
-
-      console.error("Tldraw Error:", e.detail);
+      });
     };
 
     document.addEventListener(

--- a/apps/roam/src/components/canvas/Tldraw.tsx
+++ b/apps/roam/src/components/canvas/Tldraw.tsx
@@ -518,7 +518,7 @@ const TldrawCanvas = ({ title }: { title: string }) => {
 
       internalError({
         error,
-        type: "tldraw-error",
+        type: "Tldraw Error",
         context: {
           title: title,
           lastActions: lastActionsRef.current,

--- a/apps/roam/src/components/canvas/useRoamStore.ts
+++ b/apps/roam/src/components/canvas/useRoamStore.ts
@@ -169,7 +169,7 @@ export const useRoamStore = ({
     } catch (e) {
       handleStoreError({
         error: e as Error,
-        type: "tlstore-creation-failure",
+        type: "Failed to create TLStore",
       });
       return null;
     }
@@ -180,7 +180,7 @@ export const useRoamStore = ({
       } catch (e) {
         handleStoreError({
           error: e as Error,
-          type: "snapshot-migration-failure",
+          type: "Failed to migrate snapshot",
         });
         return null;
       }
@@ -305,7 +305,7 @@ export const useRoamStore = ({
       setError(error);
       internalError({
         error,
-        type: "canvas-upgrade-error",
+        type: "Failed to perform Canvas upgrade",
         context: {
           data: { oldData },
         },

--- a/apps/roam/src/components/canvas/useRoamStore.ts
+++ b/apps/roam/src/components/canvas/useRoamStore.ts
@@ -25,8 +25,7 @@ import {
 } from "tldraw";
 import { AddPullWatch } from "roamjs-components/types";
 import { LEGACY_SCHEMA } from "~/data/legacyTldrawSchema";
-import sendErrorEmail from "~/utils/sendErrorEmail";
-import getCurrentUserDisplayName from "roamjs-components/queries/getCurrentUserDisplayName";
+import internalError from "~/utils/internalError";
 
 const THROTTLE = 350;
 
@@ -142,21 +141,20 @@ export const useRoamStore = ({
       error: Error;
       errorMessage: string;
     }): void => {
-      console.error(errorMessage, error);
       setError(error);
       setLoading(false);
       const snapshotSize = initialSnapshot
         ? JSON.stringify(initialSnapshot).length
         : 0;
-      sendErrorEmail({
+      internalError({
         error,
-        type: errorMessage,
+        type: "roam-store-error",
         context: {
           pageUid,
           snapshotSize,
           ...(snapshotSize < 10000 ? { initialSnapshot } : {}),
         },
-      }).catch(() => {});
+      });
     };
 
     // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -305,14 +303,13 @@ export const useRoamStore = ({
       setNeedsUpgrade(false);
       setInitialSnapshot(null);
       setError(error);
-      sendErrorEmail({
+      internalError({
         error,
-        type: "Failed to perform Canvas upgrade",
+        type: "canvas-upgrade-error",
         context: {
           data: { oldData },
         },
-      }).catch(() => {});
-      console.error("Failed to perform Canvas upgrade", error);
+      });
     }
   };
 

--- a/apps/roam/src/components/canvas/useRoamStore.ts
+++ b/apps/roam/src/components/canvas/useRoamStore.ts
@@ -136,10 +136,10 @@ export const useRoamStore = ({
 
     const handleStoreError = ({
       error,
-      errorMessage,
+      type,
     }: {
       error: Error;
-      errorMessage: string;
+      type: string;
     }): void => {
       setError(error);
       setLoading(false);
@@ -148,7 +148,7 @@ export const useRoamStore = ({
         : 0;
       internalError({
         error,
-        type: "roam-store-error",
+        type,
         context: {
           pageUid,
           snapshotSize,
@@ -169,7 +169,7 @@ export const useRoamStore = ({
     } catch (e) {
       handleStoreError({
         error: e as Error,
-        errorMessage: "Failed to create TLStore",
+        type: "tlstore-creation-failure",
       });
       return null;
     }
@@ -180,7 +180,7 @@ export const useRoamStore = ({
       } catch (e) {
         handleStoreError({
           error: e as Error,
-          errorMessage: "Failed to migrate snapshot",
+          type: "snapshot-migration-failure",
         });
         return null;
       }

--- a/apps/roam/src/components/settings/AdminPanel.tsx
+++ b/apps/roam/src/components/settings/AdminPanel.tsx
@@ -30,7 +30,7 @@ import {
 import migrateRelations from "~/utils/migrateRelations";
 import { countReifiedRelations } from "~/utils/createReifiedBlock";
 import { DGSupabaseClient } from "@repo/database/lib/client";
-import sendErrorEmail from "~/utils/sendErrorEmail";
+import internalError from "~/utils/internalError";
 import SuggestiveModeSettings from "./SuggestiveModeSettings";
 import { getFormattedConfigTree } from "~/utils/discourseConfigRef";
 import refreshConfigTree from "~/utils/refreshConfigTree";
@@ -452,7 +452,7 @@ const FeatureFlagsTab = (): React.ReactElement => {
           internalError({
             error: new Error("test"),
             type: "Test",
-            sendErrorEmail: true,
+            sendEmail: true,
             forceSendInDev: true,
           });
         }}

--- a/apps/roam/src/components/settings/AdminPanel.tsx
+++ b/apps/roam/src/components/settings/AdminPanel.tsx
@@ -452,6 +452,7 @@ const FeatureFlagsTab = (): React.ReactElement => {
           internalError({
             error: new Error("test"),
             type: "Test",
+            sendErrorEmail: true,
             forceSendInDev: true,
           });
         }}

--- a/apps/roam/src/components/settings/AdminPanel.tsx
+++ b/apps/roam/src/components/settings/AdminPanel.tsx
@@ -449,10 +449,11 @@ const FeatureFlagsTab = (): React.ReactElement => {
         icon="send-message"
         onClick={() => {
           console.log("sending error email");
-          sendErrorEmail({
+          internalError({
             error: new Error("test"),
             type: "Test",
-          }).catch(() => {});
+            forceSendInDev: true,
+          });
         }}
       >
         Send Error Email

--- a/apps/roam/src/utils/getRelationData.ts
+++ b/apps/roam/src/utils/getRelationData.ts
@@ -2,6 +2,7 @@ import fireQuery from "./fireQuery";
 import getDiscourseNodes from "./getDiscourseNodes";
 import getDiscourseRelations from "./getDiscourseRelations";
 import type { DiscourseRelation } from "./getDiscourseRelations";
+import internalError from "./internalError";
 
 // lifted from getExportTypes
 
@@ -39,14 +40,23 @@ export const getRelationDataUtil = async (
                   label: "target",
                 },
               ],
-            }).then((results) =>
-              results.map((result) => ({
-                source: result.uid,
-                target: result["target-uid"],
-                relUid: s.id,
-                label: s.label,
-              })),
-            );
+            })
+              .then((results) =>
+                results.map((result) => ({
+                  source: result.uid,
+                  target: result["target-uid"],
+                  relUid: s.id,
+                  label: s.label,
+                })),
+              )
+              .catch((error) => {
+                internalError({
+                  error,
+                  type: "Get relation data",
+                  userMessage: `Could not find relations of type ${s.label}`,
+                });
+                return [];
+              });
       }),
   ).then((r) => r.flat());
 

--- a/apps/roam/src/utils/internalError.ts
+++ b/apps/roam/src/utils/internalError.ts
@@ -1,0 +1,55 @@
+import posthog from "posthog-js";
+import type { Properties } from "posthog-js";
+import renderToast from "roamjs-components/components/Toast";
+import { getVersionWithDate } from "~/utils/getVersion";
+import getCurrentUserDisplayName from "roamjs-components/queries/getCurrentUserDisplayName";
+
+const internalError = ({
+  error,
+  userMessage,
+  type,
+  context,
+}: {
+  error: unknown;
+  type?: string;
+  userMessage?: string;
+  context?: Properties;
+}) => {
+  if (process.env.NODE_ENV === "development") {
+    console.error(error, context);
+  } else {
+    const { version, buildDate } = getVersionWithDate();
+    const username = getCurrentUserDisplayName();
+    if (username) posthog.identify(username);
+    context = {
+      app: "Roam",
+      type: type || "internal-error",
+      graphName: window.roamAlphaAPI?.graph?.name || "unknown",
+      version: version || "-",
+      buildDate: buildDate || "-",
+      ...(context || {}),
+    };
+
+    if (typeof error === "string") {
+      error = new Error(error);
+    } else if (!(error instanceof Error)) {
+      try {
+        const serialized = JSON.stringify(error);
+        error = new Error(serialized);
+      } catch {
+        error = new Error(typeof error);
+      }
+    }
+    posthog.captureException(error, context);
+  }
+  if (userMessage !== undefined) {
+    renderToast({
+      id: `${type || "internal-error"}-${Date.now()}`,
+      intent: "danger",
+      timeout: 5000,
+      content: userMessage,
+    });
+  }
+};
+
+export default internalError;

--- a/apps/roam/src/utils/internalError.ts
+++ b/apps/roam/src/utils/internalError.ts
@@ -12,7 +12,7 @@ const internalError = ({
   userMessage,
   type,
   context,
-  sendEmail, // true by default
+  sendEmail = true,
 }: {
   error: unknown;
   type?: string;

--- a/apps/roam/src/utils/internalError.ts
+++ b/apps/roam/src/utils/internalError.ts
@@ -14,7 +14,7 @@ const internalError = ({
   type?: string;
   userMessage?: string;
   context?: Properties;
-}) => {
+}): void => {
   if (process.env.NODE_ENV === "development") {
     console.error(error, context);
   } else {

--- a/apps/roam/src/utils/internalError.ts
+++ b/apps/roam/src/utils/internalError.ts
@@ -1,8 +1,6 @@
 import posthog from "posthog-js";
 import type { Properties } from "posthog-js";
 import renderToast from "roamjs-components/components/Toast";
-import { getVersionWithDate } from "~/utils/getVersion";
-import getCurrentUserDisplayName from "roamjs-components/queries/getCurrentUserDisplayName";
 import sendErrorEmail from "~/utils/sendErrorEmail";
 
 const NON_WORD = /\W+/g;
@@ -13,27 +11,22 @@ const internalError = ({
   type,
   context,
   sendEmail = true,
+  forceSendInDev = false,
 }: {
   error: unknown;
   type?: string;
   userMessage?: string;
   context?: Properties;
   sendEmail?: boolean;
+  forceSendInDev?: boolean;
 }): void => {
-  if (process.env.NODE_ENV === "development") {
+  if (process.env.NODE_ENV === "development" && forceSendInDev !== true) {
     console.error(error, context);
   } else {
-    const { version, buildDate } = getVersionWithDate();
-    const username = getCurrentUserDisplayName();
-    if (username) posthog.identify(username);
     type = type || "Internal Error";
     const slugType = type.replaceAll(NON_WORD, "-").toLowerCase();
     context = {
-      app: "Roam",
       type,
-      graphName: window.roamAlphaAPI?.graph?.name || "unknown",
-      version: version || "-",
-      buildDate: buildDate || "-",
       ...(context || {}),
     };
 

--- a/apps/roam/src/utils/internalError.ts
+++ b/apps/roam/src/utils/internalError.ts
@@ -3,17 +3,20 @@ import type { Properties } from "posthog-js";
 import renderToast from "roamjs-components/components/Toast";
 import { getVersionWithDate } from "~/utils/getVersion";
 import getCurrentUserDisplayName from "roamjs-components/queries/getCurrentUserDisplayName";
+import sendErrorEmail from "~/utils/sendErrorEmail";
 
 const internalError = ({
   error,
   userMessage,
   type,
   context,
+  sendEmail, // true by default
 }: {
   error: unknown;
   type?: string;
   userMessage?: string;
   context?: Properties;
+  sendEmail?: boolean;
 }): void => {
   if (process.env.NODE_ENV === "development") {
     console.error(error, context);
@@ -21,9 +24,10 @@ const internalError = ({
     const { version, buildDate } = getVersionWithDate();
     const username = getCurrentUserDisplayName();
     if (username) posthog.identify(username);
+    type = type || "internal-error";
     context = {
       app: "Roam",
-      type: type || "internal-error",
+      type,
       graphName: window.roamAlphaAPI?.graph?.name || "unknown",
       version: version || "-",
       buildDate: buildDate || "-",
@@ -41,6 +45,16 @@ const internalError = ({
       }
     }
     posthog.captureException(error, context);
+    if (sendEmail !== false) {
+      sendErrorEmail({
+        // by now error is an Error but TS did not figure it out
+        error: error as Error,
+        type,
+        context,
+      }).catch(() => {
+        console.error("Could not send error email", error, type, context);
+      });
+    }
   }
   if (userMessage !== undefined) {
     renderToast({

--- a/apps/roam/src/utils/syncDgNodesToSupabase.ts
+++ b/apps/roam/src/utils/syncDgNodesToSupabase.ts
@@ -21,7 +21,7 @@ import { convertRoamNodeToLocalContent } from "./upsertNodesAsContentWithEmbeddi
 import { createClient, type DGSupabaseClient } from "@repo/database/lib/client";
 import type { Json, CompositeTypes, Enums } from "@repo/database/dbTypes";
 import { render as renderToast } from "roamjs-components/components/Toast";
-import sendErrorEmail from "~/utils/sendErrorEmail";
+import internalError from "~/utils/internalError";
 type LocalContentDataInput = Partial<CompositeTypes<"content_local_input">>;
 type AccountLocalInput = CompositeTypes<"account_local_input">;
 
@@ -60,11 +60,11 @@ const notifyEndSyncFailure = ({
     });
   }
 
-  sendErrorEmail({
+  internalError({
     error: new Error(reason),
-    type: "Sync Failed",
+    type: "sync-error",
     context: { status },
-  }).catch(() => {});
+  });
 };
 
 export const endSyncTask = async (

--- a/apps/roam/src/utils/syncDgNodesToSupabase.ts
+++ b/apps/roam/src/utils/syncDgNodesToSupabase.ts
@@ -62,7 +62,7 @@ const notifyEndSyncFailure = ({
 
   internalError({
     error: new Error(reason),
-    type: "sync-error",
+    type: "Sync Failed",
     context: { status },
   });
 };


### PR DESCRIPTION
created an internalError handler that either logs to console.error or sends a report to posthog; and optionally shows a toast to the user. This should provide a pattern that combines many common use cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Centralized and standardized error reporting across the app, improving consistency of user-facing error notifications and reducing redundant console/email noise.

* **Chores**
  * Added a unified internal error handler and refactored components to use it for richer diagnostics and safer error flows.
  * Consolidated telemetry on extension load to include version/build context for better monitoring.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->