### PR TITLE
[ENG-1123] Right sidebar page title

### DIFF
--- a/apps/roam/src/components/canvas/DiscourseRelationShape/DiscourseRelationUtil.tsx
+++ b/apps/roam/src/components/canvas/DiscourseRelationShape/DiscourseRelationUtil.tsx
@@ -654,7 +654,9 @@ export const createAllRelationShapeUtils = (
               relation,
               target,
             }));
-          const parentUid = getCurrentPageUid();
+          // Get canvas page UID from editor instance, fallback to current page UID
+          // @ts-expect-error - Custom property added to editor
+          const parentUid = this.editor.canvasPageUid || getCurrentPageUid();
           const title = getPageTitleByPageUid(parentUid);
           await triplesToBlocks({
             defaultPageTitle: `Auto generated from [[${title}]]`,

--- a/apps/roam/src/components/canvas/DiscourseRelationShape/DiscourseRelationUtil.tsx
+++ b/apps/roam/src/components/canvas/DiscourseRelationShape/DiscourseRelationUtil.tsx
@@ -654,8 +654,7 @@ export const createAllRelationShapeUtils = (
               relation,
               target,
             }));
-          // Get canvas page UID for this specific editor instance from the map
-          // This ensures we use the correct canvas even when multiple are open
+          // Ensure we use the correct canvas even when multiple are open
           const canvasPageUid = discourseContext.editorToPageUid.get(
             this.editor,
           );

--- a/apps/roam/src/components/canvas/DiscourseRelationShape/DiscourseRelationUtil.tsx
+++ b/apps/roam/src/components/canvas/DiscourseRelationShape/DiscourseRelationUtil.tsx
@@ -654,9 +654,8 @@ export const createAllRelationShapeUtils = (
               relation,
               target,
             }));
-          // Get canvas page UID from editor instance, fallback to current page UID
-          // @ts-expect-error - Custom property added to editor
-          const parentUid = this.editor.canvasPageUid || getCurrentPageUid();
+          // Get canvas page UID from discourse context, fallback to current page UID
+          const parentUid = discourseContext.canvasPageUid || getCurrentPageUid();
           const title = getPageTitleByPageUid(parentUid);
           await triplesToBlocks({
             defaultPageTitle: `Auto generated from [[${title}]]`,

--- a/apps/roam/src/components/canvas/DiscourseRelationShape/DiscourseRelationUtil.tsx
+++ b/apps/roam/src/components/canvas/DiscourseRelationShape/DiscourseRelationUtil.tsx
@@ -654,8 +654,12 @@ export const createAllRelationShapeUtils = (
               relation,
               target,
             }));
-          // Get canvas page UID from discourse context, fallback to current page UID
-          const parentUid = discourseContext.canvasPageUid || getCurrentPageUid();
+          // Get canvas page UID for this specific editor instance from the map
+          // This ensures we use the correct canvas even when multiple are open
+          const canvasPageUid = discourseContext.editorToPageUid.get(
+            this.editor,
+          );
+          const parentUid = canvasPageUid || getCurrentPageUid();
           const title = getPageTitleByPageUid(parentUid);
           await triplesToBlocks({
             defaultPageTitle: `Auto generated from [[${title}]]`,

--- a/apps/roam/src/components/canvas/DiscourseRelationShape/DiscourseRelationUtil.tsx
+++ b/apps/roam/src/components/canvas/DiscourseRelationShape/DiscourseRelationUtil.tsx
@@ -91,7 +91,7 @@ const getCanvasPageUidFromDOM = (): string | null => {
     }
   }
 
-  // Fallback: use the first container (shouldn't happen in practice)
+  // Fallback: use the first container
   return containers[0].getAttribute("data-page-uid");
 };
 import { InputTextNode } from "roamjs-components/types";
@@ -103,7 +103,6 @@ import {
   BaseDiscourseNodeUtil,
   DiscourseNodeShape,
 } from "~/components/canvas/DiscourseNodeUtil";
-import getCurrentPageUid from "roamjs-components/dom/getCurrentPageUid";
 import getPageTitleByPageUid from "roamjs-components/queries/getPageTitleByPageUid";
 import { AddReferencedNodeType } from "./DiscourseRelationTool";
 import { dispatchToastEvent } from "~/components/canvas/ToastListener";
@@ -683,8 +682,10 @@ export const createAllRelationShapeUtils = (
             }));
           // Get canvas page UID from the DOM (supports multiple canvases)
           const canvasPageUid = getCanvasPageUidFromDOM();
-          const parentUid = canvasPageUid || getCurrentPageUid();
-          const title = getPageTitleByPageUid(parentUid);
+          if (!canvasPageUid) {
+            return deleteAndWarn("No canvas page UID found");
+          }
+          const title = getPageTitleByPageUid(canvasPageUid);
           await triplesToBlocks({
             defaultPageTitle: `Auto generated from [[${title}]]`,
             toPage: async (title: string, blocks: InputTextNode[]) => {

--- a/apps/roam/src/components/canvas/Tldraw.tsx
+++ b/apps/roam/src/components/canvas/Tldraw.tsx
@@ -112,6 +112,7 @@ export type DiscourseContextType = {
   relations: Record<string, DiscourseRelation[]>;
   lastAppEvent: string;
   lastActions: HistoryEntry<TLRecord>[];
+  canvasPageUid: string;
 };
 
 export const discourseContext: DiscourseContextType = {
@@ -119,6 +120,7 @@ export const discourseContext: DiscourseContextType = {
   relations: {},
   lastAppEvent: "",
   lastActions: [],
+  canvasPageUid: "",
 };
 
 export const DEFAULT_WIDTH = 160;
@@ -685,9 +687,8 @@ const TldrawCanvas = ({ title }: { title: string }) => {
 
               appRef.current = app;
 
-              // Store canvas page UID on editor instance for relation creation
-              // @ts-expect-error - Adding custom property to editor
-              app.canvasPageUid = pageUid;
+              // Store canvas page UID in discourse context for relation creation
+              discourseContext.canvasPageUid = pageUid;
 
               app.on("change", (entry) => {
                 lastActionsRef.current.push(entry);

--- a/apps/roam/src/components/canvas/Tldraw.tsx
+++ b/apps/roam/src/components/canvas/Tldraw.tsx
@@ -613,7 +613,6 @@ const TldrawCanvas = ({ title }: { title: string }) => {
       tabIndex={-1}
       onDragOver={handleDragOver}
       onDrop={handleDrop}
-      data-page-uid={pageUid}
     >
       <style>{tldrawStyles}</style>
 

--- a/apps/roam/src/components/canvas/Tldraw.tsx
+++ b/apps/roam/src/components/canvas/Tldraw.tsx
@@ -112,8 +112,6 @@ export type DiscourseContextType = {
   relations: Record<string, DiscourseRelation[]>;
   lastAppEvent: string;
   lastActions: HistoryEntry<TLRecord>[];
-  // Map editor instances to their canvas page UIDs to support multiple canvases
-  editorToPageUid: WeakMap<Editor, string>;
 };
 
 export const discourseContext: DiscourseContextType = {
@@ -121,7 +119,6 @@ export const discourseContext: DiscourseContextType = {
   relations: {},
   lastAppEvent: "",
   lastActions: [],
-  editorToPageUid: new WeakMap<Editor, string>(),
 };
 
 export const DEFAULT_WIDTH = 160;
@@ -616,6 +613,7 @@ const TldrawCanvas = ({ title }: { title: string }) => {
       tabIndex={-1}
       onDragOver={handleDragOver}
       onDrop={handleDrop}
+      data-page-uid={pageUid}
     >
       <style>{tldrawStyles}</style>
 
@@ -687,7 +685,6 @@ const TldrawCanvas = ({ title }: { title: string }) => {
               }
 
               appRef.current = app;
-              discourseContext.editorToPageUid.set(app, pageUid);
 
               app.on("change", (entry) => {
                 lastActionsRef.current.push(entry);

--- a/apps/roam/src/components/canvas/Tldraw.tsx
+++ b/apps/roam/src/components/canvas/Tldraw.tsx
@@ -685,6 +685,10 @@ const TldrawCanvas = ({ title }: { title: string }) => {
 
               appRef.current = app;
 
+              // Store canvas page UID on editor instance for relation creation
+              // @ts-expect-error - Adding custom property to editor
+              app.canvasPageUid = pageUid;
+
               app.on("change", (entry) => {
                 lastActionsRef.current.push(entry);
                 if (lastActionsRef.current.length > 5)

--- a/apps/roam/src/components/canvas/Tldraw.tsx
+++ b/apps/roam/src/components/canvas/Tldraw.tsx
@@ -112,7 +112,8 @@ export type DiscourseContextType = {
   relations: Record<string, DiscourseRelation[]>;
   lastAppEvent: string;
   lastActions: HistoryEntry<TLRecord>[];
-  canvasPageUid: string;
+  // Map editor instances to their canvas page UIDs to support multiple canvases
+  editorToPageUid: WeakMap<Editor, string>;
 };
 
 export const discourseContext: DiscourseContextType = {
@@ -120,7 +121,7 @@ export const discourseContext: DiscourseContextType = {
   relations: {},
   lastAppEvent: "",
   lastActions: [],
-  canvasPageUid: "",
+  editorToPageUid: new WeakMap<Editor, string>(),
 };
 
 export const DEFAULT_WIDTH = 160;
@@ -687,8 +688,9 @@ const TldrawCanvas = ({ title }: { title: string }) => {
 
               appRef.current = app;
 
-              // Store canvas page UID in discourse context for relation creation
-              discourseContext.canvasPageUid = pageUid;
+              // Map this editor instance to its canvas page UID
+              // This supports multiple canvases open simultaneously (e.g., in sidebars)
+              discourseContext.editorToPageUid.set(app, pageUid);
 
               app.on("change", (entry) => {
                 lastActionsRef.current.push(entry);

--- a/apps/roam/src/components/canvas/Tldraw.tsx
+++ b/apps/roam/src/components/canvas/Tldraw.tsx
@@ -687,9 +687,6 @@ const TldrawCanvas = ({ title }: { title: string }) => {
               }
 
               appRef.current = app;
-
-              // Map this editor instance to its canvas page UID
-              // This supports multiple canvases open simultaneously (e.g., in sidebars)
               discourseContext.editorToPageUid.set(app, pageUid);
 
               app.on("change", (entry) => {


### PR DESCRIPTION
https://www.loom.com/share/c409751c64654304b8ba05c64c7168c0

Fixes auto-generated page title using the main page instead of the canvas page when the canvas is in the right sidebar.

The relation creation logic was incorrectly retrieving the main page's UID via `getCurrentPageUid()` instead of the active canvas page's UID. This PR stores the canvas page UID on the editor instance when it mounts and uses this stored UID for relation title generation.

---
Linear Issue: [ENG-1123](https://linear.app/discourse-graphs/issue/ENG-1123/auto-generated-page-title-is-incorrect-when-canvas-is-in-the-right)

<a href="https://cursor.com/background-agent?bcId=bc-f9ecd592-5119-4336-a1c9-6d2cfef9f37f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f9ecd592-5119-4336-a1c9-6d2cfef9f37f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/729" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
