### PR TITLE
ENG-1194 Suggestive Mode Overlay in personal settings should only show if suggestive mode is enabled

### DIFF
--- a/apps/roam/src/components/settings/HomePersonalSettings.tsx
+++ b/apps/roam/src/components/settings/HomePersonalSettings.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { OnloadArgs } from "roamjs-components/types";
 import { Label, Checkbox } from "@blueprintjs/core";
 import Description from "roamjs-components/components/Description";
@@ -28,11 +28,6 @@ import KeyboardShortcutInput from "./KeyboardShortcutInput";
 import { getSetting, setSetting } from "~/utils/extensionSettings";
 import streamlineStyling from "~/styles/streamlineStyling";
 import { getFormattedConfigTree } from "~/utils/discourseConfigRef";
-
-const HomePersonalSettings = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
-  const extensionAPI = onloadArgs.extensionAPI;
-  const overlayHandler = getOverlayHandler(onloadArgs);
-import React, { useMemo } from "react";
 
 const HomePersonalSettings = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
   const extensionAPI = onloadArgs.extensionAPI;

--- a/apps/roam/src/components/settings/HomePersonalSettings.tsx
+++ b/apps/roam/src/components/settings/HomePersonalSettings.tsx
@@ -27,10 +27,12 @@ import internalError from "~/utils/internalError";
 import KeyboardShortcutInput from "./KeyboardShortcutInput";
 import { getSetting, setSetting } from "~/utils/extensionSettings";
 import streamlineStyling from "~/styles/streamlineStyling";
+import { getFormattedConfigTree } from "~/utils/discourseConfigRef";
 
 const HomePersonalSettings = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
   const extensionAPI = onloadArgs.extensionAPI;
   const overlayHandler = getOverlayHandler(onloadArgs);
+  const settings = getFormattedConfigTree();
 
   return (
     <div className="flex flex-col gap-4 p-1">
@@ -83,31 +85,33 @@ const HomePersonalSettings = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
           </>
         }
       />
-      <Checkbox
-        defaultChecked={
-          extensionAPI.settings.get("suggestive-mode-overlay") as boolean
-        }
-        onChange={(e) => {
-          const target = e.target as HTMLInputElement;
-          void extensionAPI.settings.set(
-            "suggestive-mode-overlay",
-            target.checked,
-          );
-          onPageRefObserverChange(getSuggestiveOverlayHandler(onloadArgs))(
-            target.checked,
-          );
-        }}
-        labelElement={
-          <>
-            Suggestive Mode Overlay
-            <Description
-              description={
-                "Whether or not to overlay Suggestive Mode button over Discourse Node references."
-              }
-            />
-          </>
-        }
-      />
+      {settings.suggestiveModeEnabled.value && (
+        <Checkbox
+          defaultChecked={
+            extensionAPI.settings.get("suggestive-mode-overlay") as boolean
+          }
+          onChange={(e) => {
+            const target = e.target as HTMLInputElement;
+            void extensionAPI.settings.set(
+              "suggestive-mode-overlay",
+              target.checked,
+            );
+            onPageRefObserverChange(getSuggestiveOverlayHandler(onloadArgs))(
+              target.checked,
+            );
+          }}
+          labelElement={
+            <>
+              Suggestive Mode Overlay
+              <Description
+                description={
+                  "Whether or not to overlay Suggestive Mode button over Discourse Node references."
+                }
+              />
+            </>
+          }
+        />
+      )}
       <Checkbox
         defaultChecked={
           extensionAPI.settings.get("text-selection-popup") !== false

--- a/apps/roam/src/components/settings/HomePersonalSettings.tsx
+++ b/apps/roam/src/components/settings/HomePersonalSettings.tsx
@@ -32,7 +32,12 @@ import { getFormattedConfigTree } from "~/utils/discourseConfigRef";
 const HomePersonalSettings = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
   const extensionAPI = onloadArgs.extensionAPI;
   const overlayHandler = getOverlayHandler(onloadArgs);
-  const settings = getFormattedConfigTree();
+import React, { useMemo } from "react";
+
+const HomePersonalSettings = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
+  const extensionAPI = onloadArgs.extensionAPI;
+  const overlayHandler = getOverlayHandler(onloadArgs);
+  const settings = useMemo(() => getFormattedConfigTree(), []);
 
   return (
     <div className="flex flex-col gap-4 p-1">

--- a/apps/roam/src/components/settings/HomePersonalSettings.tsx
+++ b/apps/roam/src/components/settings/HomePersonalSettings.tsx
@@ -90,7 +90,7 @@ const HomePersonalSettings = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
           </>
         }
       />
-      {settings.suggestiveModeEnabled.value && (
+      {settings.suggestiveModeEnabled?.value && (
         <Checkbox
           defaultChecked={
             extensionAPI.settings.get("suggestive-mode-overlay") as boolean


### PR DESCRIPTION
https://www.loom.com/share/dfd5b513a6354908bd91b3aff0434656

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Suggestive Mode Overlay checkbox now displays conditionally based on system configuration settings, ensuring the control appears only when applicable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->