### PR TITLE
ENG-879 A node can have no specification or format

### DIFF
--- a/apps/roam/src/components/settings/DiscourseNodeSpecification.tsx
+++ b/apps/roam/src/components/settings/DiscourseNodeSpecification.tsx
@@ -8,6 +8,7 @@ import refreshConfigTree from "~/utils/refreshConfigTree";
 import getDiscourseNodes from "~/utils/getDiscourseNodes";
 import getDiscourseNodeFormatExpression from "~/utils/getDiscourseNodeFormatExpression";
 import QueryEditor from "~/components/QueryEditor";
+import internalError from "~/utils/internalError";
 
 const NodeSpecification = ({
   parentUid,
@@ -68,17 +69,24 @@ const NodeSpecification = ({
               },
             }),
           )
-          .then(() => setMigrated(true));
+          .then(() => setMigrated(true))
+          .catch((error) => {
+            internalError({ error });
+          });
       }
     } else {
       const tree = getBasicTreeByParentUid(parentUid);
       const scratchNode = getSubTree({ tree, key: "scratch" });
-      Promise.all(scratchNode.children.map((c) => deleteBlock(c.uid)));
+      Promise.all(scratchNode.children.map((c) => deleteBlock(c.uid))).catch(
+        (error) => {
+          internalError({ error });
+        },
+      );
     }
     return () => {
       refreshConfigTree();
     };
-  }, [parentUid, setMigrated, enabled]);
+  }, [parentUid, setMigrated, enabled, node.format, node.text]);
   return (
     <div className={"roamjs-node-specification"}>
       <style>
@@ -95,15 +103,23 @@ const NodeSpecification = ({
                 parentUid,
                 order: 2,
                 node: { text: "enabled" },
-              }).then((uid: string) => {
-                setEnabled(uid);
-                if (parentSetEnabled) parentSetEnabled(true);
-              });
+              })
+                .then((uid: string) => {
+                  setEnabled(uid);
+                  if (parentSetEnabled) parentSetEnabled(true);
+                })
+                .catch((error) => {
+                  internalError({ error });
+                });
             } else {
-              deleteBlock(enabled).then(() => {
-                setEnabled("");
-                if (parentSetEnabled) parentSetEnabled(false);
-              });
+              deleteBlock(enabled)
+                .then(() => {
+                  setEnabled("");
+                  if (parentSetEnabled) parentSetEnabled(false);
+                })
+                .catch((error) => {
+                  internalError({ error });
+                });
             }
           }}
         />

--- a/apps/roam/src/components/settings/DiscourseNodeSpecification.tsx
+++ b/apps/roam/src/components/settings/DiscourseNodeSpecification.tsx
@@ -12,12 +12,14 @@ import QueryEditor from "~/components/QueryEditor";
 const NodeSpecification = ({
   parentUid,
   node,
+  parentSetEnabled,
 }: {
   parentUid: string;
   node: ReturnType<typeof getDiscourseNodes>[number];
+  parentSetEnabled?: (enabled: boolean) => void;
 }) => {
   const [migrated, setMigrated] = React.useState(false);
-  const [enabled, setEnabled] = React.useState(
+  const [enabled, setEnabled] = React.useState<string>(
     () =>
       getSubTree({ tree: getBasicTreeByParentUid(parentUid), key: "enabled" })
         ?.uid,
@@ -93,9 +95,15 @@ const NodeSpecification = ({
                 parentUid,
                 order: 2,
                 node: { text: "enabled" },
-              }).then(setEnabled);
+              }).then((uid: string) => {
+                setEnabled(uid);
+                if (parentSetEnabled) parentSetEnabled(true);
+              });
             } else {
-              deleteBlock(enabled).then(() => setEnabled(""));
+              deleteBlock(enabled).then(() => {
+                setEnabled("");
+                if (parentSetEnabled) parentSetEnabled(false);
+              });
             }
           }}
         />

--- a/apps/roam/src/components/settings/NodeConfig.tsx
+++ b/apps/roam/src/components/settings/NodeConfig.tsx
@@ -233,10 +233,10 @@ const NodeConfig = ({
   const validate = useCallback(
     (tag: string, format: string) => {
       const enabled =
-        getSubTree({
+        (getSubTree({
           tree: getBasicTreeByParentUid(specificationUid),
           key: "enabled",
-        })?.uid?.length || 0 !== 0;
+        })?.uid?.length || 0) !== 0;
       if (format.trim().length === 0 && !enabled) {
         setTagError("");
         setFormatError("Error: you must set either a format or specification");

--- a/apps/roam/src/components/settings/NodeConfig.tsx
+++ b/apps/roam/src/components/settings/NodeConfig.tsx
@@ -231,13 +231,21 @@ const NodeConfig = ({
   );
 
   const validate = useCallback(
-    (tag: string, format: string) => {
-      const enabled =
-        (getSubTree({
+    ({
+      tag,
+      format,
+      isSpecificationEnabled,
+    }: {
+      tag: string;
+      format: string;
+      isSpecificationEnabled?: boolean;
+    }) => {
+      if (isSpecificationEnabled === undefined)
+        isSpecificationEnabled = !!getSubTree({
           tree: getBasicTreeByParentUid(specificationUid),
           key: "enabled",
-        })?.uid?.length || 0) !== 0;
-      if (format.trim().length === 0 && !enabled) {
+        })?.uid?.length;
+      if (format.trim().length === 0 && !isSpecificationEnabled) {
         setTagError("");
         setFormatError("Error: you must set either a format or specification");
         return;
@@ -278,17 +286,17 @@ const NodeConfig = ({
   );
 
   useEffect(() => {
-    validate(tagValue, formatValue);
+    validate({ tag: tagValue, format: formatValue });
   }, [tagValue, formatValue, validate]);
 
   const handleTagBlur = useCallback(() => {
     handleTagBlurFromHook();
-    validate(tagValue, formatValue);
+    validate({ tag: tagValue, format: formatValue });
   }, [handleTagBlurFromHook, tagValue, formatValue, validate]);
 
   const handleFormatBlur = useCallback(() => {
     handleFormatBlurFromHook();
-    validate(tagValue, formatValue);
+    validate({ tag: tagValue, format: formatValue });
   }, [handleFormatBlurFromHook, tagValue, formatValue, validate]);
 
   return (
@@ -366,8 +374,12 @@ const NodeConfig = ({
                 <DiscourseNodeSpecification
                   node={node}
                   parentUid={specificationUid}
-                  parentSetEnabled={() => {
-                    validate(tagValue, formatValue);
+                  parentSetEnabled={(isSpecificationEnabled) => {
+                    validate({
+                      tag: tagValue,
+                      format: formatValue,
+                      isSpecificationEnabled,
+                    });
                   }}
                 />
               </Label>

--- a/apps/roam/src/components/settings/NodeConfig.tsx
+++ b/apps/roam/src/components/settings/NodeConfig.tsx
@@ -230,49 +230,52 @@ const NodeConfig = ({
     true,
   );
 
-  const validate = useCallback((tag: string, format: string) => {
-    const enabled =
-      getSubTree({
-        tree: getBasicTreeByParentUid(specificationUid),
-        key: "enabled",
-      })?.uid?.length || 0 !== 0;
-    if (format.trim().length === 0 && !enabled) {
-      setTagError("");
-      setFormatError("Error: you must set either a format or specification");
-      return;
-    }
-    const cleanTag = getCleanTagText(tag);
-
-    if (!cleanTag) {
-      setTagError("");
-      setFormatError("");
-      return;
-    }
-
-    const roamTagRegex = /#?\[\[(.*?)\]\]|#(\S+)/g;
-    const matches = format.matchAll(roamTagRegex);
-    const formatTags: string[] = [];
-    for (const match of matches) {
-      const tagName = match[1] || match[2];
-      if (tagName) {
-        formatTags.push(tagName.toUpperCase());
+  const validate = useCallback(
+    (tag: string, format: string) => {
+      const enabled =
+        getSubTree({
+          tree: getBasicTreeByParentUid(specificationUid),
+          key: "enabled",
+        })?.uid?.length || 0 !== 0;
+      if (format.trim().length === 0 && !enabled) {
+        setTagError("");
+        setFormatError("Error: you must set either a format or specification");
+        return;
       }
-    }
+      const cleanTag = getCleanTagText(tag);
 
-    const hasConflict = formatTags.includes(cleanTag);
+      if (!cleanTag) {
+        setTagError("");
+        setFormatError("");
+        return;
+      }
 
-    if (hasConflict) {
-      setFormatError(
-        `The format references the node's tag "${tag}". Please use a different format or tag.`,
-      );
-      setTagError(
-        `The tag "${tag}" is referenced in the format. Please use a different tag or format.`,
-      );
-    } else {
-      setTagError("");
-      setFormatError("");
-    }
-  }, []);
+      const roamTagRegex = /#?\[\[(.*?)\]\]|#(\S+)/g;
+      const matches = format.matchAll(roamTagRegex);
+      const formatTags: string[] = [];
+      for (const match of matches) {
+        const tagName = match[1] || match[2];
+        if (tagName) {
+          formatTags.push(tagName.toUpperCase());
+        }
+      }
+
+      const hasConflict = formatTags.includes(cleanTag);
+
+      if (hasConflict) {
+        setFormatError(
+          `The format references the node's tag "${tag}". Please use a different format or tag.`,
+        );
+        setTagError(
+          `The tag "${tag}" is referenced in the format. Please use a different tag or format.`,
+        );
+      } else {
+        setTagError("");
+        setFormatError("");
+      }
+    },
+    [specificationUid],
+  );
 
   useEffect(() => {
     validate(tagValue, formatValue);

--- a/apps/roam/src/components/settings/NodeConfig.tsx
+++ b/apps/roam/src/components/settings/NodeConfig.tsx
@@ -231,6 +231,16 @@ const NodeConfig = ({
   );
 
   const validate = useCallback((tag: string, format: string) => {
+    const enabled =
+      getSubTree({
+        tree: getBasicTreeByParentUid(specificationUid),
+        key: "enabled",
+      })?.uid?.length || 0 !== 0;
+    if (format.trim().length === 0 && !enabled) {
+      setTagError("");
+      setFormatError("Error: you must set either a format or specification");
+      return;
+    }
     const cleanTag = getCleanTagText(tag);
 
     if (!cleanTag) {
@@ -353,6 +363,9 @@ const NodeConfig = ({
                 <DiscourseNodeSpecification
                   node={node}
                   parentUid={specificationUid}
+                  parentSetEnabled={() => {
+                    validate(tagValue, formatValue);
+                  }}
                 />
               </Label>
             </div>


### PR DESCRIPTION
https://linear.app/discourse-graphs/issue/ENG-879/a-node-can-have-no-specification-or-format

https://www.loom.com/share/22b8b9ced45e49c5a42efab46785d2b3

Added an error message if format and specification are both empty.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Parent/child setting sync: toggling a specification now notifies parent and immediately triggers re-validation.
  * UI state consistency: enabled/disabled state is tracked and propagated so controls stay in sync.

* **Bug Fixes**
  * Validation now respects specification enabled state and avoids stale errors via early-exit logic.
  * Improved error handling for asynchronous operations to surface and handle failures.
  * Re-validation runs when node content or format changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->