### PR TITLE
ENG-1164 Ability to add a canvas page to the clipboard to view the nodes on that canvas

### DIFF
--- a/apps/roam/src/components/canvas/Clipboard.tsx
+++ b/apps/roam/src/components/canvas/Clipboard.tsx
@@ -39,7 +39,7 @@ import { useAtom } from "@tldraw/state";
 import AutocompleteInput from "roamjs-components/components/AutocompleteInput";
 import { Result } from "roamjs-components/types/query-builder";
 import fuzzy from "fuzzy";
-import { getAllReferencesOnPage } from "~/utils/hyde";
+import getAllReferencesOnPage from "~/utils/getAllReferencesOnPage";
 import isDiscourseNode from "~/utils/isDiscourseNode";
 import {
   DiscourseNodeShape,

--- a/apps/roam/src/utils/getAllReferencesOnPage.ts
+++ b/apps/roam/src/utils/getAllReferencesOnPage.ts
@@ -1,0 +1,51 @@
+import normalizePageTitle from "roamjs-components/queries/normalizePageTitle";
+import type { Result } from "./types";
+import { isCanvasPage } from "./isCanvasPage";
+
+const getAllReferencesOnPage = async (title: string): Promise<Result[]> => {
+  title = normalizePageTitle(title);
+  let referencedPages: Array<[string, string]> = [];
+  if (isCanvasPage({ title })) {
+    const oldCanvasContent = window.roamAlphaAPI.data.fast.q(
+      `[:find ?uid ?title
+      :where
+      [?c :node/title "${title}"]
+      [?c :block/props ?props]
+      [(get ?props :roamjs-query-builder) ?rqb]
+      [(get ?rqb :tldraw) [[?k ?v]]]
+      [(get ?v :props) ?shape-props]
+      [(get ?shape-props :uid) ?uid]
+      [?n :block/uid ?uid]
+      [?n :node/title ?title]
+      ]`,
+    ) as Array<[string, string]>;
+    const newCanvasContent = window.roamAlphaAPI.data.fast.q(
+      `[:find ?uid ?title
+      :where
+      [?c :node/title "${title}"]
+      [?c :block/props ?props]
+      [(get ?props :roamjs-query-builder) ?rqb]
+      [(get ?rqb :tldraw) ?tldraw]
+      [(get ?tldraw :store) [[?k ?v]]]
+      [(get ?v :props) ?shape-props]
+      [(get ?shape-props :uid) ?uid]
+      [?n :block/uid ?uid]
+      [?n :node/title ?title]
+      ]`,
+    ) as Array<[string, string]>;
+    referencedPages = [...oldCanvasContent, ...newCanvasContent];
+  } else {
+    referencedPages = (await window.roamAlphaAPI.data.backend.q(
+      `[:find ?uid ?text
+      :where
+        [?page :node/title "${title}"]
+        [?b :block/page ?page]
+        [?b :block/refs ?refPage]
+        [?refPage :block/uid ?uid]
+        [?refPage :node/title ?text]]`,
+    )) as Array<[string, string]>;
+  }
+  return referencedPages.map(([uid, text]) => ({ uid, text }));
+};
+
+export default getAllReferencesOnPage;

--- a/apps/roam/src/utils/hyde.ts
+++ b/apps/roam/src/utils/hyde.ts
@@ -6,6 +6,7 @@ import { nextApiRoot } from "@repo/utils/execContext";
 import { DiscourseNode } from "./getDiscourseNodes";
 import getExtensionAPI from "roamjs-components/util/extensionApiContext";
 import { getNodesByType } from "@repo/database/lib/queries";
+import getAllReferencesOnPage from "./getAllReferencesOnPage";
 
 type ApiEmbeddingResponse = {
   data: Array<{
@@ -382,21 +383,6 @@ export const extractPagesFromParentBlock = async (
         [?rf :node/title ?title]]]`,
   )) as Array<[string, string]>;
   return results.map(([uid, title]) => ({ uid, text: title }));
-};
-
-export const getAllReferencesOnPage = async (
-  pageTitle: string,
-): Promise<{ uid: string; text: string }[]> => {
-  const referencedPages = (await window.roamAlphaAPI.data.backend.q(
-    `[:find ?uid ?text
-      :where
-        [?page :node/title "${normalizePageTitle(pageTitle)}"]
-        [?b :block/page ?page]
-        [?b :block/refs ?refPage]
-        [?refPage :block/uid ?uid]
-        [?refPage :node/title ?text]]`,
-  )) as Array<[string, string]>;
-  return referencedPages.map(([uid, text]) => ({ uid, text }));
 };
 
 export type PerformHydeSearchParams = {


### PR DESCRIPTION
https://linear.app/discourse-graphs/issue/ENG-1164/ability-to-add-a-canvas-page-to-the-clipboard-to-view-the-nodes-on

Allow the references in a Canvas page to be accessible through the Canvas clipboard.
Did this through simply expanding getAllReferencesOnPage to handle canvas pages.
Curious if this would have side effects on Hyde? I expect Hyde to never deal with Canvas pages.
Also: Could a Canvas page also have non-canvas node references?
Also: Can canvas references include non-node pages? I do not (yet) filter them out. Would that be required?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal utilities for improved code maintainability.
  * Minor formatting adjustments to query structures with no functional impact.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->