### PR TITLE
ENG-1336 - Remove redundant 'Convert To' prefix in Roam tldraw context menu

### DIFF
--- a/apps/roam/src/components/canvas/uiOverrides.tsx
+++ b/apps/roam/src/components/canvas/uiOverrides.tsx
@@ -163,7 +163,7 @@ export const CustomContextMenu = ({
                   <TldrawUiMenuItem
                     key={node.type}
                     id={`convert-to-${node.type}`}
-                    label={`Convert To ${node.text}`}
+                    label={node.text}
                     readonlyOk
                     onSelect={getOnSelectForShape({
                       shape: selectedShape,


### PR DESCRIPTION
### Motivation
- The tldraw context submenu was labeled `Convert To` and each submenu item also prefixed its label with `Convert To`, causing duplicated text in the menu.

### Description
- Updated `apps/roam/src/components/canvas/uiOverrides.tsx` to change the submenu item label from ``label={`Convert To ${node.text}`}`` to ``label={node.text}`` so items show only the target node name.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697120f6328083268ded4fb4dfca607b)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/734">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
