### PR TITLE
ENG-1266: Bug: Component not loading on any page

### DIFF
--- a/apps/roam/src/components/canvas/Tldraw.tsx
+++ b/apps/roam/src/components/canvas/Tldraw.tsx
@@ -479,7 +479,7 @@ const TldrawCanvas = ({ title }: { title: string }) => {
         ? { x: lastTime.x + w * 0.025, y: lastTime.y + h * 0.05 }
         : { x: x - DEFAULT_WIDTH / 2, y: y - DEFAULT_HEIGHT / 2 };
       const nodeType = findDiscourseNode({
-        uid: e.detail.uid,
+        uid: e.detail.uid || "",
         nodes: allNodes,
       });
       if (nodeType) {

--- a/apps/roam/src/utils/findDiscourseNode.ts
+++ b/apps/roam/src/utils/findDiscourseNode.ts
@@ -22,7 +22,7 @@ const findDiscourseNode = ({
         ? matchDiscourseNode({ ...node, uid })
         : matchDiscourseNode({ ...node, title }),
     ) || false;
-  if (uid) discourseNodeTypeCache[uid] = matchingNode;
+  discourseNodeTypeCache[uid] = matchingNode;
   return matchingNode;
 };
 export default findDiscourseNode;

--- a/apps/roam/src/utils/findDiscourseNode.ts
+++ b/apps/roam/src/utils/findDiscourseNode.ts
@@ -12,18 +12,18 @@ const findDiscourseNode = ({
   title?: string;
   nodes?: DiscourseNode[];
 }): DiscourseNode | false => {
-  if (uid === undefined) return false;
-  if (typeof discourseNodeTypeCache[uid] !== "undefined") {
+  if (uid === undefined && title === undefined) return false;
+  if (uid && typeof discourseNodeTypeCache[uid] !== "undefined") {
     return discourseNodeTypeCache[uid];
   }
 
   const matchingNode =
     nodes.find((node) =>
       title === undefined
-        ? matchDiscourseNode({ ...node, uid: uid })
+        ? matchDiscourseNode({ ...node, uid: uid! })
         : matchDiscourseNode({ ...node, title }),
     ) || false;
-  discourseNodeTypeCache[uid] = matchingNode;
+  if (uid) discourseNodeTypeCache[uid] = matchingNode;
   return matchingNode;
 };
 export default findDiscourseNode;

--- a/apps/roam/src/utils/findDiscourseNode.ts
+++ b/apps/roam/src/utils/findDiscourseNode.ts
@@ -8,19 +8,18 @@ const findDiscourseNode = ({
   title,
   nodes = getDiscourseNodes(),
 }: {
-  uid?: string;
+  uid: string;
   title?: string;
   nodes?: DiscourseNode[];
 }): DiscourseNode | false => {
-  if (uid === undefined && title === undefined) return false;
-  if (uid && typeof discourseNodeTypeCache[uid] !== "undefined") {
+  if (typeof discourseNodeTypeCache[uid] !== "undefined") {
     return discourseNodeTypeCache[uid];
   }
 
   const matchingNode =
     nodes.find((node) =>
       title === undefined
-        ? matchDiscourseNode({ ...node, uid: uid! })
+        ? matchDiscourseNode({ ...node, uid })
         : matchDiscourseNode({ ...node, title }),
     ) || false;
   if (uid) discourseNodeTypeCache[uid] = matchingNode;

--- a/apps/roam/src/utils/formatUtils.ts
+++ b/apps/roam/src/utils/formatUtils.ts
@@ -136,7 +136,7 @@ export const getReferencedNodeInFormat = ({
 }) => {
   let format = providedFormat;
   if (!format) {
-    const discourseNode = findDiscourseNode({ uid });
+    const discourseNode = findDiscourseNode({ uid: uid || "" });
     if (discourseNode) format = discourseNode.format;
   }
   if (!format) return null;

--- a/apps/roam/src/utils/initializeObserversAndListeners.ts
+++ b/apps/roam/src/utils/initializeObserversAndListeners.ts
@@ -95,11 +95,10 @@ export const initObservers = async ({
         text: "(BETA) Suggestive Mode Enabled",
       }).value;
 
-      const nodes = getDiscourseNodes();
-      const node = findDiscourseNode({ title, nodes });
+      const uid = getPageUidByPageTitle(title);
+      const node = findDiscourseNode({ uid, title });
       const isDiscourseNode = node && node.backedBy !== "default";
       if (isDiscourseNode) {
-        const uid = getPageUidByPageTitle(title);
         if (isSuggestiveModeEnabled) {
           renderPossibleDuplicates(h1, title, node);
         }


### PR DESCRIPTION
currently `findDiscourseNode` exists if we don't pass the uid which is wrong because both `uid` and `title` are optional

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Node lookup and caching logic streamlined to always use a consistent identifier, improving reliability of reference discovery.
* **Bug Fixes**
  * More consistent behavior when item identifiers are missing, reducing missed or duplicated reference suggestions and improving canvas/reference rendering.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->