### PR TITLE
Eng 1343 f10a sync node schema definitions

### DIFF
--- a/apps/obsidian/src/utils/conceptConversion.ts
+++ b/apps/obsidian/src/utils/conceptConversion.ts
@@ -33,16 +33,16 @@ export const discourseNodeSchemaToLocalConcept = ({
   node: DiscourseNode;
   accountLocalId: string;
 }): LocalConceptDataInput => {
-  const now = new Date().toISOString();
-  const { description, template, id, name, ...otherData } = node;
+  const { description, template, id, name, created, modified, ...otherData } =
+    node;
   return {
     space_id: context.spaceId,
     name: name,
     source_local_id: id,
     is_schema: true,
     author_local_id: accountLocalId,
-    created: now,
-    last_modified: now,
+    created: new Date(created).toISOString(),
+    last_modified: new Date(modified).toISOString(),
     description: description,
     literal_content: {
       label: name,

--- a/apps/obsidian/src/utils/conceptConversion.ts
+++ b/apps/obsidian/src/utils/conceptConversion.ts
@@ -1,10 +1,10 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import { TFile } from "obsidian";
-import { DiscourseNode } from "~/types";
-import { SupabaseContext } from "./supabaseContext";
-import { LocalConceptDataInput } from "@repo/database/inputTypes";
-import { ObsidianDiscourseNodeData } from "./syncDgNodesToSupabase";
-import { Json } from "@repo/database/dbTypes";
+import type { TFile } from "obsidian";
+import type { DiscourseNode } from "~/types";
+import type { SupabaseContext } from "./supabaseContext";
+import type { LocalConceptDataInput } from "@repo/database/inputTypes";
+import type { ObsidianDiscourseNodeData } from "./syncDgNodesToSupabase";
+import type { Json } from "@repo/database/dbTypes";
 
 /**
  * Get extra data (author, timestamps) from file metadata
@@ -34,15 +34,21 @@ export const discourseNodeSchemaToLocalConcept = ({
   accountLocalId: string;
 }): LocalConceptDataInput => {
   const now = new Date().toISOString();
+  const { description, template, id, name, ...otherData } = node;
   return {
     space_id: context.spaceId,
-    name: node.name,
-    source_local_id: node.id,
+    name: name,
+    source_local_id: id,
     is_schema: true,
     author_local_id: accountLocalId,
     created: now,
-    // TODO: get the template or any other info to put into literal_content jsonb
     last_modified: now,
+    description: description,
+    literal_content: {
+      label: name,
+      template: template,
+      source_data: otherData,
+    },
   };
 };
 
@@ -59,22 +65,19 @@ export const discourseNodeInstanceToLocalConcept = ({
   accountLocalId: string;
 }): LocalConceptDataInput => {
   const extraData = getNodeExtraData(nodeData.file, accountLocalId);
-  console.log(nodeData.frontmatter);
-  const concept = {
+  const { nodeInstanceId, nodeTypeId, ...otherData } = nodeData.frontmatter;
+  return {
     space_id: context.spaceId,
-    name: nodeData.file.basename,
-    source_local_id: nodeData.nodeInstanceId,
-    schema_represented_by_local_id: nodeData.nodeTypeId,
+    name: nodeData.file.path,
+    source_local_id: nodeInstanceId as string,
+    schema_represented_by_local_id: nodeTypeId as string,
     is_schema: false,
     literal_content: {
-      ...nodeData.frontmatter,
-    } as unknown as Json,
+      label: nodeData.file.basename,
+      source_data: otherData as unknown as Json,
+    },
     ...extraData,
   };
-  console.log(
-    `[discourseNodeInstanceToLocalConcept] Converting concept: source_local_id=${nodeData.nodeInstanceId}, name="${nodeData.file.basename}"`,
-  );
-  return concept;
 };
 
 export const relatedConcepts = (concept: LocalConceptDataInput): string[] => {
@@ -135,6 +138,7 @@ export const orderConceptsByDependency = (
       ...missing,
       ...orderConceptsRec(ordered, first, conceptById),
     ]);
+    if (missing.size > 0) console.error(`missing: ${[...missing]}`);
   }
   return { ordered, missing: Array.from(missing) };
 };

--- a/apps/obsidian/src/utils/syncDgNodesToSupabase.ts
+++ b/apps/obsidian/src/utils/syncDgNodesToSupabase.ts
@@ -16,7 +16,7 @@ import {
 } from "./conceptConversion";
 import type { LocalConceptDataInput } from "@repo/database/inputTypes";
 
-const DEFAULT_TIME = new Date("1970-01-01");
+const DEFAULT_TIME = "1970-01-01";
 export type ChangeType = "title" | "content";
 
 export type ObsidianDiscourseNodeData = {


### PR DESCRIPTION
This PR uploads Obsidian node schemas to supabase.
It includes small adjustments to the node schemas.
This is a new PR for the eng-1343 branch, which is a rename of the old eng-1181 branch.
I basically split 1181 into two separate tasks : 1343 (this one) and 1344 (uploading relationships and their schema.)
Original commit work by @trangdoan982 

https://www.loom.com/share/3bf410c8e27e45b08ece66d510fe176d


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced sync performance with optimized content and schema synchronization
  * Improved tracking of schema changes during sync operations to Supabase
  * Refined embedding-based content upsert mechanism

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/720">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
