### PR TITLE
ENG-1167 Center dg logo svg so its vertically aligned

### DIFF
--- a/apps/obsidian/src/components/GeneralSettings.tsx
+++ b/apps/obsidian/src/components/GeneralSettings.tsx
@@ -30,7 +30,7 @@ const InfoSection = () => {
       >
         <div
           ref={logoRef}
-          className="h-12 w-12"
+          className="flex h-12 w-12 items-center justify-center"
           style={{ color: "var(--interactive-accent)" }}
         />
         <div


### PR DESCRIPTION
> the discourse graphs logo is aligned top left and should be centered both vertically and horizontally

before
<img width="596" height="634" alt="image" src="https://github.com/user-attachments/assets/85e6b804-9404-4fd0-a755-f9e0e44a6a02" />

after
<img width="541" height="338" alt="image" src="https://github.com/user-attachments/assets/7c09f3d5-6ad1-4874-bb5c-b5e2bc2683c3" />
