### PR TITLE
ENG-1153 maximum update limit error on canvas after adding supports relation between evd and clm

### DIFF
--- a/apps/roam/src/components/canvas/DiscourseRelationShape/DiscourseRelationBindings.tsx
+++ b/apps/roam/src/components/canvas/DiscourseRelationShape/DiscourseRelationBindings.tsx
@@ -231,7 +231,7 @@ function reparentArrow(editor: Editor, arrowId: TLShapeId) {
   let finalIndex: IndexKey;
 
   const relationIds = new Set(getDiscourseRelations().map((r) => r.id));
-  relationIds.add(arrow.type);
+  relationIds.add("arrow");
 
   // if the next sibling is also a bound arrow though, we can end up
   // all fighting for the same indexes. so lets find the next


### PR DESCRIPTION
https://linear.app/discourse-graphs/issue/ENG-1153/maximum-update-limit-error-on-canvas-after-adding-supports-relation
The issue was that the reparent arrow function looking at non-arrow siblings in a way that did not take relations into account, leading to a reparenting cascade.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed index calculation logic when reparenting arrows to prevent conflicts with relation bindings.
  * Improved sibling selection and neighbor determination to correctly position arrows relative to adjacent elements.
  * Prevents visual overlap issues when repositioning bound relation arrows, ensuring proper ordering in diagram layout.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->