### PR TITLE
ENG-1149 add try / catch to migration when querying for relation patterns

### DIFF
--- a/apps/roam/src/utils/getRelationData.ts
+++ b/apps/roam/src/utils/getRelationData.ts
@@ -55,6 +55,7 @@ export const getRelationDataUtil = async (
             type: "Get relation data",
             userMessage: `Could not find relations of type ${s.label}`,
           });
+          return [];
         }
       }),
   ).then((r) => r.flat());

--- a/apps/roam/src/utils/getRelationData.ts
+++ b/apps/roam/src/utils/getRelationData.ts
@@ -2,6 +2,7 @@ import fireQuery from "./fireQuery";
 import getDiscourseNodes from "./getDiscourseNodes";
 import getDiscourseRelations from "./getDiscourseRelations";
 import type { DiscourseRelation } from "./getDiscourseRelations";
+import internalError from "./internalError";
 
 // lifted from getExportTypes
 
@@ -17,36 +18,44 @@ export const getRelationDataUtil = async (
           s.triples.some((t) => t[2] === "destination"),
       )
       .flatMap((s) => {
-        const sourceLabel = nodeLabelByType[s.source];
-        const targetLabel = nodeLabelByType[s.destination];
-        return !sourceLabel || !targetLabel
-          ? []
-          : fireQuery({
-              returnNode: sourceLabel,
-              conditions: [
-                {
-                  relation: s.label,
-                  source: sourceLabel,
-                  target: targetLabel,
-                  uid: s.id,
-                  type: "clause",
-                },
-              ],
-              selections: [
-                {
-                  uid: window.roamAlphaAPI.util.generateUID(),
-                  text: `node:${targetLabel}`,
-                  label: "target",
-                },
-              ],
-            }).then((results) =>
-              results.map((result) => ({
-                source: result.uid,
-                target: result["target-uid"],
-                relUid: s.id,
-                label: s.label,
-              })),
-            );
+        try {
+          const sourceLabel = nodeLabelByType[s.source];
+          const targetLabel = nodeLabelByType[s.destination];
+          return !sourceLabel || !targetLabel
+            ? []
+            : fireQuery({
+                returnNode: sourceLabel,
+                conditions: [
+                  {
+                    relation: s.label,
+                    source: sourceLabel,
+                    target: targetLabel,
+                    uid: s.id,
+                    type: "clause",
+                  },
+                ],
+                selections: [
+                  {
+                    uid: window.roamAlphaAPI.util.generateUID(),
+                    text: `node:${targetLabel}`,
+                    label: "target",
+                  },
+                ],
+              }).then((results) =>
+                results.map((result) => ({
+                  source: result.uid,
+                  target: result["target-uid"],
+                  relUid: s.id,
+                  label: s.label,
+                })),
+              );
+        } catch (error) {
+          internalError({
+            error,
+            type: "Get relation data",
+            userMessage: `Could not find relations of type ${s.label}`,
+          });
+        }
       }),
   ).then((r) => r.flat());
 

--- a/apps/roam/src/utils/getRelationData.ts
+++ b/apps/roam/src/utils/getRelationData.ts
@@ -18,45 +18,45 @@ export const getRelationDataUtil = async (
           s.triples.some((t) => t[2] === "destination"),
       )
       .flatMap((s) => {
-        try {
-          const sourceLabel = nodeLabelByType[s.source];
-          const targetLabel = nodeLabelByType[s.destination];
-          return !sourceLabel || !targetLabel
-            ? []
-            : fireQuery({
-                returnNode: sourceLabel,
-                conditions: [
-                  {
-                    relation: s.label,
-                    source: sourceLabel,
-                    target: targetLabel,
-                    uid: s.id,
-                    type: "clause",
-                  },
-                ],
-                selections: [
-                  {
-                    uid: window.roamAlphaAPI.util.generateUID(),
-                    text: `node:${targetLabel}`,
-                    label: "target",
-                  },
-                ],
-              }).then((results) =>
+        const sourceLabel = nodeLabelByType[s.source];
+        const targetLabel = nodeLabelByType[s.destination];
+        return !sourceLabel || !targetLabel
+          ? []
+          : fireQuery({
+              returnNode: sourceLabel,
+              conditions: [
+                {
+                  relation: s.label,
+                  source: sourceLabel,
+                  target: targetLabel,
+                  uid: s.id,
+                  type: "clause",
+                },
+              ],
+              selections: [
+                {
+                  uid: window.roamAlphaAPI.util.generateUID(),
+                  text: `node:${targetLabel}`,
+                  label: "target",
+                },
+              ],
+            })
+              .then((results) =>
                 results.map((result) => ({
                   source: result.uid,
                   target: result["target-uid"],
                   relUid: s.id,
                   label: s.label,
                 })),
-              );
-        } catch (error) {
-          internalError({
-            error,
-            type: "Get relation data",
-            userMessage: `Could not find relations of type ${s.label}`,
-          });
-          return [];
-        }
+              )
+              .catch((error) => {
+                internalError({
+                  error,
+                  type: "Get relation data",
+                  userMessage: `Could not find relations of type ${s.label}`,
+                });
+                return [];
+              });
       }),
   ).then((r) => r.flat());
 


### PR DESCRIPTION
https://linear.app/discourse-graphs/issue/ENG-1149/add-try-catch-to-migration-when-querying-for-relation-patterns
Added a try-catch to getRelationData, this will also affect export.
I used the new internalError, I think it's the simplest way to alert both the user and the developers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for relation data retrieval: failed relation fetches are now handled gracefully, returning empty results and surfacing clearer, user-facing error messages instead of causing unhandled exceptions. This reduces visible failures and provides more predictable behavior when relation data cannot be fetched.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->