### PR TITLE
[ENG-1315] Canvas node type mismatch

### DIFF
--- a/apps/roam/src/components/ModifyNodeDialog.tsx
+++ b/apps/roam/src/components/ModifyNodeDialog.tsx
@@ -50,6 +50,7 @@ export type ModifyNodeDialogProps = {
     text: string;
     uid: string;
     action: string;
+    nodeType: string;
   }) => Promise<void>;
   onClose: () => void;
 };
@@ -333,6 +334,7 @@ const ModifyNodeDialog = ({
             text: content.text,
             uid: content.uid,
             action: "create",
+            nodeType: selectedNodeType.type,
           });
 
           onClose();
@@ -441,6 +443,7 @@ const ModifyNodeDialog = ({
           text: formattedTitle,
           uid: newPageUid,
           action: "create",
+          nodeType: selectedNodeType.type,
         });
       } else {
         // Edit mode: update the existing block
@@ -477,6 +480,7 @@ const ModifyNodeDialog = ({
           text: updatedContent,
           uid: sourceBlockUid || content.uid,
           action: "edit",
+          nodeType: selectedNodeType.type,
         });
       }
       onClose();

--- a/apps/roam/src/components/canvas/DiscourseNodeUtil.tsx
+++ b/apps/roam/src/components/canvas/DiscourseNodeUtil.tsx
@@ -499,7 +499,7 @@ export class BaseDiscourseNodeUtil extends BaseBoxShapeUtil<DiscourseNodeShape> 
               : undefined,
           extensionAPI,
           includeDefaultNodes: true,
-          onSuccess: async ({ text, uid, action }) => {
+          onSuccess: async ({ text, uid, action, nodeType }) => {
             if (action === "edit") {
               if (isPageUid(shape.props.uid))
                 await window.roamAlphaAPI.updatePage({
@@ -511,7 +511,10 @@ export class BaseDiscourseNodeUtil extends BaseBoxShapeUtil<DiscourseNodeShape> 
             // Node creation is handled by ModifyNodeDialog - no fallback needed here
 
             void setSizeAndImgPropsLocal({ text, uid });
-            this.updateProps(shape.id, shape.type, {
+            
+            // Update shape type if it has changed (e.g., user changed from Claim to Hypothesis during creation)
+            const finalShapeType = nodeType || shape.type;
+            this.updateProps(shape.id, finalShapeType, {
               title: text,
               uid,
             });

--- a/apps/roam/src/components/canvas/uiOverrides.tsx
+++ b/apps/roam/src/components/canvas/uiOverrides.tsx
@@ -73,9 +73,11 @@ export const getOnSelectForShape = ({
       extensionAPI,
       includeDefaultNodes: true,
       imageUrl,
-      onSuccess: async ({ text, uid }) => {
+      onSuccess: async ({ text, uid, nodeType: selectedNodeType }) => {
         editor.deleteShapes([shape.id]);
 
+        // Use the selected node type from the dialog, which may have changed during creation
+        const finalNodeType = selectedNodeType || nodeType;
         const {
           h,
           w,
@@ -83,12 +85,12 @@ export const getOnSelectForShape = ({
         } = await calcCanvasNodeSizeAndImg({
           nodeText: text,
           extensionAPI,
-          nodeType,
+          nodeType: finalNodeType,
           uid,
         });
         editor.createShapes([
           {
-            type: nodeType,
+            type: finalNodeType,
             id: createShapeId(),
             props: {
               uid,

--- a/apps/roam/src/utils/renderNodeTagPopup.tsx
+++ b/apps/roam/src/utils/renderNodeTagPopup.tsx
@@ -91,7 +91,7 @@ export const renderNodeTagPopupButton = (
       nodeType: matchedNode.type,
       initialValue: { text: cleanedBlockText, uid: "" },
       initialReferencedNode,
-      onSuccess: async () => {
+      onSuccess: async ({ nodeType }) => {
         // Success is handled by the dialog itself
       },
       onClose: () => {},


### PR DESCRIPTION
Update Canvas node creation to correctly reflect the selected node type when changed mid-creation.

Previously, if a user changed the node type in the `ModifyNodeDialog` during creation (e.g., from Claim to Hypothesis), the Canvas shape's underlying type would not update, leading to a mismatch between the UI and the internal data. This change ensures the selected node type is propagated and used to create the correct Canvas shape.

---
Linear Issue: [ENG-1315](https://linear.app/discourse-graphs/issue/ENG-1315/canvas-node-type-mismatch-when-changing-node-type-during-creation)

<a href="https://cursor.com/background-agent?bcId=bc-60cd5bcf-caf2-4423-ba9d-0e8458651245"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-60cd5bcf-caf2-4423-ba9d-0e8458651245"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

