### PR TITLE
ENG-1285 Base user affordance to trigger node sharing

### DIFF
--- a/apps/obsidian/src/utils/publishNode.ts
+++ b/apps/obsidian/src/utils/publishNode.ts
@@ -2,11 +2,15 @@ import type { FrontMatterCache, TFile } from "obsidian";
 import type { default as DiscourseGraphPlugin } from "~/index";
 import { getLoggedInClient } from "./supabaseContext";
 
-export const publishNode = async (
-  plugin: DiscourseGraphPlugin,
-  file: TFile,
-  frontmatter: FrontMatterCache,
-): Promise<void> => {
+export const publishNode = async ({
+  plugin,
+  file,
+  frontmatter,
+}: {
+  plugin: DiscourseGraphPlugin;
+  file: TFile;
+  frontmatter: FrontMatterCache;
+}): Promise<void> => {
   const nodeId = frontmatter.nodeInstanceId as string | undefined;
   if (!nodeId) throw new Error("Please sync the node first");
   const client = await getLoggedInClient(plugin);

--- a/apps/obsidian/src/utils/publishNode.ts
+++ b/apps/obsidian/src/utils/publishNode.ts
@@ -1,0 +1,49 @@
+import type { FrontMatterCache, TFile } from "obsidian";
+import type { default as DiscourseGraphPlugin } from "~/index";
+import { getLoggedInClient } from "./supabaseContext";
+
+export const publishNode = async (
+  plugin: DiscourseGraphPlugin,
+  file: TFile,
+  frontmatter: FrontMatterCache,
+): Promise<void> => {
+  const nodeId = frontmatter.nodeInstanceId as string | undefined;
+  if (!nodeId) throw new Error("Please sync the node first");
+  const client = await getLoggedInClient(plugin);
+  if (!client) throw new Error("Cannot get client");
+  const myGroupResponse = await client
+    .from("group_membership")
+    .select("group_id");
+  if (myGroupResponse.error) throw myGroupResponse.error;
+  const myGroup = myGroupResponse.data[0]?.group_id;
+  if (!myGroup) throw new Error("Cannot get group");
+  const existingPublish =
+    (frontmatter.publishedToGroups as undefined | string[]) || [];
+  if (existingPublish && existingPublish.includes(myGroup)) return; // already published
+  const idResponse = await client
+    .from("Content")
+    .select("id")
+    .eq("source_local_id", nodeId)
+    .eq("variant", "direct")
+    .maybeSingle();
+  if (idResponse.error || !idResponse.data) {
+    throw idResponse.error || new Error("no data while fetching node");
+  }
+  const contentId = idResponse.data.id;
+  const publishResponse = await client.from("ContentAccess").insert({
+    /* eslint-disable @typescript-eslint/naming-convention */
+    account_uid: myGroup,
+    content_id: contentId,
+    /* eslint-enable @typescript-eslint/naming-convention */
+  });
+  if (publishResponse.error && publishResponse.error.code !== "23505")
+    // 23505 is duplicate key, which counts as a success.
+    throw publishResponse.error;
+  existingPublish.push(myGroup);
+  await plugin.app.fileManager.processFrontMatter(
+    file,
+    (fm: Record<string, unknown>) => {
+      fm.publishedToGroups = existingPublish;
+    },
+  );
+};

--- a/apps/obsidian/src/utils/publishNode.ts
+++ b/apps/obsidian/src/utils/publishNode.ts
@@ -19,7 +19,7 @@ export const publishNode = async (
   if (!myGroup) throw new Error("Cannot get group");
   const existingPublish =
     (frontmatter.publishedToGroups as undefined | string[]) || [];
-  if (existingPublish && existingPublish.includes(myGroup)) return; // already published
+  if (existingPublish.includes(myGroup)) return; // already published
   const idResponse = await client
     .from("Content")
     .select("id")
@@ -39,11 +39,10 @@ export const publishNode = async (
   if (publishResponse.error && publishResponse.error.code !== "23505")
     // 23505 is duplicate key, which counts as a success.
     throw publishResponse.error;
-  existingPublish.push(myGroup);
   await plugin.app.fileManager.processFrontMatter(
     file,
     (fm: Record<string, unknown>) => {
-      fm.publishedToGroups = existingPublish;
+      fm.publishedToGroups = [...existingPublish, myGroup];
     },
   );
 };

--- a/apps/obsidian/src/utils/publishNode.ts
+++ b/apps/obsidian/src/utils/publishNode.ts
@@ -27,7 +27,7 @@ export const publishNode = async ({
   const existingPublish =
     (frontmatter.publishedToGroups as undefined | string[]) || [];
   if (existingPublish.includes(myGroup)) return; // already published
-  const publishResponse = await client.from("ContentAccess").insert({
+  const publishResponse = await client.from("ResourceAccess").insert({
     /* eslint-disable @typescript-eslint/naming-convention */
     account_uid: myGroup,
     source_local_id: nodeId,

--- a/apps/obsidian/src/utils/publishNode.ts
+++ b/apps/obsidian/src/utils/publishNode.ts
@@ -1,6 +1,6 @@
 import type { FrontMatterCache, TFile } from "obsidian";
 import type { default as DiscourseGraphPlugin } from "~/index";
-import { getLoggedInClient } from "./supabaseContext";
+import { getLoggedInClient, getSupabaseContext } from "./supabaseContext";
 
 export const publishNode = async ({
   plugin,
@@ -15,6 +15,9 @@ export const publishNode = async ({
   if (!nodeId) throw new Error("Please sync the node first");
   const client = await getLoggedInClient(plugin);
   if (!client) throw new Error("Cannot get client");
+  const context = await getSupabaseContext(plugin);
+  if (!context) throw new Error("Cannot get context");
+  const spaceId = context.spaceId;
   const myGroupResponse = await client
     .from("group_membership")
     .select("group_id");
@@ -24,46 +27,16 @@ export const publishNode = async ({
   const existingPublish =
     (frontmatter.publishedToGroups as undefined | string[]) || [];
   if (existingPublish.includes(myGroup)) return; // already published
-  const idResponse = await client
-    .from("Content")
-    .select("id")
-    .eq("source_local_id", nodeId)
-    .eq("variant", "direct")
-    .maybeSingle();
-  if (idResponse.error || !idResponse.data) {
-    throw idResponse.error || new Error("no data while fetching node");
-  }
-  const contentId = idResponse.data.id;
   const publishResponse = await client.from("ContentAccess").insert({
     /* eslint-disable @typescript-eslint/naming-convention */
     account_uid: myGroup,
-    content_id: contentId,
+    source_local_id: nodeId,
+    space_id: spaceId,
     /* eslint-enable @typescript-eslint/naming-convention */
   });
   if (publishResponse.error && publishResponse.error.code !== "23505")
     // 23505 is duplicate key, which counts as a success.
     throw publishResponse.error;
-  // check if there is a corresponding concept.
-  const conceptIdResponse = await client
-    .from("Concept")
-    .select("id")
-    .eq("represented_by_id", contentId)
-    .maybeSingle();
-  if (conceptIdResponse.error) throw conceptIdResponse.error;
-  if (conceptIdResponse.data) {
-    const publishConceptResponse = await client.from("ConceptAccess").insert({
-      /* eslint-disable @typescript-eslint/naming-convention */
-      account_uid: myGroup,
-      concept_id: conceptIdResponse.data.id,
-      /* eslint-enable @typescript-eslint/naming-convention */
-    });
-    if (
-      publishConceptResponse.error &&
-      publishConceptResponse.error.code !== "23505"
-    )
-      // 23505 is duplicate key, which counts as a success.
-      throw publishConceptResponse.error;
-  }
   await plugin.app.fileManager.processFrontMatter(
     file,
     (fm: Record<string, unknown>) => {

--- a/apps/obsidian/src/utils/registerCommands.ts
+++ b/apps/obsidian/src/utils/registerCommands.ts
@@ -183,7 +183,7 @@ export const registerCommands = (plugin: DiscourseGraphPlugin) => {
         // Maybe sync the node now if unsynced
         // Ensure that the node schema is synced to the database, and shared
         // sync the assets to the database
-        publishNode(plugin, file, frontmatter)
+        publishNode({ plugin, file, frontmatter })
           .then(() => {
             new Notice("Published");
           })

--- a/apps/obsidian/src/utils/registerCommands.ts
+++ b/apps/obsidian/src/utils/registerCommands.ts
@@ -1,4 +1,4 @@
-import { Editor } from "obsidian";
+import { Editor, MarkdownView, Notice } from "obsidian";
 import type DiscourseGraphPlugin from "~/index";
 import { NodeTypeModal } from "~/components/NodeTypeModal";
 import ModifyNodeModal from "~/components/ModifyNodeModal";
@@ -7,7 +7,7 @@ import { createDiscourseNode } from "./createNode";
 import { VIEW_TYPE_MARKDOWN, VIEW_TYPE_TLDRAW_DG_PREVIEW } from "~/constants";
 import { createCanvas } from "~/components/canvas/utils/tldraw";
 import { createOrUpdateDiscourseEmbedding } from "./syncDgNodesToSupabase";
-import { Notice } from "obsidian";
+import { publishNode } from "./publishNode";
 
 export const registerCommands = (plugin: DiscourseGraphPlugin) => {
   plugin.addCommand({
@@ -151,6 +151,46 @@ export const registerCommands = (plugin: DiscourseGraphPlugin) => {
               error instanceof Error ? error.message : String(error);
             new Notice(`Sync failed: ${errorMessage}`, 5000);
             console.error("Manual sync failed:", error);
+          });
+      }
+      return true;
+    },
+  });
+  plugin.addCommand({
+    id: "publish-discourse-node",
+    name: "Publish current node to lab space",
+    checkCallback: (checking: boolean) => {
+      if (!plugin.settings.syncModeEnabled) {
+        new Notice("Sync mode is not enabled", 3000);
+        return false;
+      }
+      if (!checking) {
+        const activeView =
+          plugin.app.workspace.getActiveViewOfType(MarkdownView);
+        if (!activeView || !activeView.file) {
+          new Notice("Apply to a discourse node");
+          return;
+        }
+        const file = activeView.file;
+        const cache = plugin.app.metadataCache.getFileCache(file);
+        const frontmatter = cache?.frontmatter || {};
+        if (!frontmatter.nodeTypeId) {
+          new Notice("Apply to a discourse node");
+          return;
+        }
+        if (!frontmatter.nodeInstanceId)
+          throw new Error("Please sync the node first");
+        // TODO (in follow-up PRs):
+        // Maybe sync the node now if unsynced
+        // Ensure that the node schema is synced to the database, and shared
+        // sync the assets to the database
+        publishNode(plugin, file, frontmatter)
+          .then(() => {
+            new Notice("Published");
+          })
+          .catch((error: Error) => {
+            new Notice(error.message);
+            console.error(error);
           });
       }
       return true;

--- a/apps/obsidian/src/utils/registerCommands.ts
+++ b/apps/obsidian/src/utils/registerCommands.ts
@@ -164,22 +164,21 @@ export const registerCommands = (plugin: DiscourseGraphPlugin) => {
         new Notice("Sync mode is not enabled", 3000);
         return false;
       }
+      const activeView = plugin.app.workspace.getActiveViewOfType(MarkdownView);
+      if (!activeView || !activeView.file) {
+        return false;
+      }
+      const file = activeView.file;
+      const cache = plugin.app.metadataCache.getFileCache(file);
+      const frontmatter = cache?.frontmatter || {};
+      if (!frontmatter.nodeTypeId) {
+        return false;
+      }
       if (!checking) {
-        const activeView =
-          plugin.app.workspace.getActiveViewOfType(MarkdownView);
-        if (!activeView || !activeView.file) {
-          new Notice("Apply to a discourse node");
-          return;
+        if (!frontmatter.nodeInstanceId) {
+          new Notice("Please sync the node first");
+          return true;
         }
-        const file = activeView.file;
-        const cache = plugin.app.metadataCache.getFileCache(file);
-        const frontmatter = cache?.frontmatter || {};
-        if (!frontmatter.nodeTypeId) {
-          new Notice("Apply to a discourse node");
-          return;
-        }
-        if (!frontmatter.nodeInstanceId)
-          throw new Error("Please sync the node first");
         // TODO (in follow-up PRs):
         // Maybe sync the node now if unsynced
         // Ensure that the node schema is synced to the database, and shared


### PR DESCRIPTION
https://linear.app/discourse-graphs/issue/ENG-1285/base-user-affordance-to-trigger-node-sharing

https://www.loom.com/share/74b40632fe4946d8b47f4d904424660f

This PR creates the command (affordance) to trigger node sharing, and invokes a minimal publishNode function.
Many things will be added to publishNode later: notably verifying that the schemas are shared, sending the assets.
We are considering factoring out sending the text so it is only sent for published nodes. 
But we decided that would be another PR if decided.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Publish current node to lab space" command to share a node with your group.
  * Requires sync mode and a previously synced node; prompts to sync if missing.
  * Shows success and error notifications during publish, and treats already-published nodes as non-error.
  * Records the group in the node’s metadata after successful publishing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->