### PR TITLE
[ENG-1340] Node type label removal

### DIFF
--- a/apps/obsidian/src/components/canvas/shapes/DiscourseNodeShape.tsx
+++ b/apps/obsidian/src/components/canvas/shapes/DiscourseNodeShape.tsx
@@ -458,15 +458,6 @@ const discourseNodeContent = memo(
         >
           {title || "..."}
         </h1>
-        <p
-          className="m-0 opacity-80"
-          style={{
-            fontSize: `${fontSize * 0.75}px`,
-            fontFamily,
-          }}
-        >
-          {nodeType?.name || ""}
-        </p>
       </div>
     );
   },

--- a/apps/obsidian/src/utils/calcDiscourseNodeSize.ts
+++ b/apps/obsidian/src/utils/calcDiscourseNodeSize.ts
@@ -32,11 +32,9 @@ export const calcDiscourseNodeSize = async ({
   fontFamily = "draw",
 }: CalcNodeSizeParams): Promise<{ w: number; h: number }> => {
   const nodeType = getNodeTypeById(plugin, nodeTypeId);
-  const nodeTypeName = nodeType?.name || "";
 
   const { w, h: textHeight } = measureNodeText({
     title,
-    subtitle: nodeTypeName,
     size,
     fontFamily,
   });

--- a/apps/obsidian/src/utils/measureNodeText.ts
+++ b/apps/obsidian/src/utils/measureNodeText.ts
@@ -31,22 +31,18 @@ import {
  * Structure matches DiscourseNodeShape.tsx:
  * - Container: p-2 border-2 rounded-md (box-border flex-col)
  * - Title (h1): m-1 with dynamic fontSize and fontFamily
- * - Subtitle (p): m-0 opacity-80 with fontSize * 0.75 and same fontFamily
  */
 export const measureNodeText = ({
   title,
-  subtitle,
   size = "s",
   fontFamily = "draw",
 }: {
   title: string;
-  subtitle: string;
   size?: TLDefaultSizeStyle;
   fontFamily?: TLDefaultFontStyle;
 }): { w: number; h: number } => {
   const fontSize = FONT_SIZES[size];
   const fontFamilyValue = FONT_FAMILIES[fontFamily];
-  const subtitleFontSize = fontSize * 0.75;
   // Create a container matching the actual component structure
   const container = document.createElement("div");
   container.style.setProperty("position", "absolute");
@@ -83,17 +79,7 @@ export const measureNodeText = ({
   titleEl.style.setProperty("font-weight", TITLE_FONT_WEIGHT as string);
   titleEl.textContent = title || "...";
 
-  // Create subtitle element: <p className="m-0 opacity-80" with fontSize * 0.75 and same fontFamily>
-  const subtitleEl = document.createElement("p");
-  subtitleEl.style.setProperty("margin", SUBTITLE_MARGIN as string);
-  subtitleEl.style.setProperty("font-size", `${subtitleFontSize}px`);
-  subtitleEl.style.setProperty("font-family", fontFamilyValue);
-  subtitleEl.style.setProperty("line-height", String(SUBTITLE_LINE_HEIGHT));
-  subtitleEl.style.setProperty("opacity", "0.8");
-  subtitleEl.textContent = subtitle || "";
-
   container.appendChild(titleEl);
-  container.appendChild(subtitleEl);
 
   // Append to body, measure, and remove
   document.body.appendChild(container);


### PR DESCRIPTION
Remove the node type label from Obsidian node cards to make them cleaner and more concise.

<img width="1728" height="1117" alt="image" src="https://github.com/user-attachments/assets/12728f65-4128-402e-a84a-8bef28388470" />


---
Linear Issue: [ENG-1340](https://linear.app/discourse-graphs/issue/ENG-1340/remove-node-type-label-from-node-card-obsidian)

<a href="https://cursor.com/background-agent?bcId=bc-0dd3342b-cf23-4cc6-8618-22ee9d34187f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0dd3342b-cf23-4cc6-8618-22ee9d34187f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/732">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed the subtitle displaying node type information that previously appeared below discourse node titles in the canvas. Discourse nodes now display only the node title and optional image element, with the secondary text line completely removed. This affects the visual presentation of all discourse nodes throughout the canvas application interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->