### PR TITLE
ENG-892 - Use sentence case for discourse labels and docs

### DIFF
--- a/apps/obsidian/README.md
+++ b/apps/obsidian/README.md
@@ -19,7 +19,7 @@ For more information about Discourse Graphs, check out our website at [https://d
 1. Open Obsidian Settings
 2. Go to Community Plugins and disable Restricted Mode
 3. Click "Browse" and search for "BRAT"
-![BRAT](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2Faar5LKpLOk.png?alt=media&token=6f51ac48-19d3-4bb5-9a07-7b32cfa6afe6)
+   ![BRAT](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2Faar5LKpLOk.png?alt=media&token=6f51ac48-19d3-4bb5-9a07-7b32cfa6afe6)
 4. Install BRAT and enable it
 
 #### Install DataCore via BRAT
@@ -27,9 +27,9 @@ For more information about Discourse Graphs, check out our website at [https://d
 1. Open Obsidian Settings
 2. Go to "Community Plugins" → "BRAT"
 3. Click "Add Beta Plugin"
-![Add plugin](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FdMtstUHPXe.png?alt=media&token=3f139ab9-9802-404d-9554-4a63bac080c5)
+   ![Add plugin](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FdMtstUHPXe.png?alt=media&token=3f139ab9-9802-404d-9554-4a63bac080c5)
 4. Enter the repository URL: `https://github.com/blacksmithgu/datacore` and choose "Latest version"
-![Add datacore](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FEY3vNGt1Rf.png?alt=media&token=32c60ff1-5272-4cde-8b5f-8f049fb2cf50)
+   ![Add datacore](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FEY3vNGt1Rf.png?alt=media&token=32c60ff1-5272-4cde-8b5f-8f049fb2cf50)
 5. Check the box for "Enable after installing the plugin"
 6. Click "Add plugin"
 
@@ -38,13 +38,12 @@ For more information about Discourse Graphs, check out our website at [https://d
 1. Open Obsidian Settings
 2. Go to "Community Plugins" → "BRAT"
 3. Click "Add Beta Plugin"
-![Add plugin](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FdMtstUHPXe.png?alt=media&token=3f139ab9-9802-404d-9554-4a63bac080c5)
+   ![Add plugin](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FdMtstUHPXe.png?alt=media&token=3f139ab9-9802-404d-9554-4a63bac080c5)
 
-4. Enter the repository URL: `https://github.com/DiscourseGraphs/discourse-graph-obsidian`  and choose "Latest version"
-![Add discourse graph](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FSBCK-2lkcu.png?alt=media&token=0375c828-da4d-43b4-8f2c-e691692cb019)
+4. Enter the repository URL: `https://github.com/DiscourseGraphs/discourse-graph-obsidian` and choose "Latest version"
+   ![Add discourse graph](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FSBCK-2lkcu.png?alt=media&token=0375c828-da4d-43b4-8f2c-e691692cb019)
 5. Check the box for "Enable after installing the plugin"
 6. Click "Add Plugin"
-
 
 ## Creating Nodes and Relationships
 
@@ -52,46 +51,51 @@ For more information about Discourse Graphs, check out our website at [https://d
 
 1. Open Obsidian Settings
 2. Navigate to the "Discourse Graphs" settings tab
+
 #### Edit Node Types
-   - Under "Node Types," click "Add Node Type"
-   - Enter a name for your node type (e.g., "Claim", "Evidence", "Question")
-   - Add the format for your node type. eg a claim node will have page title "CLM - {content}"
-   - **Template (Optional)**: Select a template from the dropdown to automatically apply template content when creating nodes of this type
-     - Templates are sourced from Obsidian's core Templates plugin
-     - Ensure you have the Templates plugin enabled and configured with a template folder
-     - The dropdown will show all available template files from your configured template folder
 
-      ![add node types with template](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FHMg_Tq6qiR.png?alt=media&token=69828bfc-c939-41b0-abd4-2cc8931c5a38)
-     - Click "Save Changes"
+- Under "Node Types," click "Add Node Type"
+- Enter a name for your node type (e.g., "Claim", "Evidence", "Question")
+- Add the format for your node type. eg a claim node will have page title "CLM - {content}"
+- **Template (Optional)**: Select a template from the dropdown to automatically apply template content when creating nodes of this type
+  - Templates are sourced from Obsidian's core Templates plugin
+  - Ensure you have the Templates plugin enabled and configured with a template folder
+  - The dropdown will show all available template files from your configured template folder
 
-    
+  ![add node types with template](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FHMg_Tq6qiR.png?alt=media&token=69828bfc-c939-41b0-abd4-2cc8931c5a38)
+  - Click "Save Changes"
+
 - To create a new template:
-  + Create new folder to store templates
-  ![new folder](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FyTtJ1a0iI2.png?alt=media&token=b5d09b10-f170-47cd-a239-ee5f7acd89dc)
+  - Create new folder to store templates
+    ![new folder](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FyTtJ1a0iI2.png?alt=media&token=b5d09b10-f170-47cd-a239-ee5f7acd89dc)
 
-  + Specify template folder location in plugin settings menu
-  ![template](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FhzZg_GJXY9.png?alt=media&token=508c8d19-1f13-4fb3-adf1-898dcf694f08)
+  - Specify template folder location in plugin settings menu
+    ![template](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FhzZg_GJXY9.png?alt=media&token=508c8d19-1f13-4fb3-adf1-898dcf694f08)
 
-  + Create new file in template folder (A) and add text to file (B)
-  ![create template file](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FtTr9vOnXnX.png?alt=media&token=dda1fe25-3ccf-42b4-8f3c-1cd29f82c3f7)
+  - Create new file in template folder (A) and add text to file (B)
+    ![create template file](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FtTr9vOnXnX.png?alt=media&token=dda1fe25-3ccf-42b4-8f3c-1cd29f82c3f7)
 
   ![add node types](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FYRZ6ocI_d-.png?alt=media&token=c623bec7-02bd-42b4-a994-cd1c40a54d82)
   - Click "Save Changes"
+
 #### Edit Relation Types
-   - Under "Relation Types," click "Add Relationship Type"
-   - A relation type is a kind of relationship that can exist between any two node types
-   - Enter a name for your relationship (e.g., "supports", "contradicts")
-   - Enter the complement label (e.g., "is supported by", "is contradicted by")
-   ![add relation type](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2Fjk367dcO_K.png?alt=media&token=22d74e9f-882c-434b-8b50-afd7a754fb2b)
-   - Click "Save Changes"
+
+- Under "Relation Types," click "Add Relationship Type"
+- A relation type is a kind of relationship that can exist between any two node types
+- Enter a name for your relationship (e.g., "supports", "contradicts")
+- Enter the complement label (e.g., "is supported by", "is contradicted by")
+  ![add relation type](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2Fjk367dcO_K.png?alt=media&token=22d74e9f-882c-434b-8b50-afd7a754fb2b)
+- Click "Save Changes"
+
 #### Define possible relations between nodes
+
 - Open the Discourse Relations tab in the Discourse Graph settings
-![discourse relation](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FNgm7Ha4Ul5.png?alt=media&token=a933bd3a-d9a6-42c1-9c6e-d779d41c7ebf)
+  ![discourse relation](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FNgm7Ha4Ul5.png?alt=media&token=a933bd3a-d9a6-42c1-9c6e-d779d41c7ebf)
 - Choose Source Node Type, Relation Type, and Target Node Type
-![choose relation](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FlflJBkfdaK.png?alt=media&token=5de9617c-6099-46e8-931f-feafc604cabb)
+  ![choose relation](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FlflJBkfdaK.png?alt=media&token=5de9617c-6099-46e8-931f-feafc604cabb)
 - Once you see the source, relation, and target selected:
-![final relations](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FycPW-N-rY8.png?alt=media&token=54867be2-9030-4c6c-82d2-b96069e52d81)
-E.g: this means that *Claim* nodes can supports *Questions* nodes
+  ![final relations](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FycPW-N-rY8.png?alt=media&token=54867be2-9030-4c6c-82d2-b96069e52d81)
+  E.g: this means that _Claim_ nodes can supports _Questions_ nodes
 - Click "Save changes"
 
 ## Using Discourse Graphs
@@ -99,40 +103,38 @@ E.g: this means that *Claim* nodes can supports *Questions* nodes
 ### Instantiate a Node
 
 - Select the text you want to turn into a Discourse Node
-![select text](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FInIer-iPGs.png?alt=media&token=fad214f6-f426-4249-8b0a-d5a403894600)
+  ![select text](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FInIer-iPGs.png?alt=media&token=fad214f6-f426-4249-8b0a-d5a403894600)
 - There are two ways you can create a node from here:
-  
-  1. Using command keys: Cmd + \ 
-  <br>
+  1. Using command keys: Cmd + \
+     <br>
   - As you press these keys, the Node Menu will open up as a popup
-  
+
   ![node menu](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FS6eU6y70eX.png?alt=media&token=00e61ddf-877b-4752-a65b-272e80a0a19c)
   - Select the node type you want to turn the text into
   - Voila, you've created a new discourse node
-  ![node created](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2F1VNkJC0aH8.png?alt=media&token=df9a26aa-997b-4b56-a307-87a80e350b28)
-  
+    ![node created](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2F1VNkJC0aH8.png?alt=media&token=df9a26aa-997b-4b56-a307-87a80e350b28)
   2. Right-click menu:
   - Alternatively, you can right-click on the selected text
-  ![right click menu](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2F4UqeVkqLz7.png?alt=media&token=d2373152-d251-45fe-afb6-56373d6092aa)
-  - Then choose a node type from the "Turn into Discourse Node" menu
+    ![right click menu](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2F4UqeVkqLz7.png?alt=media&token=d2373152-d251-45fe-afb6-56373d6092aa)
+  - Then choose a node type from the "Turn into discourse node" menu
 
 ### Open Discourse Context
 
--  Click on the telescope icon on the left bar
-![open discourse context](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FE10krHZcDM.png?alt=media&token=c1796a9f-7e51-437f-913d-91f5433d9bab)
+- Click on the telescope icon on the left bar
+  ![open discourse context](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FE10krHZcDM.png?alt=media&token=c1796a9f-7e51-437f-913d-91f5433d9bab)
 - Alternatively, you can set a hotkey to toggle the Discourse Context view or access it via the Command Palette
-![command palette](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2F5ybScaQISO.png?alt=media&token=2b36f0e7-4247-47b7-a53d-c784dfd4609b)
+  ![command palette](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2F5ybScaQISO.png?alt=media&token=2b36f0e7-4247-47b7-a53d-c784dfd4609b)
 
 ### Instantiate a Relationship
 
 1. Open a note that you want to create a relationship from
 2. Open the Discourse Context
-![open discourse context](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FE10krHZcDM.png?alt=media&token=c1796a9f-7e51-437f-913d-91f5433d9bab)
+   ![open discourse context](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FE10krHZcDM.png?alt=media&token=c1796a9f-7e51-437f-913d-91f5433d9bab)
 3. Click "Add a new relation"
 4. The dropdown that shows Relationship Types will be all available relations that you have defined in the setings.
-<br> It will also show you what node type you can link with
-![add relation](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FXQsgznWuV2.png?alt=media&token=9442b9fa-0904-4847-8eb8-a5791705c4c5)
+   <br> It will also show you what node type you can link with
+   ![add relation](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FXQsgznWuV2.png?alt=media&token=9442b9fa-0904-4847-8eb8-a5791705c4c5)
 5. Search the nodes you want to link with by the title
-![search](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2F4NW4UjYDrC.png?alt=media&token=bae307d0-ebec-4e6b-a03d-0943d9d03754)
+   ![search](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2F4NW4UjYDrC.png?alt=media&token=bae307d0-ebec-4e6b-a03d-0943d9d03754)
 6. Click "Confirm", now a new relationship has been created
-![relationship created](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FK8XAhCqrUL.png?alt=media&token=a559c477-c7f6-4b3e-8b00-ece7da5d4fec)
+   ![relationship created](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FK8XAhCqrUL.png?alt=media&token=a559c477-c7f6-4b3e-8b00-ece7da5d4fec)

--- a/apps/obsidian/src/components/BulkIdentifyDiscourseNodesModal.tsx
+++ b/apps/obsidian/src/components/BulkIdentifyDiscourseNodesModal.tsx
@@ -379,7 +379,7 @@ const BulkImportContent = ({ plugin, onClose }: BulkImportModalProps) => {
             className="!bg-accent !text-on-accent rounded px-4 py-2"
             disabled={candidates.filter((c) => c.selected).length === 0}
           >
-            Identify Selected as Discourse Nodes (
+            Identify selected as discourse nodes (
             {candidates.filter((c) => c.selected).length})
           </button>
         </div>
@@ -389,7 +389,7 @@ const BulkImportContent = ({ plugin, onClose }: BulkImportModalProps) => {
 
   const renderIdentifyingStep = () => (
     <div className="text-center">
-      <h3 className="mb-4">Identifying Files as Discourse Nodes</h3>
+      <h3 className="mb-4">Identifying files as discourse nodes</h3>
       <div className="mb-4">
         <div className="bg-modifier-border mb-2 h-2 rounded-full">
           <div

--- a/apps/obsidian/src/components/DiscourseContextView.tsx
+++ b/apps/obsidian/src/components/DiscourseContextView.tsx
@@ -78,7 +78,7 @@ const DiscourseContext = ({ activeFile }: DiscourseContextProps) => {
 
   return (
     <div>
-      <h3 className="dg-h3">Discourse Context</h3>
+      <h3 className="dg-h3">Discourse context</h3>
       {renderContent()}
     </div>
   );
@@ -104,7 +104,7 @@ export class DiscourseContextView extends ItemView {
   }
 
   getDisplayText(): string {
-    return "Discourse Context";
+    return "Discourse context";
   }
 
   getIcon(): string {

--- a/apps/obsidian/src/components/GeneralSettings.tsx
+++ b/apps/obsidian/src/components/GeneralSettings.tsx
@@ -231,9 +231,9 @@ const GeneralSettings = () => {
 
       <div className="setting-item">
         <div className="setting-item-info">
-          <div className="setting-item-name">Discourse Nodes folder path</div>
+          <div className="setting-item-name">Discourse nodes folder path</div>
           <div className="setting-item-description">
-            Specify the folder where new Discourse Nodes should be created.
+            Specify the folder where new discourse nodes should be created.
             Leave empty to create nodes in the root folder.
           </div>
         </div>

--- a/apps/obsidian/src/components/ModifyNodeModal.tsx
+++ b/apps/obsidian/src/components/ModifyNodeModal.tsx
@@ -256,7 +256,7 @@ export const ModifyNodeForm = ({
 
   return (
     <div>
-      <h2>{isEditMode ? "Modify Discourse Node" : "Create Discourse Node"}</h2>
+      <h2>{isEditMode ? "Modify discourse node" : "Create discourse node"}</h2>
       <div className="setting-item">
         <div className="setting-item-name">Type</div>
         <div className="setting-item-control">

--- a/apps/obsidian/src/components/canvas/TldrawViewComponent.tsx
+++ b/apps/obsidian/src/components/canvas/TldrawViewComponent.tsx
@@ -384,7 +384,7 @@ export const TldrawPreviewComponent = ({
               tools: (editor, tools) => {
                 tools["discourse-node"] = {
                   id: "discourse-node",
-                  label: "Discourse Node",
+                  label: "Discourse node",
                   readonlyOk: false,
                   icon: "discourseNodeIcon",
                   onSelect: () => {
@@ -393,7 +393,7 @@ export const TldrawPreviewComponent = ({
                 };
                 tools["discourse-relation"] = {
                   id: "discourse-relation",
-                  label: "Discourse Relation",
+                  label: "Discourse relation",
                   readonlyOk: false,
                   icon: "tool-arrow",
                   onSelect: () => {

--- a/apps/obsidian/src/components/canvas/shapes/nodeConstants.ts
+++ b/apps/obsidian/src/components/canvas/shapes/nodeConstants.ts
@@ -1,7 +1,7 @@
 /**
- * Constants for Discourse Node styling and sizing.
+ * Constants for discourse node styling and sizing.
  * These values match the Tailwind classes used in DiscourseNodeShape component.
- * 
+ *
  * IMPORTANT: If you change these values, you must also update:
  * - The Tailwind classes in DiscourseNodeShape.tsx (line ~263)
  * - The measurement function in measureNodeText.ts
@@ -44,4 +44,3 @@ export const IMAGE_GAP = 4;
 
 // Base height for nodes without images (estimated)
 export const BASE_HEIGHT_NO_IMAGE = 100;
-

--- a/apps/obsidian/src/index.ts
+++ b/apps/obsidian/src/index.ts
@@ -109,7 +109,7 @@ export default class DiscourseGraphPlugin extends Plugin {
       (leaf) => new DiscourseContextView(leaf, this),
     );
 
-    this.addRibbonIcon("telescope", "Toggle Discourse Context", () => {
+    this.addRibbonIcon("telescope", "Toggle discourse context", () => {
       this.toggleDiscourseContextView();
     });
 
@@ -181,7 +181,7 @@ export default class DiscourseGraphPlugin extends Plugin {
         if (!editor.getSelection()) return;
 
         menu.addItem((menuItem) => {
-          menuItem.setTitle("Turn into Discourse Node");
+          menuItem.setTitle("Turn into discourse node");
           menuItem.setIcon("file-type");
 
           // Create submenu using the unofficial API pattern

--- a/apps/obsidian/src/services/QueryEngine.ts
+++ b/apps/obsidian/src/services/QueryEngine.ts
@@ -38,7 +38,7 @@ export class QueryEngine {
   }
 
   /**
-   * Search across all Discourse Nodes (files that have frontmatter nodeTypeId)
+   * Search across all discourse nodes (files that have frontmatter nodeTypeId)
    */
   searchDiscourseNodesByTitle = async (
     query: string,

--- a/apps/obsidian/src/utils/registerCommands.ts
+++ b/apps/obsidian/src/utils/registerCommands.ts
@@ -12,7 +12,7 @@ import { Notice } from "obsidian";
 export const registerCommands = (plugin: DiscourseGraphPlugin) => {
   plugin.addCommand({
     id: "open-node-type-menu",
-    name: "Open Node Type Menu",
+    name: "Open node type menu",
     hotkeys: [{ modifiers: ["Mod"], key: "\\" }],
     editorCallback: (editor: Editor) => {
       const hasSelection = !!editor.getSelection();
@@ -42,7 +42,7 @@ export const registerCommands = (plugin: DiscourseGraphPlugin) => {
 
   plugin.addCommand({
     id: "create-discourse-node",
-    name: "Create Discourse Node",
+    name: "Create discourse node",
     editorCallback: (editor: Editor) => {
       new ModifyNodeModal(plugin.app, {
         nodeTypes: plugin.settings.nodeTypes,
@@ -65,7 +65,7 @@ export const registerCommands = (plugin: DiscourseGraphPlugin) => {
 
   plugin.addCommand({
     id: "bulk-identify-discourse-nodes",
-    name: "Bulk Identify Discourse Nodes",
+    name: "Bulk identify discourse nodes",
     callback: () => {
       new BulkIdentifyDiscourseNodesModal(plugin.app, plugin).open();
     },
@@ -73,7 +73,7 @@ export const registerCommands = (plugin: DiscourseGraphPlugin) => {
 
   plugin.addCommand({
     id: "toggle-discourse-context",
-    name: "Toggle Discourse Context",
+    name: "Toggle discourse context",
     callback: () => {
       plugin.toggleDiscourseContextView();
     },
@@ -81,7 +81,7 @@ export const registerCommands = (plugin: DiscourseGraphPlugin) => {
 
   plugin.addCommand({
     id: "open-discourse-graph-settings",
-    name: "Open Discourse Graph Settings",
+    name: "Open Discourse Graphs settings",
     callback: () => {
       // plugin.app.setting is an unofficial API
       /* eslint-disable @typescript-eslint/no-unsafe-call */
@@ -94,7 +94,7 @@ export const registerCommands = (plugin: DiscourseGraphPlugin) => {
 
   plugin.addCommand({
     id: "switch-to-tldraw-edit",
-    name: "Switch to Discourse Markdown Edit",
+    name: "Switch to discourse markdown edit",
     checkCallback: (checking: boolean) => {
       const leaf = plugin.app.workspace.activeLeaf;
       if (!leaf) return false;
@@ -111,7 +111,7 @@ export const registerCommands = (plugin: DiscourseGraphPlugin) => {
 
   plugin.addCommand({
     id: "switch-to-tldraw-preview",
-    name: "Switch to Discourse Graph Canvas View",
+    name: "Switch to Discourse Graph canvas view",
     checkCallback: (checking: boolean) => {
       const leaf = plugin.app.workspace.activeLeaf;
       if (!leaf) return false;

--- a/apps/obsidian/src/utils/registerCommands.ts
+++ b/apps/obsidian/src/utils/registerCommands.ts
@@ -135,7 +135,7 @@ export const registerCommands = (plugin: DiscourseGraphPlugin) => {
 
   plugin.addCommand({
     id: "sync-discourse-nodes-to-supabase",
-    name: "Sync Discourse Nodes to Supabase",
+    name: "Sync discourse nodes to Supabase",
     checkCallback: (checking: boolean) => {
       if (!plugin.settings.syncModeEnabled) {
         new Notice("Sync mode is not enabled", 3000);

--- a/apps/roam/CHANGELOG.md
+++ b/apps/roam/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project does not follow [Semantic Versioning](https://semver.org/), her
 ### Changed
 
 - **Query metadata is hidden by default**, plus a command palette command to toggle it
-- **Performance:** optimize Discourse Node page observer checks
+- **Performance:** optimize discourse node page observer checks
 
 ### Fixed
 

--- a/apps/roam/src/components/DiscourseContext.tsx
+++ b/apps/roam/src/components/DiscourseContext.tsx
@@ -458,7 +458,7 @@ const DiscourseContext = ({ uid }: Props) => {
         />
         <div style={{ flex: "0 1 2px" }} />
         <div style={{ color: "rgb(206, 217, 224)" }}>
-          <strong>Discourse Context</strong>
+          <strong>Discourse context</strong>
         </div>
       </div>
       <div style={{ paddingLeft: 16 }}>

--- a/apps/roam/src/components/Export.tsx
+++ b/apps/roam/src/components/Export.tsx
@@ -810,10 +810,10 @@ const ExportDialog: ExportDialogComponent = ({
                   <Tooltip
                     className="m-0"
                     content={
-                      "Include the Discourse Context of each result in the export."
+                      "Include the discourse context of each result in the export."
                     }
                   >
-                    <span>Discourse Context</span>
+                    <span>Discourse context</span>
                   </Tooltip>
                 }
               />

--- a/apps/roam/src/components/ExportDiscourseContext.tsx
+++ b/apps/roam/src/components/ExportDiscourseContext.tsx
@@ -154,7 +154,7 @@ const getAllDiscourseContext = async (
 ) => {
   await updateProgressWithDelay({
     progress: 0.01,
-    message: "Gathering Initial Discourse Results",
+    message: "Gathering initial discourse results",
   });
   const discourseNodeUids = initialUids.filter((uid) => isDiscourseNode(uid));
 
@@ -278,7 +278,7 @@ const GraphExportDialog: GraphExportDialogComponent = ({
   const ByDiscourseContextPanel = (
     <>
       <Callout className="mb-5">
-        Export Discourse Nodes and their Discourse Context based on relation
+        Export discourse nodes and their discourse context based on relation
         depth from the initial nodes.
       </Callout>
       <Label>Depth</Label>
@@ -299,7 +299,7 @@ const GraphExportDialog: GraphExportDialogComponent = ({
   const ByReferencesPanel = (
     <>
       <Callout className="mb-5">
-        Export any Discourse Nodes and their Discourse Context that reference or
+        Export any discourse nodes and their discourse context that reference or
         are referenced by any page starting from the initial pages.
       </Callout>
       <Tooltip placement="top" content={"Pages that link to a selected page"}>
@@ -415,7 +415,7 @@ const GraphExportDialog: GraphExportDialogComponent = ({
 
       await updateProgressWithDelay({
         progress: 0.5,
-        message: "Filtering Discourse Nodes",
+        message: "Filtering discourse nodes",
       });
       const discourseNodeUids = Array.from(referenceUids).filter((uid) =>
         isDiscourseNode(uid),
@@ -469,7 +469,7 @@ const GraphExportDialog: GraphExportDialogComponent = ({
   const onExport = async () => {
     exportRender({
       results,
-      title: "Export Discourse Graph",
+      title: "Export discourse graph",
     });
     onClose();
   };
@@ -477,7 +477,7 @@ const GraphExportDialog: GraphExportDialogComponent = ({
   return (
     <Dialog
       isOpen={isOpen}
-      title="Discourse Graph Context Export"
+      title="Discourse graph context export"
       onClose={onClose}
       autoFocus={false}
     >
@@ -493,12 +493,12 @@ const GraphExportDialog: GraphExportDialogComponent = ({
         >
           <Tab
             id="by-references"
-            title="By References"
+            title="By references"
             panel={ByReferencesPanel}
           />
           <Tab
             id="by-discourse-relations"
-            title="By Discourse Relations"
+            title="By discourse relations"
             panel={ByDiscourseContextPanel}
           />
         </Tabs>

--- a/apps/roam/src/components/settings/DiscourseNodeCanvasSettings.tsx
+++ b/apps/roam/src/components/settings/DiscourseNodeCanvasSettings.tsx
@@ -114,7 +114,7 @@ const DiscourseNodeCanvasSettings = ({ uid }: { uid: string }) => {
         }}
       >
         Key Image
-        <Tooltip content={"Add an image to the Discourse Node"}>
+        <Tooltip content={"Add an image to the discourse node"}>
           <Icon
             icon={"info-sign"}
             iconSize={12}

--- a/apps/roam/src/components/settings/HomePersonalSettings.tsx
+++ b/apps/roam/src/components/settings/HomePersonalSettings.tsx
@@ -37,19 +37,19 @@ const HomePersonalSettings = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
   return (
     <div className="flex flex-col gap-4 p-1">
       <Label>
-        Personal Node Menu Trigger
+        Personal node menu trigger
         <Description
           description={
-            "Override the global trigger for the Discourse Node Menu. Must refresh after editing."
+            "Override the global trigger for the discourse node menu. Must refresh after editing."
           }
         />
         <NodeMenuTriggerComponent extensionAPI={extensionAPI} />
       </Label>
       <Label>
-        Node Search Menu Trigger
+        Node search menu trigger
         <Description
           description={
-            "Set the trigger character for the Node Search Menu. Must refresh after editing."
+            "Set the trigger character for the node search menu. Must refresh after editing."
           }
         />
         <NodeSearchMenuTriggerSetting onloadArgs={onloadArgs} />
@@ -57,8 +57,8 @@ const HomePersonalSettings = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
       <KeyboardShortcutInput
         onloadArgs={onloadArgs}
         settingKey={DISCOURSE_TOOL_SHORTCUT_KEY}
-        label="Discourse Tool Keyboard Shortcut"
-        description="Set a single key to activate the Discourse Tool in tldraw. Only single keys (no modifiers) are supported. Leave empty for no shortcut."
+        label="Discourse tool keyboard shortcut"
+        description="Set a single key to activate the discourse tool in tldraw. Only single keys (no modifiers) are supported. Leave empty for no shortcut."
         placeholder="Click to set single key"
       />
       <Checkbox
@@ -79,7 +79,7 @@ const HomePersonalSettings = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
             Overlay
             <Description
               description={
-                "Whether or not to overlay Discourse Context information over Discourse Node references."
+                "Whether or not to overlay discourse context information over discourse node references."
               }
             />
           </>
@@ -101,11 +101,11 @@ const HomePersonalSettings = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
             );
           }}
           labelElement={
-            <>
-              Suggestive Mode Overlay
+          <>
+              Suggestive mode overlay
               <Description
                 description={
-                  "Whether or not to overlay Suggestive Mode button over Discourse Node references."
+                  "Whether or not to overlay suggestive mode button over discourse node references."
                 }
               />
             </>
@@ -122,10 +122,10 @@ const HomePersonalSettings = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
         }}
         labelElement={
           <>
-            Text Selection Popup
+            Text selection popup
             <Description
               description={
-                "Whether or not to show the Discourse Node Menu when selecting text."
+                "Whether or not to show the discourse node menu when selecting text."
               }
             />
           </>
@@ -232,7 +232,7 @@ const HomePersonalSettings = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
             (BETA) Overlay in Canvas
             <Description
               description={
-                "Whether or not to overlay Discourse Context information over Canvas Nodes."
+                "Whether or not to overlay discourse context information over canvas nodes."
               }
             />
           </>

--- a/apps/roam/src/utils/getExportTypes.ts
+++ b/apps/roam/src/utils/getExportTypes.ts
@@ -292,7 +292,7 @@ const getExportTypes = ({
               )
               .join("\n");
 
-            return `### Discourse Context\n\n${formattedResults}`;
+            return `### Discourse context\n\n${formattedResults}`;
           };
           const getReferenceResultsContent = async () => {
             const normalizedTitle = normalizePageTitle(text);

--- a/apps/roam/src/utils/pageToMarkdown.ts
+++ b/apps/roam/src/utils/pageToMarkdown.ts
@@ -292,7 +292,7 @@ export const pageToMarkdown = async (
     )
     .join("\n")}\n${
     discourseResults.length
-      ? `\n###### Discourse Context\n\n${discourseResults
+      ? `\n###### Discourse context\n\n${discourseResults
           .flatMap((r) =>
             Object.values(r.results).map(
               (t) =>

--- a/apps/roam/src/utils/registerDiscourseDatalogTranslators.ts
+++ b/apps/roam/src/utils/registerDiscourseDatalogTranslators.ts
@@ -86,7 +86,7 @@ const collectVariables = (clauses: DatalogClause[]): Set<string> =>
     }),
   );
 
-const ANY_DISCOURSE_NODE = "Any Discourse Node";
+const ANY_DISCOURSE_NODE = "Any discourse node";
 
 const registerDiscourseDatalogTranslators = () => {
   const discourseRelations = getDiscourseRelations();

--- a/apps/website/app/(docs)/docs/obsidian/navigation.ts
+++ b/apps/website/app/(docs)/docs/obsidian/navigation.ts
@@ -4,17 +4,17 @@ const ROOT = "/docs/obsidian";
 
 export const navigation: NavigationList = [
   {
-    title: "🏠 Getting Started",
+    title: "🏠 Getting started",
     links: [
-      { title: "Getting Started", href: `${ROOT}/getting-started` },
+      { title: "Getting started", href: `${ROOT}/getting-started` },
       { title: "Installation", href: `${ROOT}/installation` },
     ],
   },
   {
-    title: "🧱 FUNDAMENTALS",
+    title: "🧱 Fundamentals",
     links: [
       {
-        title: "What is a Discourse Graph?",
+        title: "What is a discourse graph?",
         href: `${ROOT}/what-is-discourse-graph`,
       },
       {
@@ -27,32 +27,32 @@ export const navigation: NavigationList = [
     title: "⚙️ Configuration",
     links: [
       {
-        title: "Node Types & Templates",
+        title: "Node types & templates",
         href: `${ROOT}/node-types-templates`,
       },
       {
-        title: "Relationship Types",
+        title: "Relationship types",
         href: `${ROOT}/relationship-types`,
       },
       {
-        title: "General Settings",
+        title: "General settings",
         href: `${ROOT}/general-settings`,
       },
     ],
   },
   {
-    title: "🗺️ Core Features",
+    title: "🗺️ Core features",
     links: [
       {
-        title: "Creating Nodes",
+        title: "Creating nodes",
         href: `${ROOT}/creating-discourse-nodes`,
       },
       {
-        title: "Discourse Context",
+        title: "Discourse context",
         href: `${ROOT}/discourse-context`,
       },
       {
-        title: "Creating Relationships",
+        title: "Creating relationships",
         href: `${ROOT}/creating-discourse-relationships`,
       },
       {
@@ -67,7 +67,7 @@ export const navigation: NavigationList = [
   },
 
   {
-    title: "🔍 Advanced Features",
+    title: "🔍 Advanced features",
     links: [
       {
         title: "Commands",
@@ -76,22 +76,22 @@ export const navigation: NavigationList = [
     ],
   },
   {
-    title: "🚢 Use Cases",
+    title: "🚢 Use cases",
     links: [
       {
-        title: "Literature Review",
+        title: "Literature review",
         href: `${ROOT}/literature-reviewing`,
       },
       {
-        title: "Research Notes",
+        title: "Research notes",
         href: `${ROOT}/research-roadmapping`,
       },
       {
-        title: "Reading Clubs & Seminars",
+        title: "Reading clubs & seminars",
         href: `${ROOT}/reading-clubs`,
       },
       {
-        title: "Lab Notebooks",
+        title: "Lab notebooks",
         href: `${ROOT}/lab-notebooks`,
       },
     ],

--- a/apps/website/app/(docs)/docs/obsidian/pages/canvas.md
+++ b/apps/website/app/(docs)/docs/obsidian/pages/canvas.md
@@ -33,7 +33,7 @@ Or click on the canvas icon at the top right corner
 
 **WARNING: DO NOT MODIFY MARKDOWN CONTENT OF FILE**
 
-## Discourse Nodes
+## Discourse nodes
 
 ### Creating new discourse nodes
 
@@ -52,7 +52,7 @@ Or click on the canvas icon at the top right corner
 **Using node search**
 
 - Use the search bar in the top-right of the canvas
-- Type to search for existing Discourse Nodes
+- Type to search for existing discourse Nodes
 - Click on a node from the search results to add it to the canvas
 
 ![Node search](/docs/obsidian/node-search.gif)
@@ -73,7 +73,7 @@ Or click on the canvas icon at the top right corner
 
 ![Create relations](/docs/obsidian/create-relations.gif)
 
-_Note_: The relation type selected must be compatible between the source and target nodes. Otherwise, you will receive a relation tool error. To update the setting on what relation types are possible between two kinds of Discourse Nodes, you can change the setting [Relation types setting](./relationship-types#configuring-valid-relationships)
+_Note_: The relation type selected must be compatible between the source and target nodes. Otherwise, you will receive a relation tool error. To update the setting on what relation types are possible between two kinds of discourse nodes, you can change the setting [Relation types setting](./relationship-types#configuring-valid-relationships)
 
 ![Relation error](/docs/obsidian/relation-error.png)
 
@@ -82,7 +82,7 @@ _Note_: The relation type selected must be compatible between the source and tar
 - Click on the discourse node you're trying to add existing relations of
 - Click on the "Relations" button that pops up. You'll see a panel showing all the relations that this node has
 - Click on the '+' or '-' to add these relations to the canvas
-  - For relations whose target Discourse Node isn't on canvas yet, it will be added to the canvas along with the relation
+  - For relations whose target discourse node isn't on canvas yet, it will be added to the canvas along with the relation
 
 ![Adding existing relations](/docs/obsidian/adding-existing-relations.gif)
 

--- a/apps/website/app/(docs)/docs/obsidian/pages/canvas.md
+++ b/apps/website/app/(docs)/docs/obsidian/pages/canvas.md
@@ -4,6 +4,7 @@ date: "2025-01-01"
 author: ""
 published: true
 ---
+
 The canvas feature in Discourse Graph provides an interactive visual workspace for creating and connecting discourse nodes and relations. Built on top of tldraw, it allows you to visually map out discourse structures with drag-and-drop functionality, adding other visual elements like texts, scribbles, embeddings, and images.
 
 ## Creating a new canvas
@@ -14,21 +15,21 @@ The canvas feature in Discourse Graph provides an interactive visual workspace f
 2. Search for "Create new Discourse Graph canvas"
 3. Press Enter to create a new canvas
 
-![Create Canvas Command](/docs/obsidian/create-canvas-command.png)
+![Create canvas command](/docs/obsidian/create-canvas-command.png)
 The canvas will be created in your configured canvas folder (default: `Discourse Canvas/`) with a timestamp-based filename like `Canvas-2025-01-15-1430.md`.
 
 ## Opening and viewing canvas
 
 ### Opening a canvas
+
 1. Open the file of the canvas
 2. In case the file is still in markdown format, you can open the canvas mode by either
 
 Using the command palette
 
-![Open Canvas Command](/docs/obsidian/open-canvas-command.png)
+![Open canvas command](/docs/obsidian/open-canvas-command.png)
 Or click on the canvas icon at the top right corner
-![Canvas Icon Button](/docs/obsidian/canvas-icon-button.png)
-
+![Canvas icon button](/docs/obsidian/canvas-icon-button.png)
 
 **WARNING: DO NOT MODIFY MARKDOWN CONTENT OF FILE**
 
@@ -37,53 +38,58 @@ Or click on the canvas icon at the top right corner
 ### Creating new discourse nodes
 
 **Using the discourse node tool**
-   - Click the discourse node icon in the toolbar
-   - Select a node type from the right side panel
-   - Click anywhere on the canvas to place a new node
-   - Or drag the selected node type to the canvas
-   - Enter the node title in the modal that appears
 
-![Create Discourse Node](/docs/obsidian/create-discourse-node.gif)
+- Click the discourse node icon in the toolbar
+- Select a node type from the right side panel
+- Click anywhere on the canvas to place a new node
+- Or drag the selected node type to the canvas
+- Enter the node title in the modal that appears
 
+![Create discourse node](/docs/obsidian/create-discourse-node.gif)
 
 ### Adding existing nodes
 
 **Using node search**
-   - Use the search bar in the top-right of the canvas
-   - Type to search for existing Discourse Nodes
-   - Click on a node from the search results to add it to the canvas
 
-![Node Search](/docs/obsidian/node-search.gif)
+- Use the search bar in the top-right of the canvas
+- Type to search for existing Discourse Nodes
+- Click on a node from the search results to add it to the canvas
+
+![Node search](/docs/obsidian/node-search.gif)
 
 **Search filtering**
-   - When a specific node type is selected, search results are filtered to that type
 
-![Search Filtering](/docs/obsidian/search-filtering.gif)
+- When a specific node type is selected, search results are filtered to that type
 
+![Search filtering](/docs/obsidian/search-filtering.gif)
 
 ## Discourse relations
+
 ### Create new relations between nodes
-   - Click the discourse node icon in the toolbar
-   - Click the type of relations you want to create between two nodes
-   - Click and drag the arrow from the source node to target node
 
-   ![Create Relations](/docs/obsidian/create-relations.gif)
+- Click the discourse node icon in the toolbar
+- Click the type of relations you want to create between two nodes
+- Click and drag the arrow from the source node to target node
 
-   *Note*: The relation type selected must be compatible between the source and target nodes. Otherwise, you will receive a relation tool error. To update the setting on what relation types are possible between two kinds of Discourse Nodes, you can change the setting [Relation Types setting](./relationship-types#configuring-valid-relationships)
+![Create relations](/docs/obsidian/create-relations.gif)
 
-   ![Relation Error](/docs/obsidian/relation-error.png)
+_Note_: The relation type selected must be compatible between the source and target nodes. Otherwise, you will receive a relation tool error. To update the setting on what relation types are possible between two kinds of Discourse Nodes, you can change the setting [Relation types setting](./relationship-types#configuring-valid-relationships)
+
+![Relation error](/docs/obsidian/relation-error.png)
+
 ### Adding existing relations
-   - Click on the discourse node you're trying to add existing relations of
-   - Click on the "Relations" button that pops up. You'll see a panel showing all the relations that this node has
-   - Click on the '+' or '-' to add these relations to the canvas
-      + For relations whose target Discourse Node isn't on canvas yet, it will be added to the canvas along with the relation
 
+- Click on the discourse node you're trying to add existing relations of
+- Click on the "Relations" button that pops up. You'll see a panel showing all the relations that this node has
+- Click on the '+' or '-' to add these relations to the canvas
+  - For relations whose target Discourse Node isn't on canvas yet, it will be added to the canvas along with the relation
 
-   ![Adding Existing Relations](/docs/obsidian/adding-existing-relations.gif)
+![Adding existing relations](/docs/obsidian/adding-existing-relations.gif)
 
 ## Canvas Features
 
 ### Key figures
+
 You can choose to show the first image of discourse nodes of certain type. To change the setting on whether this first image show up, you can edit it in the Node Type Setting
 
 ![Key figure](/docs/obsidian/key-figure.png)
@@ -93,6 +99,7 @@ Then you will see the image show up if any is present in the file.
 ![Key figure example](/docs/obsidian/key-figure-example.png)
 
 ### Open discourse node files
+
 - To open a discourse node to the side panel, you can press Shift + Click, or click on the sidebar icon when hover on discourse node.
 - To open file to a new tab, you can press Cmd + click on the file
 
@@ -108,27 +115,31 @@ Then you will see the image show up if any is present in the file.
 - **SVG Export**: Export canvas as SVG image (via tldraw)
 - **PNG Export**: Export canvas as PNG image (via tldraw)
 
-![Export Options](/docs/obsidian/export-options.png)
+![Export options](/docs/obsidian/export-options.png)
 
 ## Troubleshooting
 
 ### Common Issues
 
 **Canvas Won't Load**:
+
 - Check that the file has proper frontmatter with `tldr-dg: true`
 - Verify the JSON data block is properly formatted
 - Try switching to markdown view and back to canvas view
 
 **Relations Won't Connect**:
+
 - Ensure the node types allow the relation type you're trying to create
 - Check your discourse relation configuration in settings
 - Verify both nodes are valid discourse nodes
 
 **Performance Issues**:
+
 - Consider splitting large canvases into multiple smaller ones
 - Close other resource-intensive applications
 
 **Search Not Working**:
+
 - Verify nodes have proper frontmatter with `nodeTypeId`
 - Check that the Obsidian metadata cache is up to date
 - Try restarting Obsidian to refresh the cache

--- a/apps/website/app/(docs)/docs/obsidian/pages/command-palette.md
+++ b/apps/website/app/(docs)/docs/obsidian/pages/command-palette.md
@@ -1,5 +1,5 @@
 ---
-title: "Command Palette Integration"
+title: "Command palette integration"
 date: "2025-01-01"
 author: ""
 published: true
@@ -11,7 +11,7 @@ The Command Palette is a powerful way to access all Discourse Graph features wit
 
 1. Press `Cmd/Ctrl + P`
 2. Type "Discourse" to see all available commands
-![command palette](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2F5ybScaQISO.png?alt=media&token=2b36f0e7-4247-47b7-a53d-c784dfd4609b)
+   ![command palette](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2F5ybScaQISO.png?alt=media&token=2b36f0e7-4247-47b7-a53d-c784dfd4609b)
 
 ## Customizing Commands
 

--- a/apps/website/app/(docs)/docs/obsidian/pages/creating-discourse-nodes.md
+++ b/apps/website/app/(docs)/docs/obsidian/pages/creating-discourse-nodes.md
@@ -1,11 +1,11 @@
 ---
-title: "Creating Discourse Nodes"
+title: "Creating discourse nodes"
 date: "2025-01-01"
 author: ""
 published: true
 ---
 
-## Creating a Node
+## Creating a node
 
 To create a discourse node, first select the text you want to turn into a node:
 
@@ -13,8 +13,8 @@ To create a discourse node, first select the text you want to turn into a node:
 
 There are two ways you can create a node:
 
-### 1. Using Command Keys (Recommended)
-#### 1.1 Turn selected text into Discourse Node
+### 1. Using command keys (recommended)
+#### 1.1 Turn selected text into discourse node
 
 1. Press `Cmd + \` (or your configured hotkey)
 2. The Node Menu will open as a popup
@@ -28,22 +28,22 @@ There are two ways you can create a node:
 2. Enter the title and node type
 ![](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FyYxtLKkx6B.png?alt=media&token=7f4f02df-d1fe-4529-8530-90acb0dc74b8)
 
-### 2. Using the Right-Click Menu
+### 2. Using the right-click menu
 
 1. Right-click on the selected text
 Alternatively, you can right-click on the selected text
 
 ![right click menu](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2F4UqeVkqLz7.png?alt=media&token=d2373152-d251-45fe-afb6-56373d6092aa)
-2. Choose a node type from the "Turn into Discourse Node" menu
+2. Choose a node type from the "Turn into discourse node" menu
 
-### 3. Turn existing page into Discourse Node
+### 3. Turn existing page into discourse node
 
-If a page is not a Discourse Node, you can turn it into one by clicking on the file menu, and chosing "Convert into" option
+If a page is not a discourse node, you can turn it into one by clicking on the file menu, and chosing "Convert into" option
 ![](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FCAGcQrCONJ.png?alt=media&token=fba6a6c9-038c-4a63-a46f-920bb8b37df1)
 
 After choosing a node type, you can edit the title and node type in the menu
 ![](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FVZ-jWbffHY.png?alt=media&token=6d7e5861-1df6-4148-8c11-4767a6e130f0)
-## Node Templates
+## Node templates
 
 When creating a node, if you've configured a [template for that node type](./node-types-templates#working-with-templates), the template content will be automatically applied to the new node.
 

--- a/apps/website/app/(docs)/docs/obsidian/pages/creating-discourse-relationships.md
+++ b/apps/website/app/(docs)/docs/obsidian/pages/creating-discourse-relationships.md
@@ -1,20 +1,20 @@
 ---
-title: "Creating Discourse Relationships"
+title: "Creating discourse relationships"
 date: "2025-01-01"
 author: ""
 published: true
 ---
 
-## Creating a Relationship
+## Creating a relationship
 
 To create a relationship between discourse nodes:
 
 1. Open a note that you want to create a relationship from
-2. Open the Discourse Context by clicking the telescope icon on the left bar
+2. Open the discourse context by clicking the telescope icon on the left bar
 ![open discourse context](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FE10krHZcDM.png?alt=media&token=c1796a9f-7e51-437f-913d-91f5433d9bab)
 
    Alternatively, you can:
-   - Set a hotkey to toggle the Discourse Context view
+   - Set a hotkey to toggle the discourse context view
    - Access it via the Command Palette
    ![command palette](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2F5ybScaQISO.png?alt=media&token=2b36f0e7-4247-47b7-a53d-c784dfd4609b)
 
@@ -29,7 +29,7 @@ To create a relationship between discourse nodes:
 6. Click "Confirm" to create the relationship
 ![relationship created](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FK8XAhCqrUL.png?alt=media&token=a559c477-c7f6-4b3e-8b00-ece7da5d4fec)
 
-## Next Steps
+## Next steps
 
 After creating relationships:
 - [Learn how to explore your graph](./exploring-discourse-graph)

--- a/apps/website/app/(docs)/docs/obsidian/pages/discourse-context.md
+++ b/apps/website/app/(docs)/docs/obsidian/pages/discourse-context.md
@@ -1,34 +1,34 @@
 ---
-title: "Exploring Your Discourse Graph"
+title: "Exploring your discourse graph"
 date: "2025-01-01"
 author: ""
 published: true
 ---
 
-## Opening the Discourse Context
+## Opening the discourse context
 
-The Discourse Context view is your main tool for exploring relationships between nodes in your graph. There are several ways to open it:
+The discourse context view is your main tool for exploring relationships between nodes in your graph. There are several ways to open it:
 
-### Method 1: Using the Sidebar Icon
+### Method 1: Using the sidebar icon
 
-Click the telescope icon on the left sidebar to toggle the Discourse Context view.
+Click the telescope icon on the left sidebar to toggle the discourse context view.
 ![open discourse context](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FE10krHZcDM.png?alt=media&token=c1796a9f-7e51-437f-913d-91f5433d9bab)
 
-### Method 2: Using the Command Palette
+### Method 2: Using the command palette
 
 1. Open the Command Palette (`Cmd/Ctrl + P`)
-2. Search for "Discourse Context"
+2. Search for "Discourse context"
 ![command palette](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2F5ybScaQISO.png?alt=media&token=2b36f0e7-4247-47b7-a53d-c784dfd4609b)
 
-### Method 3: Using Hotkeys
+### Method 3: Using hotkeys
 
-You can configure a custom hotkey in the Obsidian settings to quickly toggle the Discourse Context view.
+You can configure a custom hotkey in the Obsidian settings to quickly toggle the discourse context view.
 
 3. Configure a custom hotkey in settings
 
-## Using the Discourse Context
+## Using the discourse context
 
-The Discourse Context view shows you:
+The discourse context view shows you:
 - All relationships the current node has with other nodes
 - Types of relationships (supports, contradicts, etc.)
 - Quick access to related nodes

--- a/apps/website/app/(docs)/docs/obsidian/pages/discourse-context.md
+++ b/apps/website/app/(docs)/docs/obsidian/pages/discourse-context.md
@@ -17,8 +17,8 @@ Click the telescope icon on the left sidebar to toggle the discourse context vie
 ### Method 2: Using the command palette
 
 1. Open the Command Palette (`Cmd/Ctrl + P`)
-2. Search for "Discourse context"
-![command palette](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2F5ybScaQISO.png?alt=media&token=2b36f0e7-4247-47b7-a53d-c784dfd4609b)
+2. Search for "discourse context"
+   ![command palette](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2F5ybScaQISO.png?alt=media&token=2b36f0e7-4247-47b7-a53d-c784dfd4609b)
 
 ### Method 3: Using hotkeys
 
@@ -29,12 +29,14 @@ You can configure a custom hotkey in the Obsidian settings to quickly toggle the
 ## Using the discourse context
 
 The discourse context view shows you:
+
 - All relationships the current node has with other nodes
 - Types of relationships (supports, contradicts, etc.)
 - Quick access to related nodes
 - Tools for creating new relationships
 
 You can use this view to:
+
 - Navigate between related nodes
 - Understand how nodes connect to each other
 - Add new relationships

--- a/apps/website/app/(docs)/docs/obsidian/pages/general-settings.md
+++ b/apps/website/app/(docs)/docs/obsidian/pages/general-settings.md
@@ -1,13 +1,13 @@
 ---
-title: "General Settings"
+title: "General settings"
 date: "2025-06-27"
 author: ""
 published: true
 ---
 
-The General Settings page in the Discourse Graph plugin provides fundamental configuration options that affect how the plugin operates. Here are the available settings:
+The General settings page in the Discourse Graph plugin provides fundamental configuration options that affect how the plugin operates. Here are the available settings:
 
-## Show IDs in Frontmatter
+## Show IDs in frontmatter
 
 This setting controls the visibility of identifiers in your note's frontmatter section.
 
@@ -15,11 +15,11 @@ This setting controls the visibility of identifiers in your note's frontmatter s
 - When disabled, these IDs will be hidden from view
 - This can be useful if you prefer a cleaner frontmatter appearance while still maintaining the underlying structure
 
-## Discourse Nodes Folder Path
+## Discourse nodes folder path
 
-This setting determines where new Discourse Nodes will be created in your vault.
+This setting determines where new discourse nodes will be created in your vault.
 
-- Specify a folder path where you want all new Discourse Nodes to be stored
+- Specify a folder path where you want all new discourse nodes to be stored
 - Leave the field empty to create nodes in the root folder of your vault
 - You can use the folder suggester to easily navigate and select existing folders
 - Example format: `folder1/folder2`

--- a/apps/website/app/(docs)/docs/obsidian/pages/getting-started.md
+++ b/apps/website/app/(docs)/docs/obsidian/pages/getting-started.md
@@ -31,12 +31,12 @@ Follow our handy guides to get started on the basics as quickly as possible:
 - [Creating discourse relationships](./creating-discourse-relationships)
 - [Exploring your Discourse Graph](./exploring-discourse-graph)
 - [Querying your Discourse Graph](./querying-discourse-graph)
-- [Extending and Personalizing your Discourse Graph](./extending-personalizing-graph)
+- [Extending and personalizing your Discourse Graph](./extending-personalizing-graph)
 
 ## Fundamentals: Dive a little deeper
 
 Learn the fundamentals of the Discourse Graph plugin to get a deeper understanding of our main features:
 
 - [What is a Discourse Graph?](./what-is-discourse-graph)
-- [The Discourse Graph Plugin Grammar](./grammar)
-- [The Base Grammar: Questions, Claims, and Evidence](./base-grammar) 
+- [The Discourse Graph plugin grammar](./grammar)
+- [The Base Grammar: questions, claims, and evidence](./base-grammar)

--- a/apps/website/app/(docs)/docs/obsidian/pages/getting-started.md
+++ b/apps/website/app/(docs)/docs/obsidian/pages/getting-started.md
@@ -1,5 +1,5 @@
 ---
-title: "Getting Started"
+title: "Getting started"
 date: "2025-01-01"
 author: ""
 published: true
@@ -27,8 +27,8 @@ For more information about Discourse Graphs, check out our website at [https://d
 
 Follow our handy guides to get started on the basics as quickly as possible:
 
-- [Creating Discourse Nodes](./creating-discourse-nodes)
-- [Creating Discourse Relationships](./creating-discourse-relationships)
+- [Creating discourse nodes](./creating-discourse-nodes)
+- [Creating discourse relationships](./creating-discourse-relationships)
 - [Exploring your Discourse Graph](./exploring-discourse-graph)
 - [Querying your Discourse Graph](./querying-discourse-graph)
 - [Extending and Personalizing your Discourse Graph](./extending-personalizing-graph)

--- a/apps/website/app/(docs)/docs/obsidian/pages/node-types-templates.md
+++ b/apps/website/app/(docs)/docs/obsidian/pages/node-types-templates.md
@@ -1,5 +1,5 @@
 ---
-title: "Node Types & Templates"
+title: "Node types & templates"
 date: "2025-01-01"
 author: ""
 published: true
@@ -19,7 +19,8 @@ Node types are the building blocks of your discourse graph. Each node type repre
    - Ensure you have the Templates plugin enabled and configured with a template folder
    - The dropdown will show all available template files from your configured template folder
 
-      ![add node types with template](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FHMg_Tq6qiR.png?alt=media&token=69828bfc-c939-41b0-abd4-2cc8931c5a38)
+     ![add node types with template](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FHMg_Tq6qiR.png?alt=media&token=69828bfc-c939-41b0-abd4-2cc8931c5a38)
+
    - Click "Save Changes"
 
 ## Working with Templates
@@ -29,13 +30,13 @@ Templates allow you to automatically add predefined content when creating new no
 ### Setting Up Templates
 
 1. Create a new folder for templates
-![new folder](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FyTtJ1a0iI2.png?alt=media&token=b5d09b10-f170-47cd-a239-ee5f7acd89dc)
+   ![new folder](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FyTtJ1a0iI2.png?alt=media&token=b5d09b10-f170-47cd-a239-ee5f7acd89dc)
 
 2. Configure the template folder location in settings
-![template](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FhzZg_GJXY9.png?alt=media&token=508c8d19-1f13-4fb3-adf1-898dcf694f08)
+   ![template](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FhzZg_GJXY9.png?alt=media&token=508c8d19-1f13-4fb3-adf1-898dcf694f08)
 
 3. Create template files
-![create template file](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FtTr9vOnXnX.png?alt=media&token=dda1fe25-3ccf-42b4-8f3c-1cd29f82c3f7)
+   ![create template file](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FtTr9vOnXnX.png?alt=media&token=dda1fe25-3ccf-42b4-8f3c-1cd29f82c3f7)
 
 ## Template Requirements
 
@@ -48,4 +49,4 @@ Templates allow you to automatically add predefined content when creating new no
 
 - [Configure relationship types](./relationship-types)
 - [Learn about creating nodes](./creating-discourse-nodes)
-- [Explore advanced template usage](./using-templates) 
+- [Explore advanced template usage](./using-templates)

--- a/apps/website/app/(docs)/docs/obsidian/pages/relationship-types.md
+++ b/apps/website/app/(docs)/docs/obsidian/pages/relationship-types.md
@@ -1,18 +1,18 @@
 ---
-title: "Relationship Types"
+title: "Relationship types"
 date: "2025-01-01"
 author: ""
 published: true
 ---
 
-## Understanding Relationship Types
+## Understanding relationship types
 
 Relationship types define how different nodes in your discourse graph can connect to each other. Each relationship type has:
 - A primary label (e.g., "supports")
 - A complement label (e.g., "is supported by")
 - Rules about which node types can be connected
 
-## Adding Relationship Types
+## Adding relationship types
 
 1. Open Obsidian Settings
 2. Navigate to the "Discourse Graphs" settings tab
@@ -23,7 +23,7 @@ Relationship types define how different nodes in your discourse graph can connec
    ![add relation type](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2Fjk367dcO_K.png?alt=media&token=22d74e9f-882c-434b-8b50-afd7a754fb2b)
 5. Click "Save Changes"
 
-## Configuring Valid Relationships
+## Configuring valid relationships
 
 After creating relationship types, you need to define which node types can be connected by each relationship.
 
@@ -39,7 +39,7 @@ After creating relationship types, you need to define which node types can be co
 3. Review and confirm the configuration
 ![final relations](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FycPW-N-rY8.png?alt=media&token=54867be2-9030-4c6c-82d2-b96069e52d81)
 
-## Example Relationships
+## Example relationships
 
 Here are some common relationship types:
 - Claim → supports → Question
@@ -47,8 +47,8 @@ Here are some common relationship types:
 - Evidence → contradicts → Claim
 - Source → informs → Question
 
-## Next Steps
+## Next steps
 
 - [Create your first relationship](./creating-discourse-relationships)
-- [Learn about the Discourse Context](./using-discourse-context)
+- [Learn about the discourse context](./using-discourse-context)
 - [Explore your graph](./exploring-discourse-graph) 

--- a/apps/website/app/(docs)/docs/roam/navigation.ts
+++ b/apps/website/app/(docs)/docs/roam/navigation.ts
@@ -6,23 +6,23 @@ export const navigation: NavigationList = [
   {
     title: "🏠 Welcome!",
     links: [
-      { title: "Getting Started", href: `${ROOT}/getting-started` },
+      { title: "Getting started", href: `${ROOT}/getting-started` },
       { title: "Installation", href: `${ROOT}/installation` },
     ],
   },
   {
-    title: "🗺️ GUIDES",
+    title: "🗺️ Guides",
     links: [
       {
-        title: "Creating Nodes",
+        title: "Creating nodes",
         href: `${ROOT}/creating-discourse-nodes`,
       },
       {
-        title: "Tagging Candidate Nodes",
+        title: "Tagging candidate nodes",
         href: `${ROOT}/tagging-candidate-nodes`,
       },
       {
-        title: "Creating Relationships",
+        title: "Creating relationships",
         href: `${ROOT}/creating-discourse-relationships`,
       },
       {
@@ -44,10 +44,10 @@ export const navigation: NavigationList = [
     ],
   },
   {
-    title: "🧱 FUNDAMENTALS",
+    title: "🧱 Fundamentals",
     links: [
       {
-        title: "What is a Discourse Graph?",
+        title: "What is a discourse graph?",
         href: `${ROOT}/what-is-discourse-graph`,
       },
       {
@@ -57,10 +57,10 @@ export const navigation: NavigationList = [
     ],
   },
   {
-    title: "🚢 USE CASES",
+    title: "🚢 Use cases",
     links: [
       {
-        title: "Literature Reviewing",
+        title: "Literature reviewing",
         href: `${ROOT}/literature-reviewing`,
       },
       {
@@ -68,7 +68,7 @@ export const navigation: NavigationList = [
         href: `${ROOT}/enhanced-zettelkasten`,
       },
       {
-        title: "Reading Clubs / Seminars",
+        title: "Reading clubs / seminars",
         href: `${ROOT}/reading-clubs`,
       },
       {
@@ -76,7 +76,7 @@ export const navigation: NavigationList = [
         href: `${ROOT}/lab-notebooks`,
       },
       {
-        title: "Product / Research Roadmapping",
+        title: "Product / research roadmapping",
         href: `${ROOT}/research-roadmapping`,
       },
     ],

--- a/apps/website/app/(docs)/docs/roam/pages/creating-discourse-nodes.md
+++ b/apps/website/app/(docs)/docs/roam/pages/creating-discourse-nodes.md
@@ -1,5 +1,5 @@
 ---
-title: "Creating Discourse Nodes"
+title: "Creating discourse nodes"
 date: "2025-01-01"
 author: ""
 published: true

--- a/apps/website/app/(docs)/docs/roam/pages/creating-discourse-relationships.md
+++ b/apps/website/app/(docs)/docs/roam/pages/creating-discourse-relationships.md
@@ -1,5 +1,5 @@
 ---
-title: "Creating Discourse Relationships"
+title: "Creating discourse relationships"
 date: "2025-01-01"
 author: ""
 published: true

--- a/apps/website/app/(docs)/docs/roam/pages/discourse-attributes.md
+++ b/apps/website/app/(docs)/docs/roam/pages/discourse-attributes.md
@@ -5,8 +5,8 @@ author: ""
 published: true
 ---
 
-- [Discourse Context](./discourse-context)
-- [Discourse Context Overlay](./discourse-context-overlay)
+- [Discourse context](./discourse-context)
+- [Discourse context overlay](./discourse-context-overlay)
 - [Discourse Attributes](./discourse-attributes)
 - [Node Index](./node-index)
 

--- a/apps/website/app/(docs)/docs/roam/pages/discourse-attributes.md
+++ b/apps/website/app/(docs)/docs/roam/pages/discourse-attributes.md
@@ -1,5 +1,5 @@
 ---
-title: "Discourse Attributes"
+title: "Discourse attributes"
 date: "2025-01-01"
 author: ""
 published: true
@@ -7,8 +7,8 @@ published: true
 
 - [Discourse context](./discourse-context)
 - [Discourse context overlay](./discourse-context-overlay)
-- [Discourse Attributes](./discourse-attributes)
-- [Node Index](./node-index)
+- [Discourse attributes](./discourse-attributes)
+- [Node index](./node-index)
 
 ## Define Discourse Attributes
 

--- a/apps/website/app/(docs)/docs/roam/pages/discourse-context-overlay.md
+++ b/apps/website/app/(docs)/docs/roam/pages/discourse-context-overlay.md
@@ -1,19 +1,19 @@
 ---
-title: "Discourse Context Overlay"
+title: "Discourse context overlay"
 date: "2025-01-01"
 author: ""
 published: true
 ---
 
-- [Discourse Context](./discourse-context)
-- [Discourse Context Overlay](./discourse-context-overlay)
-- [Discourse Attributes](./discourse-attributes)
-- [Node Index](./node-index)
+- [Discourse context](./discourse-context)
+- [Discourse context overlay](./discourse-context-overlay)
+- [Discourse attributes](./discourse-attributes)
+- [Node index](./node-index)
 
-The Discourse Context Overlay adds an icon next to each discourse node wherever it is referenced. This icon provides access to two key features:
+The discourse context overlay adds an icon next to each discourse node wherever it is referenced. This icon provides access to two key features:
 
 1. a popover to view the [Discourse context](./discourse-context) of the node inline, and
-2. a "Discourse Score" component that displays a customizable score for the node that is some function of its relations to other nodes in the discourse graph.
+2. a "Discourse score" component that displays a customizable score for the node that is some function of its relations to other nodes in the discourse graph.
 
 The overlay is an optional feature that is turned off by default. To turn it on, go to the grammar tab in the config page and check the box for overlay.
 
@@ -25,15 +25,15 @@ The popover is simple to operate. Simply click on the icon to bring up the [disc
 
 ![](/docs/roam/discourse-context-overlay.gif)
 
-## Discourse Score
+## Discourse score
 
-By default, the Discourse Score displays the count of the total number of discourse relations for that node (the number on the left), as well as a count of the total number of references to that node in the graph.
+By default, the discourse score displays the count of the total number of discourse relations for that node (the number on the left), as well as a count of the total number of references to that node in the graph.
 
 For example, the following score display denotes that the node participates in 5 discourse relations with other nodes, which can be seen in detail in the discourse context popover (1 informs, 1 supports, 2 consistent with, and 1 sourced by; note that 2 of these relations are [custom relations](./extending-personalizing-graph)).
 
 ![](/docs/roam/discourse-context-overlay-score.png)
 
-You can think of this default Discourse Score as a rough sense of how "robust" a given node is (discourse relations are more structured, high-signal relationships) relative to how "important" it is (raw references are often noisy). If you'd like, you can also experiment with different functions of discourse relations to a node by defining your own [Discourse Attributes](./discourse-attributes), and have them show up in the overlay!
+You can think of this default discourse score as a rough sense of how "robust" a given node is (discourse relations are more structured, high-signal relationships) relative to how "important" it is (raw references are often noisy). If you'd like, you can also experiment with different functions of discourse relations to a node by defining your own [Discourse attributes](./discourse-attributes), and have them show up in the overlay!
 
 ## Demo
 

--- a/apps/website/app/(docs)/docs/roam/pages/discourse-context.md
+++ b/apps/website/app/(docs)/docs/roam/pages/discourse-context.md
@@ -1,14 +1,14 @@
 ---
-title: "Discourse Context"
+title: "Discourse context"
 date: "2025-01-01"
 author: ""
 published: true
 ---
 
-- [Discourse Context](./discourse-context)
-- [Discourse Context Overlay](./discourse-context-overlay)
-- [Discourse Attributes](./discourse-attributes)
-- [Node Index](./node-index)
+- [Discourse context](./discourse-context)
+- [Discourse context overlay](./discourse-context-overlay)
+- [Discourse attributes](./discourse-attributes)
+- [Node index](./node-index)
 
 The discourse context component adds a "higher-signal" linked references section to each discourse node, that allows you to explore _discourse_ relations (e.g., inform, support, etc.) between this node and other nodes in your discourse graph.
 

--- a/apps/website/app/(docs)/docs/roam/pages/exploring-discourse-graph.md
+++ b/apps/website/app/(docs)/docs/roam/pages/exploring-discourse-graph.md
@@ -7,7 +7,7 @@ published: true
 
 The extension adds features to enable you to seamlessly explore your discourse graph to enhance your thinking.
 
-- [Discourse Context](./discourse-context)
-- [Discourse Context Overlay](./discourse-context-overlay)
+- [Discourse context](./discourse-context)
+- [Discourse context overlay](./discourse-context-overlay)
 - [Discourse Attributes](./discourse-attributes)
 - [Node Index](./node-index)

--- a/apps/website/app/(docs)/docs/roam/pages/exploring-discourse-graph.md
+++ b/apps/website/app/(docs)/docs/roam/pages/exploring-discourse-graph.md
@@ -9,5 +9,5 @@ The extension adds features to enable you to seamlessly explore your discourse g
 
 - [Discourse context](./discourse-context)
 - [Discourse context overlay](./discourse-context-overlay)
-- [Discourse Attributes](./discourse-attributes)
-- [Node Index](./node-index)
+- [Discourse attributes](./discourse-attributes)
+- [Node index](./node-index)

--- a/apps/website/app/(docs)/docs/roam/pages/extending-personalizing-graph.md
+++ b/apps/website/app/(docs)/docs/roam/pages/extending-personalizing-graph.md
@@ -1,5 +1,5 @@
 ---
-title: "Extending and Personalizing Your Discourse Graph"
+title: "Extending and personalizing Your Discourse Graph"
 date: "2025-01-01"
 author: ""
 published: true

--- a/apps/website/app/(docs)/docs/roam/pages/extending-personalizing-graph.md
+++ b/apps/website/app/(docs)/docs/roam/pages/extending-personalizing-graph.md
@@ -1,5 +1,5 @@
 ---
-title: "Extending and personalizing Your Discourse Graph"
+title: "Extending and personalizing your Discourse Graph"
 date: "2025-01-01"
 author: ""
 published: true

--- a/apps/website/app/(docs)/docs/roam/pages/getting-started.md
+++ b/apps/website/app/(docs)/docs/roam/pages/getting-started.md
@@ -28,5 +28,5 @@ Follow our handy guides to get started on the basics as quickly as possible:
 Learn the fundamentals of the Discourse Graph extension to get a deeper understanding of our main features:
 
 - [What is a Discourse Graph?](./what-is-discourse-graph)
-- [The Discourse Graph Extension Grammar](./grammar)
-- [The Base Grammar: Questions, Claims, and Evidence](./base-grammar)
+- [The Discourse Graph extension grammar](./grammar)
+- [The base grammar: questions, claims, and evidence](./base-grammar)

--- a/apps/website/app/(docs)/docs/roam/pages/getting-started.md
+++ b/apps/website/app/(docs)/docs/roam/pages/getting-started.md
@@ -1,5 +1,5 @@
 ---
-title: "Getting Started"
+title: "Getting started"
 date: "2025-01-01"
 author: ""
 published: true
@@ -17,8 +17,8 @@ Here is a relatively brief walkthrough of some of the main features of the exten
 
 Follow our handy guides to get started on the basics as quickly as possible:
 
-- [Creating Discourse Nodes](./creating-discourse-nodes)
-- [Creating Discourse Relationships](./creating-discourse-relationships)
+- [Creating discourse nodes](./creating-discourse-nodes)
+- [Creating discourse relationships](./creating-discourse-relationships)
 - [Exploring your Discourse Graph](./exploring-discourse-graph)
 - [Querying your Discourse Graph](./querying-discourse-graph)
 - [Extending and Personalizing your Discourse Graph](./extending-personalizing-discourse-graph)

--- a/apps/website/app/(docs)/docs/roam/pages/grammar.md
+++ b/apps/website/app/(docs)/docs/roam/pages/grammar.md
@@ -1,14 +1,14 @@
 ---
-title: "Extension Grammar"
+title: "Extension grammar"
 date: "2025-01-01"
 author: ""
 published: true
 ---
 
 - [Nodes](./nodes)
-- [Operators and Relations](./operators-relations)
-- [Relations Patterns](./relations-patterns)
-- [Base Grammar](./base-grammar)
+- [Operators and relations](./operators-relations)
+- [Relations patterns](./relations-patterns)
+- [Base grammar](./base-grammar)
 
 The basic technical intuition behind the extension is that it creates a mapping between the following two elements:
 

--- a/apps/website/app/(docs)/docs/roam/pages/node-index.md
+++ b/apps/website/app/(docs)/docs/roam/pages/node-index.md
@@ -5,8 +5,8 @@ author: ""
 published: true
 ---
 
-- [Discourse Context](./discourse-context)
-- [Discourse Context Overlay](./discourse-context-overlay)
+- [Discourse context](./discourse-context)
+- [Discourse context overlay](./discourse-context-overlay)
 - [Discourse Attributes](./discourse-attributes)
 - [Node Index](./node-index)
 

--- a/apps/website/app/(docs)/docs/roam/pages/node-index.md
+++ b/apps/website/app/(docs)/docs/roam/pages/node-index.md
@@ -1,5 +1,5 @@
 ---
-title: "Node Index"
+title: "Node index"
 date: "2025-01-01"
 author: ""
 published: true
@@ -7,8 +7,8 @@ published: true
 
 - [Discourse context](./discourse-context)
 - [Discourse context overlay](./discourse-context-overlay)
-- [Discourse Attributes](./discourse-attributes)
-- [Node Index](./node-index)
+- [Discourse attributes](./discourse-attributes)
+- [Node index](./node-index)
 
 The extension has node settings tabs for each node you define, which provides a query over all of your nodes of that type. For example, you can go to the Claim tab to see all the Claim nodes in your graph.
 

--- a/apps/website/app/(docs)/docs/roam/pages/nodes.md
+++ b/apps/website/app/(docs)/docs/roam/pages/nodes.md
@@ -6,7 +6,6 @@ published: true
 ---
 
 - `discourse node`
-
   - as defined in your grammar (e.g., base grammar will include CLM or EVD, for example)
 
 - `block`
@@ -20,4 +19,4 @@ When in doubt, check the preview of your relation pattern to ensure you're corre
 
 ## Next
 
-- [Operators and Relations](./operators-relations)
+- [Operators and relations](./operators-relations)

--- a/apps/website/app/(docs)/docs/roam/pages/operators-relations.md
+++ b/apps/website/app/(docs)/docs/roam/pages/operators-relations.md
@@ -1,5 +1,5 @@
 ---
-title: "Operators and Relations"
+title: "Operators and relations"
 date: "2025-01-01"
 author: ""
 published: true
@@ -13,7 +13,6 @@ published: true
 - **source**: a `block`
 - **target**: a `page`
 - example:
-
   - this block references \[\[some page\]\]
 
 ### `is in page`
@@ -68,4 +67,4 @@ published: true
 
 ## Next
 
-- [Relations Patterns](./relations-patterns)
+- [Relations patterns](./relations-patterns)

--- a/apps/website/app/(docs)/docs/roam/pages/relations-patterns.md
+++ b/apps/website/app/(docs)/docs/roam/pages/relations-patterns.md
@@ -1,5 +1,5 @@
 ---
-title: "Relations and Patterns"
+title: "Relations and patterns"
 date: "2025-01-01"
 author: ""
 published: true

--- a/apps/website/app/(docs)/docs/roam/pages/sharing-discourse-graph.md
+++ b/apps/website/app/(docs)/docs/roam/pages/sharing-discourse-graph.md
@@ -23,15 +23,15 @@ We have a range of options for customizing the markdown export. These can be fou
 
 Here is a brief explanation of each option:
 
-`Max Filename Length`
+`Max filename length`
 
 - sets the maximum length of the filenames; this is important if you have page names that are quite long and may run afoul of, say, Windows' filename length limit of 250-260 characters.
 
-`Remove Special Characters`
+`Remove special characters`
 
 - removes all "special characters" that may lead to trouble for filenames in different operating systems, such as `?` (not allowed on Windows) or `/` (denotes file/folder boundaries).
 
-`Simplified Filename`
+`Simplified filename`
 
 - strips away all "template" characters (i.e., everything except the `{content}` in the node format: for example, if you define a Claim node as `[[CLM]] - {content}`, and have a Claim node `[[[[CLM]] - people are lazy]]`, the exported filename will be `people are lazy`
 
@@ -40,20 +40,18 @@ Here is a brief explanation of each option:
 - specifies what properties to add to the YAML.
 
 - By default, the properties are:
-
   - `title: {text}`
   - `author: {author}`
   - `date: {date}`
 
 - You can add properties as key-value pairs in the same format:
-
   - ![](/docs/roam/settings-export-frontmatter.png)
 
-`Resolve Block References` and `Resolve Block Embeds`
+`Resolve block references` and `Resolve block embeds`
 
 - control whether you want to resolve block references/embeds in your export. You can keep this turned off if you are unsure of the privacy implications of references/embeds.
 
-`Link Type`
+`Link type`
 
 - controls whether inline page references are wikilinks (`[[like this]]`) or alias (`[like this](pageName.md)`)
 

--- a/apps/website/app/(docs)/docs/roam/pages/tagging-candidate-nodes.md
+++ b/apps/website/app/(docs)/docs/roam/pages/tagging-candidate-nodes.md
@@ -1,5 +1,5 @@
 ---
-title: "Tagging Candidate Nodes"
+title: "Tagging candidate nodes"
 date: "2025-09-16"
 author: ""
 published: true
@@ -14,7 +14,7 @@ It's helpful to quickly tag these. Later, you can search for them and formalize 
 
 In the discourse graphs settings, for each node type, list a "candidate node" tag label:
 
-![Tagging Candidate Nodes Demo](/docs/roam/tagging-config.gif)
+![Tagging candidate nodes demo](/docs/roam/tagging-config.gif)
 
 ⚠️ _Important: A tag cannot use text that is already part of its associated node's format. For example, if the "Claim" node format is CLM, you cannot use #CLM as its tag. You'll get an error message if you attempt to do this._
 
@@ -22,7 +22,7 @@ In the discourse graphs settings, for each node type, list a "candidate node" ta
 
 Tag candidate nodes with the keyboard shortcut: `\`
 
-![Tagging Candidate Nodes keyboard shortcut](/docs/roam/tagging-demo.gif)
+![Tagging candidate nodes keyboard shortcut](/docs/roam/tagging-demo.gif)
 
 Click or use the down arrow key to select a candidate node type.
 
@@ -34,7 +34,7 @@ Hover your mouse over the node tag, and click "Create Evidence"
 
 <!-- TODO: update this gif with smoother UX, including auto-remove tag -->
 
-![Formalizing Candidate Nodes](/docs/roam/tagging-formalization.gif)
+![Formalizing candidate nodes](/docs/roam/tagging-formalization.gif)
 
 ## Candidate node styling
 

--- a/apps/website/app/(docs)/docs/sharedPages/base-grammar.md
+++ b/apps/website/app/(docs)/docs/sharedPages/base-grammar.md
@@ -1,5 +1,5 @@
 ---
-title: "Base Grammar"
+title: "Base grammar"
 date: "2025-01-01"
 author: ""
 published: true

--- a/apps/website/app/(docs)/docs/sharedPages/lab-notebooks.md
+++ b/apps/website/app/(docs)/docs/sharedPages/lab-notebooks.md
@@ -1,5 +1,5 @@
 ---
-title: "Lab Notebooks"
+title: "Lab notebooks"
 date: "2025-01-01"
 author: ""
 published: true

--- a/apps/website/app/(docs)/docs/sharedPages/literature-reviewing.md
+++ b/apps/website/app/(docs)/docs/sharedPages/literature-reviewing.md
@@ -1,5 +1,5 @@
 ---
-title: "Literature Reviewing"
+title: "Literature reviewing"
 date: "2025-01-01"
 author: ""
 published: true

--- a/apps/website/app/(docs)/docs/sharedPages/reading-clubs.md
+++ b/apps/website/app/(docs)/docs/sharedPages/reading-clubs.md
@@ -1,5 +1,5 @@
 ---
-title: "Reading Clubs"
+title: "Reading clubs"
 date: "2025-01-01"
 author: ""
 published: true

--- a/apps/website/app/(docs)/docs/sharedPages/research-roadmapping.md
+++ b/apps/website/app/(docs)/docs/sharedPages/research-roadmapping.md
@@ -1,5 +1,5 @@
 ---
-title: "Research Roadmapping"
+title: "Research roadmapping"
 date: "2025-01-01"
 author: ""
 published: true


### PR DESCRIPTION
### Motivation
- Standardize UI copy and docs to sentence case for branded components (e.g., `Discourse context`, `discourse node`) to improve readability and match the new style guidance.
- Reduce Title Case occurrences across the codebase so product and feature language is consistent between Roam, Obsidian, and website docs.
- Make export and tooling labels (commands, modals, tooltips) use sentence case to reduce visual noise and emphasize actions over branded nouns.

### Description
- Converted UI strings, command names, modal titles, tool labels, and help text from Title Case to sentence case across `apps/obsidian/src`, `apps/roam/src`, and `apps/website/app/(docs)/docs` files (examples include `DiscourseContext`, `CreateNodeDialog`, and docs pages under `docs/roam` and `docs/obsidian`).
- Updated doc frontmatter titles and headings to sentence case for pages like `creating-discourse-nodes.md`, `creating-discourse-relationships.md`, and `discourse-context.md` to align navigation and content.
- Normalized export and markdown headings and progress messages in the export flows (e.g., `Export discourse graph`, `Discourse context`) and updated generated markdown headings in `pageToMarkdown` and `getExportTypes`.
- Adjusted a few constants and datalog translator labels (e.g., `ANY_DISCOURSE_NODE`) and tldraw/canvas tool labels to sentence case to keep API/UX naming consistent.

### Testing
- Started the website dev server with `pnpm dev` and the Next app compiled and served at `http://localhost:3000`, which reported readiness and served pages.
- Ran a Playwright script that navigated to `/docs/roam/getting-started` and produced a screenshot artifact (`artifacts/roam-docs-navigation.png`), indicating the updated navigation renders correctly.
- The Next build logged a font fetch warning for `Inter` but fell back successfully and compilation completed; this is informational and did not block verification.
- No unit or E2E test suites were executed as part of this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69648a0d312483268e0794fb275b2085)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized capitalization conventions throughout the application and documentation, converting titles and labels to lowercase (e.g., "Discourse Context" → "discourse context", "Discourse Node" → "discourse node").
  * Updated UI text in buttons, tooltips, dialog headers, and command names for consistent formatting.
  * Adjusted documentation titles, headings, and navigation text to align with updated style guidelines.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->