### PR TITLE
eng-1262: allow for same id, different triples

### DIFF
--- a/apps/roam/src/components/CreateRelationDialog.tsx
+++ b/apps/roam/src/components/CreateRelationDialog.tsx
@@ -141,7 +141,7 @@ const CreateRelationDialog = ({
       if (setOfRels.size > 1) {
         internalError({
           type: "Create Relation dialog",
-          error: `Too many relations between ${selectedTargetType.type} and ${selectedSourceType.type}: ${setOfRels.values().join(",")}`,
+          error: `Too many relations between ${selectedTargetType.type} and ${selectedSourceType.type}: ${[...setOfRels].join(",")}`,
         });
         // let it still fall through to the first
       }

--- a/apps/roam/src/components/CreateRelationDialog.tsx
+++ b/apps/roam/src/components/CreateRelationDialog.tsx
@@ -133,13 +133,18 @@ const CreateRelationDialog = ({
       });
       return null;
     }
-    if (candidateRelations.length !== 1) {
-      // This seems to happen... I need more data.
-      internalError({
-        type: "Create Relation dialog",
-        error: `Too many relations between ${selectedTargetType.type} and ${selectedSourceType.type}: ${candidateRelations.map((r) => r.id).join(",")}`,
-      });
-      return null;
+    if (candidateRelations.length > 1) {
+      // Control for one very innocuous case: Many times the same relation, with different triples.
+      const setOfRels = new Set(
+        candidateRelations.map((r) => (r.forward ? r.id : `-${r.id}`)),
+      );
+      if (setOfRels.size > 1) {
+        internalError({
+          type: "Create Relation dialog",
+          error: `Too many relations between ${selectedTargetType.type} and ${selectedSourceType.type}: ${setOfRels.values().join(",")}`,
+        });
+        // let it still fall through to the first
+      }
     }
     return candidateRelations[0];
   };


### PR DESCRIPTION
The source of the problem is that I failed if many relations had the same source, target and name. But relations can differ through their triple and have the same Id. I do not send an internal error in that innocuous case anymore.
Also, I do not fail the process even in that case but take the first relation.
https://www.loom.com/share/1c829585567c49fa873d51697847ffbb


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined relation matching error handling to reduce false error reporting when multiple similar relations exist, with improved fallback behavior for edge cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->