### PR TITLE
ENG-1351 Obsidian schema should have ID, created and modified date

### DIFF
--- a/apps/obsidian/src/components/NodeTypeSettings.tsx
+++ b/apps/obsidian/src/components/NodeTypeSettings.tsx
@@ -25,7 +25,10 @@ const generateTagPlaceholder = (format: string, nodeName?: string): string => {
   return "Enter tag (e.g., clm-candidate)";
 };
 
-type EditableFieldKey = keyof Omit<DiscourseNode, "id" | "shortcut">;
+type EditableFieldKey = keyof Omit<
+  DiscourseNode,
+  "id" | "shortcut" | "modified" | "created"
+>;
 
 type BaseFieldConfig = {
   key: EditableFieldKey;
@@ -323,7 +326,11 @@ const NodeTypeSettings = () => {
   ): void => {
     if (!editingNodeType) return;
 
-    const updatedNodeType = { ...editingNodeType, [field]: value };
+    const updatedNodeType = {
+      ...editingNodeType,
+      [field]: value,
+      modified: new Date().getTime(),
+    };
     if (typeof value === "string") {
       validateField(field, value, updatedNodeType);
     }
@@ -332,12 +339,15 @@ const NodeTypeSettings = () => {
   };
 
   const handleAddNodeType = (): void => {
+    const now = new Date().getTime();
     const newNodeType: DiscourseNode = {
       id: generateUid("node"),
       name: "",
       format: "",
       template: "",
       tag: "",
+      created: now,
+      modified: now,
     };
     setEditingNodeType(newNodeType);
     setSelectedNodeIndex(nodeTypes.length);

--- a/apps/obsidian/src/components/RelationshipSettings.tsx
+++ b/apps/obsidian/src/components/RelationshipSettings.tsx
@@ -4,6 +4,7 @@ import { Notice } from "obsidian";
 import { usePlugin } from "./PluginContext";
 import { ConfirmationModal } from "./ConfirmationModal";
 import { getNodeTypeById } from "~/utils/typeUtils";
+import generateUid from "~/utils/generateUid";
 
 const RelationshipSettings = () => {
   const plugin = usePlugin();
@@ -18,33 +19,49 @@ const RelationshipSettings = () => {
     return plugin.settings.relationTypes.find((relType) => relType.id === id);
   };
 
+  type EditableFieldKey = keyof Omit<
+    DiscourseRelation,
+    "id" | "modified" | "created"
+  >;
+
   const handleRelationChange = async (
     index: number,
-    field: keyof DiscourseRelation,
+    field: EditableFieldKey,
     value: string,
   ): Promise<void> => {
     const updatedRelations = [...discourseRelations];
 
+    const now = new Date().getTime();
     if (!updatedRelations[index]) {
+      const newId = generateUid("rel3");
       updatedRelations[index] = {
+        id: newId,
         sourceId: "",
         destinationId: "",
         relationshipTypeId: "",
+        created: now,
+        modified: now,
       };
     }
 
     updatedRelations[index][field] = value;
+    updatedRelations[index].modified = now;
     setDiscourseRelations(updatedRelations);
     setHasUnsavedChanges(true);
   };
 
   const handleAddRelation = (): void => {
+    const newId = generateUid("rel3");
+    const now = new Date().getTime();
     const updatedRelations = [
       ...discourseRelations,
       {
+        id: newId,
         sourceId: "",
         destinationId: "",
         relationshipTypeId: "",
+        created: now,
+        modified: now,
       },
     ];
     setDiscourseRelations(updatedRelations);

--- a/apps/obsidian/src/components/RelationshipTypeSettings.tsx
+++ b/apps/obsidian/src/components/RelationshipTypeSettings.tsx
@@ -97,11 +97,17 @@ const RelationshipTypeSettings = () => {
   );
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
 
+  type EditableFieldKey = keyof Omit<
+    DiscourseRelationType,
+    "id" | "modified" | "created"
+  >;
+
   const handleRelationTypeChange = (
     index: number,
-    field: keyof DiscourseRelationType,
+    field: EditableFieldKey,
     value: string,
   ): void => {
+    const now = new Date().getTime();
     const updatedRelationTypes = [...relationTypes];
     if (!updatedRelationTypes[index]) {
       const newId = generateUid("rel");
@@ -110,8 +116,11 @@ const RelationshipTypeSettings = () => {
         label: "",
         complement: "",
         color: DEFAULT_TLDRAW_COLOR,
+        created: now,
+        modified: now,
       };
     }
+    updatedRelationTypes[index].modified = now;
     if (field === "color") {
       updatedRelationTypes[index].color = value as TldrawColorName;
     } else {
@@ -123,6 +132,7 @@ const RelationshipTypeSettings = () => {
 
   const handleAddRelationType = (): void => {
     const newId = generateUid("rel");
+    const now = new Date().getTime();
 
     const updatedRelationTypes = [
       ...relationTypes,
@@ -131,6 +141,8 @@ const RelationshipTypeSettings = () => {
         label: "",
         complement: "",
         color: DEFAULT_TLDRAW_COLOR,
+        created: now,
+        modified: now,
       },
     ];
     setRelationTypes(updatedRelationTypes);

--- a/apps/obsidian/src/constants.ts
+++ b/apps/obsidian/src/constants.ts
@@ -2,12 +2,16 @@ import { TLDefaultSizeStyle } from "tldraw";
 import { DiscourseNode, DiscourseRelationType, Settings } from "~/types";
 import generateUid from "~/utils/generateUid";
 
+const now = new Date().getTime();
+
 export const DEFAULT_NODE_TYPES: Record<string, DiscourseNode> = {
   Question: {
     id: generateUid("node"),
     name: "Question",
     format: "QUE - {content}",
     color: "#99890e",
+    created: now,
+    modified: now,
   },
   Claim: {
     id: generateUid("node"),
@@ -15,6 +19,8 @@ export const DEFAULT_NODE_TYPES: Record<string, DiscourseNode> = {
     format: "CLM - {content}",
     color: "#7DA13E",
     tag: "clm-candidate",
+    created: now,
+    modified: now,
   },
   Evidence: {
     id: generateUid("node"),
@@ -22,6 +28,8 @@ export const DEFAULT_NODE_TYPES: Record<string, DiscourseNode> = {
     format: "EVD - {content}",
     color: "#DB134A",
     tag: "evd-candidate",
+    created: now,
+    modified: now,
   },
 };
 export const DEFAULT_RELATION_TYPES: Record<string, DiscourseRelationType> = {
@@ -30,18 +38,24 @@ export const DEFAULT_RELATION_TYPES: Record<string, DiscourseRelationType> = {
     label: "supports",
     complement: "is supported by",
     color: "green",
+    created: now,
+    modified: now,
   },
   opposes: {
     id: generateUid("relation"),
     label: "opposes",
     complement: "is opposed by",
     color: "red",
+    created: now,
+    modified: now,
   },
   informs: {
     id: generateUid("relation"),
     label: "informs",
     complement: "is informed by",
     color: "grey",
+    created: now,
+    modified: now,
   },
 };
 
@@ -50,19 +64,28 @@ export const DEFAULT_SETTINGS: Settings = {
   relationTypes: Object.values(DEFAULT_RELATION_TYPES),
   discourseRelations: [
     {
+      id: generateUid("rel3"),
       sourceId: DEFAULT_NODE_TYPES.Evidence!.id,
       destinationId: DEFAULT_NODE_TYPES.Question!.id,
       relationshipTypeId: DEFAULT_RELATION_TYPES.informs!.id,
+      created: now,
+      modified: now,
     },
     {
+      id: generateUid("rel3"),
       sourceId: DEFAULT_NODE_TYPES.Evidence!.id,
       destinationId: DEFAULT_NODE_TYPES.Claim!.id,
       relationshipTypeId: DEFAULT_RELATION_TYPES.supports!.id,
+      created: now,
+      modified: now,
     },
     {
+      id: generateUid("rel3"),
       sourceId: DEFAULT_NODE_TYPES.Evidence!.id,
       destinationId: DEFAULT_NODE_TYPES.Claim!.id,
       relationshipTypeId: DEFAULT_RELATION_TYPES.opposes!.id,
+      created: now,
+      modified: now,
     },
   ],
   showIdsInFrontmatter: false,

--- a/apps/obsidian/src/index.ts
+++ b/apps/obsidian/src/index.ts
@@ -355,6 +355,7 @@ export default class DiscourseGraphPlugin extends Plugin {
       }
       if (!typeObject.id) {
         typeObject.id = generateUid("rel3");
+        changed = true;
       }
     }
     return changed;

--- a/apps/obsidian/src/index.ts
+++ b/apps/obsidian/src/index.ts
@@ -26,6 +26,7 @@ import { NodeTagSuggestPopover } from "~/components/NodeTagSuggestModal";
 import { initializeSupabaseSync } from "~/utils/syncDgNodesToSupabase";
 import { FileChangeListener } from "~/utils/fileChangeListener";
 import generateUid from "~/utils/generateUid";
+import type { DiscourseNode, DiscourseRelation } from "~/types";
 
 export default class DiscourseGraphPlugin extends Plugin {
   settings: Settings = { ...DEFAULT_SETTINGS };
@@ -353,6 +354,9 @@ export default class DiscourseGraphPlugin extends Plugin {
         typeObject.modified = now;
         changed = true;
       }
+    }
+    // nodeTypes and relationTypes already have Ids
+    for (const typeObject of this.settings.discourseRelations) {
       if (!typeObject.id) {
         typeObject.id = generateUid("rel3");
         changed = true;

--- a/apps/obsidian/src/types.ts
+++ b/apps/obsidian/src/types.ts
@@ -11,6 +11,8 @@ export type DiscourseNode = {
   color?: string;
   tag?: string;
   keyImage?: boolean;
+  created: number;
+  modified: number;
 };
 
 export type DiscourseRelationType = {
@@ -18,12 +20,17 @@ export type DiscourseRelationType = {
   label: string;
   complement: string;
   color: TldrawColorName;
+  created: number;
+  modified: number;
 };
 
 export type DiscourseRelation = {
+  id: string;
   sourceId: string;
   destinationId: string;
   relationshipTypeId: string;
+  created: number;
+  modified: number;
 };
 
 export type Settings = {


### PR DESCRIPTION
https://linear.app/discourse-graphs/issue/ENG-1351/obsidian-schema-should-have-id-created-and-modified-date

Aim: add created/modified date to schema types, and id to relation triple types.

Added ID and modified date to all schema types; added to constants; set in the respective components; added setting migrations.

https://www.loom.com/share/746d98f412614ae8b680d020f3df9f78

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/725">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
