### PR TITLE
ENG-1352 Use UUIDv7 in node identifiers to make for better database indexes

### DIFF
--- a/apps/obsidian/package.json
+++ b/apps/obsidian/package.json
@@ -34,6 +34,7 @@
     "tslib": "2.5.1",
     "tsx": "^4.19.2",
     "typescript": "5.5.4",
+    "uuidv7": "1.1.0",
     "zod": "^3.24.1"
   },
   "dependencies": {

--- a/apps/obsidian/src/utils/syncDgNodesToSupabase.ts
+++ b/apps/obsidian/src/utils/syncDgNodesToSupabase.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
+import { uuidv7 } from "uuidv7";
 import { Notice, TFile } from "obsidian";
 import { DGSupabaseClient } from "@repo/database/lib/client";
 import { Json } from "@repo/database/dbTypes";
@@ -101,7 +102,10 @@ const deleteNodesFromSupabase = async (
     if (conceptDeleteError) {
       result.success = false;
       result.errors.concept = conceptDeleteError;
-      console.error("Failed to delete concepts from Supabase:", conceptDeleteError);
+      console.error(
+        "Failed to delete concepts from Supabase:",
+        conceptDeleteError,
+      );
     }
 
     const { error: contentDeleteError } = await supabaseClient
@@ -152,7 +156,7 @@ const ensureNodeInstanceId = async (
     return existingId;
   }
 
-  const nodeInstanceId = crypto.randomUUID();
+  const nodeInstanceId = uuidv7();
   await plugin.app.fileManager.processFrontMatter(file, (fm) => {
     (fm as Record<string, unknown>).nodeInstanceId = nodeInstanceId;
   });
@@ -194,7 +198,6 @@ const mergeChangeTypes = (
   const merged = new Set<ChangeType>([...base, ...additional]);
   return Array.from(merged);
 };
-
 
 /**
  * Step 1: Collect all discourse nodes from the vault
@@ -635,10 +638,7 @@ export const syncSpecificFiles = async (
   const changeTypesByPath = new Map<string, ChangeType[]>();
   for (const filePath of filePaths) {
     const existing = changeTypesByPath.get(filePath) ?? [];
-    changeTypesByPath.set(
-      filePath,
-      mergeChangeTypes(existing, ["content"]),
-    );
+    changeTypesByPath.set(filePath, mergeChangeTypes(existing, ["content"]));
   }
 
   await syncDiscourseNodeChanges(plugin, changeTypesByPath);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,6 +184,9 @@ importers:
       typescript:
         specifier: 5.5.4
         version: 5.5.4
+      uuidv7:
+        specifier: 1.1.0
+        version: 1.1.0
       zod:
         specifier: ^3.24.1
         version: 3.25.76
@@ -15225,6 +15228,13 @@ packages:
       }
     hasBin: true
 
+  uuidv7@1.1.0:
+    resolution:
+      {
+        integrity: sha512-2VNnOC0+XQlwogChUDzy6pe8GQEys9QFZBGOh54l6qVfwoCUwwRvk7rDTgaIsRgsF5GFa5oiNg8LqXE3jofBBg==,
+      }
+    hasBin: true
+
   v8-compile-cache-lib@3.0.1:
     resolution:
       {
@@ -26287,6 +26297,8 @@ snapshots:
   uuid@9.0.0: {}
 
   uuid@9.0.1: {}
+
+  uuidv7@1.1.0: {}
 
   v8-compile-cache-lib@3.0.1: {}
 


### PR DESCRIPTION
https://linear.app/discourse-graphs/issue/ENG-1352/use-uuidv7-in-node-identifiers-to-make-for-better-database-indexes

Replace UUIDv4 with UUIDv7 for node identifiers; it plays better with database indices.
See eg https://dev.to/umangsinha12/postgresql-uuid-performance-benchmarking-random-v4-and-time-based-v7-uuids-n9b

https://www.loom.com/share/d197320bc0df42fca26fc170bcef7863
