### PR TITLE
ENG-1331 Discourse relation panel does not reliably update when relations are created or deleted

### DIFF
--- a/apps/roam/src/components/DiscourseContext.tsx
+++ b/apps/roam/src/components/DiscourseContext.tsx
@@ -280,7 +280,7 @@ const ContextTab = ({
             <CreateRelationButton
               sourceNodeUid={parentUid}
               onClose={() => {
-                window.setTimeout(onRefresh, 450, true);
+                window.setTimeout(onRefresh, 150, true);
               }}
             />
             <Switch
@@ -360,7 +360,7 @@ export const ContextContent = ({ uid, results, overlayRefresh }: Props) => {
   );
 
   const delayedRefresh = () => {
-    window.setTimeout(onRefresh, 450, true);
+    window.setTimeout(onRefresh, 150, true);
   };
 
   useEffect(() => {

--- a/apps/roam/src/utils/getDiscourseContextResults.ts
+++ b/apps/roam/src/utils/getDiscourseContextResults.ts
@@ -124,7 +124,9 @@ const buildQueryConfig = ({
     isComplement,
   };
 
-  if (resultCache[cacheKey] && !ignoreCache) {
+  if (ignoreCache) delete resultCache[cacheKey];
+
+  if (resultCache[cacheKey]) {
     return {
       relation,
       queryPromise: () => Promise.resolve(resultCache[cacheKey]),


### PR DESCRIPTION
https://linear.app/discourse-graphs/issue/ENG-1331/discourse-relation-panel-does-not-reliably-update-when-relations-are

First, when the ignoreCache is sent to calculations, don't just ignore the cache but clear it. Otherwise another query can come in and  use the invalid cache.

Second, there were a few refresh functions that did not clear the cache.

https://www.loom.com/share/30db4346f43648ff8a3f18a5570b97fa


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/742">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
