### PR TITLE
ENG-1110 - Move discourse context to top of discourse node page

### DIFF
--- a/apps/roam/src/components/DiscourseContextOverlay.tsx
+++ b/apps/roam/src/components/DiscourseContextOverlay.tsx
@@ -286,11 +286,7 @@ export const DiscourseContextCollapseOverlay = ({
           setOpen(!open);
         }}
       />
-      <Collapse
-        isOpen={open}
-        keepChildrenMounted={true}
-        className="discourse-context-collapse-el"
-      >
+      <Collapse isOpen={open} keepChildrenMounted={true}>
         <Card className={"my-3" + (loading ? " bp3-skeleton" : "")}>
           <ContextContent
             uid={tagUid}

--- a/apps/roam/src/components/DiscourseContextOverlay.tsx
+++ b/apps/roam/src/components/DiscourseContextOverlay.tsx
@@ -168,11 +168,7 @@ export const DiscourseContextButton = ({
   );
 };
 
-const useDiscourseContext = (
-  tag: string | undefined,
-  uid: string | undefined,
-) => {
-  const tagUid = useMemo(() => uid ?? getPageUidByPageTitle(tag), [uid, tag]);
+const useDiscourseContext = (uid: string, tag: string) => {
   const [loading, setLoading] = useState(true);
   const [results, setResults] = useState<DiscourseData["results"]>([]);
   const [refs, setRefs] = useState(0);
@@ -180,12 +176,9 @@ const useDiscourseContext = (
 
   const getInfo = useCallback(
     (ignoreCache?: boolean) =>
-      getOverlayInfo(
-        tag ?? (uid ? (getPageTitleByPageUid(uid) ?? "") : ""),
-        ignoreCache,
-      )
+      getOverlayInfo(tag, ignoreCache)
         .then(({ refs, results }) => {
-          const discourseNode = findDiscourseNode({ uid: tagUid });
+          const discourseNode = findDiscourseNode({ uid: uid });
           if (discourseNode) {
             const attribute = getSettingValueFromTree({
               tree: getBasicTreeByParentUid(discourseNode.type),
@@ -193,7 +186,7 @@ const useDiscourseContext = (
               defaultValue: "Overlay",
             });
             return deriveDiscourseNodeAttribute({
-              uid: tagUid,
+              uid: uid,
               attribute,
             }).then((score) => {
               setResults(results);
@@ -203,7 +196,7 @@ const useDiscourseContext = (
           }
         })
         .finally(() => setLoading(false)),
-    [tag, uid, tagUid],
+    [tag, uid],
   );
 
   const refresh = useCallback(() => {
@@ -215,7 +208,7 @@ const useDiscourseContext = (
     void getInfo();
   }, [getInfo]);
 
-  return { tagUid, loading, results, refs, score, refresh };
+  return { loading, results, refs, score, refresh };
 };
 
 const DiscourseContextPopupOverlay = ({
@@ -226,8 +219,12 @@ const DiscourseContextPopupOverlay = ({
   textColor,
   opacity = "100",
 }: DiscourseContextOverlayProps) => {
-  const { tagUid, loading, results, refs, score, refresh } =
-    useDiscourseContext(tag, uid);
+  const tagUid = useMemo(() => uid ?? getPageUidByPageTitle(tag), [uid, tag]);
+  const uidTag = tag ?? (uid ? (getPageTitleByPageUid(uid) ?? "") : "");
+  const { loading, results, refs, score, refresh } = useDiscourseContext(
+    tagUid,
+    uidTag,
+  );
   return (
     <Popover
       autoFocus={false}
@@ -269,8 +266,12 @@ export const DiscourseContextCollapseOverlay = ({
   opacity = "100",
 }: DiscourseContextOverlayProps) => {
   const [open, setOpen] = useState(false);
-  const { tagUid, loading, results, refs, score, refresh } =
-    useDiscourseContext(tag, uid);
+  const tagUid = useMemo(() => uid ?? getPageUidByPageTitle(tag), [uid, tag]);
+  const uidTag = tag ?? (uid ? (getPageTitleByPageUid(uid) ?? "") : "");
+  const { loading, results, refs, score, refresh } = useDiscourseContext(
+    tagUid,
+    uidTag,
+  );
   return (
     <>
       <DiscourseContextButton

--- a/apps/roam/src/components/DiscourseContextOverlay.tsx
+++ b/apps/roam/src/components/DiscourseContextOverlay.tsx
@@ -1,4 +1,11 @@
-import { Button, Icon, Popover, Position, Collapse } from "@blueprintjs/core";
+import {
+  Button,
+  Icon,
+  Popover,
+  Position,
+  Collapse,
+  Card,
+} from "@blueprintjs/core";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import ReactDOM from "react-dom";
 import { ContextContent } from "./DiscourseContext";
@@ -302,26 +309,18 @@ export const DiscourseContextCollapseOverlay = ({
           setOpen(!open);
         }}
       />
-      <Collapse isOpen={open} keepChildrenMounted={true}>
-        {loading ? (
-          <div />
-        ) : (
-          <div
-            style={{
-              margin: "1ex",
-              padding: "1ex",
-              border: "1px",
-              borderStyle: "solid",
-              borderColor: iconColor,
-            }}
-          >
-            <ContextContent
-              uid={tagUid}
-              results={results}
-              overlayRefresh={refresh}
-            />
-          </div>
-        )}
+      <Collapse
+        isOpen={open}
+        keepChildrenMounted={true}
+        className="discourse-context-collapse-el"
+      >
+        <Card className={"my-3" + (loading ? " bp3-skeleton" : "")}>
+          <ContextContent
+            uid={tagUid}
+            results={results}
+            overlayRefresh={refresh}
+          />
+        </Card>
       </Collapse>
     </>
   );

--- a/apps/roam/src/utils/initializeObserversAndListeners.ts
+++ b/apps/roam/src/utils/initializeObserversAndListeners.ts
@@ -4,7 +4,10 @@ import {
   getPageTitleValueByHtmlElement,
 } from "roamjs-components/dom";
 import { createBlock } from "roamjs-components/writes";
-import { renderDiscourseContextAndCanvasReferences } from "~/utils/renderLinkedReferenceAdditions";
+import {
+  renderCanvasReferences,
+  renderDiscourseContext,
+} from "~/utils/renderLinkedReferenceAdditions";
 import { createConfigObserver } from "roamjs-components/components/ConfigPage";
 import {
   renderTldrawCanvas,
@@ -112,6 +115,7 @@ export const initObservers = async ({
       const node = findDiscourseNode({ uid, title });
       const isDiscourseNode = node && node.backedBy !== "default";
       if (isDiscourseNode) {
+        renderDiscourseContext({ h1, uid, tag: title });
         if (isSuggestiveModeEnabled) {
           renderPossibleDuplicates(h1, title, node);
         }
@@ -119,11 +123,7 @@ export const initObservers = async ({
           ".rm-reference-main",
         ) as HTMLDivElement;
         if (linkedReferencesDiv) {
-          renderDiscourseContextAndCanvasReferences(
-            linkedReferencesDiv,
-            uid,
-            onloadArgs,
-          );
+          renderCanvasReferences(linkedReferencesDiv, uid, onloadArgs);
         }
       }
 
@@ -232,7 +232,7 @@ export const initObservers = async ({
     const overlayHandler = getOverlayHandler(onloadArgs);
     onPageRefObserverChange(overlayHandler)(true);
   }
-  if (!!getPageRefObserversSize()) enablePageRefObserver();
+  if (getPageRefObserversSize()) enablePageRefObserver();
 
   const { pageUid: configPageUid, observer: configPageObserver } =
     await createConfigObserver({

--- a/apps/roam/src/utils/initializeObserversAndListeners.ts
+++ b/apps/roam/src/utils/initializeObserversAndListeners.ts
@@ -115,7 +115,7 @@ export const initObservers = async ({
       const node = findDiscourseNode({ uid, title });
       const isDiscourseNode = node && node.backedBy !== "default";
       if (isDiscourseNode) {
-        renderDiscourseContext({ h1, uid, tag: title });
+        renderDiscourseContext({ h1, uid });
         if (isSuggestiveModeEnabled) {
           renderPossibleDuplicates(h1, title, node);
         }

--- a/apps/roam/src/utils/renderLinkedReferenceAdditions.ts
+++ b/apps/roam/src/utils/renderLinkedReferenceAdditions.ts
@@ -13,12 +13,7 @@ export const renderDiscourseContext = ({
   h1: HTMLHeadingElement;
   uid: string;
 }): void => {
-  if (
-    h1
-      .closest(".rm-title-display-container")
-      ?.parentElement?.querySelector(".discourse-context-collapse-el")
-  )
-    return;
+  if (h1.getAttribute("data-roamjs-top-discourse-context")) return;
   handleTitleAdditions(
     h1,
     createElement(DiscourseContextCollapseOverlay, {
@@ -26,6 +21,7 @@ export const renderDiscourseContext = ({
       id: nanoid(),
     }),
   );
+  h1.setAttribute("data-roamjs-top-discourse-context", "true");
 };
 
 export const renderCanvasReferences = (

--- a/apps/roam/src/utils/renderLinkedReferenceAdditions.ts
+++ b/apps/roam/src/utils/renderLinkedReferenceAdditions.ts
@@ -2,7 +2,7 @@ import { createElement } from "react";
 import renderWithUnmount from "roamjs-components/util/renderWithUnmount";
 import CanvasReferences from "~/components/canvas/CanvasReferences";
 import { OnloadArgs } from "roamjs-components/types";
-import DiscourseContextOverlay from "~/components/DiscourseContextOverlay";
+import { DiscourseContextCollapseOverlay } from "~/components/DiscourseContextOverlay";
 import { handleTitleAdditions } from "./handleTitleAdditions";
 
 export const renderDiscourseContext = ({
@@ -13,10 +13,9 @@ export const renderDiscourseContext = ({
   uid: string;
 }): void => {
   if (document.getElementById("top-discourse-context")) return;
-
   handleTitleAdditions(
     h1,
-    createElement(DiscourseContextOverlay, {
+    createElement(DiscourseContextCollapseOverlay, {
       uid,
       id: "top-discourse-context",
     }),

--- a/apps/roam/src/utils/renderLinkedReferenceAdditions.ts
+++ b/apps/roam/src/utils/renderLinkedReferenceAdditions.ts
@@ -1,10 +1,26 @@
 import { createElement } from "react";
 import renderWithUnmount from "roamjs-components/util/renderWithUnmount";
-import { DiscourseContext } from "~/components";
 import CanvasReferences from "~/components/canvas/CanvasReferences";
 import { OnloadArgs } from "roamjs-components/types";
+import DiscourseContextOverlay from "~/components/DiscourseContextOverlay";
+import { handleTitleAdditions } from "./handleTitleAdditions";
 
-export const renderDiscourseContextAndCanvasReferences = (
+export const renderDiscourseContext = ({
+  h1,
+  uid,
+  tag,
+}: {
+  h1: HTMLHeadingElement;
+  uid: string;
+  tag: string;
+}): void => {
+  handleTitleAdditions(
+    h1,
+    createElement(DiscourseContextOverlay, { uid, tag }),
+  );
+};
+
+export const renderCanvasReferences = (
   div: HTMLDivElement,
   uid: string,
   onloadArgs: OnloadArgs,
@@ -16,17 +32,6 @@ export const renderDiscourseContextAndCanvasReferences = (
   if (!parent) return;
 
   const insertBefore = parent.firstElementChild;
-
-  const p = document.createElement("div");
-  parent.insertBefore(p, insertBefore);
-  renderWithUnmount(
-    createElement(DiscourseContext, {
-      uid,
-      results: [],
-    }),
-    p,
-    onloadArgs,
-  );
 
   const canvasP = document.createElement("div");
   parent.insertBefore(canvasP, insertBefore);

--- a/apps/roam/src/utils/renderLinkedReferenceAdditions.ts
+++ b/apps/roam/src/utils/renderLinkedReferenceAdditions.ts
@@ -1,3 +1,4 @@
+import nanoid from "nanoid";
 import { createElement } from "react";
 import renderWithUnmount from "roamjs-components/util/renderWithUnmount";
 import CanvasReferences from "~/components/canvas/CanvasReferences";
@@ -12,12 +13,17 @@ export const renderDiscourseContext = ({
   h1: HTMLHeadingElement;
   uid: string;
 }): void => {
-  if (h1.parentElement!.querySelector("#top-discourse-context")) return;
+  if (
+    h1
+      .closest(".rm-title-display-container")
+      ?.parentElement?.querySelector(".discourse-context-collapse-el")
+  )
+    return;
   handleTitleAdditions(
     h1,
     createElement(DiscourseContextCollapseOverlay, {
       uid,
-      id: "top-discourse-context",
+      id: nanoid(),
     }),
   );
 };

--- a/apps/roam/src/utils/renderLinkedReferenceAdditions.ts
+++ b/apps/roam/src/utils/renderLinkedReferenceAdditions.ts
@@ -4,19 +4,18 @@ import CanvasReferences from "~/components/canvas/CanvasReferences";
 import { OnloadArgs } from "roamjs-components/types";
 import DiscourseContextOverlay from "~/components/DiscourseContextOverlay";
 import { handleTitleAdditions } from "./handleTitleAdditions";
+import nanoid from "nanoid";
 
 export const renderDiscourseContext = ({
   h1,
   uid,
-  tag,
 }: {
   h1: HTMLHeadingElement;
   uid: string;
-  tag: string;
 }): void => {
   handleTitleAdditions(
     h1,
-    createElement(DiscourseContextOverlay, { uid, tag }),
+    createElement(DiscourseContextOverlay, { uid, id: nanoid() }),
   );
 };
 

--- a/apps/roam/src/utils/renderLinkedReferenceAdditions.ts
+++ b/apps/roam/src/utils/renderLinkedReferenceAdditions.ts
@@ -4,7 +4,6 @@ import CanvasReferences from "~/components/canvas/CanvasReferences";
 import { OnloadArgs } from "roamjs-components/types";
 import DiscourseContextOverlay from "~/components/DiscourseContextOverlay";
 import { handleTitleAdditions } from "./handleTitleAdditions";
-import nanoid from "nanoid";
 
 export const renderDiscourseContext = ({
   h1,
@@ -13,9 +12,14 @@ export const renderDiscourseContext = ({
   h1: HTMLHeadingElement;
   uid: string;
 }): void => {
+  if (document.getElementById("top-discourse-context")) return;
+
   handleTitleAdditions(
     h1,
-    createElement(DiscourseContextOverlay, { uid, id: nanoid() }),
+    createElement(DiscourseContextOverlay, {
+      uid,
+      id: "top-discourse-context",
+    }),
   );
 };
 
@@ -24,9 +28,9 @@ export const renderCanvasReferences = (
   uid: string,
   onloadArgs: OnloadArgs,
 ): void => {
-  if (div.getAttribute("data-roamjs-discourse-context")) return;
+  if (div.getAttribute("data-roamjs-canvas-reference")) return;
 
-  div.setAttribute("data-roamjs-discourse-context", "true");
+  div.setAttribute("data-roamjs-canvas-reference", "true");
   const parent = div.firstElementChild;
   if (!parent) return;
 

--- a/apps/roam/src/utils/renderLinkedReferenceAdditions.ts
+++ b/apps/roam/src/utils/renderLinkedReferenceAdditions.ts
@@ -12,7 +12,7 @@ export const renderDiscourseContext = ({
   h1: HTMLHeadingElement;
   uid: string;
 }): void => {
-  if (document.getElementById("top-discourse-context")) return;
+  if (h1.parentElement!.querySelector("#top-discourse-context")) return;
   handleTitleAdditions(
     h1,
     createElement(DiscourseContextCollapseOverlay, {


### PR DESCRIPTION
https://linear.app/discourse-graphs/issue/ENG-1110/move-discourse-context-to-top-of-discourse-node-page


https://www.loom.com/share/604f9070cfe84d3dbda2f6bc6b9c3627

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate rendering in the linked references section so context and references no longer appear twice.

* **Refactor**
  * Split context and linked-reference rendering into separate flows for clearer behavior.
  * Context rendering now uses a dedicated overlay approach and initialization logic was simplified for more reliable page-observer activation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/692">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
