### PR TITLE
[ENG-1416] Fix 'create node modal' focus on input box on load

### DIFF
--- a/apps/roam/src/components/FuzzySelectInput.tsx
+++ b/apps/roam/src/components/FuzzySelectInput.tsx
@@ -20,9 +20,7 @@ type FuzzySelectInputProps<T extends Result = Result> = {
   options?: T[];
   placeholder?: string;
   autoFocus?: boolean;
-  disabled?: boolean;
   initialIsLocked?: boolean;
-  inputRef?: React.RefObject<HTMLInputElement>;
 };
 
 const FuzzySelectInput = <T extends Result = Result>({
@@ -34,9 +32,7 @@ const FuzzySelectInput = <T extends Result = Result>({
   options = [],
   placeholder = "Enter value",
   autoFocus,
-  disabled,
   initialIsLocked,
-  inputRef,
 }: FuzzySelectInputProps<T>) => {
   const [isLocked, setIsLocked] = useState(initialIsLocked || false);
   const [query, setQuery] = useState<string>(() => value?.text || "");
@@ -144,7 +140,6 @@ const FuzzySelectInput = <T extends Result = Result>({
         growVertically
         placeholder={placeholder}
         autoFocus={autoFocus}
-        disabled={disabled}
       />
     );
   }
@@ -179,6 +174,8 @@ const FuzzySelectInput = <T extends Result = Result>({
         preventOverflow: { enabled: false },
       }}
       className="fuzzy-select-input-popover w-full"
+      autoFocus={false}
+      enforceFocus={false}
       content={
         <Menu className="max-h-64 max-w-md overflow-auto" ulRef={menuRef}>
           {filteredItems.map((item, index) => (
@@ -199,7 +196,6 @@ const FuzzySelectInput = <T extends Result = Result>({
         <InputGroup
           fill
           className="w-full"
-          disabled={disabled}
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           onKeyDown={handleKeyDown}
@@ -212,7 +208,6 @@ const FuzzySelectInput = <T extends Result = Result>({
             setIsFocused(false);
             setTimeout(() => setIsOpen(false), 200);
           }}
-          inputRef={inputRef}
         />
       }
     />

--- a/apps/roam/src/components/FuzzySelectInput.tsx
+++ b/apps/roam/src/components/FuzzySelectInput.tsx
@@ -41,6 +41,7 @@ const FuzzySelectInput = <T extends Result = Result>({
   const [isFocused, setIsFocused] = useState(false);
 
   const menuRef = useRef<HTMLUListElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
 
   const filteredItems = useMemo(() => {
     if (!query) return options;
@@ -61,6 +62,7 @@ const FuzzySelectInput = <T extends Result = Result>({
         setQuery(item.text);
         setValue(item);
         setIsOpen(false);
+        requestAnimationFrame(() => inputRef.current?.focus());
       }
     },
     [mode, initialUid, setValue, onLockedChange],
@@ -129,6 +131,12 @@ const FuzzySelectInput = <T extends Result = Result>({
     }
   }, [activeIndex, isOpen]);
 
+  useEffect(() => {
+    if (!autoFocus || mode !== "create" || isLocked) return;
+    const id = setTimeout(() => inputRef.current?.focus(), 150);
+    return () => clearTimeout(id);
+  }, [autoFocus, mode, isLocked]);
+
   if (mode === "edit") {
     return (
       <TextArea
@@ -195,6 +203,7 @@ const FuzzySelectInput = <T extends Result = Result>({
       target={
         <InputGroup
           fill
+          inputRef={inputRef}
           className="w-full"
           value={query}
           onChange={(e) => setQuery(e.target.value)}

--- a/apps/roam/src/components/FuzzySelectInput.tsx
+++ b/apps/roam/src/components/FuzzySelectInput.tsx
@@ -46,14 +46,6 @@ const FuzzySelectInput = <T extends Result = Result>({
 
   const menuRef = useRef<HTMLUListElement>(null);
 
-  useEffect(() => {
-    if (!autoFocus) return;
-    const id = window.setTimeout(() => {
-      inputRef?.current?.focus();
-    }, 150);
-    return () => window.clearTimeout(id);
-  }, [autoFocus, inputRef]);
-
   const filteredItems = useMemo(() => {
     if (!query) return options;
     return fuzzy
@@ -181,8 +173,6 @@ const FuzzySelectInput = <T extends Result = Result>({
     <Popover
       isOpen={isOpen}
       minimal
-      autoFocus={false}
-      enforceFocus={false}
       position={PopoverPosition.BOTTOM_LEFT}
       modifiers={{
         flip: { enabled: false },

--- a/apps/roam/src/components/FuzzySelectInput.tsx
+++ b/apps/roam/src/components/FuzzySelectInput.tsx
@@ -65,6 +65,10 @@ const FuzzySelectInput = <T extends Result = Result>({
         setValue(item);
         setIsOpen(false);
       }
+      // Refocus the input after selection to maintain keyboard workflow
+      setTimeout(() => {
+        inputRef.current?.focus();
+      }, 0);
     },
     [mode, initialUid, setValue, onLockedChange],
   );

--- a/apps/roam/src/components/FuzzySelectInput.tsx
+++ b/apps/roam/src/components/FuzzySelectInput.tsx
@@ -22,6 +22,7 @@ type FuzzySelectInputProps<T extends Result = Result> = {
   autoFocus?: boolean;
   disabled?: boolean;
   initialIsLocked?: boolean;
+  inputRef?: React.RefObject<HTMLInputElement>;
 };
 
 const FuzzySelectInput = <T extends Result = Result>({
@@ -35,6 +36,7 @@ const FuzzySelectInput = <T extends Result = Result>({
   autoFocus,
   disabled,
   initialIsLocked,
+  inputRef,
 }: FuzzySelectInputProps<T>) => {
   const [isLocked, setIsLocked] = useState(initialIsLocked || false);
   const [query, setQuery] = useState<string>(() => value?.text || "");
@@ -43,7 +45,14 @@ const FuzzySelectInput = <T extends Result = Result>({
   const [isFocused, setIsFocused] = useState(false);
 
   const menuRef = useRef<HTMLUListElement>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!autoFocus) return;
+    const id = window.setTimeout(() => {
+      inputRef?.current?.focus();
+    }, 150);
+    return () => window.clearTimeout(id);
+  }, [autoFocus, inputRef]);
 
   const filteredItems = useMemo(() => {
     if (!query) return options;
@@ -65,10 +74,6 @@ const FuzzySelectInput = <T extends Result = Result>({
         setValue(item);
         setIsOpen(false);
       }
-      // Refocus the input after selection to maintain keyboard workflow
-      setTimeout(() => {
-        inputRef.current?.focus();
-      }, 0);
     },
     [mode, initialUid, setValue, onLockedChange],
   );
@@ -210,7 +215,6 @@ const FuzzySelectInput = <T extends Result = Result>({
           onKeyDown={handleKeyDown}
           autoFocus={autoFocus}
           placeholder={placeholder}
-          inputRef={inputRef}
           onFocus={() => {
             setIsFocused(true);
           }}
@@ -218,6 +222,7 @@ const FuzzySelectInput = <T extends Result = Result>({
             setIsFocused(false);
             setTimeout(() => setIsOpen(false), 200);
           }}
+          inputRef={inputRef}
         />
       }
     />

--- a/apps/roam/src/components/ModifyNodeDialog.tsx
+++ b/apps/roam/src/components/ModifyNodeDialog.tsx
@@ -91,6 +91,15 @@ const ModifyNodeDialog = ({
       ),
     [referencedNodeValue.uid, initialReferencedNode?.uid],
   );
+  const contentInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const id = window.setTimeout(() => {
+      contentInputRef.current?.focus();
+    }, 100);
+    return () => window.clearTimeout(id);
+  }, [isOpen]);
 
   const [options, setOptions] = useState<{
     content: Result[];
@@ -540,6 +549,7 @@ const ModifyNodeDialog = ({
               mode={mode}
               initialUid={content.uid}
               autoFocus={true}
+              inputRef={contentInputRef}
             />
           </div>
 

--- a/apps/roam/src/components/ModifyNodeDialog.tsx
+++ b/apps/roam/src/components/ModifyNodeDialog.tsx
@@ -101,8 +101,6 @@ const ModifyNodeDialog = ({
 
   const contentRequestIdRef = useRef(0);
   const referencedNodeRequestIdRef = useRef(0);
-  const confirmButtonRef = useRef<HTMLButtonElement>(null);
-  const prevContentLockedRef = useRef(isContentLocked);
   const [error, setError] = useState("");
 
   const discourseNodes = useMemo(() => {
@@ -133,13 +131,6 @@ const ModifyNodeDialog = ({
       nodeType: refNode.type,
     };
   }, [nodeFormat]);
-
-  useEffect(() => {
-    if (isContentLocked && !prevContentLockedRef.current) {
-      requestAnimationFrame(() => confirmButtonRef.current?.focus());
-    }
-    prevContentLockedRef.current = isContentLocked;
-  }, [isContentLocked]);
 
   useEffect(() => {
     setLoading(true);
@@ -574,7 +565,6 @@ const ModifyNodeDialog = ({
             className={`${Classes.DIALOG_FOOTER_ACTIONS} flex-row-reverse items-center`}
           >
             <Button
-              elementRef={confirmButtonRef}
               text="Confirm"
               intent={Intent.PRIMARY}
               onClick={() => void onSubmit()}

--- a/apps/roam/src/components/ModifyNodeDialog.tsx
+++ b/apps/roam/src/components/ModifyNodeDialog.tsx
@@ -92,22 +92,6 @@ const ModifyNodeDialog = ({
     [referencedNodeValue.uid, initialReferencedNode?.uid],
   );
 
-  const contentInputRef = useRef<HTMLInputElement>(null);
-  const hasFocusedContentRef = useRef(false);
-
-  useEffect(() => {
-    if (!isOpen) {
-      hasFocusedContentRef.current = false;
-      return;
-    }
-    if (hasFocusedContentRef.current) return;
-    hasFocusedContentRef.current = true;
-    const id = window.setTimeout(() => {
-      contentInputRef.current?.focus();
-    }, 100);
-    return () => window.clearTimeout(id);
-  }, [isOpen]);
-
   const [options, setOptions] = useState<{
     content: Result[];
     referencedNode: Result[];
@@ -117,6 +101,8 @@ const ModifyNodeDialog = ({
 
   const contentRequestIdRef = useRef(0);
   const referencedNodeRequestIdRef = useRef(0);
+  const confirmButtonRef = useRef<HTMLButtonElement>(null);
+  const prevContentLockedRef = useRef(isContentLocked);
   const [error, setError] = useState("");
 
   const discourseNodes = useMemo(() => {
@@ -147,6 +133,13 @@ const ModifyNodeDialog = ({
       nodeType: refNode.type,
     };
   }, [nodeFormat]);
+
+  useEffect(() => {
+    if (isContentLocked && !prevContentLockedRef.current) {
+      requestAnimationFrame(() => confirmButtonRef.current?.focus());
+    }
+    prevContentLockedRef.current = isContentLocked;
+  }, [isContentLocked]);
 
   useEffect(() => {
     setLoading(true);
@@ -552,10 +545,9 @@ const ModifyNodeDialog = ({
                   ? "..."
                   : `Enter a ${selectedNodeType.text.toLowerCase()} ...`
               }
-              disabled={loading}
               mode={mode}
               initialUid={content.uid}
-              inputRef={contentInputRef}
+              autoFocus
             />
           </div>
 
@@ -568,10 +560,10 @@ const ModifyNodeDialog = ({
                 setValue={setReferencedNodeValueCallback}
                 options={options.referencedNode}
                 placeholder={loading ? "..." : "Select a referenced node"}
-                disabled={loading}
                 mode={"create"}
                 initialUid={referencedNodeValue.uid}
                 initialIsLocked={isReferencedNodeLocked}
+                autoFocus={false}
               />
             </div>
           )}
@@ -582,6 +574,7 @@ const ModifyNodeDialog = ({
             className={`${Classes.DIALOG_FOOTER_ACTIONS} flex-row-reverse items-center`}
           >
             <Button
+              elementRef={confirmButtonRef}
               text="Confirm"
               intent={Intent.PRIMARY}
               onClick={() => void onSubmit()}

--- a/apps/roam/src/components/ModifyNodeDialog.tsx
+++ b/apps/roam/src/components/ModifyNodeDialog.tsx
@@ -539,6 +539,7 @@ const ModifyNodeDialog = ({
               disabled={loading}
               mode={mode}
               initialUid={content.uid}
+              autoFocus={true}
             />
           </div>
 

--- a/apps/roam/src/components/ModifyNodeDialog.tsx
+++ b/apps/roam/src/components/ModifyNodeDialog.tsx
@@ -91,10 +91,17 @@ const ModifyNodeDialog = ({
       ),
     [referencedNodeValue.uid, initialReferencedNode?.uid],
   );
+
   const contentInputRef = useRef<HTMLInputElement>(null);
+  const hasFocusedContentRef = useRef(false);
 
   useEffect(() => {
-    if (!isOpen) return;
+    if (!isOpen) {
+      hasFocusedContentRef.current = false;
+      return;
+    }
+    if (hasFocusedContentRef.current) return;
+    hasFocusedContentRef.current = true;
     const id = window.setTimeout(() => {
       contentInputRef.current?.focus();
     }, 100);
@@ -548,7 +555,6 @@ const ModifyNodeDialog = ({
               disabled={loading}
               mode={mode}
               initialUid={content.uid}
-              autoFocus={true}
               inputRef={contentInputRef}
             />
           </div>


### PR DESCRIPTION
https://www.loom.com/share/a092cd458bef479daefce722473e0f0f

Fixes focus jumping to the node type dropdown after selecting a node in ModifyNodeDialog.

This ensures the content input field remains focused, both on dialog open and after selection, for a smoother keyboard-first workflow.

---
<a href="https://cursor.com/background-agent?bcId=bc-39fa1509-7f28-4b22-85b0-73c24be6a2f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-39fa1509-7f28-4b22-85b0-73c24be6a2f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/723">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

UPDATE from @mdroidian : PR title and linear task linked changed.  ENG-1416 is the correct task.  ENG-1316 is a different issue.