### PR TITLE
ENG-1408 - Suppress env errors if SUPABASE_USE_DB="none"

### DIFF
--- a/apps/roam/scripts/compile.ts
+++ b/apps/roam/scripts/compile.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 import esbuild from "esbuild";
 import fs from "fs";
 import path from "path";

--- a/apps/roam/scripts/compile.ts
+++ b/apps/roam/scripts/compile.ts
@@ -159,7 +159,9 @@ export const compile = ({
       bundle: true,
       format,
       define: {
-        "process.env.SUPABASE_USE_DB": `"${process.env.SUPABASE_USE_DB}"`,
+        "process.env.SUPABASE_USE_DB": dbEnv.SUPABASE_USE_DB
+          ? `"${dbEnv.SUPABASE_USE_DB}"`
+          : "null",
         "process.env.SUPABASE_URL": dbEnv.SUPABASE_URL
           ? `"${dbEnv.SUPABASE_URL}"`
           : "null",

--- a/apps/roam/scripts/compile.ts
+++ b/apps/roam/scripts/compile.ts
@@ -159,6 +159,7 @@ export const compile = ({
       bundle: true,
       format,
       define: {
+        "process.env.SUPABASE_USE_DB": `"${process.env.SUPABASE_USE_DB}"`,
         "process.env.SUPABASE_URL": dbEnv.SUPABASE_URL
           ? `"${dbEnv.SUPABASE_URL}"`
           : "null",

--- a/apps/roam/src/index.ts
+++ b/apps/roam/src/index.ts
@@ -120,7 +120,7 @@ export default runExtension(async (onloadArgs) => {
     text: "(BETA) Suggestive Mode Enabled",
   }).value;
 
-  if (isSuggestiveModeEnabled) {
+  if (isSuggestiveModeEnabled && process.env.SUPABASE_USE_DB !== "none") {
     initializeSupabaseSync();
   }
 

--- a/packages/database/src/dbDotEnv.mjs
+++ b/packages/database/src/dbDotEnv.mjs
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 import { readFileSync, existsSync } from "node:fs";
 import { join, dirname, basename } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -69,10 +70,12 @@ export const envFilePath = () => {
 };
 
 export const envContents = () => {
+  const variant = getVariant();
   const path = envFilePath();
   if (!path) {
     // Fallback to process.env when running in production environments
     const raw = {
+      SUPABASE_USE_DB: variant,
       SUPABASE_URL: process.env.SUPABASE_URL,
       SUPABASE_ANON_KEY: process.env.SUPABASE_ANON_KEY,
       NEXT_API_ROOT: process.env.NEXT_API_ROOT,
@@ -80,7 +83,10 @@ export const envContents = () => {
     return Object.fromEntries(Object.entries(raw).filter(([, v]) => !!v));
   }
   const data = readFileSync(path, "utf8");
-  return dotenv.parse(data);
+  return {
+    ...dotenv.parse(data),
+    SUPABASE_USE_DB: variant,
+  };
 };
 
 let configDone = false;


### PR DESCRIPTION
<img width="900" height="376" alt="image" src="https://github.com/user-attachments/assets/6f0cec9c-6bf5-4421-a78e-3035b235cdec" />

These error messages appear on every plugin load/reload, which is poor DX—especially when the configuration explicitly indicates that the database is not in use (`SUPABASE_USE_DB="none"`).

https://github.com/DiscourseGraphs/discourse-graph/blob/main/packages/database/README.md#L11-L12

```
## Developing without the database

Your frontend will not use the database.
Optional: Set `SUPABASE_USE_DB=none` in your console before running `turbo dev`. (This is now the default.)
```

This PR introduces a small, targeted fix and establishes a clear pattern we can reuse for handling future database-specific functionality.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/760" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
