### PR TITLE
ENG-1238 Group creation function

### DIFF
--- a/packages/database/supabase/functions/create-group/deno.json
+++ b/packages/database/supabase/functions/create-group/deno.json
@@ -3,9 +3,6 @@
     "@supabase/functions-js/edge-runtime": "jsr:@supabase/functions-js/edge-runtime.d.ts",
     "@supabase/supabase-js": "jsr:@supabase/supabase-js@2",
     "@supabase/functions-js": "jsr:@supabase/functions-js@2",
-    "@repo/database/dbTypes": "../../../src/dbTypes.ts",
-    "@repo/database/lib/contextFunctions": "../../../src/lib/contextFunctions.ts",
-    "@repo/database/lib/client": "../../../src/lib/client.ts",
-    "@repo/utils/lib/execContext": "../../../../utils/src/lib/execContext.ts"
+    "@repo/database/lib/client": "../../../src/lib/client.ts"
   }
 }

--- a/packages/database/supabase/functions/create-group/deno.json
+++ b/packages/database/supabase/functions/create-group/deno.json
@@ -1,0 +1,11 @@
+{
+  "imports": {
+    "@supabase/functions-js/edge-runtime": "jsr:@supabase/functions-js/edge-runtime.d.ts",
+    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2",
+    "@supabase/functions-js": "jsr:@supabase/functions-js@2",
+    "@repo/database/dbTypes": "../../../src/dbTypes.ts",
+    "@repo/database/lib/contextFunctions": "../../../src/lib/contextFunctions.ts",
+    "@repo/database/lib/client": "../../../src/lib/client.ts",
+    "@repo/utils/lib/execContext": "../../../../utils/src/lib/execContext.ts"
+  }
+}

--- a/packages/database/supabase/functions/create-group/index.ts
+++ b/packages/database/supabase/functions/create-group/index.ts
@@ -32,6 +32,12 @@ Deno.serve(async (req) => {
       },
     });
   }
+  if (req.method !== "POST") {
+    return Response.json(
+      { msg: 'Method not allowed' },
+      { status: 405 }
+    );
+  }
 
   // @ts-ignore Deno is not visible to the IDE
   const url = Deno.env.get("SUPABASE_URL");
@@ -84,7 +90,7 @@ Deno.serve(async (req) => {
   if (membershipResponse.error)
     return Response.json({ msg: `Failed to create membership for group ${group_id}`, error: membershipResponse.error.message }, { status: 500 });
 
-  const res = new Response(group_id);
+  const res = Response.json({group_id});
 
   if (originIsAllowed) {
     res.headers.set("Access-Control-Allow-Origin", origin as string);

--- a/packages/database/supabase/functions/create-group/index.ts
+++ b/packages/database/supabase/functions/create-group/index.ts
@@ -1,0 +1,93 @@
+// Follow this setup guide to integrate the Deno language server with your editor:
+// https://deno.land/manual/getting_started/setup_your_environment
+// This enables autocomplete, go to definition, etc.
+
+import "@supabase/functions-js/edge-runtime";
+import { createClient } from "@supabase/supabase-js";
+import type { DGSupabaseClient } from "@repo/database/lib/client";
+
+// The following lines are duplicated from apps/website/app/utils/llm/cors.ts
+const allowedOrigins = ["https://roamresearch.com", "http://localhost:3000"];
+
+const isVercelPreviewUrl = (origin: string): boolean =>
+  /^https:\/\/.*-discourse-graph-[a-z0-9]+\.vercel\.app$/.test(origin);
+
+const isAllowedOrigin = (origin: string): boolean =>
+  allowedOrigins.some((allowed) => origin.startsWith(allowed)) ||
+  isVercelPreviewUrl(origin);
+
+// @ts-ignore Deno is not visible to the IDE
+Deno.serve(async (req) => {
+  const origin = req.headers.get("origin");
+  const originIsAllowed = origin && isAllowedOrigin(origin);
+  if (req.method === "OPTIONS") {
+    return new Response(null, {
+      status: 204,
+      headers: {
+        ...(originIsAllowed ? { "Access-Control-Allow-Origin": origin } : {}),
+        "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+        "Access-Control-Allow-Headers":
+          "Content-Type, Authorization, x-vercel-protection-bypass, x-client-info, apikey",
+        "Access-Control-Max-Age": "86400",
+      },
+    });
+  }
+
+  // @ts-ignore Deno is not visible to the IDE
+  const url = Deno.env.get("SUPABASE_URL");
+  // @ts-ignore Deno is not visible to the IDE
+  const service_key = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+  // @ts-ignore Deno is not visible to the IDE
+  const anon_key = Deno.env.get("SUPABASE_ANON_KEY");
+
+  if (!url || !anon_key || !service_key) {
+    return new Response("Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY or SUPABASE_ANON_KEY", {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+  const supabase = createClient(url, anon_key)
+  const authHeader = req.headers.get('Authorization')!
+  const token = authHeader.replace('Bearer ', '')
+  const { data, error } = await supabase.auth.getClaims(token)
+
+  const userEmail = data?.claims?.email
+  if (!userEmail || error || data?.claims?.is_anonymous === true) {
+    return Response.json(
+      { msg: 'Invalid JWT' },
+      {
+        status: 401,
+      }
+    )
+  }
+  const groupName = crypto.randomUUID();
+  const password = crypto.randomUUID();
+  const supabaseAdmin: DGSupabaseClient = createClient(url, service_key);
+  const userResponse = await supabaseAdmin.auth.admin.createUser({
+    email: `${groupName}@groups.discoursegraphs.com`,
+    password,
+    email_confirm: false, // eslint-disable-line @typescript-eslint/naming-convention
+  });
+  if (userResponse.error)
+    throw userResponse.error;
+  if (!userResponse.data.user)
+    throw new Error("Did not create user");
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  const group_id = userResponse.data.user.id;
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  const membershipResponse = await supabaseAdmin.from("group_membership").insert({group_id, member_id:data.claims.sub, admin:true});
+  console.log(membershipResponse)
+
+  const res = new Response(group_id);
+
+  if (originIsAllowed) {
+    res.headers.set("Access-Control-Allow-Origin", origin as string);
+    res.headers.set("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
+    res.headers.set(
+      "Access-Control-Allow-Headers",
+      "Content-Type, Authorization, x-vercel-protection-bypass, x-client-info, apikey",
+    );
+  }
+
+  return res;
+});

--- a/packages/database/supabase/functions/create-group/index.ts
+++ b/packages/database/supabase/functions/create-group/index.ts
@@ -7,7 +7,7 @@ import { createClient, type UserResponse } from "@supabase/supabase-js";
 import type { DGSupabaseClient } from "@repo/database/lib/client";
 
 // The following lines are duplicated from apps/website/app/utils/llm/cors.ts
-const allowedOrigins = ["https://roamresearch.com", "http://localhost:3000"];
+const allowedOrigins = ["https://roamresearch.com", "http://localhost:3000", "app://obsidian.md"];
 
 const isVercelPreviewUrl = (origin: string): boolean =>
   /^https:\/\/.*-discourse-graph-[a-z0-9]+\.vercel\.app$/.test(origin);

--- a/packages/database/supabase/functions/create-group/index.ts
+++ b/packages/database/supabase/functions/create-group/index.ts
@@ -3,7 +3,7 @@
 // This enables autocomplete, go to definition, etc.
 
 import "@supabase/functions-js/edge-runtime";
-import { createClient, UserResponse } from "@supabase/supabase-js";
+import { createClient, type UserResponse } from "@supabase/supabase-js";
 import type { DGSupabaseClient } from "@repo/database/lib/client";
 
 // The following lines are duplicated from apps/website/app/utils/llm/cors.ts

--- a/packages/database/supabase/functions/create-space/deno.json
+++ b/packages/database/supabase/functions/create-space/deno.json
@@ -6,6 +6,6 @@
     "@repo/database/dbTypes": "../../../src/dbTypes.ts",
     "@repo/database/lib/contextFunctions": "../../../src/lib/contextFunctions.ts",
     "@repo/database/lib/client": "../../../src/lib/client.ts",
-    "@repo/utils/lib/execContext": "../../../../utils/src/lib/execContext.ts"
+    "@repo/utils/lib/execContext": "../../../../utils/src/execContext.ts"
   }
 }


### PR DESCRIPTION
https://linear.app/discourse-graphs/issue/ENG-1238/group-creation-function
An edge function that will create a group, owned by the currently logged in user.
The user should then be able to add members normally.

Loom video: https://www.loom.com/share/2725c1614adf4b4eb4443b818908ad72

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a serverless POST endpoint to create groups with JWT-based auth; requester becomes group administrator.
  * Endpoint returns the new group ID and supports CORS for approved origins and preview environments.
  * Exposed a logged-in client accessor on the RoamJS extension API for use by integrations.

* **Chores**
  * Added module import path aliases to simplify project imports and runtime resolution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->