### PR TITLE
ENG-940 - Remove ellipses from settings input placeholders

### DIFF
--- a/apps/roam/src/components/DiscourseNodeMenu.tsx
+++ b/apps/roam/src/components/DiscourseNodeMenu.tsx
@@ -443,7 +443,7 @@ export const NodeMenuTriggerComponent = ({
   return (
     <InputGroup
       inputRef={inputRef}
-      placeholder={isActive ? "Press keys ..." : "Click to set trigger"}
+      placeholder={isActive ? "Press keys" : "Click to set trigger"}
       value={shortcut}
       onKeyDown={handleKeyDown}
       onFocus={() => setIsActive(true)}

--- a/apps/roam/src/components/settings/HomePersonalSettings.tsx
+++ b/apps/roam/src/components/settings/HomePersonalSettings.tsx
@@ -59,7 +59,7 @@ const HomePersonalSettings = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
         settingKey={DISCOURSE_TOOL_SHORTCUT_KEY}
         label="Discourse Tool Keyboard Shortcut"
         description="Set a single key to activate the Discourse Tool in tldraw. Only single keys (no modifiers) are supported. Leave empty for no shortcut."
-        placeholder="Click to set single key..."
+        placeholder="Click to set single key"
       />
       <Checkbox
         defaultChecked={

--- a/apps/roam/src/components/settings/KeyboardShortcutInput.tsx
+++ b/apps/roam/src/components/settings/KeyboardShortcutInput.tsx
@@ -67,7 +67,7 @@ const KeyboardShortcutInput = ({
   settingKey,
   label,
   description,
-  placeholder = "Click to set shortcut...",
+  placeholder = "Click to set shortcut",
 }: KeyboardShortcutInputProps) => {
   const extensionAPI = onloadArgs.extensionAPI;
   const inputRef = useRef<HTMLInputElement>(null);
@@ -141,7 +141,7 @@ const KeyboardShortcutInput = ({
       <Description description={description} />
       <InputGroup
         inputRef={inputRef}
-        placeholder={isActive ? "Press keys ..." : placeholder}
+        placeholder={isActive ? "Press keys" : placeholder}
         value={shortcut}
         onKeyDown={handleKeyDown}
         onFocus={() => setIsActive(true)}

--- a/apps/roam/src/components/settings/PageGroupPanel.tsx
+++ b/apps/roam/src/components/settings/PageGroupPanel.tsx
@@ -132,7 +132,7 @@ const PageGroupsPanel = ({
             key={groupKey}
             value={newGroupName}
             onChange={(e) => handleNewGroupNameChange(e.target.value)}
-            placeholder="Page group name ..."
+            placeholder="Page group name"
           />
           <Button
             icon="plus"


### PR DESCRIPTION
<img width="548" height="482" alt="image" src="https://github.com/user-attachments/assets/226527e6-10f4-4b04-969f-34cb2f33abb7" />

### Motivation
- Remove the `...` ellipses from several settings input placeholders to unify interaction patterns across menus and shortcut inputs.
- Improve consistency in how active vs. idle input states are presented to users.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69647d8aaae48326817a45f31e1f2220)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated placeholder text across input fields by removing trailing ellipses for a more concise user interface appearance. Changes include placeholder text in keyboard shortcut inputs, discourse node menu, home settings, and page group panels.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->