### PR TITLE
ENG-1260 Permission denied when attempting to sync megacog nodes w/ database for embeddings

### DIFF
--- a/packages/database/supabase/migrations/20260109035002_update_policy_using.sql
+++ b/packages/database/supabase/migrations/20260109035002_update_policy_using.sql
@@ -1,3 +1,5 @@
+DROP POLICY IF EXISTS content_update_policy ON public."Content";
+CREATE POLICY content_update_policy ON public."Content" FOR UPDATE USING (public.in_space(space_id));
 DROP POLICY content_access_update_policy ON public."ContentAccess";
 CREATE POLICY content_access_update_policy ON public."ContentAccess" FOR UPDATE USING (public.content_in_editable_space(content_id));
 DROP POLICY concept_update_policy ON public."Concept";

--- a/packages/database/supabase/migrations/20260109035002_update_policy_using.sql
+++ b/packages/database/supabase/migrations/20260109035002_update_policy_using.sql
@@ -1,0 +1,16 @@
+DROP POLICY content_access_update_policy ON public."ContentAccess";
+CREATE POLICY content_access_update_policy ON public."ContentAccess" FOR UPDATE USING (public.content_in_editable_space(content_id));
+DROP POLICY concept_update_policy ON public."Concept";
+CREATE POLICY concept_update_policy ON public."Concept" FOR UPDATE USING (public.in_space(space_id));
+DROP POLICY concept_access_update_policy ON public."ConceptAccess";
+CREATE POLICY concept_access_update_policy ON public."ConceptAccess" FOR UPDATE USING (public.concept_in_editable_space(concept_id));
+DROP POLICY platform_account_update_policy ON public."PlatformAccount";
+CREATE POLICY platform_account_update_policy ON public."PlatformAccount" FOR UPDATE USING (dg_account = (SELECT auth.uid() LIMIT 1) OR (dg_account IS null AND public.unowned_account_in_shared_space(id)));
+DROP POLICY space_access_update_policy ON public."SpaceAccess";
+CREATE POLICY space_access_update_policy ON public."SpaceAccess" FOR UPDATE USING (account_uid = auth.uid());
+DROP POLICY local_access_update_policy ON public."LocalAccess";
+CREATE POLICY local_access_update_policy ON public."LocalAccess" FOR UPDATE USING (public.unowned_account_in_shared_space(account_id) OR public.is_my_account(account_id));
+DROP POLICY agent_identifier_update_policy ON public."AgentIdentifier";
+CREATE POLICY agent_identifier_update_policy ON public."AgentIdentifier" FOR UPDATE USING (public.unowned_account_in_shared_space(account_id) OR public.is_my_account(account_id));
+DROP POLICY group_membership_update_policy ON public.group_membership;
+CREATE POLICY group_membership_update_policy ON public.group_membership FOR UPDATE USING (public.is_group_admin(group_id));

--- a/packages/database/supabase/schemas/account.sql
+++ b/packages/database/supabase/schemas/account.sql
@@ -451,7 +451,7 @@ DROP POLICY IF EXISTS platform_account_insert_policy ON public."PlatformAccount"
 CREATE POLICY platform_account_insert_policy ON public."PlatformAccount" FOR INSERT WITH CHECK (dg_account = (SELECT auth.uid() LIMIT 1) OR (dg_account IS null AND public.unowned_account_in_shared_space(id)));
 
 DROP POLICY IF EXISTS platform_account_update_policy ON public."PlatformAccount";
-CREATE POLICY platform_account_update_policy ON public."PlatformAccount" FOR UPDATE WITH CHECK (dg_account = (SELECT auth.uid() LIMIT 1) OR (dg_account IS null AND public.unowned_account_in_shared_space(id)));
+CREATE POLICY platform_account_update_policy ON public."PlatformAccount" FOR UPDATE USING (dg_account = (SELECT auth.uid() LIMIT 1) OR (dg_account IS null AND public.unowned_account_in_shared_space(id)));
 
 -- SpaceAccess: Created through the create_account_in_space and the Space create route, both of which bypass RLS.
 -- Can be updated by a space peer for now, unless claimed by a user.
@@ -471,7 +471,7 @@ DROP POLICY IF EXISTS space_access_insert_policy ON public."SpaceAccess";
 CREATE POLICY space_access_insert_policy ON public."SpaceAccess" FOR INSERT WITH CHECK (account_uid = auth.uid());
 
 DROP POLICY IF EXISTS space_access_update_policy ON public."SpaceAccess";
-CREATE POLICY space_access_update_policy ON public."SpaceAccess" FOR UPDATE WITH CHECK (account_uid = auth.uid());
+CREATE POLICY space_access_update_policy ON public."SpaceAccess" FOR UPDATE USING (account_uid = auth.uid());
 
 ALTER TABLE public."LocalAccess" ENABLE ROW LEVEL SECURITY;
 
@@ -487,7 +487,7 @@ DROP POLICY IF EXISTS local_access_insert_policy ON public."LocalAccess";
 CREATE POLICY local_access_insert_policy ON public."LocalAccess" FOR INSERT WITH CHECK (public.unowned_account_in_shared_space(account_id) OR public.is_my_account(account_id));
 
 DROP POLICY IF EXISTS local_access_update_policy ON public."LocalAccess";
-CREATE POLICY local_access_update_policy ON public."LocalAccess" FOR UPDATE WITH CHECK (public.unowned_account_in_shared_space(account_id) OR public.is_my_account(account_id));
+CREATE POLICY local_access_update_policy ON public."LocalAccess" FOR UPDATE USING (public.unowned_account_in_shared_space(account_id) OR public.is_my_account(account_id));
 
 -- AgentIdentifier: Allow space members to do anything, to allow editing authors.
 -- Eventually: Once the account is claimed by a user, only allow this user to modify it.
@@ -506,7 +506,7 @@ DROP POLICY IF EXISTS agent_identifier_insert_policy ON public."AgentIdentifier"
 CREATE POLICY agent_identifier_insert_policy ON public."AgentIdentifier" FOR INSERT WITH CHECK (public.unowned_account_in_shared_space(account_id) OR public.is_my_account(account_id));
 
 DROP POLICY IF EXISTS agent_identifier_update_policy ON public."AgentIdentifier";
-CREATE POLICY agent_identifier_update_policy ON public."AgentIdentifier" FOR UPDATE WITH CHECK (public.unowned_account_in_shared_space(account_id) OR public.is_my_account(account_id));
+CREATE POLICY agent_identifier_update_policy ON public."AgentIdentifier" FOR UPDATE USING (public.unowned_account_in_shared_space(account_id) OR public.is_my_account(account_id));
 
 ALTER TABLE public.group_membership ENABLE ROW LEVEL SECURITY;
 
@@ -520,4 +520,4 @@ DROP POLICY IF EXISTS group_membership_insert_policy ON public.group_membership;
 CREATE POLICY group_membership_insert_policy ON public.group_membership FOR INSERT WITH CHECK (public.is_group_admin(group_id) OR NOT public.group_exists(group_id));
 
 DROP POLICY IF EXISTS group_membership_update_policy ON public.group_membership;
-CREATE POLICY group_membership_update_policy ON public.group_membership FOR UPDATE WITH CHECK (public.is_group_admin(group_id));
+CREATE POLICY group_membership_update_policy ON public.group_membership FOR UPDATE USING (public.is_group_admin(group_id));

--- a/packages/database/supabase/schemas/concept.sql
+++ b/packages/database/supabase/schemas/concept.sql
@@ -459,7 +459,7 @@ CREATE POLICY concept_delete_policy ON public."Concept" FOR DELETE USING (public
 DROP POLICY IF EXISTS concept_insert_policy ON public."Concept";
 CREATE POLICY concept_insert_policy ON public."Concept" FOR INSERT WITH CHECK (public.in_space(space_id));
 DROP POLICY IF EXISTS concept_update_policy ON public."Concept";
-CREATE POLICY concept_update_policy ON public."Concept" FOR UPDATE WITH CHECK (public.in_space(space_id));
+CREATE POLICY concept_update_policy ON public."Concept" FOR UPDATE USING (public.in_space(space_id));
 
 ALTER TABLE public."ConceptAccess" ENABLE ROW LEVEL SECURITY;
 
@@ -471,4 +471,4 @@ CREATE POLICY concept_access_delete_policy ON public."ConceptAccess" FOR DELETE 
 DROP POLICY IF EXISTS concept_access_insert_policy ON public."ConceptAccess";
 CREATE POLICY concept_access_insert_policy ON public."ConceptAccess" FOR INSERT WITH CHECK (public.concept_in_editable_space(concept_id));
 DROP POLICY IF EXISTS concept_access_update_policy ON public."ConceptAccess";
-CREATE POLICY concept_access_update_policy ON public."ConceptAccess" FOR UPDATE WITH CHECK (public.concept_in_editable_space(concept_id));
+CREATE POLICY concept_access_update_policy ON public."ConceptAccess" FOR UPDATE USING (public.concept_in_editable_space(concept_id));

--- a/packages/database/supabase/schemas/content.sql
+++ b/packages/database/supabase/schemas/content.sql
@@ -660,7 +660,7 @@ CREATE POLICY content_delete_policy ON public."Content" FOR DELETE USING (public
 DROP POLICY IF EXISTS content_insert_policy ON public."Content";
 CREATE POLICY content_insert_policy ON public."Content" FOR INSERT WITH CHECK (public.in_space(space_id));
 DROP POLICY IF EXISTS content_update_policy ON public."Content";
-CREATE POLICY content_update_policy ON public."Content" FOR UPDATE WITH CHECK (public.in_space(space_id));
+CREATE POLICY content_update_policy ON public."Content" FOR UPDATE USING (public.in_space(space_id));
 
 ALTER TABLE public."ContentAccess" ENABLE ROW LEVEL SECURITY;
 
@@ -672,4 +672,4 @@ CREATE POLICY content_access_delete_policy ON public."ContentAccess" FOR DELETE 
 DROP POLICY IF EXISTS content_access_insert_policy ON public."ContentAccess";
 CREATE POLICY content_access_insert_policy ON public."ContentAccess" FOR INSERT WITH CHECK (public.content_in_editable_space(content_id));
 DROP POLICY IF EXISTS content_access_update_policy ON public."ContentAccess";
-CREATE POLICY content_access_update_policy ON public."ContentAccess" FOR UPDATE WITH CHECK (public.content_in_editable_space(content_id));
+CREATE POLICY content_access_update_policy ON public."ContentAccess" FOR UPDATE USING (public.content_in_editable_space(content_id));


### PR DESCRIPTION
https://linear.app/discourse-graphs/issue/ENG-1260/permission-denied-when-attempting-to-sync-megacog-nodes-w-database-for

The upsert_content fails in the case of content update. It probably never worked, this has nothing to do with the latest changes; we were mostly testing with inserts. 
It turns out this is not an issue if the update policy is defined with "using" instead of "with check". The latter syntax applies only after the change; leaving the before case unspecified, hence restrictive. "using" used alone applies both before and after the update. 


https://www.loom.com/share/00ac64c512004161905909ed5a45cfdd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database access control policies to improve consistency and ensure proper enforcement of content modification and sharing permissions across the platform.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->