### PR TITLE
ENG-1279 Discourse Context Overlay doesn't update number

### DIFF
--- a/apps/roam/src/components/DiscourseContext.tsx
+++ b/apps/roam/src/components/DiscourseContext.tsx
@@ -31,6 +31,7 @@ export type DiscourseContextResults = Awaited<
 type Props = {
   uid: string;
   results?: DiscourseContextResults;
+  overlayRefresh?: () => void;
 };
 
 const ExtraColumnRow = (r: Result) => {
@@ -279,7 +280,7 @@ const ContextTab = ({
             <CreateRelationButton
               sourceNodeUid={parentUid}
               onClose={() => {
-                window.setTimeout(onRefresh, 250);
+                window.setTimeout(onRefresh, 450, true);
               }}
             />
             <Switch
@@ -316,7 +317,7 @@ const ContextTab = ({
   );
 };
 
-export const ContextContent = ({ uid, results }: Props) => {
+export const ContextContent = ({ uid, results, overlayRefresh }: Props) => {
   const [rawQueryResults, setRawQueryResults] = useState<
     Record<string, DiscourseContextResults[number]>
   >({});
@@ -350,13 +351,16 @@ export const ContextContent = ({ uid, results }: Props) => {
         uid,
         onResult: addLabels,
         ignoreCache,
-      }).finally(() => setLoading(false));
+      }).finally(() => {
+        if (overlayRefresh) overlayRefresh();
+        setLoading(false);
+      });
     },
     [uid, setRawQueryResults, setLoading, addLabels],
   );
 
   const delayedRefresh = () => {
-    window.setTimeout(onRefresh, 250);
+    window.setTimeout(onRefresh, 450, true);
   };
 
   useEffect(() => {

--- a/apps/roam/src/components/DiscourseContext.tsx
+++ b/apps/roam/src/components/DiscourseContext.tsx
@@ -356,7 +356,7 @@ export const ContextContent = ({ uid, results, overlayRefresh }: Props) => {
         setLoading(false);
       });
     },
-    [uid, setRawQueryResults, setLoading, addLabels],
+    [uid, setRawQueryResults, setLoading, addLabels, overlayRefresh],
   );
 
   const delayedRefresh = () => {

--- a/apps/roam/src/components/DiscourseContextOverlay.tsx
+++ b/apps/roam/src/components/DiscourseContextOverlay.tsx
@@ -148,7 +148,11 @@ const DiscourseContextOverlay = ({
             results.length === 0 ? "flex items-center justify-center" : ""
           }`}
         >
-          <ContextContent uid={tagUid} results={results} />
+          <ContextContent
+            uid={tagUid}
+            results={results}
+            overlayRefresh={refresh}
+          />
         </div>
       }
       target={

--- a/apps/roam/src/components/results-view/ResultsTable.tsx
+++ b/apps/roam/src/components/results-view/ResultsTable.tsx
@@ -350,7 +350,7 @@ const ResultRow = ({
               content: "Relation deleted",
               intent: "success",
             });
-            onRefresh();
+            onRefresh(true);
           })
           .catch((e) => {
             // this one should be an internalError


### PR DESCRIPTION
https://linear.app/discourse-graphs/issue/ENG-1279/discourse-context-overlay-doesnt-update-number

I added a way to update the number of the calling overlay.
Note it does not help with other overlays with the same node, which is a separate issue.

I also made the delays a bit longer, which helps with some discrepancies. 

https://www.loom.com/share/91b1b48e367349bc98dad6d2e80e6e98


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for an optional external overlay-refresh callback to coordinate updates between views.
* **Bug Fixes**
  * Increased delayed refresh timing to improve UI synchronization after changes.
  * Now signals refreshes to bypass cache after relation deletions to ensure consistent, up-to-date displays.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->