### PR TITLE
ENG-1374 Use a singleton for the supabaseClient

### DIFF
--- a/apps/obsidian/src/utils/supabaseContext.ts
+++ b/apps/obsidian/src/utils/supabaseContext.ts
@@ -119,50 +119,35 @@ let loggedInClient: DGSupabaseClient | null = null;
 export const getLoggedInClient = async (
   plugin: DiscourseGraphPlugin,
 ): Promise<DGSupabaseClient | null> => {
-  if (loggedInClient === null) {
-    const context = await getSupabaseContext(plugin);
-    if (context === null) {
-      throw new Error("Could not create Supabase context");
-    }
-    try {
-      loggedInClient = await createLoggedInClient({
-        platform: context.platform,
-        spaceId: context.spaceId,
-        password: context.spacePassword,
-      });
-      if (!loggedInClient) {
-        throw new Error(
-          "Failed to create Supabase client - check environment variables",
-        );
-      }
-    } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : String(error);
-      console.error("Failed to create logged-in client:", errorMessage);
-      throw new Error(`Supabase authentication failed: ${errorMessage}`);
-    }
-  } else {
+  if (loggedInClient !== null) {
     // renew session
     const { error } = await loggedInClient.auth.getSession();
     if (error) {
       console.warn("Session renewal failed, re-authenticating:", error);
       loggedInClient = null;
-      const context = await getSupabaseContext(plugin);
-      if (context === null) {
-        throw new Error(
-          "Could not create Supabase context for re-authentication",
-        );
-      }
-
-      loggedInClient = await createLoggedInClient({
-        platform: context.platform,
-        spaceId: context.spaceId,
-        password: context.spacePassword,
-      });
-      if (!loggedInClient) {
-        throw new Error("Failed to re-authenticate Supabase client");
-      }
     }
+  }
+  if (loggedInClient === null) {
+    const context = await getSupabaseContext(plugin);
+    if (context === null) {
+      console.error("Could not create Supabase context");
+    } else
+      try {
+        loggedInClient = await createLoggedInClient({
+          platform: context.platform,
+          spaceId: context.spaceId,
+          password: context.spacePassword,
+        });
+        if (!loggedInClient) {
+          console.error(
+            "Failed to create Supabase client - check environment variables",
+          );
+        }
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : String(error);
+        console.error("Failed to create logged-in client:", errorMessage);
+      }
   }
   return loggedInClient;
 };

--- a/apps/obsidian/src/utils/supabaseContext.ts
+++ b/apps/obsidian/src/utils/supabaseContext.ts
@@ -4,6 +4,7 @@ import {
   fetchOrCreateSpaceDirect,
   fetchOrCreatePlatformAccount,
   createLoggedInClient,
+  FatalError,
 } from "@repo/database/lib/contextFunctions";
 import type DiscourseGraphPlugin from "~/index";
 
@@ -108,6 +109,7 @@ export const getSupabaseContext = async (
       };
     } catch (error) {
       console.error(error);
+      if (error instanceof FatalError) throw error;
       return null;
     }
   }

--- a/apps/roam/src/components/settings/AdminPanel.tsx
+++ b/apps/roam/src/components/settings/AdminPanel.tsx
@@ -29,7 +29,7 @@ import {
 } from "@repo/database/lib/queries";
 import migrateRelations from "~/utils/migrateRelations";
 import { countReifiedRelations } from "~/utils/createReifiedBlock";
-import { DGSupabaseClient } from "@repo/database/lib/client";
+import type { DGSupabaseClient } from "@repo/database/lib/client";
 import internalError from "~/utils/internalError";
 import SuggestiveModeSettings from "./SuggestiveModeSettings";
 import { getFormattedConfigTree } from "~/utils/discourseConfigRef";

--- a/apps/roam/src/utils/supabaseContext.ts
+++ b/apps/roam/src/utils/supabaseContext.ts
@@ -8,6 +8,7 @@ import getBlockProps from "~/utils/getBlockProps";
 import setBlockProps from "~/utils/setBlockProps";
 import type { Enums } from "@repo/database/dbTypes";
 import type { DGSupabaseClient } from "@repo/database/lib/client";
+import internalError from "./internalError";
 import {
   fetchOrCreateSpaceDirect,
   fetchOrCreatePlatformAccount,
@@ -90,23 +91,30 @@ export const getSupabaseContext = async (): Promise<SupabaseContext | null> => {
   return _contextCache;
 };
 
-let _loggedInClient: DGSupabaseClient | null = null;
+let loggedInClient: DGSupabaseClient | null = null;
 
 export const getLoggedInClient = async (): Promise<DGSupabaseClient | null> => {
-  if (_loggedInClient === null) {
-    const context = await getSupabaseContext();
-    if (context === null) throw new Error("Could not create context");
-    _loggedInClient = await createLoggedInClient({
-      platform: context.platform,
-      spaceId: context.spaceId,
-      password: context.spacePassword,
-    });
-  } else {
+  if (loggedInClient !== null) {
     // renew session
-    const { error } = await _loggedInClient.auth.getSession();
+    const { error } = await loggedInClient.auth.getSession();
     if (error) {
-      _loggedInClient = null;
+      loggedInClient = null;
     }
   }
-  return _loggedInClient;
+  if (loggedInClient === null) {
+    const context = await getSupabaseContext();
+    if (context === null) {
+      internalError({ error: "Could not create context" });
+    } else
+      try {
+        loggedInClient = await createLoggedInClient({
+          platform: context.platform,
+          spaceId: context.spaceId,
+          password: context.spacePassword,
+        });
+      } catch (error) {
+        internalError({ error, userMessage: "Could not access database" });
+      }
+  }
+  return loggedInClient;
 };

--- a/apps/roam/src/utils/supabaseContext.ts
+++ b/apps/roam/src/utils/supabaseContext.ts
@@ -13,6 +13,7 @@ import {
   fetchOrCreateSpaceDirect,
   fetchOrCreatePlatformAccount,
   createLoggedInClient,
+  FatalError,
 } from "@repo/database/lib/contextFunctions";
 
 declare const crypto: { randomUUID: () => string };
@@ -85,6 +86,7 @@ export const getSupabaseContext = async (): Promise<SupabaseContext | null> => {
       };
     } catch (error) {
       console.error(error);
+      if (error instanceof FatalError) throw error;
       return null;
     }
   }

--- a/apps/roam/src/utils/syncDgNodesToSupabase.ts
+++ b/apps/roam/src/utils/syncDgNodesToSupabase.ts
@@ -24,6 +24,7 @@ import { render as renderToast } from "roamjs-components/components/Toast";
 import internalError from "~/utils/internalError";
 type LocalContentDataInput = Partial<CompositeTypes<"content_local_input">>;
 type AccountLocalInput = CompositeTypes<"account_local_input">;
+import { FatalError } from "@repo/database/lib/contextFunctions";
 
 const SYNC_FUNCTION = "embedding";
 // Minimal interval between syncs of all clients for this task.
@@ -33,8 +34,6 @@ const BASE_SYNC_INTERVAL = 5 * 60 * 1000; // 5 minutes
 const SYNC_TIMEOUT = "20s";
 const BATCH_SIZE = 200;
 const DEFAULT_TIME = new Date("1970-01-01");
-
-class FatalError extends Error {}
 
 type SyncTaskInfo = {
   lastUpdateTime?: Date;
@@ -399,6 +398,7 @@ export const createOrUpdateDiscourseEmbedding = async (showToast = false) => {
     if (!worker) {
       throw new FatalError("Unable to obtain user UID.");
     }
+
     const supabaseClient = await getLoggedInClient();
     if (!supabaseClient) {
       // TODO: Distinguish connection vs credentials error

--- a/apps/roam/src/utils/syncDgNodesToSupabase.ts
+++ b/apps/roam/src/utils/syncDgNodesToSupabase.ts
@@ -18,7 +18,7 @@ import {
 } from "./conceptConversion";
 import { fetchEmbeddingsForNodes } from "./upsertNodesAsContentWithEmbeddings";
 import { convertRoamNodeToLocalContent } from "./upsertNodesAsContentWithEmbeddings";
-import { createClient, type DGSupabaseClient } from "@repo/database/lib/client";
+import type { DGSupabaseClient } from "@repo/database/lib/client";
 import type { Json, CompositeTypes, Enums } from "@repo/database/dbTypes";
 import { render as renderToast } from "roamjs-components/components/Toast";
 import internalError from "~/utils/internalError";
@@ -398,11 +398,6 @@ export const createOrUpdateDiscourseEmbedding = async (showToast = false) => {
   try {
     if (!worker) {
       throw new FatalError("Unable to obtain user UID.");
-    }
-    if (!createClient()) {
-      // not worth retrying
-      // TODO: Differentiate setup vs connetion error
-      throw new FatalError("Could not access supabase.");
     }
     const supabaseClient = await getLoggedInClient();
     if (!supabaseClient) {

--- a/packages/database/src/lib/client.ts
+++ b/packages/database/src/lib/client.ts
@@ -8,14 +8,19 @@ import type { Database } from "@repo/database/dbTypes";
 
 export type DGSupabaseClient = SupabaseClient<Database, "public">;
 
+let client: DGSupabaseClient | null | undefined = undefined;
+
 export const createClient = (): DGSupabaseClient | null => {
-  const url = process.env.SUPABASE_URL;
-  const key = process.env.SUPABASE_ANON_KEY;
+  if (client === undefined) {
+    const url = process.env.SUPABASE_URL;
+    const key = process.env.SUPABASE_ANON_KEY;
 
-  if (!url || !key) {
-    console.error("Missing required Supabase environment variables");
-    return null;
+    if (!url || !key) {
+      console.error("Missing required Supabase environment variables");
+      client = null;
+    } else {
+      client = createSupabaseClient<Database, "public">(url, key);
+    }
   }
-
-  return createSupabaseClient<Database, "public">(url, key);
+  return client;
 };

--- a/packages/database/src/lib/client.ts
+++ b/packages/database/src/lib/client.ts
@@ -1,26 +1,6 @@
-import {
-  type SupabaseClient,
-  createClient as createSupabaseClient,
-} from "@supabase/supabase-js";
+import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@repo/database/dbTypes";
 
 // Inspired by https://supabase.com/ui/docs/react/password-based-auth
 
 export type DGSupabaseClient = SupabaseClient<Database, "public">;
-
-let client: DGSupabaseClient | null | undefined = undefined;
-
-export const createClient = (): DGSupabaseClient | null => {
-  if (client === undefined) {
-    const url = process.env.SUPABASE_URL;
-    const key = process.env.SUPABASE_ANON_KEY;
-
-    if (!url || !key) {
-      console.error("Missing required Supabase environment variables");
-      client = null;
-    } else {
-      client = createSupabaseClient<Database, "public">(url, key);
-    }
-  }
-  return client;
-};

--- a/packages/database/src/lib/contextFunctions.ts
+++ b/packages/database/src/lib/contextFunctions.ts
@@ -37,6 +37,8 @@ export const asPostgrestFailure = (
   };
 };
 
+export class FatalError extends Error {}
+
 export const spaceValidator = (space: SpaceCreationInput): string | null => {
   if (!space || typeof space !== "object")
     return "Invalid request body: expected a JSON object.";
@@ -91,8 +93,8 @@ const createSingletonClient = (): DGSupabaseClient | null => {
     const key = process.env.SUPABASE_ANON_KEY;
 
     if (!url || !key) {
-      console.error("Missing required Supabase environment variables");
       client = null;
+      throw new FatalError("Missing required Supabase environment variables");
     } else {
       client = createClient<Database, "public">(url, key);
     }

--- a/packages/database/src/lib/contextFunctions.ts
+++ b/packages/database/src/lib/contextFunctions.ts
@@ -164,10 +164,14 @@ export const createLoggedInClient = async ({
 }): Promise<DGSupabaseClient | null> => {
   const client: DGSupabaseClient | null = createSingletonClient();
   if (!client) return null;
-  const session = await client.auth.getSession();
-  if (session.data.session)
-    return client;  // already logged in
   const email = spaceAnonUserEmail(platform, spaceId);
+  const session = await client.auth.getSession();
+  if (session.data.session) {
+    if (session.data.session.user.email === email)
+      return client;  // already logged in
+    else
+      await client.auth.signOut();
+  }
   const { error } = await client.auth.signInWithPassword({
     email,
     password: password,


### PR DESCRIPTION
https://linear.app/discourse-graphs/issue/ENG-1374/use-a-singleton-for-the-supabaseclient

Problem: 

When we log into supabase, the token is added to localStorage, and is shared between supabase instances, leading to many erratic behaviours.

We also get error messages about multiple GoTrue clients.

Solution: use a singleton for the base createClient function, and force supabase to use a vault-specific key in localStorage.

Hide the createClient function, and it is now only used in the fetchOrCreateSpaceDirect function, where we have vault information.

An earlier attempt at solving the problem was [ENG-1372](https://linear.app/discourse-graphs/issue/ENG-1372/index-supabasecontext-and-loggedinclient-with-vaultid-since-globals), which will be reverted in this PR.

https://www.loom.com/share/3fb193fe206b43a8bea1ecf9e2ed6939

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/739">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
