### PR TITLE
[ENG-1332] Automatic node relationships

### DIFF
--- a/apps/obsidian/src/components/ModifyNodeModal.tsx
+++ b/apps/obsidian/src/components/ModifyNodeModal.tsx
@@ -19,9 +19,9 @@ type ModifyNodeFormProps = {
     title: string;
     initialFile?: TFile; // for edit mode
     selectedExistingNode?: TFile;
-    relationshipTypeId?: string;
+    /** DiscourseRelation.id; when set, relation is created with currentFile as the other end. */
+    relationshipId?: string;
     relationshipTargetFile?: TFile;
-    isCurrentFileSource?: boolean;
   }) => Promise<void>;
   onCancel: () => void;
   initialTitle?: string;
@@ -314,9 +314,8 @@ export const ModifyNodeForm = ({
         title: trimmedTitle,
         initialFile,
         selectedExistingNode: selectedExistingNode || undefined,
-        relationshipTypeId: selectedRel?.relationTypeId || undefined,
+        relationshipId: selectedRel?.uniqueKey || undefined,
         relationshipTargetFile: currentFile || undefined,
-        isCurrentFileSource: selectedRel?.isCurrentFileSource,
       });
       onCancel();
     } catch (error) {
@@ -525,9 +524,8 @@ type ModifyNodeModalProps = {
     title: string;
     initialFile?: TFile;
     selectedExistingNode?: TFile;
-    relationshipTypeId?: string;
+    relationshipId?: string;
     relationshipTargetFile?: TFile;
-    isCurrentFileSource?: boolean;
   }) => Promise<void>;
   initialTitle?: string;
   initialNodeType?: DiscourseNode;
@@ -542,9 +540,8 @@ class ModifyNodeModal extends Modal {
     title: string;
     initialFile?: TFile;
     selectedExistingNode?: TFile;
-    relationshipTypeId?: string;
+    relationshipId?: string;
     relationshipTargetFile?: TFile;
-    isCurrentFileSource?: boolean;
   }) => Promise<void>;
   private root: Root | null = null;
   private initialTitle?: string;

--- a/apps/obsidian/src/components/ModifyNodeModal.tsx
+++ b/apps/obsidian/src/components/ModifyNodeModal.tsx
@@ -21,6 +21,7 @@ type ModifyNodeFormProps = {
     selectedExistingNode?: TFile;
     relationshipTypeId?: string;
     relationshipTargetFile?: TFile;
+    isCurrentFileSource?: boolean;
   }) => Promise<void>;
   onCancel: () => void;
   initialTitle?: string;
@@ -52,8 +53,9 @@ export const ModifyNodeForm = ({
   const [isFocused, setIsFocused] = useState(false);
   const [searchResults, setSearchResults] = useState<TFile[]>([]);
   const [isSearching, setIsSearching] = useState(false);
-  const [selectedRelationshipTypeId, setSelectedRelationshipTypeId] =
-    useState<string>("");
+  const [selectedRelationshipTypeId, setSelectedRelationshipTypeId] = useState<
+    string | undefined
+  >(undefined);
   const queryEngine = useRef(new QueryEngine(plugin.app));
   const titleInputRef = useRef<HTMLInputElement>(null);
   const popoverRef = useRef<HTMLDivElement>(null);
@@ -188,7 +190,7 @@ export const ModifyNodeForm = ({
   }, [currentFile, selectedNodeType, isEditMode, plugin]);
 
   useEffect(() => {
-    if (!selectedRelationshipTypeId && availableRelationships[0]) {
+    if (selectedRelationshipTypeId === undefined && availableRelationships[0]) {
       setSelectedRelationshipTypeId(availableRelationships[0].relationTypeId);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- only run when availableRelationships changes
@@ -281,6 +283,11 @@ export const ModifyNodeForm = ({
 
     try {
       setIsSubmitting(true);
+      const selectedRel = selectedRelationshipTypeId
+        ? availableRelationships.find(
+            (r) => r.relationTypeId === selectedRelationshipTypeId,
+          )
+        : undefined;
       await onSubmit({
         nodeType: selectedNodeType,
         title: trimmedTitle,
@@ -288,6 +295,7 @@ export const ModifyNodeForm = ({
         selectedExistingNode: selectedExistingNode || undefined,
         relationshipTypeId: selectedRelationshipTypeId || undefined,
         relationshipTargetFile: currentFile || undefined,
+        isCurrentFileSource: selectedRel?.isCurrentFileSource,
       });
       onCancel();
     } catch (error) {
@@ -314,6 +322,7 @@ export const ModifyNodeForm = ({
     selectedExistingNode,
     selectedRelationshipTypeId,
     currentFile,
+    availableRelationships,
   ]);
 
   return (
@@ -495,6 +504,7 @@ type ModifyNodeModalProps = {
     selectedExistingNode?: TFile;
     relationshipTypeId?: string;
     relationshipTargetFile?: TFile;
+    isCurrentFileSource?: boolean;
   }) => Promise<void>;
   initialTitle?: string;
   initialNodeType?: DiscourseNode;
@@ -511,6 +521,7 @@ class ModifyNodeModal extends Modal {
     selectedExistingNode?: TFile;
     relationshipTypeId?: string;
     relationshipTargetFile?: TFile;
+    isCurrentFileSource?: boolean;
   }) => Promise<void>;
   private root: Root | null = null;
   private initialTitle?: string;

--- a/apps/obsidian/src/components/ModifyNodeModal.tsx
+++ b/apps/obsidian/src/components/ModifyNodeModal.tsx
@@ -254,6 +254,7 @@ export const ModifyNodeForm = ({
       setQuery("");
       setTitle("");
     }
+    setSelectedRelationshipTypeId(undefined);
   };
 
   const handleQueryChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/apps/obsidian/src/components/ModifyNodeModal.tsx
+++ b/apps/obsidian/src/components/ModifyNodeModal.tsx
@@ -319,7 +319,7 @@ export const ModifyNodeForm = ({
   return (
     <div>
       <h2>
-        {isEditMode ? "Modify discourse node" : "Create discourse nodeeeee"}
+        {isEditMode ? "Modify discourse node" : "Create discourse node"}
       </h2>
       <div className="setting-item">
         <div className="setting-item-name">Type</div>

--- a/apps/obsidian/src/components/ModifyNodeModal.tsx
+++ b/apps/obsidian/src/components/ModifyNodeModal.tsx
@@ -148,8 +148,7 @@ export const ModifyNodeForm = ({
       return [];
     }
 
-    const currentFileCache =
-      plugin.app.metadataCache.getFileCache(currentFile);
+    const currentFileCache = plugin.app.metadataCache.getFileCache(currentFile);
     const currentNodeTypeId = currentFileCache?.frontmatter?.nodeTypeId;
 
     if (!currentNodeTypeId) {
@@ -165,37 +164,35 @@ export const ModifyNodeForm = ({
           relation.destinationId === currentNodeTypeId),
     );
 
-    return relevantRelations.map((relation) => {
-      const relationType = plugin.settings.relationTypes.find(
-        (rt) => rt.id === relation.relationshipTypeId,
-      );
-      if (!relationType) return null;
+    return relevantRelations
+      .map((relation) => {
+        const relationType = plugin.settings.relationTypes.find(
+          (rt) => rt.id === relation.relationshipTypeId,
+        );
+        if (!relationType) return null;
 
-      const isCurrentFileSource = relation.sourceId === currentNodeTypeId;
-      return {
-        relationTypeId: relationType.id,
-        label: isCurrentFileSource
-          ? relationType.label
-          : relationType.complement,
-        isCurrentFileSource,
-      };
-    }).filter(Boolean) as Array<{
+        const isCurrentFileSource = relation.sourceId === currentNodeTypeId;
+        return {
+          relationTypeId: relationType.id,
+          label: isCurrentFileSource
+            ? relationType.label
+            : relationType.complement,
+          isCurrentFileSource,
+        };
+      })
+      .filter(Boolean) as Array<{
       relationTypeId: string;
       label: string;
       isCurrentFileSource: boolean;
     }>;
   }, [currentFile, selectedNodeType, isEditMode, plugin]);
 
-  // Auto-select relationship if there's only one option
   useEffect(() => {
-    if (
-      availableRelationships.length === 1 &&
-      !selectedRelationshipTypeId &&
-      availableRelationships[0]
-    ) {
+    if (!selectedRelationshipTypeId && availableRelationships[0]) {
       setSelectedRelationshipTypeId(availableRelationships[0].relationTypeId);
     }
-  }, [availableRelationships, selectedRelationshipTypeId]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only run when availableRelationships changes
+  }, [availableRelationships]);
 
   const isFormValid = title.trim() && selectedNodeType;
 
@@ -289,8 +286,7 @@ export const ModifyNodeForm = ({
         title: trimmedTitle,
         initialFile,
         selectedExistingNode: selectedExistingNode || undefined,
-        relationshipTypeId:
-          selectedRelationshipTypeId || undefined,
+        relationshipTypeId: selectedRelationshipTypeId || undefined,
         relationshipTargetFile: currentFile || undefined,
       });
       onCancel();
@@ -322,7 +318,9 @@ export const ModifyNodeForm = ({
 
   return (
     <div>
-      <h2>{isEditMode ? "Modify discourse node" : "Create discourse node"}</h2>
+      <h2>
+        {isEditMode ? "Modify discourse node" : "Create discourse nodeeeee"}
+      </h2>
       <div className="setting-item">
         <div className="setting-item-name">Type</div>
         <div className="setting-item-control">
@@ -450,7 +448,8 @@ export const ModifyNodeForm = ({
               <option value="">No relation</option>
               {availableRelationships.map((rel) => (
                 <option key={rel.relationTypeId} value={rel.relationTypeId}>
-                  {rel.label} {currentFile?.basename}
+                  {rel.label} &quot;{currentFile?.basename}
+                  &quot;
                 </option>
               ))}
             </select>

--- a/apps/obsidian/src/components/RelationshipSection.tsx
+++ b/apps/obsidian/src/components/RelationshipSection.tsx
@@ -367,11 +367,6 @@ const CurrentRelationships = ({
     const fileCache = plugin.app.metadataCache.getFileCache(activeFile);
     if (!fileCache?.frontmatter) return;
 
-    const activeNodeTypeId = fileCache.frontmatter.nodeTypeId as
-      | string
-      | undefined;
-    if (!activeNodeTypeId) return;
-
     const nodeInstanceId = await getNodeInstanceIdForFile(plugin, activeFile);
     if (!nodeInstanceId) return;
 
@@ -381,21 +376,17 @@ const CurrentRelationships = ({
     );
     const tempRelationships = new Map<string, GroupedRelation>();
 
-    for (const relationType of plugin.settings.relationTypes) {
-      const typeLevelRelation = plugin.settings.discourseRelations.find(
-        (rel) =>
-          (rel.sourceId === activeNodeTypeId ||
-            rel.destinationId === activeNodeTypeId) &&
-          rel.relationshipTypeId === relationType.id,
+    for (const r of relations) {
+      const relationType = plugin.settings.relationTypes.find(
+        (rt) => rt.id === r.type,
       );
-      if (!typeLevelRelation) continue;
+      if (!relationType) continue;
 
-      const instanceRels = relations.filter((r) => r.type === relationType.id);
-      const isSource = typeLevelRelation.sourceId === activeNodeTypeId;
+      const isSource = r.source === nodeInstanceId;
       const relationLabel = isSource
         ? relationType.label
         : relationType.complement;
-      const relationKey = `${relationType.id}-${isSource}`;
+      const relationKey = `${r.type}-${isSource ? "source" : "target"}`;
 
       if (!tempRelationships.has(relationKey)) {
         tempRelationships.set(relationKey, {
@@ -409,16 +400,13 @@ const CurrentRelationships = ({
       }
 
       const group = tempRelationships.get(relationKey)!;
-      for (const r of instanceRels) {
-        const otherId = r.source === nodeInstanceId ? r.destination : r.source;
-        const linkedFile = await getFileForNodeInstanceId(plugin, otherId);
-        if (!linkedFile) continue;
-        if (
-          linkedFile &&
-          !group.linkedFiles.some((f) => f.path === linkedFile.path)
-        ) {
-          group.linkedFiles.push(linkedFile);
-        }
+      const otherId = isSource ? r.destination : r.source;
+      const linkedFile = await getFileForNodeInstanceId(plugin, otherId);
+      if (
+        linkedFile &&
+        !group.linkedFiles.some((f) => f.path === linkedFile.path)
+      ) {
+        group.linkedFiles.push(linkedFile);
       }
     }
 

--- a/apps/obsidian/src/components/RelationshipSection.tsx
+++ b/apps/obsidian/src/components/RelationshipSection.tsx
@@ -74,7 +74,8 @@ const AddRelationship = ({
         : relation.sourceId,
     );
 
-    const compatibleNodeTypes = compatibleNodeTypeIds
+    const uniqueNodeTypeIds = [...new Set(compatibleNodeTypeIds)];
+    const compatibleNodeTypes = uniqueNodeTypeIds
       .map((id) => getNodeTypeById(plugin, id))
       .filter(Boolean) as DiscourseNode[];
 

--- a/apps/obsidian/src/components/canvas/shapes/DiscourseRelationShape.tsx
+++ b/apps/obsidian/src/components/canvas/shapes/DiscourseRelationShape.tsx
@@ -1212,7 +1212,6 @@ export class DiscourseRelationUtil extends ShapeUtil<DiscourseRelationShape> {
 
       const { alreadyExisted, relationInstanceId } =
         await addRelationToRelationsJson({
-          app: this.options.app,
           plugin: this.options.plugin,
           sourceFile,
           targetFile,

--- a/apps/obsidian/src/components/canvas/utils/convertToDiscourseNode.ts
+++ b/apps/obsidian/src/components/canvas/utils/convertToDiscourseNode.ts
@@ -129,10 +129,7 @@ const convertImageShapeToNode = async ({
     plugin,
     initialNodeType: nodeType,
     initialTitle: "",
-    onSubmit: async ({
-      nodeType: selectedNodeType,
-      title,
-    }) => {
+    onSubmit: async ({ nodeType: selectedNodeType, title }) => {
       try {
         const createdFile = await createDiscourseNodeFile({
           plugin,

--- a/apps/obsidian/src/components/canvas/utils/convertToDiscourseNode.ts
+++ b/apps/obsidian/src/components/canvas/utils/convertToDiscourseNode.ts
@@ -129,7 +129,10 @@ const convertImageShapeToNode = async ({
     plugin,
     initialNodeType: nodeType,
     initialTitle: "",
-    onSubmit: async ({ nodeType: selectedNodeType, title }) => {
+    onSubmit: async ({
+      nodeType: selectedNodeType,
+      title,
+    }) => {
       try {
         const createdFile = await createDiscourseNodeFile({
           plugin,

--- a/apps/obsidian/src/components/canvas/utils/nodeCreationFlow.ts
+++ b/apps/obsidian/src/components/canvas/utils/nodeCreationFlow.ts
@@ -24,10 +24,13 @@ export const openCreateDiscourseNodeAt = (args: CreateNodeAtArgs): void => {
     nodeTypes: plugin.settings.nodeTypes,
     plugin,
     initialNodeType,
+    currentFile: canvasFile,
     onSubmit: async ({
       nodeType: selectedNodeType,
       title,
       selectedExistingNode,
+      relationshipTypeId,
+      relationshipTargetFile,
     }) => {
       try {
         // If user selected an existing node, use it instead of creating a new one
@@ -41,6 +44,20 @@ export const openCreateDiscourseNodeAt = (args: CreateNodeAtArgs): void => {
 
         if (!fileToUse) {
           throw new Error("Failed to get discourse node file");
+        }
+
+        // Add relationship to frontmatter if specified
+        if (relationshipTypeId && relationshipTargetFile) {
+          const { addRelationToFrontmatter } = await import(
+            "~/components/canvas/utils/frontmatterUtils"
+          );
+          await addRelationToFrontmatter({
+            app: plugin.app,
+            plugin,
+            sourceFile: fileToUse,
+            targetFile: relationshipTargetFile,
+            relationTypeId: relationshipTypeId,
+          });
         }
 
         const src = await addWikilinkBlockrefForFile({

--- a/apps/obsidian/src/components/canvas/utils/nodeCreationFlow.ts
+++ b/apps/obsidian/src/components/canvas/utils/nodeCreationFlow.ts
@@ -32,6 +32,7 @@ export const openCreateDiscourseNodeAt = (args: CreateNodeAtArgs): void => {
       selectedExistingNode,
       relationshipTypeId,
       relationshipTargetFile,
+      isCurrentFileSource,
     }) => {
       try {
         // If user selected an existing node, use it instead of creating a new one
@@ -49,10 +50,13 @@ export const openCreateDiscourseNodeAt = (args: CreateNodeAtArgs): void => {
 
         // Add relationship to frontmatter if specified
         if (relationshipTypeId && relationshipTargetFile) {
+          const [sourceFile, targetFile] = isCurrentFileSource
+            ? [relationshipTargetFile, fileToUse]
+            : [fileToUse, relationshipTargetFile];
           await addRelationToRelationsJson({
             plugin,
-            sourceFile: fileToUse,
-            targetFile: relationshipTargetFile,
+            sourceFile,
+            targetFile,
             relationTypeId: relationshipTypeId,
           });
         }

--- a/apps/obsidian/src/components/canvas/utils/nodeCreationFlow.ts
+++ b/apps/obsidian/src/components/canvas/utils/nodeCreationFlow.ts
@@ -30,9 +30,8 @@ export const openCreateDiscourseNodeAt = (args: CreateNodeAtArgs): void => {
       nodeType: selectedNodeType,
       title,
       selectedExistingNode,
-      relationshipTypeId,
+      relationshipId,
       relationshipTargetFile,
-      isCurrentFileSource,
     }) => {
       try {
         // If user selected an existing node, use it instead of creating a new one
@@ -48,12 +47,10 @@ export const openCreateDiscourseNodeAt = (args: CreateNodeAtArgs): void => {
           throw new Error("Failed to get discourse node file");
         }
 
-        // Add relationship to frontmatter if specified
-        if (relationshipTypeId && relationshipTargetFile) {
+        if (relationshipId && relationshipTargetFile) {
           await addRelationIfRequested(plugin, fileToUse, {
-            relationshipTypeId,
+            relationshipId,
             relationshipTargetFile,
-            isCurrentFileSource,
           });
         }
 

--- a/apps/obsidian/src/components/canvas/utils/nodeCreationFlow.ts
+++ b/apps/obsidian/src/components/canvas/utils/nodeCreationFlow.ts
@@ -8,7 +8,7 @@ import { addWikilinkBlockrefForFile } from "~/components/canvas/stores/assetStor
 import { showToast } from "./toastUtils";
 import { calcDiscourseNodeSize } from "~/utils/calcDiscourseNodeSize";
 import { getFirstImageSrcForFile } from "~/components/canvas/shapes/discourseNodeShapeUtils";
-import { addRelationToRelationsJson } from "./relationJsonUtils";
+import { addRelationIfRequested } from "./relationJsonUtils";
 
 export type CreateNodeAtArgs = {
   plugin: DiscourseGraphPlugin;
@@ -50,14 +50,10 @@ export const openCreateDiscourseNodeAt = (args: CreateNodeAtArgs): void => {
 
         // Add relationship to frontmatter if specified
         if (relationshipTypeId && relationshipTargetFile) {
-          const [sourceFile, targetFile] = isCurrentFileSource
-            ? [relationshipTargetFile, fileToUse]
-            : [fileToUse, relationshipTargetFile];
-          await addRelationToRelationsJson({
-            plugin,
-            sourceFile,
-            targetFile,
-            relationTypeId: relationshipTypeId,
+          await addRelationIfRequested(plugin, fileToUse, {
+            relationshipTypeId,
+            relationshipTargetFile,
+            isCurrentFileSource,
           });
         }
 

--- a/apps/obsidian/src/components/canvas/utils/nodeCreationFlow.ts
+++ b/apps/obsidian/src/components/canvas/utils/nodeCreationFlow.ts
@@ -8,6 +8,7 @@ import { addWikilinkBlockrefForFile } from "~/components/canvas/stores/assetStor
 import { showToast } from "./toastUtils";
 import { calcDiscourseNodeSize } from "~/utils/calcDiscourseNodeSize";
 import { getFirstImageSrcForFile } from "~/components/canvas/shapes/discourseNodeShapeUtils";
+import { addRelationToFrontmatter } from "./frontmatterUtils";
 
 export type CreateNodeAtArgs = {
   plugin: DiscourseGraphPlugin;
@@ -48,9 +49,6 @@ export const openCreateDiscourseNodeAt = (args: CreateNodeAtArgs): void => {
 
         // Add relationship to frontmatter if specified
         if (relationshipTypeId && relationshipTargetFile) {
-          const { addRelationToFrontmatter } = await import(
-            "~/components/canvas/utils/frontmatterUtils"
-          );
           await addRelationToFrontmatter({
             app: plugin.app,
             plugin,

--- a/apps/obsidian/src/components/canvas/utils/nodeCreationFlow.ts
+++ b/apps/obsidian/src/components/canvas/utils/nodeCreationFlow.ts
@@ -8,7 +8,7 @@ import { addWikilinkBlockrefForFile } from "~/components/canvas/stores/assetStor
 import { showToast } from "./toastUtils";
 import { calcDiscourseNodeSize } from "~/utils/calcDiscourseNodeSize";
 import { getFirstImageSrcForFile } from "~/components/canvas/shapes/discourseNodeShapeUtils";
-import { addRelationToFrontmatter } from "./frontmatterUtils";
+import { addRelationToRelationsJson } from "./relationJsonUtils";
 
 export type CreateNodeAtArgs = {
   plugin: DiscourseGraphPlugin;
@@ -49,8 +49,7 @@ export const openCreateDiscourseNodeAt = (args: CreateNodeAtArgs): void => {
 
         // Add relationship to frontmatter if specified
         if (relationshipTypeId && relationshipTargetFile) {
-          await addRelationToFrontmatter({
-            app: plugin.app,
+          await addRelationToRelationsJson({
             plugin,
             sourceFile: fileToUse,
             targetFile: relationshipTargetFile,

--- a/apps/obsidian/src/components/canvas/utils/relationJsonUtils.ts
+++ b/apps/obsidian/src/components/canvas/utils/relationJsonUtils.ts
@@ -44,3 +44,31 @@ export const addRelationToRelationsJson = async ({
   });
   return { alreadyExisted, relationInstanceId: id };
 };
+
+type RelationParams = {
+  relationshipTypeId?: string;
+  relationshipTargetFile?: TFile;
+  isCurrentFileSource?: boolean;
+};
+
+export const addRelationIfRequested = async (
+  plugin: DiscourseGraphPlugin,
+  createdOrSelectedFile: TFile,
+  params: RelationParams,
+): Promise<void> => {
+  const { relationshipTypeId, relationshipTargetFile, isCurrentFileSource } =
+    params;
+  if (!relationshipTypeId || !relationshipTargetFile) return;
+  if (relationshipTargetFile === createdOrSelectedFile) return;
+
+  const [sourceFile, targetFile] =
+    isCurrentFileSource === true
+      ? [relationshipTargetFile, createdOrSelectedFile]
+      : [createdOrSelectedFile, relationshipTargetFile];
+  await addRelationToRelationsJson({
+    plugin,
+    sourceFile,
+    targetFile,
+    relationTypeId: relationshipTypeId,
+  });
+};

--- a/apps/obsidian/src/components/canvas/utils/relationJsonUtils.ts
+++ b/apps/obsidian/src/components/canvas/utils/relationJsonUtils.ts
@@ -1,4 +1,4 @@
-import type { App, TFile } from "obsidian";
+import { Notice, type TFile } from "obsidian";
 import type DiscourseGraphPlugin from "~/index";
 import { addRelation, getNodeInstanceIdForFile } from "~/utils/relationsStore";
 
@@ -9,13 +9,11 @@ import { addRelation, getNodeInstanceIdForFile } from "~/utils/relationsStore";
  * @returns Object indicating whether the relation already existed and the relation instance id.
  */
 export const addRelationToRelationsJson = async ({
-  app,
   plugin,
   sourceFile,
   targetFile,
   relationTypeId,
 }: {
-  app: App;
   plugin: DiscourseGraphPlugin;
   sourceFile: TFile;
   targetFile: TFile;
@@ -23,8 +21,19 @@ export const addRelationToRelationsJson = async ({
 }): Promise<{ alreadyExisted: boolean; relationInstanceId?: string }> => {
   const sourceId = await getNodeInstanceIdForFile(plugin, sourceFile);
   const destId = await getNodeInstanceIdForFile(plugin, targetFile);
+
   if (!sourceId || !destId) {
-    console.warn("Could not resolve nodeInstanceIds for relation files");
+    const missing: string[] = [];
+    if (!sourceId) missing.push(`source (${sourceFile.basename})`);
+    if (!destId) missing.push(`target (${targetFile.basename})`);
+    console.warn(
+      "Could not resolve nodeInstanceIds for relation files:",
+      missing.join(", "),
+    );
+    new Notice(
+      "Could not create relation: one or both files are not discourse nodes or metadata is not ready.",
+      3000,
+    );
     return { alreadyExisted: false };
   }
 

--- a/apps/obsidian/src/constants.ts
+++ b/apps/obsidian/src/constants.ts
@@ -31,6 +31,13 @@ export const DEFAULT_NODE_TYPES: Record<string, DiscourseNode> = {
     created: now,
     modified: now,
   },
+  Source: {
+    id: generateUid("node"),
+    name: "Source",
+    format: "SRC - {content}",
+    color: "#3B82F6",
+    tag: "src-candidate",
+  },
 };
 export const DEFAULT_RELATION_TYPES: Record<string, DiscourseRelationType> = {
   supports: {
@@ -56,6 +63,12 @@ export const DEFAULT_RELATION_TYPES: Record<string, DiscourseRelationType> = {
     color: "grey",
     created: now,
     modified: now,
+  },
+  derivedFrom: {
+    id: generateUid("relation"),
+    label: "derived from",
+    complement: "has derivation",
+    color: "blue",
   },
 };
 
@@ -86,6 +99,11 @@ export const DEFAULT_SETTINGS: Settings = {
       relationshipTypeId: DEFAULT_RELATION_TYPES.opposes!.id,
       created: now,
       modified: now,
+    },
+    {
+      sourceId: DEFAULT_NODE_TYPES.Evidence!.id,
+      destinationId: DEFAULT_NODE_TYPES.Source!.id,
+      relationshipTypeId: DEFAULT_RELATION_TYPES.derivedFrom!.id,
     },
   ],
   showIdsInFrontmatter: false,

--- a/apps/obsidian/src/constants.ts
+++ b/apps/obsidian/src/constants.ts
@@ -5,7 +5,7 @@ import generateUid from "~/utils/generateUid";
 const now = new Date().getTime();
 
 export const DEFAULT_NODE_TYPES: Record<string, DiscourseNode> = {
-  Question: {
+  question: {
     id: generateUid("node"),
     name: "Question",
     format: "QUE - {content}",
@@ -13,7 +13,7 @@ export const DEFAULT_NODE_TYPES: Record<string, DiscourseNode> = {
     created: now,
     modified: now,
   },
-  Claim: {
+  claim: {
     id: generateUid("node"),
     name: "Claim",
     format: "CLM - {content}",
@@ -22,7 +22,7 @@ export const DEFAULT_NODE_TYPES: Record<string, DiscourseNode> = {
     created: now,
     modified: now,
   },
-  Evidence: {
+  evidence: {
     id: generateUid("node"),
     name: "Evidence",
     format: "EVD - {content}",
@@ -31,7 +31,7 @@ export const DEFAULT_NODE_TYPES: Record<string, DiscourseNode> = {
     created: now,
     modified: now,
   },
-  Source: {
+  source: {
     id: generateUid("node"),
     name: "Source",
     format: "SRC - {content}",
@@ -82,32 +82,32 @@ export const DEFAULT_SETTINGS: Settings = {
   discourseRelations: [
     {
       id: generateUid("rel3"),
-      sourceId: DEFAULT_NODE_TYPES.Evidence!.id,
-      destinationId: DEFAULT_NODE_TYPES.Question!.id,
+      sourceId: DEFAULT_NODE_TYPES.evidence!.id,
+      destinationId: DEFAULT_NODE_TYPES.question!.id,
       relationshipTypeId: DEFAULT_RELATION_TYPES.informs!.id,
       created: now,
       modified: now,
     },
     {
       id: generateUid("rel3"),
-      sourceId: DEFAULT_NODE_TYPES.Evidence!.id,
-      destinationId: DEFAULT_NODE_TYPES.Claim!.id,
+      sourceId: DEFAULT_NODE_TYPES.evidence!.id,
+      destinationId: DEFAULT_NODE_TYPES.claim!.id,
       relationshipTypeId: DEFAULT_RELATION_TYPES.supports!.id,
       created: now,
       modified: now,
     },
     {
       id: generateUid("rel3"),
-      sourceId: DEFAULT_NODE_TYPES.Evidence!.id,
-      destinationId: DEFAULT_NODE_TYPES.Claim!.id,
+      sourceId: DEFAULT_NODE_TYPES.evidence!.id,
+      destinationId: DEFAULT_NODE_TYPES.claim!.id,
       relationshipTypeId: DEFAULT_RELATION_TYPES.opposes!.id,
       created: now,
       modified: now,
     },
     {
       id: generateUid("rel3"),
-      sourceId: DEFAULT_NODE_TYPES.Evidence!.id,
-      destinationId: DEFAULT_NODE_TYPES.Source!.id,
+      sourceId: DEFAULT_NODE_TYPES.evidence!.id,
+      destinationId: DEFAULT_NODE_TYPES.source!.id,
       relationshipTypeId: DEFAULT_RELATION_TYPES.derivedFrom!.id,
       created: now,
       modified: now,

--- a/apps/obsidian/src/constants.ts
+++ b/apps/obsidian/src/constants.ts
@@ -37,6 +37,8 @@ export const DEFAULT_NODE_TYPES: Record<string, DiscourseNode> = {
     format: "SRC - {content}",
     color: "#3B82F6",
     tag: "src-candidate",
+    created: now,
+    modified: now,
   },
 };
 export const DEFAULT_RELATION_TYPES: Record<string, DiscourseRelationType> = {
@@ -69,6 +71,8 @@ export const DEFAULT_RELATION_TYPES: Record<string, DiscourseRelationType> = {
     label: "derived from",
     complement: "has derivation",
     color: "blue",
+    created: now,
+    modified: now,
   },
 };
 
@@ -101,9 +105,12 @@ export const DEFAULT_SETTINGS: Settings = {
       modified: now,
     },
     {
+      id: generateUid("rel3"),
       sourceId: DEFAULT_NODE_TYPES.Evidence!.id,
       destinationId: DEFAULT_NODE_TYPES.Source!.id,
       relationshipTypeId: DEFAULT_RELATION_TYPES.derivedFrom!.id,
+      created: now,
+      modified: now,
     },
   ],
   showIdsInFrontmatter: false,

--- a/apps/obsidian/src/utils/registerCommands.ts
+++ b/apps/obsidian/src/utils/registerCommands.ts
@@ -8,7 +8,7 @@ import { VIEW_TYPE_MARKDOWN, VIEW_TYPE_TLDRAW_DG_PREVIEW } from "~/constants";
 import { createCanvas } from "~/components/canvas/utils/tldraw";
 import { createOrUpdateDiscourseEmbedding } from "./syncDgNodesToSupabase";
 import { publishNode } from "./publishNode";
-import { addRelationToFrontmatter } from "~/components/canvas/utils/frontmatterUtils";
+import { addRelationToRelationsJson } from "~/components/canvas/utils/relationJsonUtils";
 
 export const registerCommands = (plugin: DiscourseGraphPlugin) => {
   plugin.addCommand({
@@ -48,8 +48,7 @@ export const registerCommands = (plugin: DiscourseGraphPlugin) => {
 
               // Add relationship if specified
               if (newFile && relationshipTypeId && relationshipTargetFile) {
-                await addRelationToFrontmatter({
-                  app: plugin.app,
+                await addRelationToRelationsJson({
                   plugin,
                   sourceFile: newFile,
                   targetFile: relationshipTargetFile,
@@ -94,8 +93,7 @@ export const registerCommands = (plugin: DiscourseGraphPlugin) => {
 
             // Add relationship if specified
             if (newFile && relationshipTypeId && relationshipTargetFile) {
-              await addRelationToFrontmatter({
-                app: plugin.app,
+              await addRelationToRelationsJson({
                 plugin,
                 sourceFile: newFile,
                 targetFile: relationshipTargetFile,

--- a/apps/obsidian/src/utils/registerCommands.ts
+++ b/apps/obsidian/src/utils/registerCommands.ts
@@ -8,6 +8,7 @@ import { VIEW_TYPE_MARKDOWN, VIEW_TYPE_TLDRAW_DG_PREVIEW } from "~/constants";
 import { createCanvas } from "~/components/canvas/utils/tldraw";
 import { createOrUpdateDiscourseEmbedding } from "./syncDgNodesToSupabase";
 import { publishNode } from "./publishNode";
+import { addRelationToFrontmatter } from "~/components/canvas/utils/frontmatterUtils";
 
 export const registerCommands = (plugin: DiscourseGraphPlugin) => {
   plugin.addCommand({
@@ -47,9 +48,6 @@ export const registerCommands = (plugin: DiscourseGraphPlugin) => {
 
               // Add relationship if specified
               if (newFile && relationshipTypeId && relationshipTargetFile) {
-                const { addRelationToFrontmatter } = await import(
-                  "~/components/canvas/utils/frontmatterUtils"
-                );
                 await addRelationToFrontmatter({
                   app: plugin.app,
                   plugin,
@@ -96,9 +94,6 @@ export const registerCommands = (plugin: DiscourseGraphPlugin) => {
 
             // Add relationship if specified
             if (newFile && relationshipTypeId && relationshipTargetFile) {
-              const { addRelationToFrontmatter } = await import(
-                "~/components/canvas/utils/frontmatterUtils"
-              );
               await addRelationToFrontmatter({
                 app: plugin.app,
                 plugin,

--- a/apps/obsidian/src/utils/registerCommands.ts
+++ b/apps/obsidian/src/utils/registerCommands.ts
@@ -17,9 +17,8 @@ type ModifyNodeSubmitParams = {
   title: string;
   initialFile?: TFile;
   selectedExistingNode?: TFile;
-  relationshipTypeId?: string;
+  relationshipId?: string;
   relationshipTargetFile?: TFile;
-  isCurrentFileSource?: boolean;
 };
 
 const createModifyNodeModalSubmitHandler = (
@@ -30,16 +29,14 @@ const createModifyNodeModalSubmitHandler = (
     nodeType,
     title,
     selectedExistingNode,
-    relationshipTypeId,
+    relationshipId,
     relationshipTargetFile,
-    isCurrentFileSource,
   }: ModifyNodeSubmitParams) => {
     if (selectedExistingNode) {
       editor.replaceSelection(`[[${selectedExistingNode.basename}]]`);
       await addRelationIfRequested(plugin, selectedExistingNode, {
-        relationshipTypeId,
+        relationshipId,
         relationshipTargetFile,
-        isCurrentFileSource,
       });
     } else {
       const newFile = await createDiscourseNode({
@@ -50,9 +47,8 @@ const createModifyNodeModalSubmitHandler = (
       });
       if (newFile) {
         await addRelationIfRequested(plugin, newFile, {
-          relationshipTypeId,
+          relationshipId,
           relationshipTargetFile,
-          isCurrentFileSource,
         });
       }
     }

--- a/apps/obsidian/src/utils/registerCommands.ts
+++ b/apps/obsidian/src/utils/registerCommands.ts
@@ -8,39 +8,9 @@ import { VIEW_TYPE_MARKDOWN, VIEW_TYPE_TLDRAW_DG_PREVIEW } from "~/constants";
 import { createCanvas } from "~/components/canvas/utils/tldraw";
 import { createOrUpdateDiscourseEmbedding } from "./syncDgNodesToSupabase";
 import { publishNode } from "./publishNode";
-import { addRelationToRelationsJson } from "~/components/canvas/utils/relationJsonUtils";
+import { addRelationIfRequested } from "~/components/canvas/utils/relationJsonUtils";
 import type { DiscourseNode } from "~/types";
 
-type RelationParams = {
-  relationshipTypeId?: string;
-  relationshipTargetFile?: TFile;
-  isCurrentFileSource?: boolean;
-};
-
-const addRelationIfRequested = async (
-  plugin: DiscourseGraphPlugin,
-  createdOrSelectedFile: TFile,
-  params: RelationParams,
-): Promise<void> => {
-  const {
-    relationshipTypeId,
-    relationshipTargetFile,
-    isCurrentFileSource,
-  } = params;
-  if (!relationshipTypeId || !relationshipTargetFile) return;
-  if (relationshipTargetFile === createdOrSelectedFile) return;
-
-  const [sourceFile, targetFile] =
-    isCurrentFileSource === true
-      ? [relationshipTargetFile, createdOrSelectedFile]
-      : [createdOrSelectedFile, relationshipTargetFile];
-  await addRelationToRelationsJson({
-    plugin,
-    sourceFile,
-    targetFile,
-    relationTypeId: relationshipTypeId,
-  });
-};
 
 type ModifyNodeSubmitParams = {
   nodeType: DiscourseNode;

--- a/apps/obsidian/src/utils/relationsStore.ts
+++ b/apps/obsidian/src/utils/relationsStore.ts
@@ -217,6 +217,27 @@ export const getNodeInstanceIdForFile = async (
   return await ensureNodeInstanceId(plugin, file, frontmatter);
 }
 
+/**
+ * Returns the node type id from a file's frontmatter (nodeTypeId).
+ * Waits for metadata cache if not yet available (e.g. after file creation).
+ */
+export const getNodeTypeIdForFile = async (
+  plugin: DiscourseGraphPlugin,
+  file: TFile,
+): Promise<string | null> => {
+  let frontmatter = plugin.app.metadataCache.getFileCache(file)?.frontmatter as
+    | Record<string, unknown>
+    | undefined;
+
+  if (!frontmatter?.nodeTypeId) {
+    frontmatter =
+      (await waitForDiscourseFrontmatter(plugin, file)) ?? undefined;
+  }
+
+  const nodeTypeId = frontmatter?.nodeTypeId;
+  return typeof nodeTypeId === "string" ? nodeTypeId : null;
+};
+
 export const getFileForNodeInstanceId = async (
   plugin: DiscourseGraphPlugin,
   nodeInstanceId: string,

--- a/apps/obsidian/src/utils/tagNodeHandler.ts
+++ b/apps/obsidian/src/utils/tagNodeHandler.ts
@@ -6,7 +6,7 @@ import type DiscourseGraphPlugin from "~/index";
 import ModifyNodeModal from "~/components/ModifyNodeModal";
 import { createDiscourseNodeFile, formatNodeName } from "./createNode";
 import { getNodeTagColors } from "./colorUtils";
-import { addRelationToFrontmatter } from "~/components/canvas/utils/frontmatterUtils";
+import { addRelationToRelationsJson } from "~/components/canvas/utils/relationJsonUtils";
 
 const HOVER_DELAY = 200;
 const HIDE_DELAY = 100;
@@ -347,8 +347,7 @@ export class TagNodeHandler {
 
       // Add relationship to frontmatter if specified
       if (relationshipTypeId && relationshipTargetFile) {
-        await addRelationToFrontmatter({
-          app: this.app,
+        await addRelationToRelationsJson({
           plugin: this.plugin,
           sourceFile: createdOrSelectedFile,
           targetFile: relationshipTargetFile,

--- a/apps/obsidian/src/utils/tagNodeHandler.ts
+++ b/apps/obsidian/src/utils/tagNodeHandler.ts
@@ -6,7 +6,7 @@ import type DiscourseGraphPlugin from "~/index";
 import ModifyNodeModal from "~/components/ModifyNodeModal";
 import { createDiscourseNodeFile, formatNodeName } from "./createNode";
 import { getNodeTagColors } from "./colorUtils";
-import { addRelationToRelationsJson } from "~/components/canvas/utils/relationJsonUtils";
+import { addRelationIfRequested } from "~/components/canvas/utils/relationJsonUtils";
 
 const HOVER_DELAY = 200;
 const HIDE_DELAY = 100;
@@ -41,9 +41,8 @@ type NodeCreationParams = {
   editor: Editor;
   tagElement: HTMLElement;
   selectedExistingNode?: TFile;
-  relationshipTypeId?: string;
+  relationshipId?: string;
   relationshipTargetFile?: TFile;
-  isCurrentFileSource?: boolean;
 };
 
 /**
@@ -286,9 +285,8 @@ export class TagNodeHandler {
         nodeType: selectedNodeType,
         title,
         selectedExistingNode,
-        relationshipTypeId,
+        relationshipId,
         relationshipTargetFile,
-        isCurrentFileSource,
       }) => {
         await this.createNodeAndReplace({
           nodeType: selectedNodeType,
@@ -296,9 +294,8 @@ export class TagNodeHandler {
           editor,
           tagElement,
           selectedExistingNode,
-          relationshipTypeId,
+          relationshipId,
           relationshipTargetFile,
-          isCurrentFileSource,
         });
       },
     }).open();
@@ -316,9 +313,8 @@ export class TagNodeHandler {
       editor,
       tagElement,
       selectedExistingNode,
-      relationshipTypeId,
+      relationshipId,
       relationshipTargetFile,
-      isCurrentFileSource,
     } = params;
     try {
       let linkText: string;
@@ -349,16 +345,10 @@ export class TagNodeHandler {
         createdOrSelectedFile = newFile;
       }
 
-      // Add relationship to frontmatter if specified
-      if (relationshipTypeId && relationshipTargetFile) {
-        const [sourceFile, targetFile] = isCurrentFileSource
-          ? [relationshipTargetFile, createdOrSelectedFile]
-          : [createdOrSelectedFile, relationshipTargetFile];
-        await addRelationToRelationsJson({
-          plugin: this.plugin,
-          sourceFile,
-          targetFile,
-          relationTypeId: relationshipTypeId,
+      if (relationshipId && relationshipTargetFile) {
+        await addRelationIfRequested(this.plugin, createdOrSelectedFile, {
+          relationshipId,
+          relationshipTargetFile,
         });
       }
 

--- a/apps/obsidian/src/utils/tagNodeHandler.ts
+++ b/apps/obsidian/src/utils/tagNodeHandler.ts
@@ -6,6 +6,7 @@ import type DiscourseGraphPlugin from "~/index";
 import ModifyNodeModal from "~/components/ModifyNodeModal";
 import { createDiscourseNodeFile, formatNodeName } from "./createNode";
 import { getNodeTagColors } from "./colorUtils";
+import { addRelationToFrontmatter } from "~/components/canvas/utils/frontmatterUtils";
 
 const HOVER_DELAY = 200;
 const HIDE_DELAY = 100;
@@ -346,9 +347,6 @@ export class TagNodeHandler {
 
       // Add relationship to frontmatter if specified
       if (relationshipTypeId && relationshipTargetFile) {
-        const { addRelationToFrontmatter } = await import(
-          "~/components/canvas/utils/frontmatterUtils"
-        );
         await addRelationToFrontmatter({
           app: this.app,
           plugin: this.plugin,

--- a/apps/obsidian/src/utils/tagNodeHandler.ts
+++ b/apps/obsidian/src/utils/tagNodeHandler.ts
@@ -43,6 +43,7 @@ type NodeCreationParams = {
   selectedExistingNode?: TFile;
   relationshipTypeId?: string;
   relationshipTargetFile?: TFile;
+  isCurrentFileSource?: boolean;
 };
 
 /**
@@ -287,6 +288,7 @@ export class TagNodeHandler {
         selectedExistingNode,
         relationshipTypeId,
         relationshipTargetFile,
+        isCurrentFileSource,
       }) => {
         await this.createNodeAndReplace({
           nodeType: selectedNodeType,
@@ -296,6 +298,7 @@ export class TagNodeHandler {
           selectedExistingNode,
           relationshipTypeId,
           relationshipTargetFile,
+          isCurrentFileSource,
         });
       },
     }).open();
@@ -315,6 +318,7 @@ export class TagNodeHandler {
       selectedExistingNode,
       relationshipTypeId,
       relationshipTargetFile,
+      isCurrentFileSource,
     } = params;
     try {
       let linkText: string;
@@ -347,10 +351,13 @@ export class TagNodeHandler {
 
       // Add relationship to frontmatter if specified
       if (relationshipTypeId && relationshipTargetFile) {
+        const [sourceFile, targetFile] = isCurrentFileSource
+          ? [relationshipTargetFile, createdOrSelectedFile]
+          : [createdOrSelectedFile, relationshipTargetFile];
         await addRelationToRelationsJson({
           plugin: this.plugin,
-          sourceFile: createdOrSelectedFile,
-          targetFile: relationshipTargetFile,
+          sourceFile,
+          targetFile,
           relationTypeId: relationshipTypeId,
         });
       }


### PR DESCRIPTION
https://www.loom.com/share/e89289108cd14d529e1fc81573dceae2

Adds auto-linking for Evidence and Source nodes to automatically create relationships when nodes are created from a contextual page.

This PR enhances the `ModifyNodeModal` to detect the current file's node type and the type of node being created, then suggests relevant relationships. Upon creation, the selected relationship is automatically added to the frontmatter of both linked nodes, streamlining the workflow for users creating related content.

---
Linear Issue: [ENG-1332](https://linear.app/discourse-graphs/issue/ENG-1332/auto-linking-src-to-evd)

<a href="https://cursor.com/background-agent?bcId=bc-800c3a2a-4c6e-47df-ac47-018a6d5ec18f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-800c3a2a-4c6e-47df-ac47-018a6d5ec18f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/730">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced "Source" node type for organizing reference materials
  * Added "derivedFrom" relationship type to connect Evidence nodes to sources
  * Enabled relationship selection during node creation with a new dropdown interface
  * Integrated relationship creation across node creation workflows

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->