### PR TITLE
ENG-1156 use the pattern relation queries in migration

### DIFF
--- a/apps/roam/src/components/Export.tsx
+++ b/apps/roam/src/components/Export.tsx
@@ -199,7 +199,7 @@ const ExportDialog: ExportDialogComponent = ({
       if (response.status === 401) {
         setGitHubAccessToken(null);
         setError("Authentication failed. Please log in again.");
-        setSetting("oauth-github", "");
+        await setSetting("oauth-github", "");
         return { status: 401 };
       }
       return { status: response.status };
@@ -222,7 +222,7 @@ const ExportDialog: ExportDialogComponent = ({
   const addToSelectedCanvas = async (pageUid: string) => {
     if (typeof results !== "object") return;
 
-    let props: Record<string, unknown> = getBlockProps(pageUid);
+    const props: Record<string, unknown> = getBlockProps(pageUid);
 
     const PADDING_BETWEEN_SHAPES = 20;
     const COMMON_BOUNDS_XOFFSET = 250;
@@ -309,10 +309,10 @@ const ExportDialog: ExportDialogComponent = ({
       let minY = Number.MAX_SAFE_INTEGER;
 
       shapes.forEach((shape) => {
-        let rightX = shape.x + shape.w;
-        let leftX = shape.x;
-        let topY = shape.y;
-        let bottomY = shape.y - shape.h;
+        const rightX = shape.x + shape.w;
+        const leftX = shape.x;
+        const topY = shape.y;
+        const bottomY = shape.y - shape.h;
 
         if (rightX > maxX) maxX = rightX;
         if (leftX < minX) minX = leftX;

--- a/apps/roam/src/components/ExportGithub.tsx
+++ b/apps/roam/src/components/ExportGithub.tsx
@@ -11,7 +11,6 @@ import MenuItemSelect from "roamjs-components/components/MenuItemSelect";
 import apiGet from "roamjs-components/util/apiGet";
 import apiPost from "roamjs-components/util/apiPost";
 import { getNodeEnv } from "roamjs-components/util/env";
-import getExtensionApi from "roamjs-components/util/extensionApiContext";
 import { setSetting } from "~/utils/extensionSettings";
 
 type UserReposResponse = {
@@ -60,11 +59,11 @@ export const ExportGithub = ({
   const isDev = useMemo(() => getNodeEnv() === "development", []);
   const setRepo = (repo: string) => {
     setSelectedRepo(repo);
-    setSetting("selected-repo", repo);
+    void setSetting("selected-repo", repo).catch(() => undefined);
   };
 
-  const handleReceivedAccessToken = (token: string) => {
-    setSetting("oauth-github", token);
+  const handleReceivedAccessToken = (token: string): void => {
+    void setSetting("oauth-github", token).catch(() => undefined);
     setGitHubAccessToken(token);
     setClickedInstall(false);
     authWindow.current?.close();
@@ -93,7 +92,7 @@ export const ExportGithub = ({
 
       if (e.message === "Bad credentials") {
         setGitHubAccessToken(null);
-        setSetting("oauth-github", "");
+        void setSetting("oauth-github", "").catch(() => undefined);
       }
       return false;
     }

--- a/apps/roam/src/components/settings/AdminPanel.tsx
+++ b/apps/roam/src/components/settings/AdminPanel.tsx
@@ -260,9 +260,7 @@ const MigrationTab = (): React.ReactElement => {
   const [useMigrationResults, setMigrationResults] = useState<string>("");
   const [useOngoing, setOngoing] = useState<boolean>(false);
   const [useDryRun, setDryRun] = useState<boolean>(false);
-  const [enabled, setEnabled] = useState<boolean>(
-    getSetting("use-reified-relations", false),
-  );
+  const enabled = getSetting("use-reified-relations", false);
   const doMigrateRelations = async () => {
     setOngoing(true);
     try {
@@ -280,7 +278,6 @@ const MigrationTab = (): React.ReactElement => {
         `Migration failed: ${(e as Error).message ?? "see console for details"}`,
       );
     } finally {
-      setEnabled(true);
       setOngoing(false);
     }
   };

--- a/apps/roam/src/components/settings/AdminPanel.tsx
+++ b/apps/roam/src/components/settings/AdminPanel.tsx
@@ -257,10 +257,12 @@ const NodeListTab = (): React.ReactElement => {
 
 const MigrationTab = (): React.ReactElement => {
   let initial = true;
-  const enabled = getSetting("use-reified-relations");
   const [useMigrationResults, setMigrationResults] = useState<string>("");
   const [useOngoing, setOngoing] = useState<boolean>(false);
   const [useDryRun, setDryRun] = useState<boolean>(false);
+  const [enabled, setEnabled] = useState<boolean>(
+    getSetting("use-reified-relations", false),
+  );
   const doMigrateRelations = async () => {
     setOngoing(true);
     try {
@@ -278,6 +280,7 @@ const MigrationTab = (): React.ReactElement => {
         `Migration failed: ${(e as Error).message ?? "see console for details"}`,
       );
     } finally {
+      setEnabled(true);
       setOngoing(false);
     }
   };
@@ -428,7 +431,9 @@ const FeatureFlagsTab = (): React.ReactElement => {
         onChange={(e) => {
           const target = e.target as HTMLInputElement;
           setUseReifiedRelations(target.checked);
-          setSetting("use-reified-relations", target.checked);
+          void setSetting("use-reified-relations", target.checked).catch(
+            () => undefined,
+          );
         }}
         labelElement={
           <>

--- a/apps/roam/src/components/settings/DiscourseRelationConfigPanel.tsx
+++ b/apps/roam/src/components/settings/DiscourseRelationConfigPanel.tsx
@@ -910,10 +910,10 @@ export const RelationEditPanel = ({
               disabled={loading}
               onClick={() => {
                 saveCyToElementRef(tab);
-                setSetting(
+                void setSetting(
                   "discourse-relation-copy",
                   JSON.stringify(elementsRef.current[tab]),
-                );
+                ).catch(() => undefined);
                 renderToast({
                   id: "relation-copy",
                   content: "Copied Relation",

--- a/apps/roam/src/components/settings/HomePersonalSettings.tsx
+++ b/apps/roam/src/components/settings/HomePersonalSettings.tsx
@@ -215,7 +215,10 @@ const HomePersonalSettings = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
         )}
         onChange={(e) => {
           const target = e.target as HTMLInputElement;
-          setSetting(DISCOURSE_CONTEXT_OVERLAY_IN_CANVAS_KEY, target.checked);
+          void setSetting(
+            DISCOURSE_CONTEXT_OVERLAY_IN_CANVAS_KEY,
+            target.checked,
+          ).catch(() => undefined);
         }}
         labelElement={
           <>
@@ -232,7 +235,9 @@ const HomePersonalSettings = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
         defaultChecked={getSetting(STREAMLINE_STYLING_KEY, false)}
         onChange={(e) => {
           const target = e.target as HTMLInputElement;
-          setSetting(STREAMLINE_STYLING_KEY, target.checked);
+          void setSetting(STREAMLINE_STYLING_KEY, target.checked).catch(
+            () => undefined,
+          );
 
           // Load or unload the streamline styling
           const existingStyleElement =

--- a/apps/roam/src/utils/createReifiedBlock.ts
+++ b/apps/roam/src/utils/createReifiedBlock.ts
@@ -1,7 +1,6 @@
 import createBlock from "roamjs-components/writes/createBlock";
 import createPage from "roamjs-components/writes/createPage";
 import getPageUidByPageTitle from "roamjs-components/queries/getPageUidByPageTitle";
-import { getSetting } from "~/utils/extensionSettings";
 
 export const DISCOURSE_GRAPH_PROP_NAME = "discourse-graph";
 
@@ -117,15 +116,12 @@ export const createReifiedRelation = async ({
   relationBlockUid: string;
   destinationUid: string;
 }): Promise<string | undefined> => {
-  const authorized = getSetting("use-reified-relations");
-  if (authorized) {
-    return await createReifiedBlock({
-      destinationBlockUid: await getOrCreateRelationPageUid(),
-      schemaUid: relationBlockUid,
-      parameterUids: {
-        sourceUid,
-        destinationUid,
-      },
-    });
-  }
+  return await createReifiedBlock({
+    destinationBlockUid: await getOrCreateRelationPageUid(),
+    schemaUid: relationBlockUid,
+    parameterUids: {
+      sourceUid,
+      destinationUid,
+    },
+  });
 };

--- a/apps/roam/src/utils/extensionSettings.ts
+++ b/apps/roam/src/utils/extensionSettings.ts
@@ -1,6 +1,6 @@
 import getExtensionAPI from "roamjs-components/util/extensionApiContext";
 
-export function getSetting<T>(key: string, defaultValue?: T): T {
+export const getSetting = <T>(key: string, defaultValue?: T): T => {
   const extensionAPI = getExtensionAPI();
   const value = extensionAPI.settings.get(key);
 
@@ -8,9 +8,9 @@ export function getSetting<T>(key: string, defaultValue?: T): T {
     return value as T;
   }
   return defaultValue as T;
-}
+};
 
-export function setSetting<T>(key: string, value: T): void {
+export const setSetting = async <T>(key: string, value: T): Promise<void> => {
   const extensionAPI = getExtensionAPI();
-  extensionAPI.settings.set(key, value);
-}
+  await extensionAPI.settings.set(key, value);
+};

--- a/apps/roam/src/utils/migrateRelations.ts
+++ b/apps/roam/src/utils/migrateRelations.ts
@@ -14,7 +14,10 @@ const migrateRelations = async (dryRun = false): Promise<number> => {
   const authorized = getSetting("use-reified-relations");
   if (!authorized) return 0;
   let numProcessed = 0;
+  // eslint-disable-next-line @typescript-eslint/await-thenable
   await setSetting("use-reified-relations", false); // so queries use patterns
+  // wait for the settings to propagate
+  await new Promise((resolve) => setTimeout(resolve, 150));
   try {
     const processed = new Set<string>();
     const relationData = await getRelationData();
@@ -62,6 +65,7 @@ const migrateRelations = async (dryRun = false): Promise<number> => {
       numProcessed++;
     }
   } finally {
+    // eslint-disable-next-line @typescript-eslint/await-thenable
     await setSetting("use-reified-relations", true);
   }
   return numProcessed;

--- a/apps/roam/src/utils/migrateRelations.ts
+++ b/apps/roam/src/utils/migrateRelations.ts
@@ -14,7 +14,6 @@ const migrateRelations = async (dryRun = false): Promise<number> => {
   const authorized = getSetting("use-reified-relations");
   if (!authorized) return 0;
   let numProcessed = 0;
-  // eslint-disable-next-line @typescript-eslint/await-thenable
   await setSetting("use-reified-relations", false); // so queries use patterns
   // wait for the settings to propagate
   await new Promise((resolve) => setTimeout(resolve, 150));
@@ -65,7 +64,6 @@ const migrateRelations = async (dryRun = false): Promise<number> => {
       numProcessed++;
     }
   } finally {
-    // eslint-disable-next-line @typescript-eslint/await-thenable
     await setSetting("use-reified-relations", true);
   }
   return numProcessed;

--- a/apps/roam/src/utils/migrateRelations.ts
+++ b/apps/roam/src/utils/migrateRelations.ts
@@ -2,7 +2,7 @@ import getRelationData from "./getRelationData";
 import getBlockProps from "./getBlockProps";
 import type { json } from "./getBlockProps";
 import setBlockProps from "./setBlockProps";
-import { getSetting } from "./extensionSettings";
+import { getSetting, setSetting } from "./extensionSettings";
 import {
   createReifiedRelation,
   DISCOURSE_GRAPH_PROP_NAME,
@@ -13,50 +13,56 @@ const MIGRATION_PROP_NAME = "relation-migration";
 const migrateRelations = async (dryRun = false): Promise<number> => {
   const authorized = getSetting("use-reified-relations");
   if (!authorized) return 0;
-  const processed = new Set<string>();
-  const relationData = await getRelationData();
   let numProcessed = 0;
-  for (const rel of relationData) {
-    const key = `${rel.source}:${rel.relUid}:${rel.target}`;
-    if (processed.has(key)) continue;
-    processed.add(key);
-    if (!dryRun) {
-      const uid = (await createReifiedRelation({
-        sourceUid: rel.source,
-        destinationUid: rel.target,
-        relationBlockUid: rel.relUid,
-      }))!;
-      const sourceProps = getBlockProps(rel.source);
-      const dgDataOrig = sourceProps[DISCOURSE_GRAPH_PROP_NAME];
-      const dgData: Record<string, json> =
-        dgDataOrig !== null &&
-        typeof dgDataOrig === "object" &&
-        !Array.isArray(dgDataOrig)
-          ? dgDataOrig
-          : {};
-      const migrationDataOrig = dgData[MIGRATION_PROP_NAME];
-      let migrationData: Record<string, json> =
-        migrationDataOrig !== null &&
-        typeof migrationDataOrig === "object" &&
-        !Array.isArray(migrationDataOrig)
-          ? migrationDataOrig
-          : {};
-      if (migrationData[uid] !== undefined) {
-        console.debug(`reprocessed ${key}`);
+  await setSetting("use-reified-relations", false); // so queries use patterns
+  try {
+    const processed = new Set<string>();
+    const relationData = await getRelationData();
+    for (const rel of relationData) {
+      const key = `${rel.source}:${rel.relUid}:${rel.target}`;
+      if (processed.has(key)) continue;
+      processed.add(key);
+      if (!dryRun) {
+        const uid = (await createReifiedRelation({
+          sourceUid: rel.source,
+          destinationUid: rel.target,
+          relationBlockUid: rel.relUid,
+        }))!;
+        const sourceProps = getBlockProps(rel.source);
+        const dgDataOrig = sourceProps[DISCOURSE_GRAPH_PROP_NAME];
+        const dgData: Record<string, json> =
+          dgDataOrig !== null &&
+          typeof dgDataOrig === "object" &&
+          !Array.isArray(dgDataOrig)
+            ? dgDataOrig
+            : {};
+        const migrationDataOrig = dgData[MIGRATION_PROP_NAME];
+        let migrationData: Record<string, json> =
+          migrationDataOrig !== null &&
+          typeof migrationDataOrig === "object" &&
+          !Array.isArray(migrationDataOrig)
+            ? migrationDataOrig
+            : {};
+        if (migrationData[uid] !== undefined) {
+          console.debug(`reprocessed ${key}`);
+        }
+        // clean up old migration entries
+        migrationData = Object.fromEntries(
+          Object.entries(migrationData).filter(
+            ([uid]) =>
+              window.roamAlphaAPI.q(
+                `[:find ?p :where [?p :block/uid "${uid}"]]`,
+              ).length > 0,
+          ),
+        );
+        migrationData[uid] = new Date().valueOf();
+        dgData[MIGRATION_PROP_NAME] = migrationData;
+        setBlockProps(rel.source, { [DISCOURSE_GRAPH_PROP_NAME]: dgData });
       }
-      // clean up old migration entries
-      migrationData = Object.fromEntries(
-        Object.entries(migrationData).filter(
-          ([uid]) =>
-            window.roamAlphaAPI.q(`[:find ?p :where [?p :block/uid "${uid}"]]`)
-              .length > 0,
-        ),
-      );
-      migrationData[uid] = new Date().valueOf();
-      dgData[MIGRATION_PROP_NAME] = migrationData;
-      setBlockProps(rel.source, { [DISCOURSE_GRAPH_PROP_NAME]: dgData });
+      numProcessed++;
     }
-    numProcessed++;
+  } finally {
+    await setSetting("use-reified-relations", true);
   }
   return numProcessed;
 };


### PR DESCRIPTION
The migration code is run when reified relations are active, and hence use the reified relations instead of the patterns as basis. Wrap the migration in a change of setting, which happens to be async (made changes accordingly)

This is a rename of the #606 PR, with a few bits sanded off.

