### PR TITLE
ENG-1230 Backlinks in JSON-LD export

### DIFF
--- a/apps/roam/src/utils/jsonld.ts
+++ b/apps/roam/src/utils/jsonld.ts
@@ -171,7 +171,7 @@ export const getJsonLdData = async ({
         .filter((x) => nodeSet.has(x));
       const r: Record<string, string | string[]> = {
         "@id": `pages:${uid}`, // eslint-disable-line @typescript-eslint/naming-convention
-        "@type": nodeType ?? "nodeSchema", // eslint-disable-line @typescript-eslint/naming-convention
+        "@type": nodeType, // eslint-disable-line @typescript-eslint/naming-convention
         title: text,
         content,
         modified: modified?.toJSON(),

--- a/apps/roam/src/utils/jsonld.ts
+++ b/apps/roam/src/utils/jsonld.ts
@@ -107,7 +107,10 @@ export const getJsonLdData = async ({
   nodeLabelByType: Record<string, string>;
   updateExportProgress: (progress: number) => Promise<void>;
 }): Promise<
-  Record<string, string | Record<string, string> | Record<string, string>[]>
+  Record<
+    string,
+    string | Record<string, string> | Record<string, string | string[]>[]
+  >
 > => {
   const roamUrl = canonicalRoamUrl();
   const getRelationData = () =>

--- a/apps/website/public/schema/dg_base.ttl
+++ b/apps/website/public/schema/dg_base.ttl
@@ -43,11 +43,6 @@ dgb:destination a dgb:Role ;
     rdfs:range dgb:NodeSchema ;
     rdfs:comment "The destination of a binary relation"@en .
 
-dgb:textRefersToNode a owl:ObjectProperty;
-  rdfs:domain dgb:NodeSchema;
-  rdfs:range dgb:NodeSchema;
-  rdfs:comment "The text of a node refers to another node"@en .
-
 
 # examples
 

--- a/apps/website/public/schema/dg_core.ttl
+++ b/apps/website/public/schema/dg_core.ttl
@@ -3,11 +3,18 @@
 @prefix : <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix vs: <http://www.w3.org/2003/06/sw-vocab-status/ns#> .
-@prefix sioc: <http://rdfs.org/sioc/ns#> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
 @prefix dgb: <https://discoursegraphs.com/schema/dg_base#> .
 @prefix dg: <https://discoursegraphs.com/schema/dg_core#> .
+# http://purl.org/spar/po
+@prefix po: <http://www.essepuntato.it/2008/12/pattern#> .
+
+<https://discoursegraphs.com/schema/dg_core#>
+    dc:date "2025-12-31" ;
+    rdfs:comment "DiscourseGraph core vocabulary"@en ;
+    rdfs:label "DiscourseGraph core vocabulary"@en ;
+    owl:versionInfo "0 (tentative)" ;
+    a owl:Ontology.
 
 dg:Question a dgb:NodeSchema;
   rdfs:label "Question"@en;
@@ -90,3 +97,15 @@ dg:curatedFrom a dgb:RelationDef;
   rdfs:label "Curated from"@en;
   rdfs:range dg:Evidence;
   rdfs:domain dg:Source.
+
+dg:containsRec a owl:TransitiveProperty.
+po:contains rdfs:subClassOf dg:containsRec.
+dct:hasPart rdfs:subClassOf dg:containsRec.
+
+dg:containsRef a owl:ObjectProperty;
+  owl:propertyChainAxiom (dg:containsRec dct:references);
+  rdfs:label "Contains a reference to"@en.
+
+dg:backlink a owl:ObjectProperty;
+  owl:inverseOf dg:containsRef;
+  rdfs:label "is referred by"@en.

--- a/apps/website/public/schema/dg_core.ttl
+++ b/apps/website/public/schema/dg_core.ttl
@@ -99,8 +99,8 @@ dg:curatedFrom a dgb:RelationDef;
   rdfs:domain dg:Source.
 
 dg:containsRec a owl:TransitiveProperty.
-po:contains rdfs:subClassOf dg:containsRec.
-dc:hasPart rdfs:subClassOf dg:containsRec.
+po:contains rdfs:subPropertyOf dg:containsRec.
+dc:hasPart rdfs:subPropertyOf dg:containsRec.
 
 dg:containsRef a owl:ObjectProperty;
   owl:propertyChainAxiom (dg:containsRec dc:references);

--- a/apps/website/public/schema/dg_core.ttl
+++ b/apps/website/public/schema/dg_core.ttl
@@ -100,10 +100,10 @@ dg:curatedFrom a dgb:RelationDef;
 
 dg:containsRec a owl:TransitiveProperty.
 po:contains rdfs:subClassOf dg:containsRec.
-dct:hasPart rdfs:subClassOf dg:containsRec.
+dc:hasPart rdfs:subClassOf dg:containsRec.
 
 dg:containsRef a owl:ObjectProperty;
-  owl:propertyChainAxiom (dg:containsRec dct:references);
+  owl:propertyChainAxiom (dg:containsRec dc:references);
   rdfs:label "Contains a reference to"@en.
 
 dg:backlink a owl:ObjectProperty;


### PR DESCRIPTION
https://linear.app/discourse-graphs/issue/ENG-1230/backlinks-in-json-ld-export
Add backlink information in json-ld export
Create a backlink relationship based on common elements (dcterms) and also reference to the document structure ontology (which allows describing roam block containment)
Accessorily: Added ontology info to dg-core, consolidated per-page calculations in a single function for better progress tracking.

Loom: https://www.loom.com/share/b9fc610d5d9349e0aff6af16dc801636

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added backlink functionality to display all pages that reference the current page.
  * Enhanced vocabulary schema to better support semantic relationships between content.
  * Improved JSON-LD export with comprehensive relationship and backlink tracking.
  * Refined progress tracking during data export operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->