### PR TITLE
ENG-1182 extend findDiscourseNode to accept the title as an argument

### DIFF
--- a/apps/roam/src/components/CreateRelationDialog.tsx
+++ b/apps/roam/src/components/CreateRelationDialog.tsx
@@ -17,7 +17,7 @@ import getDiscourseRelations, {
   type DiscourseRelation,
 } from "~/utils/getDiscourseRelations";
 import { createReifiedRelation } from "~/utils/createReifiedBlock";
-import { findDiscourseNodeByTitleAndUid } from "~/utils/findDiscourseNode";
+import findDiscourseNode from "~/utils/findDiscourseNode";
 import { getDiscourseNodeFormatInnerExpression } from "~/utils/getDiscourseNodeFormatExpression";
 import type { DiscourseNode } from "~/utils/getDiscourseNodes";
 import type { Result } from "~/utils/types";
@@ -97,7 +97,7 @@ const CreateRelationDialog = ({
 
   const identifyRelationMatch = (target: Result): RelWithDirection | null => {
     if (target.text.length === 0) return null;
-    const selectedTargetType = findDiscourseNodeByTitleAndUid({
+    const selectedTargetType = findDiscourseNode({
       uid: target.uid,
       title: target.text,
       nodes: discourseNodes,
@@ -280,7 +280,7 @@ const prepareRelData = (
   nodeTitle = nodeTitle || getPageTitleByPageUid(targetNodeUid).trim();
   const discourseNodeSchemas = getDiscourseNodes();
   const relations = getDiscourseRelations();
-  const nodeSchema = findDiscourseNodeByTitleAndUid({
+  const nodeSchema = findDiscourseNode({
     uid: targetNodeUid,
     title: nodeTitle,
     nodes: discourseNodeSchemas,
@@ -319,7 +319,7 @@ const extendProps = ({
 }: CreateRelationDialogProps): ExtendedCreateRelationDialogProps | null => {
   const nodeTitle = getPageTitleByPageUid(sourceNodeUid).trim();
   const relData = prepareRelData(sourceNodeUid, nodeTitle);
-  const selectedSourceType = findDiscourseNodeByTitleAndUid({
+  const selectedSourceType = findDiscourseNode({
     uid: sourceNodeUid,
     title: nodeTitle,
   });

--- a/apps/roam/src/components/DiscourseContextOverlay.tsx
+++ b/apps/roam/src/components/DiscourseContextOverlay.tsx
@@ -112,7 +112,7 @@ const DiscourseContextOverlay = ({
     () =>
       getOverlayInfo(tag ?? (uid ? (getPageTitleByPageUid(uid) ?? "") : ""))
         .then(({ refs, results }) => {
-          const discourseNode = findDiscourseNode(tagUid);
+          const discourseNode = findDiscourseNode({ uid: tagUid });
           if (discourseNode) {
             const attribute = getSettingValueFromTree({
               tree: getBasicTreeByParentUid(discourseNode.type),

--- a/apps/roam/src/components/Export.tsx
+++ b/apps/roam/src/components/Export.tsx
@@ -328,7 +328,7 @@ const ExportDialog: ExportDialogComponent = ({
     let nextShapeX = COMMON_BOUNDS_XOFFSET;
     let shapeY = commonBounds.top;
     for (const [i, r] of results.entries()) {
-      const discourseNode = findDiscourseNode(r.uid);
+      const discourseNode = findDiscourseNode({ uid: r.uid });
       const nodeType = discourseNode ? discourseNode.type : "page-node";
       const extensionAPI = getExtensionAPI();
       const { h, w, imageUrl } = await calcCanvasNodeSizeAndImg({

--- a/apps/roam/src/components/SuggestionsBody.tsx
+++ b/apps/roam/src/components/SuggestionsBody.tsx
@@ -218,7 +218,10 @@ const SuggestionsBody = ({
   >([]);
 
   const tagUid = useMemo(() => getPageUidByPageTitle(tag), [tag]);
-  const discourseNode = useMemo(() => findDiscourseNode(tagUid), [tagUid]);
+  const discourseNode = useMemo(
+    () => findDiscourseNode({ uid: tagUid }),
+    [tagUid],
+  );
   const allRelations = useMemo(() => getDiscourseRelations(), []);
   const allNodes = useMemo(() => getDiscourseNodes(), []);
 

--- a/apps/roam/src/components/canvas/Clipboard.tsx
+++ b/apps/roam/src/components/canvas/Clipboard.tsx
@@ -587,7 +587,7 @@ const ClipboardPageSection = ({
     async (node: { uid: string; text: string }, pagePoint: Vec) => {
       if (!extensionAPI) return;
 
-      const nodeType = findDiscourseNode(node.uid);
+      const nodeType = findDiscourseNode({ uid: node.uid });
       if (!nodeType) {
         internalError({
           error: new Error("Canvas Clipboard: Node type not found"),
@@ -726,7 +726,7 @@ const ClipboardPageSection = ({
       const nodeText = target.dataset.clipboardNodeText;
       if (!nodeUid || !nodeText) return;
 
-      const nodeType = findDiscourseNode(nodeUid);
+      const nodeType = findDiscourseNode({ uid: nodeUid });
       if (!nodeType) return;
       const { backgroundColor, textColor } = getDiscourseNodeColors({
         nodeType: nodeType.type,

--- a/apps/roam/src/components/canvas/Tldraw.tsx
+++ b/apps/roam/src/components/canvas/Tldraw.tsx
@@ -478,7 +478,10 @@ const TldrawCanvas = ({ title }: { title: string }) => {
       const position = lastTime
         ? { x: lastTime.x + w * 0.025, y: lastTime.y + h * 0.05 }
         : { x: x - DEFAULT_WIDTH / 2, y: y - DEFAULT_HEIGHT / 2 };
-      const nodeType = findDiscourseNode(e.detail.uid, allNodes);
+      const nodeType = findDiscourseNode({
+        uid: e.detail.uid,
+        nodes: allNodes,
+      });
       if (nodeType) {
         app.createShapes([
           {

--- a/apps/roam/src/utils/deriveDiscourseNodeAttribute.ts
+++ b/apps/roam/src/utils/deriveDiscourseNodeAttribute.ts
@@ -49,7 +49,7 @@ const deriveNodeAttribute = async ({
 }): Promise<string | number> => {
   const relations = getDiscourseRelations();
   const nodes = getDiscourseNodes(relations);
-  const discourseNode = findDiscourseNode(uid, nodes);
+  const discourseNode = findDiscourseNode({ uid, nodes });
   if (!discourseNode) return 0;
   const nodeType = discourseNode.type;
   const attributeNode = getSubTree({

--- a/apps/roam/src/utils/findDiscourseNode.ts
+++ b/apps/roam/src/utils/findDiscourseNode.ts
@@ -1,43 +1,30 @@
+import getPageUidByPageTitle from "roamjs-components/queries/getPageUidByPageTitle";
 import getDiscourseNodes, { type DiscourseNode } from "./getDiscourseNodes";
 import matchDiscourseNode from "./matchDiscourseNode";
 
 const discourseNodeTypeCache: Record<string, DiscourseNode | false> = {};
 
-const findDiscourseNode = (
-  uid = "",
-  nodes = getDiscourseNodes(),
-): DiscourseNode | false => {
-  if (typeof discourseNodeTypeCache[uid] !== "undefined") {
-    return discourseNodeTypeCache[uid];
-  }
-
-  const matchingNode = nodes.find((node) =>
-    matchDiscourseNode({ ...node, uid }),
-  );
-
-  discourseNodeTypeCache[uid] = matchingNode || false;
-  return discourseNodeTypeCache[uid];
-};
-export default findDiscourseNode;
-
-export const findDiscourseNodeByTitleAndUid = ({
+const findDiscourseNode = ({
   uid,
   title,
-  nodes,
+  nodes = getDiscourseNodes(),
 }: {
-  uid: string;
-  title: string;
+  uid?: string;
+  title?: string;
   nodes?: DiscourseNode[];
 }): DiscourseNode | false => {
-  nodes = nodes || getDiscourseNodes();
+  if (uid === undefined) return false;
   if (typeof discourseNodeTypeCache[uid] !== "undefined") {
     return discourseNodeTypeCache[uid];
   }
 
-  const matchingNode = nodes.find((node) =>
-    matchDiscourseNode({ ...node, title }),
-  );
-
-  discourseNodeTypeCache[uid] = matchingNode || false;
-  return discourseNodeTypeCache[uid];
+  const matchingNode =
+    nodes.find((node) =>
+      title === undefined
+        ? matchDiscourseNode({ ...node, uid: uid })
+        : matchDiscourseNode({ ...node, title }),
+    ) || false;
+  discourseNodeTypeCache[uid] = matchingNode;
+  return matchingNode;
 };
+export default findDiscourseNode;

--- a/apps/roam/src/utils/findDiscourseNode.ts
+++ b/apps/roam/src/utils/findDiscourseNode.ts
@@ -1,4 +1,3 @@
-import getPageUidByPageTitle from "roamjs-components/queries/getPageUidByPageTitle";
 import getDiscourseNodes, { type DiscourseNode } from "./getDiscourseNodes";
 import matchDiscourseNode from "./matchDiscourseNode";
 

--- a/apps/roam/src/utils/formatUtils.ts
+++ b/apps/roam/src/utils/formatUtils.ts
@@ -136,7 +136,7 @@ export const getReferencedNodeInFormat = ({
 }) => {
   let format = providedFormat;
   if (!format) {
-    const discourseNode = findDiscourseNode(uid);
+    const discourseNode = findDiscourseNode({ uid });
     if (discourseNode) format = discourseNode.format;
   }
   if (!format) return null;

--- a/apps/roam/src/utils/getDiscourseContextResults.ts
+++ b/apps/roam/src/utils/getDiscourseContextResults.ts
@@ -182,7 +182,7 @@ const getDiscourseContextResults = async ({
 }) => {
   const args = { ignoreCache };
 
-  const discourseNode = findDiscourseNode(targetUid);
+  const discourseNode = findDiscourseNode({ uid: targetUid });
   if (!discourseNode) return [];
   const nodeType = discourseNode?.type;
   const nodeTextByType = Object.fromEntries(

--- a/apps/roam/src/utils/hyde.ts
+++ b/apps/roam/src/utils/hyde.ts
@@ -463,7 +463,9 @@ export const performHydeSearch = async ({
       })
     )
       .map((c) => {
-        const node = findDiscourseNode(c.Content?.source_local_id || "");
+        const node = findDiscourseNode({
+          uid: c.Content?.source_local_id || "",
+        });
         return {
           uid: c.Content?.source_local_id || "",
           text: c.Content?.text || "",
@@ -492,7 +494,7 @@ export const performHydeSearch = async ({
     );
     candidateNodesForHyde = uniqueReferenced
       .map((n) => {
-        const node = findDiscourseNode(n.uid);
+        const node = findDiscourseNode({ uid: n.uid });
         if (
           !node ||
           node.backedBy === "default" ||

--- a/apps/roam/src/utils/isDiscourseNode.ts
+++ b/apps/roam/src/utils/isDiscourseNode.ts
@@ -3,7 +3,7 @@ import findDiscourseNode from "./findDiscourseNode";
 
 const isDiscourseNode = (uid: string) => {
   const nodes = getDiscourseNodes();
-  const node = findDiscourseNode(uid, nodes);
+  const node = findDiscourseNode({ uid, nodes });
   if (!node) return false;
   return node.backedBy !== "default";
 };


### PR DESCRIPTION
https://linear.app/discourse-graphs/issue/ENG-1182/extend-finddiscoursenode-to-accept-the-title-as-an-argument

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Unified the discourse node lookup API across the application. The function signature for finding discourse nodes has been simplified to accept a single object parameter with optional properties instead of multiple argument formats. Multiple components and utilities have been updated to align with the new API structure. No changes to user-facing functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->