### PR TITLE
ENG-1195 add a constant in userSettings for use-reified-relations

### DIFF
--- a/apps/roam/src/components/CreateRelationDialog.tsx
+++ b/apps/roam/src/components/CreateRelationDialog.tsx
@@ -23,6 +23,7 @@ import type { DiscourseNode } from "~/utils/getDiscourseNodes";
 import type { Result } from "~/utils/types";
 import internalError from "~/utils/internalError";
 import getDiscourseNodes from "~/utils/getDiscourseNodes";
+import { USE_REIFIED_RELATIONS } from "~/data/userSettings";
 
 export type CreateRelationDialogProps = {
   onClose: () => void;
@@ -373,7 +374,7 @@ export const renderCreateRelationDialog = (
 export const CreateRelationButton = (
   props: CreateRelationDialogProps,
 ): React.JSX.Element | null => {
-  const showAddRelation = getSetting("use-reified-relations");
+  const showAddRelation = getSetting(USE_REIFIED_RELATIONS);
   if (!showAddRelation) return null;
   let extProps: ExtendedCreateRelationDialogProps | null = null;
   try {

--- a/apps/roam/src/components/CreateRelationDialog.tsx
+++ b/apps/roam/src/components/CreateRelationDialog.tsx
@@ -374,7 +374,7 @@ export const renderCreateRelationDialog = (
 export const CreateRelationButton = (
   props: CreateRelationDialogProps,
 ): React.JSX.Element | null => {
-  const showAddRelation = getSetting(USE_REIFIED_RELATIONS);
+  const showAddRelation = getSetting<boolean>(USE_REIFIED_RELATIONS, false);
   if (!showAddRelation) return null;
   let extProps: ExtendedCreateRelationDialogProps | null = null;
   try {

--- a/apps/roam/src/components/canvas/DiscourseRelationShape/DiscourseRelationUtil.tsx
+++ b/apps/roam/src/components/canvas/DiscourseRelationShape/DiscourseRelationUtil.tsx
@@ -81,6 +81,7 @@ import getPageTitleByPageUid from "roamjs-components/queries/getPageTitleByPageU
 import { AddReferencedNodeType } from "./DiscourseRelationTool";
 import { dispatchToastEvent } from "~/components/canvas/ToastListener";
 import internalError from "~/utils/internalError";
+import { USE_REIFIED_RELATIONS } from "~/data/userSettings";
 
 const COLOR_ARRAY = Array.from(textShapeProps.color.values)
   .filter((c) => !["red", "green", "grey"].includes(c))
@@ -553,7 +554,7 @@ export const createAllRelationShapeUtils = (
         if (arrow.type !== target.type) {
           editor.updateShapes([{ id: arrow.id, type: target.type }]);
         }
-        if (getSetting("use-reified-relations")) {
+        if (getSetting(USE_REIFIED_RELATIONS)) {
           const sourceAsDNS = asDiscourseNodeShape(source, editor);
           const targetAsDNS = asDiscourseNodeShape(target, editor);
 

--- a/apps/roam/src/components/canvas/DiscourseRelationShape/DiscourseRelationUtil.tsx
+++ b/apps/roam/src/components/canvas/DiscourseRelationShape/DiscourseRelationUtil.tsx
@@ -554,7 +554,7 @@ export const createAllRelationShapeUtils = (
         if (arrow.type !== target.type) {
           editor.updateShapes([{ id: arrow.id, type: target.type }]);
         }
-        if (getSetting(USE_REIFIED_RELATIONS)) {
+        if (getSetting<boolean>(USE_REIFIED_RELATIONS, false)) {
           const sourceAsDNS = asDiscourseNodeShape(source, editor);
           const targetAsDNS = asDiscourseNodeShape(target, editor);
 

--- a/apps/roam/src/components/results-view/ResultsTable.tsx
+++ b/apps/roam/src/components/results-view/ResultsTable.tsx
@@ -206,7 +206,7 @@ const ResultRow = ({
   onDragEnd,
   onRefresh,
 }: ResultRowProps) => {
-  const useReifiedRel = getSetting<boolean>(USE_REIFIED_RELATIONS);
+  const useReifiedRel = getSetting<boolean>(USE_REIFIED_RELATIONS, false);
   const cell = (key: string) => {
     const value = toCellValue({
       value: r[`${key}-display`] || r[key] || "",

--- a/apps/roam/src/components/results-view/ResultsTable.tsx
+++ b/apps/roam/src/components/results-view/ResultsTable.tsx
@@ -22,6 +22,7 @@ import toCellValue from "~/utils/toCellValue";
 import { ContextContent } from "~/components/DiscourseContext";
 import DiscourseContextOverlay from "~/components/DiscourseContextOverlay";
 import { CONTEXT_OVERLAY_SUGGESTION } from "~/utils/predefinedSelections";
+import { USE_REIFIED_RELATIONS } from "~/data/userSettings";
 import { getSetting } from "~/utils/extensionSettings";
 import { strictQueryForReifiedBlocks } from "~/utils/createReifiedBlock";
 
@@ -205,7 +206,7 @@ const ResultRow = ({
   onDragEnd,
   onRefresh,
 }: ResultRowProps) => {
-  const useReifiedRel = getSetting<boolean>("use-reified-relations");
+  const useReifiedRel = getSetting<boolean>(USE_REIFIED_RELATIONS);
   const cell = (key: string) => {
     const value = toCellValue({
       value: r[`${key}-display`] || r[key] || "",

--- a/apps/roam/src/components/settings/AdminPanel.tsx
+++ b/apps/roam/src/components/settings/AdminPanel.tsx
@@ -36,6 +36,7 @@ import { getFormattedConfigTree } from "~/utils/discourseConfigRef";
 import refreshConfigTree from "~/utils/refreshConfigTree";
 import createBlock from "roamjs-components/writes/createBlock";
 import deleteBlock from "roamjs-components/writes/deleteBlock";
+import { USE_REIFIED_RELATIONS } from "~/data/userSettings";
 
 const NodeRow = ({ node }: { node: PConceptFull }) => {
   return (
@@ -260,7 +261,7 @@ const MigrationTab = (): React.ReactElement => {
   const [useMigrationResults, setMigrationResults] = useState<string>("");
   const [useOngoing, setOngoing] = useState<boolean>(false);
   const [useDryRun, setDryRun] = useState<boolean>(false);
-  const enabled = getSetting("use-reified-relations", false);
+  const enabled = getSetting(USE_REIFIED_RELATIONS, false);
   const doMigrateRelations = async () => {
     setOngoing(true);
     try {
@@ -331,7 +332,7 @@ const MigrationTab = (): React.ReactElement => {
 
 const FeatureFlagsTab = (): React.ReactElement => {
   const [useReifiedRelations, setUseReifiedRelations] = useState<boolean>(
-    getSetting("use-reified-relations"),
+    getSetting(USE_REIFIED_RELATIONS),
   );
   const settings = useMemo(() => {
     refreshConfigTree();
@@ -428,7 +429,7 @@ const FeatureFlagsTab = (): React.ReactElement => {
         onChange={(e) => {
           const target = e.target as HTMLInputElement;
           setUseReifiedRelations(target.checked);
-          void setSetting("use-reified-relations", target.checked).catch(
+          void setSetting(USE_REIFIED_RELATIONS, target.checked).catch(
             () => undefined,
           );
         }}

--- a/apps/roam/src/components/settings/AdminPanel.tsx
+++ b/apps/roam/src/components/settings/AdminPanel.tsx
@@ -261,7 +261,7 @@ const MigrationTab = (): React.ReactElement => {
   const [useMigrationResults, setMigrationResults] = useState<string>("");
   const [useOngoing, setOngoing] = useState<boolean>(false);
   const [useDryRun, setDryRun] = useState<boolean>(false);
-  const enabled = getSetting(USE_REIFIED_RELATIONS, false);
+  const enabled = getSetting<boolean>(USE_REIFIED_RELATIONS, false);
   const doMigrateRelations = async () => {
     setOngoing(true);
     try {
@@ -332,7 +332,7 @@ const MigrationTab = (): React.ReactElement => {
 
 const FeatureFlagsTab = (): React.ReactElement => {
   const [useReifiedRelations, setUseReifiedRelations] = useState<boolean>(
-    getSetting(USE_REIFIED_RELATIONS),
+    getSetting<boolean>(USE_REIFIED_RELATIONS, false),
   );
   const settings = useMemo(() => {
     refreshConfigTree();

--- a/apps/roam/src/data/userSettings.ts
+++ b/apps/roam/src/data/userSettings.ts
@@ -9,3 +9,4 @@ export const DISCOURSE_CONTEXT_OVERLAY_IN_CANVAS_KEY =
   "discourse-context-overlay-in-canvas";
 export const STREAMLINE_STYLING_KEY = "streamline-styling";
 export const DISALLOW_DIAGNOSTICS = "disallow-diagnostics";
+export const USE_REIFIED_RELATIONS = "use-reified-relations";

--- a/apps/roam/src/utils/migrateRelations.ts
+++ b/apps/roam/src/utils/migrateRelations.ts
@@ -12,7 +12,7 @@ import {
 const MIGRATION_PROP_NAME = "relation-migration";
 
 const migrateRelations = async (dryRun = false): Promise<number> => {
-  const authorized = getSetting(USE_REIFIED_RELATIONS);
+  const authorized = getSetting<boolean>(USE_REIFIED_RELATIONS, false);
   if (!authorized) return 0;
   let numProcessed = 0;
   await setSetting(USE_REIFIED_RELATIONS, false); // so queries use patterns

--- a/apps/roam/src/utils/migrateRelations.ts
+++ b/apps/roam/src/utils/migrateRelations.ts
@@ -3,6 +3,7 @@ import getBlockProps from "./getBlockProps";
 import type { json } from "./getBlockProps";
 import setBlockProps from "./setBlockProps";
 import { getSetting, setSetting } from "./extensionSettings";
+import { USE_REIFIED_RELATIONS } from "~/data/userSettings";
 import {
   createReifiedRelation,
   DISCOURSE_GRAPH_PROP_NAME,
@@ -11,10 +12,10 @@ import {
 const MIGRATION_PROP_NAME = "relation-migration";
 
 const migrateRelations = async (dryRun = false): Promise<number> => {
-  const authorized = getSetting("use-reified-relations");
+  const authorized = getSetting(USE_REIFIED_RELATIONS);
   if (!authorized) return 0;
   let numProcessed = 0;
-  await setSetting("use-reified-relations", false); // so queries use patterns
+  await setSetting(USE_REIFIED_RELATIONS, false); // so queries use patterns
   // wait for the settings to propagate
   await new Promise((resolve) => setTimeout(resolve, 150));
   try {
@@ -64,7 +65,7 @@ const migrateRelations = async (dryRun = false): Promise<number> => {
       numProcessed++;
     }
   } finally {
-    await setSetting("use-reified-relations", true);
+    await setSetting(USE_REIFIED_RELATIONS, true);
   }
   return numProcessed;
 };

--- a/apps/roam/src/utils/registerDiscourseDatalogTranslators.ts
+++ b/apps/roam/src/utils/registerDiscourseDatalogTranslators.ts
@@ -21,6 +21,7 @@ import { fireQuerySync, getWhereClauses } from "./fireQuery";
 import { toVar } from "./compileDatalog";
 import { getSetting } from "./extensionSettings";
 import { getExistingRelationPageUid } from "./createReifiedBlock";
+import { USE_REIFIED_RELATIONS } from "~/data/userSettings";
 
 const hasTag = (node: DiscourseNode): node is DiscourseNode & { tag: string } =>
   !!node.tag;
@@ -410,7 +411,7 @@ const registerDiscourseDatalogTranslators = () => {
         key: label,
         callback: ({ source, target, uid }) => {
           const useReifiedRelations = getSetting<boolean>(
-            "use-reified-relations",
+            USE_REIFIED_RELATIONS,
             false,
           );
           const relationPageUid = getExistingRelationPageUid();


### PR DESCRIPTION
https://linear.app/discourse-graphs/issue/ENG-1195/add-a-constant-in-usersettings-for-use-reified-relations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized feature flag setting references across the application by introducing a dedicated constant for the reified-relations setting, replacing scattered string-based keys. This improves maintainability without affecting user-facing functionality or behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->