### PR TITLE
ENG-846 - Add Colors to Nodes in settings

### DIFF
--- a/apps/roam/src/components/settings/DiscourseNodeConfigPanel.tsx
+++ b/apps/roam/src/components/settings/DiscourseNodeConfigPanel.tsx
@@ -15,6 +15,7 @@ import type { CustomField } from "roamjs-components/components/ConfigPanels/type
 import posthog from "posthog-js";
 import getDiscourseRelations from "~/utils/getDiscourseRelations";
 import { deleteBlock } from "roamjs-components/writes";
+import { formatHexColor } from "./DiscourseNodeCanvasSettings";
 
 type DiscourseNodeConfigPanelProps = React.ComponentProps<
   CustomField["options"]["component"]
@@ -127,7 +128,16 @@ const DiscourseNodeConfigPanel: React.FC<DiscourseNodeConfigPanelProps> = ({
                 onClick={() => navigateToNode(n.type)}
                 style={{ verticalAlign: "middle" }}
               >
-                {n.text}
+                <div className="flex items-center gap-2">
+                  <span
+                    className="h-3 w-3 rounded-full"
+                    style={{
+                      backgroundColor:
+                        formatHexColor(n.canvasSettings?.color) || "#000",
+                    }}
+                  />
+                  <span>{n.text}</span>
+                </div>
               </td>
               <td>
                 <Tooltip content="Edit" hoverOpenDelay={500}>


### PR DESCRIPTION
<img width="1188" height="846" alt="image" src="https://github.com/user-attachments/assets/6ee275d8-fe74-4e02-937d-f1c12fa29490" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Node lists now display colored indicator dots next to node names, providing improved visual organization and easier node identification.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->