### PR TITLE
ENG-995 - Node bounding box doesn't align with borders of the shape in tldraw

### DIFF
--- a/apps/obsidian/src/components/canvas/shapes/DiscourseNodeShape.tsx
+++ b/apps/obsidian/src/components/canvas/shapes/DiscourseNodeShape.tsx
@@ -13,6 +13,7 @@ import {
   TLDefaultFontStyle,
   FONT_SIZES,
   FONT_FAMILIES,
+  toDomPrecision,
 } from "tldraw";
 import { App, TFile } from "obsidian";
 import { memo, createElement, useEffect } from "react";
@@ -172,7 +173,13 @@ export class DiscourseNodeUtil extends BaseBoxShapeUtil<DiscourseNodeShape> {
   }
 
   indicator(shape: DiscourseNodeShape) {
-    return <rect width={shape.props.w} height={shape.props.h} />;
+    const { bounds } = this.editor.getShapeGeometry(shape);
+    return (
+      <rect
+        width={toDomPrecision(bounds.width)}
+        height={toDomPrecision(bounds.height)}
+      />
+    );
   }
 
   getFile = async (

--- a/apps/roam/src/components/canvas/DiscourseNodeUtil.tsx
+++ b/apps/roam/src/components/canvas/DiscourseNodeUtil.tsx
@@ -21,6 +21,7 @@ import {
   FONT_FAMILIES,
   TLDefaultFontStyle,
   DefaultFontStyle,
+  toDomPrecision,
 } from "tldraw";
 import React, { useState, useEffect, useRef, useMemo } from "react";
 import { useExtensionAPI } from "roamjs-components/components/ExtensionApiContext";
@@ -424,7 +425,13 @@ export class BaseDiscourseNodeUtil extends ShapeUtil<DiscourseNodeShape> {
   };
 
   indicator(shape: DiscourseNodeShape) {
-    return <rect width={shape.props.w} height={shape.props.h} />;
+    const { bounds } = this.editor.getShapeGeometry(shape);
+    return (
+      <rect
+        width={toDomPrecision(bounds.width)}
+        height={toDomPrecision(bounds.height)}
+      />
+    );
   }
 
   updateProps(


### PR DESCRIPTION
https://www.loom.com/share/09b39df601db4a93b47359a38b4ad6ae

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved rendering accuracy for shape indicators to reflect actual geometry calculations with enhanced precision.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->