### PR TITLE
ENG-1358 - Hide canvas relation when reified relations enabled

### DIFF
--- a/apps/roam/src/components/settings/DiscourseRelationConfigPanel.tsx
+++ b/apps/roam/src/components/settings/DiscourseRelationConfigPanel.tsx
@@ -50,6 +50,7 @@ import { getConditionLabels } from "~/utils/conditionToDatalog";
 import { formatHexColor } from "./DiscourseNodeCanvasSettings";
 import posthog from "posthog-js";
 import { getSetting, setSetting } from "~/utils/extensionSettings";
+import { USE_REIFIED_RELATIONS } from "~/data/userSettings";
 
 const DEFAULT_SELECTED_RELATION = {
   display: "none",
@@ -975,6 +976,18 @@ const DiscourseRelationConfigPanel: CustomField["options"]["component"] = ({
   const [deleteConfirmation, setDeleteConfirmation] = useState<string | null>(
     null,
   );
+  const shouldHideCanvasRelation = getSetting<boolean>(
+    USE_REIFIED_RELATIONS,
+    false,
+  );
+  const visibleRelations = useMemo(() => {
+    if (!shouldHideCanvasRelation) {
+      return relations;
+    }
+    // Deprecated: hide "canvas" relations; this will be removed in the future
+    // when the pattern -> stored relation migration is complete.
+    return relations.filter((relation) => relation.text !== "canvas");
+  }, [relations, shouldHideCanvasRelation]);
   const editingRelationInfo = useMemo(
     () =>
       editingRelation ? getFullTreeByParentUid(editingRelation) : undefined,
@@ -1093,7 +1106,7 @@ const DiscourseRelationConfigPanel: CustomField["options"]["component"] = ({
           </tr>
         </thead>
         <tbody>
-          {relations.map((rel) => (
+          {visibleRelations.map((rel) => (
             <tr key={rel.uid} onClick={() => handleEdit(rel)}>
               <td style={{ verticalAlign: "middle" }}>
                 {nodes[rel.source || ""]?.label}

--- a/apps/roam/src/components/settings/DiscourseRelationConfigPanel.tsx
+++ b/apps/roam/src/components/settings/DiscourseRelationConfigPanel.tsx
@@ -387,8 +387,9 @@ export const RelationEditPanel = ({
   );
   const saveCyToElementRef = useCallback(
     (t: number) => {
-      const nodes = cyRef.current?.nodes() || [];
-      const edges = cyRef.current?.edges() || [];
+      if (!cyRef.current) return;
+      const nodes = cyRef.current.nodes();
+      const edges = cyRef.current.edges();
       elementsRef.current[t] = [
         ...nodes.map((n) => ({ data: n.data(), position: n.position() })),
         ...edges.map((n) => ({ data: n.data() })),
@@ -713,9 +714,9 @@ export const RelationEditPanel = ({
           <MenuItemSelect
             activeItem={source}
             onItemSelect={(e) => {
+              unsavedChanges();
+              setSource(e);
               if (cyRef.current) {
-                unsavedChanges();
-                setSource(e);
                 (cyRef.current.nodes("#source") as cytoscape.NodeSingular).data(
                   "node",
                   nodes[e]?.label,
@@ -731,9 +732,9 @@ export const RelationEditPanel = ({
           <MenuItemSelect
             activeItem={destination}
             onItemSelect={(e) => {
+              unsavedChanges();
+              setDestination(e);
               if (cyRef.current) {
-                unsavedChanges();
-                setDestination(e);
                 (
                   cyRef.current.nodes("#destination") as cytoscape.NodeSingular
                 ).data("node", nodes[e]?.label);


### PR DESCRIPTION
https://www.loom.com/share/41673148f5154e8583926aca5289dfc4

### Motivation
- Prevent the legacy "canvas" relation from being shown when reified relations are enabled to avoid user confusion while migrating from pattern -> stored relations.

### Description
- Read the `USE_REIFIED_RELATIONS` flag via `getSetting` and compute `shouldHideCanvasRelation` in `apps/roam/src/components/settings/DiscourseRelationConfigPanel.tsx`.
- Add a `visibleRelations` `useMemo` that filters out relations whose `text` is `"canvas"` when the flag is enabled, and use `visibleRelations` in the table render instead of `relations`.
- Add a deprecation comment noting the hidden behavior will be removed after the pattern -> stored relation migration completes.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698932c7531c8326a98761baf28f47e6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/759" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added feature flag to conditionally control visibility of reified canvas relationships in relation editing and configuration panels

* **Bug Fixes**
  * Improved state consistency in relation selection tracking and unsaved change recording

<!-- end of auto-generated comment: release notes by coderabbit.ai -->