### PR TITLE
Update Reified Relation Documentation

### DIFF
--- a/apps/website/app/(docs)/docs/roam/navigation.ts
+++ b/apps/website/app/(docs)/docs/roam/navigation.ts
@@ -27,7 +27,7 @@ export const navigation: NavigationList = [
       },
       {
         title: "Stored relations",
-        href: `${ROOT}/reified-relations`,
+        href: `${ROOT}/stored-relations`,
       },
       {
         title: "Migration to stored relations",

--- a/apps/website/app/(docs)/docs/roam/navigation.ts
+++ b/apps/website/app/(docs)/docs/roam/navigation.ts
@@ -26,6 +26,14 @@ export const navigation: NavigationList = [
         href: `${ROOT}/creating-discourse-relationships`,
       },
       {
+        title: "Stored relations",
+        href: `${ROOT}/reified-relations`,
+      },
+      {
+        title: "Migration to stored relations",
+        href: `${ROOT}/migration-to-stored-relations`,
+      },
+      {
         title: "Exploring",
         href: `${ROOT}/exploring-discourse-graph`,
       },

--- a/apps/website/app/(docs)/docs/roam/pages/creating-discourse-relationships.md
+++ b/apps/website/app/(docs)/docs/roam/pages/creating-discourse-relationships.md
@@ -9,6 +9,10 @@ One of the main features of the Discourse Graph extension is the ability to **cr
 
 The extension has an in-built [grammar](./grammar) that enables it to recognize when certain patterns of writing and outlining are meant to express particular discourse relations (e.g., support, oppose, inform) between discourse nodes. When it recognizes these patterns, it "writes" them to a formal discourse graph data structure, that you can then use to explore or query your discourse graph.
 
+## Deprecation notice
+
+Pattern-based relations are being deprecated. Please plan to move to [**stored relations**](./reified-relations), which will be the recommended way to define and persist discourse relations. Migration guidance is available in [**Migration to stored relations**](./migration-to-stored-relations).
+
 ## Stock Patterns
 
 - Take a look at [Relations Patterns](./relations-patterns)

--- a/apps/website/app/(docs)/docs/roam/pages/creating-discourse-relationships.md
+++ b/apps/website/app/(docs)/docs/roam/pages/creating-discourse-relationships.md
@@ -11,7 +11,7 @@ The extension has an in-built [grammar](./grammar) that enables it to recognize 
 
 ## Deprecation notice
 
-Pattern-based relations are being deprecated. Please plan to move to [**stored relations**](./reified-relations), which will be the recommended way to define and persist discourse relations. Migration guidance is available in [**Migration to stored relations**](./migration-to-stored-relations).
+Pattern-based relations are being deprecated. Please plan to move to [**stored relations**](./stored-relations), which will be the recommended way to define and persist discourse relations. Migration guidance is available in [**Migration to stored relations**](./migration-to-stored-relations).
 
 ## Stock Patterns
 

--- a/apps/website/app/(docs)/docs/roam/pages/migration-to-stored-relations.md
+++ b/apps/website/app/(docs)/docs/roam/pages/migration-to-stored-relations.md
@@ -11,7 +11,7 @@ published: true
 
 Stored relations make relations load faster and more reliably. To start using them, your graph needs a one-time migration that copies your existing relations into the new format.
 
-This guide covers the migration flow from **Personal Settings**. If you’re new to stored relations, start with the [stored relations overview](./reified-relations).
+This guide covers the migration flow from **Personal Settings**. If you’re new to stored relations, start with the [stored relations overview](./stored-relations).
 
 ## Turn on stored relations
 

--- a/apps/website/app/(docs)/docs/roam/pages/migration-to-stored-relations.md
+++ b/apps/website/app/(docs)/docs/roam/pages/migration-to-stored-relations.md
@@ -1,0 +1,92 @@
+---
+title: "Migration to stored relations"
+date: "2025-01-01"
+author: ""
+published: true
+---
+
+## Migrate relations to stored relations
+
+### Summary
+
+Stored relations make relations load faster and more reliably. To start using them, your graph needs a one-time migration that copies your existing relations into the new format.
+
+This guide covers the migration flow from **Personal Settings**. If you’re new to stored relations, start with the [stored relations overview](./reified-relations).
+
+## Turn on stored relations
+
+1. Open **Personal Settings**
+2. Go to the **Home** panel
+3. Find **Enable stored relations**
+4. Turn the toggle **On**
+
+When you turn this on, you’ll be shown a migration step for your graph.
+
+## Migrate your existing relations
+
+After enabling the toggle, click:
+
+**Migrate all relations**
+
+What to expect:
+
+- It may take a few minutes
+- Roam may feel frozen while it runs (this is expected)
+- You **can** work in **another Roam window** during the migration
+- When it finishes, you can continue working normally
+
+## When should I run migration again?
+
+You only need to run migration again if:
+
+- Relations were created while stored relations were turned off
+- Your team is transitioning gradually and some people are still using the older relation method
+
+## Multi-user graphs
+
+Migration runs **per graph**, but the stored relations toggle is **per user**. During rollout, it’s possible for teammates to be in different modes.
+
+If some users are still using the older relation method, running migration again later helps ensure you see the most up-to-date relations.
+
+### What each user sees
+
+#### If you do NOT opt in
+
+- You can keep using **patterns** to create relations
+- The overlay will search **only pattern-based** relations
+- You **will not** see data-based relations
+
+#### If you DO opt in
+
+- You will see **only data-based** relations
+- You **will not** see pattern-based relations
+
+### Re-running migration (multi-user / mixed mode)
+
+You can run migration **multiple times**.
+
+This matters if:
+
+- Some users are still creating **pattern-based** relations
+- Other users have opted into **data-based** relations
+
+In that case, opt-in users must re-run migration to “catch up,” otherwise:
+
+- They won’t see new pattern-based relations created since the last migration
+
+#### Important edge case
+
+If you:
+
+1. Delete a **data-based** relation that originally came from a pattern, and then
+2. Re-run migration
+
+… it will be **re-created** from the still-existing pattern.
+
+### For the technically inclined
+
+Data-based relations are stored in:
+
+- `roam/js/discourse-graph/relations`
+
+Each relation is a **block**, with relation data stored in the block’s **hidden properties**.

--- a/apps/website/app/(docs)/docs/roam/pages/migration-to-stored-relations.md
+++ b/apps/website/app/(docs)/docs/roam/pages/migration-to-stored-relations.md
@@ -5,9 +5,7 @@ author: ""
 published: true
 ---
 
-## Migrate relations to stored relations
-
-### Summary
+# Overview
 
 Stored relations make relations load faster and more reliably. To start using them, your graph needs a one-time migration that copies your existing relations into the new format.
 

--- a/apps/website/app/(docs)/docs/roam/pages/migration-to-stored-relations.md
+++ b/apps/website/app/(docs)/docs/roam/pages/migration-to-stored-relations.md
@@ -26,7 +26,7 @@ When you turn this on, you’ll be shown a migration step for your graph.
 
 After enabling the toggle, click:
 
-**Migrate all relations**
+`Migrate all relations`
 
 What to expect:
 

--- a/apps/website/app/(docs)/docs/roam/pages/reified-relations.md
+++ b/apps/website/app/(docs)/docs/roam/pages/reified-relations.md
@@ -1,0 +1,131 @@
+---
+title: "Stored relations"
+date: "2025-01-01"
+author: ""
+published: true
+---
+
+## Stored relations
+
+### Overview
+
+Stored relations change how relationships between discourse nodes are created and managed.
+
+Instead of being inferred from patterns in your Roam graph, **stored relations are created and deleted explicitly** and saved as data. This makes relations faster to query, more reliable, and easier to manage.
+
+Stored relations are the foundation for improved performance and a more usable Discourse context overlay.
+
+---
+
+### What is a stored relation?
+
+A **stored relation** is an explicit relationship between two discourse nodes (for example, a claim supporting or opposing another claim).
+
+- Created directly in the [**Discourse context overlay**](./discourse-context-overlay)
+- Persisted as data in your graph
+- Independent of page structure or pattern matching
+
+Once created, stored relations behave consistently across queries, canvases, and overlays.
+
+---
+
+### Why stored relations?
+
+Stored relations provide several benefits over pattern-based relations:
+
+- **Faster performance**
+  - Relations are read directly from stored data
+  - The global Discourse context overlay loads significantly faster
+- **More predictable behavior**
+  - Relations do not disappear due to formatting or structural changes
+  - Editing text or reorganizing blocks does not affect relations
+- **Clearer mental model**
+  - Relations exist because you created them
+  - Deleting a relation removes it explicitly
+
+---
+
+### Creating stored relations
+
+Stored relations are created from the [**Discourse context overlay**](./discourse-context-overlay).
+
+Typical flow:
+
+1. Open the Discourse context overlay for a node
+2. Click **Add relation**
+3. Select the relation type
+4. Select the source and destination nodes
+
+The relation is immediately stored and available to all users who have enabled stored relations.
+
+---
+
+### Viewing stored relations
+
+When stored relations are enabled:
+
+- The [Discourse Context Overlay](./discourse-context-overlay) shows **only stored relations**
+- Queries and canvases resolve relations from stored data
+- Pattern-based relations are ignored
+
+This ensures consistent and fast results.
+
+---
+
+### Editing and deleting stored relations
+
+- Stored relations can be **deleted explicitly** from the Discourse context overlay
+- In most cases, editing a relation is equivalent to:
+  - Deleting the old relation
+  - Creating a new one
+
+Relation labels are referenced by node identity, so renaming a relation label updates all associated relations automatically.
+
+---
+
+### Multi-user behavior
+
+Stored relations are shared across the graph:
+
+- All users with stored relations enabled see the same relations
+- Users without stored relations enabled will not see them
+- Mixed usage is supported temporarily during the transition period
+
+For details on migrating and mixed-mode behavior, see the [**stored relations migration**](./migration-to-stored-relations) documentation.
+
+---
+
+### Current limitations and notes
+
+- Stored relations are **not inferred** from patterns
+- Creating or deleting patterns does not affect stored relations
+- Stored relations are currently opt-in during the transition period
+
+These limitations will be removed once stored relations become the default.
+
+---
+
+### For the technically inclined
+
+Stored relations are implemented as:
+
+- One block per relation
+- Located at: `roam/js/discourse-graph/relations`
+- Relation data stored in the block’s hidden properties
+- Source and destination nodes referenced by UID
+
+This structure allows fast lookup, consistent rendering, and future extensions (metadata, provenance, annotations).
+
+---
+
+### Future direction
+
+Stored relations will eventually replace pattern-based relations entirely.
+
+Once the transition period ends:
+
+- Stored relations will be the default
+- Pattern-based relations will be phased out
+- Migration will be handled automatically
+
+Until then, stored relations are available as an opt-in feature for users who want improved performance and reliability.

--- a/apps/website/app/(docs)/docs/roam/pages/relations-patterns.md
+++ b/apps/website/app/(docs)/docs/roam/pages/relations-patterns.md
@@ -5,6 +5,10 @@ author: ""
 published: true
 ---
 
+## Deprecation notice
+
+Pattern-based relations are being deprecated. Please plan to move to [**stored relations**](./reified-relations), which will be the recommended way to define and persist discourse relations. Migration guidance is available in [**Migration to stored relations**](./migration-to-stored-relations).
+
 ## Stock Patterns
 
 The extension ships with the ability to recognize three such writing/outlining patterns. Give them a try!

--- a/apps/website/app/(docs)/docs/roam/pages/relations-patterns.md
+++ b/apps/website/app/(docs)/docs/roam/pages/relations-patterns.md
@@ -7,7 +7,7 @@ published: true
 
 ## Deprecation notice
 
-Pattern-based relations are being deprecated. Please plan to move to [**stored relations**](./reified-relations), which will be the recommended way to define and persist discourse relations. Migration guidance is available in [**Migration to stored relations**](./migration-to-stored-relations).
+Pattern-based relations are being deprecated. Please plan to move to [**stored relations**](./stored-relations), which will be the recommended way to define and persist discourse relations. Migration guidance is available in [**Migration to stored relations**](./migration-to-stored-relations).
 
 ## Stock Patterns
 

--- a/apps/website/app/(docs)/docs/roam/pages/stored-relations.md
+++ b/apps/website/app/(docs)/docs/roam/pages/stored-relations.md
@@ -5,9 +5,7 @@ author: ""
 published: true
 ---
 
-## Stored relations
-
-### Overview
+# Overview
 
 Stored relations change how relationships between discourse nodes are created and managed.
 
@@ -15,7 +13,7 @@ Instead of being inferred from patterns in your Roam graph, **stored relations a
 
 Stored relations are the foundation for improved performance and a more usable Discourse context overlay.
 
-### What is a stored relation?
+# What is a stored relation?
 
 A **stored relation** is an explicit relationship between two discourse nodes (for example, a claim supporting or opposing another claim).
 
@@ -25,7 +23,7 @@ A **stored relation** is an explicit relationship between two discourse nodes (f
 
 Once created, stored relations behave consistently across queries, canvases, and overlays.
 
-### Why stored relations?
+# Why stored relations?
 
 Stored relations provide several benefits over pattern-based relations:
 
@@ -39,7 +37,7 @@ Stored relations provide several benefits over pattern-based relations:
   - Relations exist because you created them
   - Deleting a relation removes it explicitly
 
-### Creating stored relations
+# Creating stored relations
 
 Stored relations are created from the [**Discourse context overlay**](./discourse-context-overlay).
 
@@ -52,7 +50,7 @@ Typical flow:
 
 The relation is immediately stored and available to all users who have enabled stored relations.
 
-### Viewing stored relations
+# Viewing stored relations
 
 When stored relations are enabled:
 
@@ -62,7 +60,7 @@ When stored relations are enabled:
 
 This ensures consistent and fast results.
 
-### Editing and deleting stored relations
+# Editing and deleting stored relations
 
 - Stored relations can be **deleted explicitly** from the Discourse context overlay
 - In most cases, editing a relation is equivalent to:
@@ -71,7 +69,7 @@ This ensures consistent and fast results.
 
 Relation labels are referenced by node identity, so renaming a relation label updates all associated relations automatically.
 
-### Multi-user behavior
+# Multi-user behavior
 
 Stored relations are shared across the graph:
 
@@ -81,7 +79,7 @@ Stored relations are shared across the graph:
 
 For details on migrating and mixed-mode behavior, see the [**stored relations migration**](./migration-to-stored-relations) documentation.
 
-### Current limitations and notes
+# Current limitations and notes
 
 - Stored relations are **not inferred** from patterns
 - Creating or deleting patterns does not affect stored relations
@@ -89,7 +87,7 @@ For details on migrating and mixed-mode behavior, see the [**stored relations mi
 
 These limitations will be removed once stored relations become the default.
 
-### For the technically inclined
+# For the technically inclined
 
 Stored relations are implemented as:
 
@@ -100,7 +98,7 @@ Stored relations are implemented as:
 
 This structure allows fast lookup, consistent rendering, and future extensions (metadata, provenance, annotations).
 
-### Future direction
+# Future direction
 
 Stored relations will eventually replace pattern-based relations entirely.
 

--- a/apps/website/app/(docs)/docs/roam/pages/stored-relations.md
+++ b/apps/website/app/(docs)/docs/roam/pages/stored-relations.md
@@ -15,8 +15,6 @@ Instead of being inferred from patterns in your Roam graph, **stored relations a
 
 Stored relations are the foundation for improved performance and a more usable Discourse context overlay.
 
----
-
 ### What is a stored relation?
 
 A **stored relation** is an explicit relationship between two discourse nodes (for example, a claim supporting or opposing another claim).
@@ -26,8 +24,6 @@ A **stored relation** is an explicit relationship between two discourse nodes (f
 - Independent of page structure or pattern matching
 
 Once created, stored relations behave consistently across queries, canvases, and overlays.
-
----
 
 ### Why stored relations?
 
@@ -43,8 +39,6 @@ Stored relations provide several benefits over pattern-based relations:
   - Relations exist because you created them
   - Deleting a relation removes it explicitly
 
----
-
 ### Creating stored relations
 
 Stored relations are created from the [**Discourse context overlay**](./discourse-context-overlay).
@@ -58,8 +52,6 @@ Typical flow:
 
 The relation is immediately stored and available to all users who have enabled stored relations.
 
----
-
 ### Viewing stored relations
 
 When stored relations are enabled:
@@ -70,8 +62,6 @@ When stored relations are enabled:
 
 This ensures consistent and fast results.
 
----
-
 ### Editing and deleting stored relations
 
 - Stored relations can be **deleted explicitly** from the Discourse context overlay
@@ -80,8 +70,6 @@ This ensures consistent and fast results.
   - Creating a new one
 
 Relation labels are referenced by node identity, so renaming a relation label updates all associated relations automatically.
-
----
 
 ### Multi-user behavior
 
@@ -93,8 +81,6 @@ Stored relations are shared across the graph:
 
 For details on migrating and mixed-mode behavior, see the [**stored relations migration**](./migration-to-stored-relations) documentation.
 
----
-
 ### Current limitations and notes
 
 - Stored relations are **not inferred** from patterns
@@ -102,8 +88,6 @@ For details on migrating and mixed-mode behavior, see the [**stored relations mi
 - Stored relations are currently opt-in during the transition period
 
 These limitations will be removed once stored relations become the default.
-
----
 
 ### For the technically inclined
 
@@ -115,8 +99,6 @@ Stored relations are implemented as:
 - Source and destination nodes referenced by UID
 
 This structure allows fast lookup, consistent rendering, and future extensions (metadata, provenance, annotations).
-
----
 
 ### Future direction
 


### PR DESCRIPTION
### Motivation

- Introduce comprehensive documentation for the new stored (reified) relations feature and provide clear migration guidance from pattern-based relations.
- Surface the new docs in the Roam documentation navigation so users can discover stored relations and migration guidance easily.
- Inform users that pattern-based relations are being deprecated and point them to the new stored relations workflow and migration instructions.

### Description

- Added `apps/website/app/(docs)/docs/roam/pages/reified-relations.md` which documents stored relations, multi-user behavior, implementation notes, and future direction.
- Added `apps/website/app/(docs)/docs/roam/pages/migration-to-stored-relations.md` which describes the migration flow, mixed-mode behavior, and edge cases.
- Updated `apps/website/app/(docs)/docs/roam/navigation.ts` to expose links for `reified-relations` and `migration-to-stored-relations` in the Roam docs navigation.
- Inserted deprecation notices into `creating-discourse-relationships.md` and `relations-patterns.md` and fixed internal cross-links to `./discourse-context-overlay` and between the stored relations and migration pages.

### Testing

- No automated tests were run because these are documentation-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698923ca6230832680960be6691bfeb2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/756" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
