### PR TITLE
Fix broken links in Obsidian installation docs

### DIFF
--- a/apps/website/app/(docs)/docs/obsidian/pages/installation.md
+++ b/apps/website/app/(docs)/docs/obsidian/pages/installation.md
@@ -40,6 +40,6 @@ published: true
 ## Next Steps
 
 After installation, you'll want to:
-1. [Configure your node types](./extending-personalizing-graph#edit-node-types)
-2. [Set up relationship types](./extending-personalizing-graph#edit-relation-types)
+1. [Configure your node types](./node-types-templates)
+2. [Set up relationship types](./relationship-types)
 3. [Create your first node](./creating-discourse-nodes) 


### PR DESCRIPTION
## Summary
- Fix broken Next Steps links in Obsidian installation docs
- Update links to point to correct doc pages (node-types-templates, relationship-types)

## Test plan
- [x] Verified locally that the website builds and links work