### PR TITLE
ENG-1349 - Implement admin panel visibility based on graph name in Settings component

### DIFF
--- a/apps/roam/src/components/settings/Settings.tsx
+++ b/apps/roam/src/components/settings/Settings.tsx
@@ -76,12 +76,16 @@ export const SettingsDialog = ({
   const [activeTabId, setActiveTabId] = useState<TabId>(
     selectedTabId ?? "discourse-graph-home-personal",
   );
+  const [showAdminPanel, setShowAdminPanel] = useState(
+    window.roamAlphaAPI.graph.name === "discourse-graphs" || false,
+  );
 
   useEffect(() => {
     const handleKeyPress = (e: KeyboardEvent) => {
       if (e.ctrlKey && e.shiftKey && e.key === "A") {
         e.stopPropagation();
         e.preventDefault();
+        setShowAdminPanel(true);
         setActiveTabId("secret-admin-panel");
       }
     };
@@ -216,11 +220,11 @@ export const SettingsDialog = ({
             />
           ))}
           <Tabs.Expander />
-          {/* Secret Dev Panel */}
+          {/* Secret Admin Panel */}
           <Tab
-            hidden={true}
+            hidden={!showAdminPanel}
             id="secret-admin-panel"
-            title="Secret Admin Panel"
+            title="Admin"
             className="overflow-y-auto"
             panel={<AdminPanel />}
           />


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/736">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
