### PR TITLE
ENG-1386: Fix bug: doing initSchema in between prevents blocks being created in roam js discourse graph page

### DIFF
--- a/apps/roam/src/index.ts
+++ b/apps/roam/src/index.ts
@@ -80,7 +80,7 @@ export default runExtension(async (onloadArgs) => {
   refreshConfigTree();
 
   // For testing purposes
-  await initSchema();
+  // await initSchema();
   addGraphViewNodeStyling();
   registerCommandPaletteCommands(onloadArgs);
   createSettingsPanel(onloadArgs);


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/746">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
