### PR TITLE
eng-1213-adjustments to markdown: use roam links

### DIFF
--- a/apps/roam/src/utils/jsonld.ts
+++ b/apps/roam/src/utils/jsonld.ts
@@ -161,7 +161,7 @@ export const getJsonLdData = async ({
       ...new Set([...(content as string).matchAll(roamUrlRe)].map((r) => r[1])),
     ]
       .filter((r) => nodeUids.has(r))
-      .map((r) => `page:${r}`);
+      .map((r) => `pages:${r}`);
     const r = {
       "@id": `pages:${uid}`, // eslint-disable-line @typescript-eslint/naming-convention
       "@type": nodeType ?? "nodeSchema", // eslint-disable-line @typescript-eslint/naming-convention

--- a/apps/roam/src/utils/jsonld.ts
+++ b/apps/roam/src/utils/jsonld.ts
@@ -108,10 +108,12 @@ export const getJsonLdData = async ({
   Record<string, string | Record<string, string> | Record<string, string>[]>
 > => {
   const roamUrl = canonicalRoamUrl();
+  const roamUrlRe = new RegExp(roamUrl + "/page/([\\w\\d-]{9,10})\\b", "g");
   const getRelationData = () =>
     getRelationDataUtil({ allRelations, nodeLabelByType });
   await updateExportProgress(0);
   const pageData = getPageData({ results, allNodes });
+  const nodeUids = new Set(pageData.map((p) => p.uid));
   const numPages = pageData.length + allNodes.length;
   let numTreatedPages = 0;
   const settings = {
@@ -138,6 +140,8 @@ export const getJsonLdData = async ({
         ...settings,
         allNodes,
         linkType: "roam url",
+        blockAnchors: true,
+        blockRefsAsLinks: true,
       });
       page.content = r.content;
       numTreatedPages += 1;
@@ -153,6 +157,11 @@ export const getJsonLdData = async ({
         error: `Unknown node type "${type}" for page "${text}"`,
       });
     }
+    const textRefersToNode = [
+      ...new Set([...(content as string).matchAll(roamUrlRe)].map((r) => r[1])),
+    ]
+      .filter((r) => nodeUids.has(r))
+      .map((r) => `page:${r}`);
     const r = {
       "@id": `pages:${uid}`, // eslint-disable-line @typescript-eslint/naming-convention
       "@type": nodeType ?? "nodeSchema", // eslint-disable-line @typescript-eslint/naming-convention
@@ -162,6 +171,7 @@ export const getJsonLdData = async ({
       created: date.toJSON(),
       creator: displayName,
     };
+    if (textRefersToNode.length > 0) return { ...r, textRefersToNode };
     return r;
   });
   const nodeSet = new Set(pageData.map((n) => n.uid));


### PR DESCRIPTION
The primary goal is to note inter-node references in text. We extract this as an extra json-ld attribute.
The secondary goal is to make markdown hyperlinks more legible to LLMs. 
For that purpose, we use roam-url linkification, so the links match the node identities.
We also introduce a (pseudo) paragraph anchor, so that block references can refer to the combination of the page and the anchor. This does not fit roam patterns, but should again be more meaningful to LLMs.
These changes are currently applied only to the json-ld export.
There is an unrelated change to the regexp escaping that was suggested to coderabbit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved special character handling during export

* **New Features**
  * Added options to convert block references to links and insert block anchors
  * Enhanced page reference tracking in exported content

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->