### PR TITLE
ENG-1310 Database change: Allow Concepts to exist without Content

### DIFF
--- a/apps/obsidian/src/utils/conceptConversion.ts
+++ b/apps/obsidian/src/utils/conceptConversion.ts
@@ -37,7 +37,7 @@ export const discourseNodeSchemaToLocalConcept = ({
   return {
     space_id: context.spaceId,
     name: node.name,
-    represented_by_local_id: node.id,
+    source_local_id: node.id,
     is_schema: true,
     author_local_id: accountLocalId,
     created: now,
@@ -63,7 +63,7 @@ export const discourseNodeInstanceToLocalConcept = ({
   const concept = {
     space_id: context.spaceId,
     name: nodeData.file.basename,
-    represented_by_local_id: nodeData.nodeInstanceId,
+    source_local_id: nodeData.nodeInstanceId,
     schema_represented_by_local_id: nodeData.nodeTypeId,
     is_schema: false,
     literal_content: {
@@ -72,7 +72,7 @@ export const discourseNodeInstanceToLocalConcept = ({
     ...extraData,
   };
   console.log(
-    `[discourseNodeInstanceToLocalConcept] Converting concept: represented_by_local_id=${nodeData.nodeInstanceId}, name="${nodeData.file.basename}"`,
+    `[discourseNodeInstanceToLocalConcept] Converting concept: source_local_id=${nodeData.nodeInstanceId}, name="${nodeData.file.basename}"`,
   );
   return concept;
 };
@@ -112,7 +112,7 @@ const orderConceptsRec = (
     }
   }
   ordered.push(concept);
-  delete remainder[concept.represented_by_local_id!];
+  delete remainder[concept.source_local_id!];
   return missing;
 };
 
@@ -123,8 +123,8 @@ export const orderConceptsByDependency = (
   const conceptById: { [key: string]: LocalConceptDataInput } =
     Object.fromEntries(
       concepts
-        .filter((c) => c.represented_by_local_id)
-        .map((c) => [c.represented_by_local_id!, c]),
+        .filter((c) => c.source_local_id)
+        .map((c) => [c.source_local_id!, c]),
     );
   const ordered: LocalConceptDataInput[] = [];
   let missing: Set<string> = new Set();

--- a/packages/database/features/addConcepts.feature
+++ b/packages/database/features/addConcepts.feature
@@ -125,7 +125,7 @@ Feature: Concept upsert
         {
           "name": "Claim",
           "author_local_id": "user2",
-          "represented_by_local_id": "s1",
+          "source_local_id": "s1",
           "created": "2000/01/01",
           "last_modified": "2001/01/02",
           "is_schema": true
@@ -133,7 +133,7 @@ Feature: Concept upsert
         {
           "name": "A Claim",
           "author_local_id": "user2",
-          "represented_by_local_id": "s2",
+          "source_local_id": "s2",
           "created": "2000/01/03",
           "last_modified": "2001/01/04",
           "is_schema": false,
@@ -142,7 +142,7 @@ Feature: Concept upsert
         {
           "name": "Another Claim",
           "author_local_id": "user2",
-          "represented_by_local_id": "s3",
+          "source_local_id": "s3",
           "created": "2000/01/03",
           "last_modified": "2001/01/04",
           "is_schema": false,

--- a/packages/database/features/queryConcepts.feature
+++ b/packages/database/features/queryConcepts.feature
@@ -30,17 +30,17 @@ Feature: Concept queries
       | ct7 | lct7            | d7           | Hypothesis | 2025/01/01 |    2025/01/01 | document | user1      | s1        |
     # First add schemas
     And Concept are added to the database:
-      | $id | name       | _space_id | _author_id | _represented_by_id | created    | last_modified | @is_schema | _schema_id | @literal_content                | @reference_content |
-      | c1  | Claim      | s1        | user1      | ct1                | 2025/01/01 |    2025/01/01 | true       |            | {}                              | {}                 |
-      | c5  | Opposes    | s1        | user1      | ct5                | 2025/01/01 |    2025/01/01 | true       |            | {"roles": ["target", "source"]} | {}                 |
-      | c7  | Hypothesis | s1        | user1      | ct7                | 2025/01/01 |    2025/01/01 | true       |            | {}                              | {}                 |
+      | $id | name       | _space_id | _author_id | source_local_id | created    | last_modified | @is_schema | _schema_id | @literal_content                | @reference_content |
+      | c1  | Claim      | s1        | user1      | lct1            | 2025/01/01 |    2025/01/01 | true       |            | {}                              | {}                 |
+      | c5  | Opposes    | s1        | user1      | lct5            | 2025/01/01 |    2025/01/01 | true       |            | {"roles": ["target", "source"]} | {}                 |
+      | c7  | Hypothesis | s1        | user1      | lct7            | 2025/01/01 |    2025/01/01 | true       |            | {}                              | {}                 |
     # Then nodes referring to the schemas
     And Concept are added to the database:
-      | $id | name         | _space_id | _author_id | created    | last_modified | @is_schema | _schema_id | @literal_content | @reference_content | _represented_by_id |
-      | c2  | claim 1      | s1        | user1      | 2025/01/01 |    2025/01/01 | false      | c1         | {}               | {}                 | ct2                |
-      | c3  | claim 2      | s1        | user2      | 2025/01/01 |    2025/01/01 | false      | c1         | {}               | {}                 |                    |
-      | c4  | claim 3      | s1        | user3      | 2025/01/01 |    2025/01/01 | false      | c1         | {}               | {}                 |                    |
-      | c8  | hypothesis 1 | s1        | user3      | 2025/01/01 |    2025/01/01 | false      | c7         | {}               | {}                 |                    |
+      | $id | name         | _space_id | _author_id | created    | last_modified | @is_schema | _schema_id | @literal_content | @reference_content | @source_local_id |
+      | c2  | claim 1      | s1        | user1      | 2025/01/01 |    2025/01/01 | false      | c1         | {}               | {}                 | "lct2"           |
+      | c3  | claim 2      | s1        | user2      | 2025/01/01 |    2025/01/01 | false      | c1         | {}               | {}                 | null             |
+      | c4  | claim 3      | s1        | user3      | 2025/01/01 |    2025/01/01 | false      | c1         | {}               | {}                 | null             |
+      | c8  | hypothesis 1 | s1        | user3      | 2025/01/01 |    2025/01/01 | false      | c7         | {}               | {}                 | null             |
     # Then relations (which refer to nodes)
     And Concept are added to the database:
       | $id | name      | _space_id | _author_id | created    | last_modified | @is_schema | _schema_id | @literal_content | @_reference_content              |
@@ -61,10 +61,10 @@ Feature: Concept queries
   Scenario Outline: Query node schemas
     And a user logged in space s1 and calling getConcepts with these parameters: '{"scope":{"schemas":true}}'
     Then query results should look like this
-      | _id | name       | _space_id | _author_id | @is_schema | _schema_id | @literal_content                | @reference_content | _represented_by_id |
-      | c1  | Claim      | s1        | user1      | true       |            | {}                              | {}                 | ct1                |
-      | c5  | Opposes    | s1        | user1      | true       |            | {"roles": ["target", "source"]} | {}                 | ct5                |
-      | c7  | Hypothesis | s1        | user1      | true       |            | {}                              | {}                 | ct7                |
+      | _id | name       | _space_id | _author_id | @is_schema | _schema_id | @literal_content                | @reference_content | source_local_id |
+      | c1  | Claim      | s1        | user1      | true       |            | {}                              | {}                 | lct1            |
+      | c5  | Opposes    | s1        | user1      | true       |            | {"roles": ["target", "source"]} | {}                 | lct5            |
+      | c7  | Hypothesis | s1        | user1      | true       |            | {}                              | {}                 | lct7            |
 
   Scenario Outline: Query by node types
     And a user logged in space s1 and calling getConcepts with these parameters: '{"scope":{"ofTypes":["lct1"]}}'

--- a/packages/database/src/dbTypes.ts
+++ b/packages/database/src/dbTypes.ts
@@ -99,8 +99,8 @@ export type Database = {
           name: string
           reference_content: Json
           refs: number[]
-          represented_by_id: number | null
           schema_id: number | null
+          source_local_id: string | null
           space_id: number
         }
         Insert: {
@@ -116,8 +116,8 @@ export type Database = {
           name: string
           reference_content?: Json
           refs?: number[]
-          represented_by_id?: number | null
           schema_id?: number | null
+          source_local_id?: string | null
           space_id: number
         }
         Update: {
@@ -133,8 +133,8 @@ export type Database = {
           name?: string
           reference_content?: Json
           refs?: number[]
-          represented_by_id?: number | null
           schema_id?: number | null
+          source_local_id?: string | null
           space_id?: number
         }
         Relationships: [
@@ -150,27 +150,6 @@ export type Database = {
             columns: ["author_id"]
             isOneToOne: false
             referencedRelation: "PlatformAccount"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "Concept_represented_by_id_fkey"
-            columns: ["represented_by_id"]
-            isOneToOne: false
-            referencedRelation: "Content"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "Concept_represented_by_id_fkey"
-            columns: ["represented_by_id"]
-            isOneToOne: false
-            referencedRelation: "my_contents"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "Concept_represented_by_id_fkey"
-            columns: ["represented_by_id"]
-            isOneToOne: false
-            referencedRelation: "my_contents_with_embedding_openai_text_embedding_3_small_1536"
             referencedColumns: ["id"]
           },
           {
@@ -847,8 +826,8 @@ export type Database = {
           name: string | null
           reference_content: Json | null
           refs: number[] | null
-          represented_by_id: number | null
           schema_id: number | null
+          source_local_id: string | null
           space_id: number | null
         }
         Insert: {
@@ -866,8 +845,8 @@ export type Database = {
           name?: string | null
           reference_content?: Json | null
           refs?: number[] | null
-          represented_by_id?: number | null
           schema_id?: number | null
+          source_local_id?: string | null
           space_id?: number | null
         }
         Update: {
@@ -885,8 +864,8 @@ export type Database = {
           name?: string | null
           reference_content?: Json | null
           refs?: number[] | null
-          represented_by_id?: number | null
           schema_id?: number | null
+          source_local_id?: string | null
           space_id?: number | null
         }
         Relationships: [
@@ -902,27 +881,6 @@ export type Database = {
             columns: ["author_id"]
             isOneToOne: false
             referencedRelation: "PlatformAccount"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "Concept_represented_by_id_fkey"
-            columns: ["represented_by_id"]
-            isOneToOne: false
-            referencedRelation: "Content"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "Concept_represented_by_id_fkey"
-            columns: ["represented_by_id"]
-            isOneToOne: false
-            referencedRelation: "my_contents"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "Concept_represented_by_id_fkey"
-            columns: ["represented_by_id"]
-            isOneToOne: false
-            referencedRelation: "my_contents_with_embedding_openai_text_embedding_3_small_1536"
             referencedColumns: ["id"]
           },
           {
@@ -1284,8 +1242,8 @@ export type Database = {
           name: string
           reference_content: Json
           refs: number[]
-          represented_by_id: number | null
           schema_id: number | null
+          source_local_id: string | null
           space_id: number
         }
         SetofOptions: {
@@ -1742,6 +1700,7 @@ export type Database = {
         schema_represented_by_local_id: string | null
         space_url: string | null
         local_reference_content: Json | null
+        source_local_id: string | null
       }
       content_local_input: {
         document_id: number | null

--- a/packages/database/src/lib/queries.ts
+++ b/packages/database/src/lib/queries.ts
@@ -292,7 +292,7 @@ const composeConceptQuery = ({
     if (documentFields.length > 0) {
       ctArgs.push(`Document:my_documents!document_id${innerContent ? "!inner" : ""} (\n ${documentFields.join(",\n")} )`);
     }
-    q += `,\nContent:my_contents!represented_by_id${innerContent ? "!inner" : ""} (\n${ctArgs.join(",\n")})`;
+    q += `,\nContent:content_of_concept${innerContent ? "!inner" : ""} (\n${ctArgs.join(",\n")})`;
   }
   if (scope.author !== undefined) {
     q += ", author:my_accounts!author_id!inner(account_local_id)";
@@ -315,7 +315,7 @@ const composeConceptQuery = ({
       if (inRelsToNodesOfType !== undefined && !args2.includes("schema_id"))
         args2.push("schema_id");
       if (inRelsToNodeLocalIds !== undefined)
-        args2.push("Content:my_contents!represented_by_id!inner(source_local_id)");
+        args2.push("Content:content_of_concept!inner(source_local_id)");
       if (inRelsToNodesOfAuthor !== undefined) {
         if (!args2.includes("author_id")) args2.push("author_id");
         args2.push("author:my_accounts!author_id!inner(account_local_id)");
@@ -540,7 +540,7 @@ export const CONCEPT_FIELDS: (keyof Concept)[] = [
   "refs",
   "is_schema",
   "schema_id",
-  "represented_by_id",
+  "source_local_id",
 ];
 
 export const CONTENT_FIELDS: (keyof Content)[] = [

--- a/packages/database/supabase/migrations/20260116214933_concepts_without_content.sql
+++ b/packages/database/supabase/migrations/20260116214933_concepts_without_content.sql
@@ -5,13 +5,14 @@ SET source_local_id = (SELECT source_local_id FROM public."Content" AS cnt WHERE
 WHERE represented_by_id IS NOT NULL;
 
 CREATE UNIQUE INDEX concept_space_local_id_idx ON public."Concept" USING btree (
-    source_local_id, space_id
+    space_id, source_local_id
 ) NULLS DISTINCT;
 
 COMMENT ON COLUMN public."Concept".source_local_id IS 'The unique identifier of the concept in the remote source';
 
 ALTER TABLE public."Concept" DROP CONSTRAINT "Concept_represented_by_id_fkey";
 DROP INDEX public."Concept_represented_by";
+DROP INDEX "Concept_space";
 
 -- explicitly dropping dependencies of my_concept
 DROP FUNCTION schema_of_concept(my_concepts);

--- a/packages/database/supabase/migrations/20260116214933_concepts_without_content.sql
+++ b/packages/database/supabase/migrations/20260116214933_concepts_without_content.sql
@@ -41,7 +41,7 @@ SELECT
     is_schema,
     source_local_id
 FROM "Concept"
-WHERE (space_id = any(my_space_ids())) OR can_view_specific_concept(id);;
+WHERE (space_id = any(my_space_ids())) OR can_view_specific_concept(id);
 
 ALTER TABLE public."Concept" DROP COLUMN represented_by_id;
 
@@ -133,7 +133,8 @@ BEGIN
   END IF;
   IF data.schema_represented_by_local_id IS NOT NULL THEN
     SELECT cpt.id FROM public."Concept" cpt
-      WHERE cpt.source_local_id = data.schema_represented_by_local_id INTO concept.schema_id;
+      WHERE cpt.source_local_id = data.schema_represented_by_local_id
+      AND cpt.space_id = concept.space_id INTO concept.schema_id;
   END IF;
   IF concept.source_local_id = '' THEN
     concept.source_local_id := NULL;
@@ -216,6 +217,6 @@ BEGIN
             RETURN NEXT -1; -- Return a special value to indicate conflict
     END;
   END LOOP;
-  RAISE DEBUG 'Completed upsert_content successfully';
+  RAISE DEBUG 'Completed upsert_concepts successfully';
 END;
 $$;

--- a/packages/database/supabase/migrations/20260116214933_concepts_without_content.sql
+++ b/packages/database/supabase/migrations/20260116214933_concepts_without_content.sql
@@ -1,0 +1,221 @@
+ALTER TABLE public."Concept" ADD COLUMN source_local_id character varying;
+
+UPDATE public."Concept" AS cpt
+SET source_local_id = (SELECT source_local_id FROM public."Content" AS cnt WHERE cnt.id = cpt.represented_by_id)
+WHERE represented_by_id IS NOT NULL;
+
+CREATE UNIQUE INDEX concept_space_local_id_idx ON public."Concept" USING btree (
+    source_local_id, space_id
+) NULLS DISTINCT;
+
+COMMENT ON COLUMN public."Concept".source_local_id IS 'The unique identifier of the concept in the remote source';
+
+ALTER TABLE public."Concept" DROP CONSTRAINT "Concept_represented_by_id_fkey";
+DROP INDEX public."Concept_represented_by";
+
+-- explicitly dropping dependencies of my_concept
+DROP FUNCTION schema_of_concept(my_concepts);
+DROP FUNCTION instances_of_schema(my_concepts);
+DROP FUNCTION concept_in_relations(my_concepts);
+DROP FUNCTION concepts_of_relation(my_concepts);
+DROP FUNCTION content_of_concept(my_concepts);
+DROP FUNCTION author_of_concept(my_concepts);
+
+DROP VIEW "public"."my_concepts";
+
+CREATE VIEW "public"."my_concepts" AS
+SELECT
+    id,
+    epistemic_status,
+    name,
+    description,
+    author_id,
+    created,
+    last_modified,
+    space_id,
+    arity,
+    schema_id,
+    literal_content,
+    reference_content,
+    refs,
+    is_schema,
+    source_local_id
+FROM "Concept"
+WHERE (space_id = any(my_space_ids())) OR can_view_specific_concept(id);;
+
+ALTER TABLE public."Concept" DROP COLUMN represented_by_id;
+
+ALTER TYPE public.concept_local_input ADD ATTRIBUTE source_local_id VARCHAR;
+
+
+CREATE OR REPLACE FUNCTION public.content_of_concept(concept public.my_concepts)
+RETURNS SETOF public.my_contents STRICT STABLE
+ROWS 1
+SET search_path = ''
+LANGUAGE sql
+AS $$
+    SELECT * from public.my_contents AS cnt
+        WHERE cnt.space_id=concept.space_id
+        AND cnt.source_local_id=concept.source_local_id;
+$$;
+
+CREATE OR REPLACE FUNCTION public.author_of_concept(concept my_concepts)
+RETURNS SETOF my_accounts
+LANGUAGE sql
+STABLE STRICT ROWS 1
+SET search_path TO ''
+AS $$
+    SELECT * from public.my_accounts WHERE id=concept.author_id;
+$$;
+
+CREATE OR REPLACE FUNCTION public.concept_in_relations(concept my_concepts)
+RETURNS SETOF my_concepts
+LANGUAGE sql
+STABLE STRICT
+SET search_path TO ''
+AS $$
+    SELECT * from public.my_concepts WHERE refs @> ARRAY[concept.id];
+$$;
+
+CREATE OR REPLACE FUNCTION public.concepts_of_relation(relation my_concepts)
+RETURNS SETOF my_concepts
+LANGUAGE sql
+STABLE STRICT
+SET search_path TO ''
+AS $$
+    SELECT * from public.my_concepts WHERE id = any(relation.refs);
+$$;
+
+CREATE OR REPLACE FUNCTION public.instances_of_schema(schema my_concepts)
+RETURNS SETOF my_concepts
+LANGUAGE sql
+STABLE STRICT
+SET search_path TO ''
+AS $$
+    SELECT * from public.my_concepts WHERE schema_id=schema.id;
+$$;
+
+CREATE OR REPLACE FUNCTION public.schema_of_concept(concept my_concepts)
+RETURNS SETOF my_concepts
+LANGUAGE sql
+STABLE STRICT ROWS 1
+SET search_path TO ''
+AS $$
+    SELECT * from public.my_concepts WHERE id=concept.schema_id;
+$$;
+
+CREATE OR REPLACE FUNCTION public._local_concept_to_db_concept(data public.concept_local_input)
+RETURNS public."Concept" STABLE
+SET search_path = ''
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  concept public."Concept"%ROWTYPE;
+  reference_content JSONB := jsonb_build_object();
+  key varchar;
+  value JSONB;
+  ref_single_val BIGINT;
+  ref_array_val BIGINT[];
+BEGIN
+  -- not fan of going through json, but not finding how to populate a record by a different shape record
+  concept := jsonb_populate_record(NULL::public."Concept", to_jsonb(data));
+  IF data.author_local_id IS NOT NULL THEN
+    SELECT id FROM public."PlatformAccount"
+      WHERE account_local_id = data.author_local_id INTO concept.author_id;
+  END IF;
+  IF data.represented_by_id IS NOT NULL THEN
+    SELECT space_id, source_local_id FROM public."Content"
+      WHERE id = data.represented_by_id INTO concept.space_id, concept.source_local_id;
+  END IF;
+  IF data.space_url IS NOT NULL THEN
+    SELECT id FROM public."Space"
+    WHERE url = data.space_url INTO concept.space_id;
+  END IF;
+  IF data.schema_represented_by_local_id IS NOT NULL THEN
+    SELECT cpt.id FROM public."Concept" cpt
+      WHERE cpt.source_local_id = data.schema_represented_by_local_id INTO concept.schema_id;
+  END IF;
+  IF concept.source_local_id = '' THEN
+    concept.source_local_id := NULL;
+  END IF;
+  IF data.represented_by_local_id = '' THEN
+    data.represented_by_local_id := NULL;
+  END IF;
+  concept.source_local_id = COALESCE(concept.source_local_id, data.represented_by_local_id); -- legacy input field
+  IF data.local_reference_content IS NOT NULL THEN
+    FOR key, value IN SELECT * FROM jsonb_each(data.local_reference_content) LOOP
+      IF jsonb_typeof(value) = 'array' THEN
+        WITH el AS (SELECT jsonb_array_elements_text(value) as x),
+        ela AS (SELECT array_agg(x) AS a FROM el)
+        SELECT array_agg(DISTINCT cpt.id) INTO STRICT ref_array_val
+            FROM public."Concept" AS cpt
+            JOIN ela ON (true) WHERE cpt.source_local_id = ANY(ela.a) AND cpt.space_id=concept.space_id;
+        reference_content := jsonb_set(reference_content, ARRAY[key], to_jsonb(ref_array_val));
+      ELSIF jsonb_typeof(value) = 'string' THEN
+        SELECT cpt.id INTO STRICT ref_single_val
+            FROM public."Concept" AS cpt
+            WHERE cpt.source_local_id = (value #>> '{}') AND cpt.space_id=concept.space_id;
+        reference_content := jsonb_set(reference_content, ARRAY[key], to_jsonb(ref_single_val));
+      ELSE
+        RAISE EXCEPTION 'Invalid value in local_reference_content % %', value, jsonb_typeof(value);
+      END IF;
+    END LOOP;
+    SELECT reference_content INTO concept.reference_content;
+  END IF;
+  RETURN concept;
+END;
+$$;
+
+
+CREATE OR REPLACE FUNCTION public.upsert_concepts(v_space_id bigint, data jsonb)
+RETURNS SETOF BIGINT
+SET search_path = ''
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_platform public."Platform";
+  local_concept public.concept_local_input;
+  db_concept public."Concept"%ROWTYPE;
+  concept_row JSONB;
+  concept_id BIGINT;
+BEGIN
+  SELECT platform INTO STRICT v_platform FROM public."Space" WHERE id=v_space_id;
+  FOR concept_row IN SELECT * FROM jsonb_array_elements(data)
+  LOOP
+    -- first set defaults
+    local_concept := jsonb_populate_record(NULL::public.concept_local_input, '{"epistemic_status": "unknown", "literal_content":{},"reference_content":{},"is_schema":false}');
+    -- then input values
+    local_concept := jsonb_populate_record(local_concept, concept_row);
+    local_concept.space_id := v_space_id;
+    db_concept := public._local_concept_to_db_concept(local_concept);
+    BEGIN
+        -- cannot use db_concept.* because of refs.
+        INSERT INTO public."Concept" (
+        epistemic_status, name, description, author_id, created, last_modified, space_id, schema_id, literal_content, is_schema, source_local_id, reference_content
+        ) VALUES (
+        db_concept.epistemic_status, db_concept.name, db_concept.description, db_concept.author_id, db_concept.created, db_concept.last_modified, db_concept.space_id, db_concept.schema_id, db_concept.literal_content, db_concept.is_schema, db_concept.source_local_id, db_concept.reference_content
+        )
+        ON CONFLICT (space_id, source_local_id) DO UPDATE SET
+            epistemic_status = db_concept.epistemic_status,
+            name = db_concept.name,
+            description = db_concept.description,
+            author_id = db_concept.author_id,
+            created = db_concept.created,
+            last_modified = db_concept.last_modified,
+            schema_id = db_concept.schema_id,
+            literal_content = db_concept.literal_content,
+            is_schema = db_concept.is_schema,
+            reference_content = db_concept.reference_content
+        -- ON CONFLICT (space_id, name) DO NOTHING... why can't I specify two conflict clauses?
+        RETURNING id INTO concept_id;
+        RETURN NEXT concept_id;
+    EXCEPTION
+        WHEN unique_violation THEN
+            -- a distinct unique constraint failed
+            RAISE WARNING 'Concept with space_id: % and name % already exists', v_space_id, local_concept.name;
+            RETURN NEXT -1; -- Return a special value to indicate conflict
+    END;
+  END LOOP;
+  RAISE DEBUG 'Completed upsert_content successfully';
+END;
+$$;

--- a/packages/database/supabase/schemas/concept.sql
+++ b/packages/database/supabase/schemas/concept.sql
@@ -341,7 +341,8 @@ BEGIN
   END IF;
   IF data.schema_represented_by_local_id IS NOT NULL THEN
     SELECT cpt.id FROM public."Concept" cpt
-      WHERE cpt.source_local_id = data.schema_represented_by_local_id INTO concept.schema_id;
+      WHERE cpt.source_local_id = data.schema_represented_by_local_id
+      AND cpt.space_id = concept.space_id INTO concept.schema_id;
   END IF;
   IF concept.source_local_id = '' THEN
     concept.source_local_id := NULL;
@@ -426,7 +427,7 @@ BEGIN
             RETURN NEXT -1; -- Return a special value to indicate conflict
     END;
   END LOOP;
-  RAISE DEBUG 'Completed upsert_content successfully';
+  RAISE DEBUG 'Completed upsert_concepts successfully';
 END;
 $$;
 

--- a/packages/database/supabase/schemas/concept.sql
+++ b/packages/database/supabase/schemas/concept.sql
@@ -79,10 +79,8 @@ CREATE INDEX concept_refs_idx ON public."Concept" USING gin (refs);
 
 CREATE INDEX "Concept_schema" ON public."Concept" USING btree (schema_id);
 
-CREATE INDEX "Concept_space" ON public."Concept" USING btree (space_id);
-
 CREATE UNIQUE INDEX concept_space_local_id_idx ON public."Concept" USING btree (
-    source_local_id, space_id
+    space_id, source_local_id
 ) NULLS DISTINCT;
 
 -- maybe make that for schemas only?


### PR DESCRIPTION
https://linear.app/discourse-graphs/issue/ENG-1310/database-change-allow-concepts-to-exist-without-content
Replace `Content.represented_by_id` by `Content.source_local_id`. This allows Concepts to exist without being rooted in a corresponding Content object.
We lose the corresponding foreign key, and we have to use the utility function in postgrest queries instead.
Allows to simplify some unrelated functions, such as orphan deletion.
Opportunistically replaced console.error by internalError in the orphanDeletion file.
Note that I left the represented_by_local_id variable in the input type, so older sync code would still work with the new database function.

https://www.loom.com/share/0892bb7c178b4be6a6e013b6e30d76ef

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Standardized and improved error reporting across cleanup and deletion flows for clearer failure messages.

* **Refactor**
  * Switched concept identification to a string-based source_local_id and migrated related lookups and upserts to use (space_id + source_local_id).
  * Streamlined concept/content upsert and retrieval paths, reducing ambiguous references and improving data integrity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->