### PR TITLE
ENG-1208 Add local flag to fireQuery

### DIFF
--- a/apps/roam/src/utils/fireQuery.ts
+++ b/apps/roam/src/utils/fireQuery.ts
@@ -30,6 +30,7 @@ type RelationInQuery = {
 export type FireQueryArgs = QueryArgs & {
   isCustomEnabled?: boolean;
   customNode?: string;
+  local?: boolean;
   context?: {
     relationsInQuery?: RelationInQuery[];
     customNodes?: DiscourseNode[];
@@ -315,7 +316,7 @@ export const fireQuerySync = (args: FireQueryArgs): QueryResult[] => {
 };
 
 const fireQuery: FireQuery = async (_args) => {
-  const { isCustomEnabled, customNode, ...args } = _args;
+  const { isCustomEnabled, customNode, local, ...args } = _args;
 
   const { query, formatResult, inputs } = isCustomEnabled
     ? {
@@ -347,10 +348,15 @@ const fireQuery: FireQuery = async (_args) => {
       console.groupEnd();
     }
 
-    const queryResults = await window.roamAlphaAPI.data.backend.q(
-      query,
-      ...inputs,
-    );
+    let queryResults: unknown[][] = [];
+    if (local) {
+      queryResults = await window.roamAlphaAPI.data.async.fast.q(
+        query,
+        ...inputs,
+      );
+    } else {
+      queryResults = await window.roamAlphaAPI.data.backend.q(query, ...inputs);
+    }
 
     if (nodeEnv === "development") {
       console.timeEnd(`Query - ${queryId}`);

--- a/apps/roam/src/utils/getExportTypes.ts
+++ b/apps/roam/src/utils/getExportTypes.ts
@@ -375,7 +375,7 @@ const getExportTypes = ({
     );
   };
   const getRelationData = () =>
-    getRelationDataUtil(allRelations, nodeLabelByType);
+    getRelationDataUtil({ allRelations, nodeLabelByType, local: true });
 
   const getJsonData = async () => {
     const grammar = allRelations.map(({ label, destination, source }) => ({

--- a/apps/roam/src/utils/getRelationData.ts
+++ b/apps/roam/src/utils/getRelationData.ts
@@ -6,10 +6,15 @@ import internalError from "./internalError";
 
 // lifted from getExportTypes
 
-export const getRelationDataUtil = async (
-  allRelations: DiscourseRelation[],
-  nodeLabelByType: Record<string, string>,
-) =>
+export const getRelationDataUtil = async ({
+  allRelations,
+  nodeLabelByType,
+  local,
+}: {
+  allRelations: DiscourseRelation[];
+  nodeLabelByType: Record<string, string>;
+  local?: boolean;
+}) =>
   Promise.all(
     allRelations
       .filter(
@@ -24,6 +29,7 @@ export const getRelationDataUtil = async (
           ? []
           : fireQuery({
               returnNode: sourceLabel,
+              local,
               conditions: [
                 {
                   relation: s.label,
@@ -60,13 +66,13 @@ export const getRelationDataUtil = async (
       }),
   ).then((r) => r.flat());
 
-const getRelationData = async () => {
+const getRelationData = async (local?: boolean) => {
   const allRelations = getDiscourseRelations();
   const allNodes = getDiscourseNodes(allRelations);
   const nodeLabelByType = Object.fromEntries(
     allNodes.map((a) => [a.type, a.text]),
   );
-  return await getRelationDataUtil(allRelations, nodeLabelByType);
+  return await getRelationDataUtil({ allRelations, nodeLabelByType, local });
 };
 
 export default getRelationData;

--- a/apps/roam/src/utils/migrateRelations.ts
+++ b/apps/roam/src/utils/migrateRelations.ts
@@ -20,7 +20,7 @@ const migrateRelations = async (dryRun = false): Promise<number> => {
   await new Promise((resolve) => setTimeout(resolve, 150));
   try {
     const processed = new Set<string>();
-    const relationData = await getRelationData();
+    const relationData = await getRelationData(true);
     for (const rel of relationData) {
       const key = `${rel.source}:${rel.relUid}:${rel.target}`;
       if (processed.has(key)) continue;


### PR DESCRIPTION
https://linear.app/discourse-graphs/issue/ENG-1208/add-local-flag-to-firequery
Problem: Battering the roam server with complex queries leads to errors.

In particular, this battering happens in the migration to materialize queries.

Solution: The alternative is to make some of the queries local instead, when we know we will make many queries.

