### PR TITLE
[ENG-1277] Fix overflow node card to pair with Roam

### DIFF
--- a/apps/obsidian/src/components/canvas/shapes/DiscourseNodeShape.tsx
+++ b/apps/obsidian/src/components/canvas/shapes/DiscourseNodeShape.tsx
@@ -400,7 +400,7 @@ const discourseNodeContent = memo(
         // NOTE: These Tailwind classes (p-2, border-2, rounded-md, m-1, text-base, m-0, text-sm)
         // correspond to constants in nodeConstants.ts. If you change these classes, update the
         // constants and the measureNodeText function to keep measurements accurate.
-        className="relative box-border flex h-full w-full flex-col items-start justify-center rounded-md border-2 p-2"
+        className="relative box-border flex h-full w-full flex-col items-start justify-center overflow-hidden rounded-md border-2 p-2"
       >
         {isHovered && (
           <button


### PR DESCRIPTION
The name:
<img width="946" height="518" alt="Screenshot 2026-02-05 at 14 45 48" src="https://github.com/user-attachments/assets/d0ed92af-a231-4136-bd7e-7618b9e48300" />

Actual render of the node card: 
<img width="695" height="278" alt="image" src="https://github.com/user-attachments/assets/28cc6967-2b21-44c7-b23f-6d5ffebe7e6f" />

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/750" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
