### PR TITLE
ENG-1280: Port Discourse node: Query builder and editor component for block props

### DIFF
--- a/apps/roam/src/components/QueryBuilder.tsx
+++ b/apps/roam/src/components/QueryBuilder.tsx
@@ -31,11 +31,17 @@ type QueryPageComponent = (props: {
   pageUid: string;
   isEditBlock?: boolean;
   showAlias?: boolean;
+  discourseNodeType?: string;
 }) => JSX.Element;
 
 type Props = Parameters<QueryPageComponent>[0];
 
-const QueryBuilder = ({ pageUid, isEditBlock, showAlias }: Props) => {
+const QueryBuilder = ({
+  pageUid,
+  isEditBlock,
+  showAlias,
+  discourseNodeType,
+}: Props) => {
   const extensionAPI = useExtensionAPI();
   const hideMetadata = useMemo(
     () =>
@@ -158,6 +164,7 @@ const QueryBuilder = ({ pageUid, isEditBlock, showAlias }: Props) => {
           <>
             <QueryEditor
               parentUid={pageUid}
+              discourseNodeType={discourseNodeType}
               onQuery={() => {
                 setHasResults(true);
                 setIsEdit(false);

--- a/apps/roam/src/components/QueryEditor.tsx
+++ b/apps/roam/src/components/QueryEditor.tsx
@@ -508,7 +508,7 @@ const QueryEditor: QueryEditorComponent = ({
     blockPropSyncTimeoutRef.current = window.setTimeout(() => {
       setDiscourseNodeSetting(discourseNodeType, ["index"], result.data);
       lastSyncedIndexRef.current = serialized;
-    }, 500);
+    }, 250);
 
     return () => window.clearTimeout(blockPropSyncTimeoutRef.current);
   }, [conditions, selections, custom, discourseNodeType]);

--- a/apps/roam/src/components/QueryEditor.tsx
+++ b/apps/roam/src/components/QueryEditor.tsx
@@ -490,8 +490,9 @@ const QueryEditor: QueryEditorComponent = ({
     if (!discourseNodeType) return;
 
     const stripped: unknown = JSON.parse(
-      JSON.stringify({ conditions, selections, custom }, (key, value: unknown) =>
-        key === "uid" ? undefined : value,
+      JSON.stringify(
+        { conditions, selections, custom },
+        (key, value: unknown) => (key === "uid" ? undefined : value),
       ),
     );
 

--- a/apps/roam/src/components/settings/DiscourseNodeIndex.tsx
+++ b/apps/roam/src/components/settings/DiscourseNodeIndex.tsx
@@ -6,6 +6,7 @@ import type { DiscourseNode } from "~/utils/getDiscourseNodes";
 import QueryBuilder from "~/components/QueryBuilder";
 import parseQuery, { DEFAULT_RETURN_NODE } from "~/utils/parseQuery";
 import createBlock from "roamjs-components/writes/createBlock";
+import { setDiscourseNodeSetting } from "~/components/settings/utils/accessors";
 
 const NodeIndex = ({
   parentUid,
@@ -25,7 +26,7 @@ const NodeIndex = ({
   );
   useEffect(() => {
     if (!showQuery) {
-      createBlock({
+      void createBlock({
         parentUid: initialQueryArgs.conditionsNodesUid,
         node: {
           text: "clause",
@@ -48,12 +49,30 @@ const NodeIndex = ({
             },
           ],
         },
-      }).then(() => setShowQuery(true));
+      }).then(() => {
+        setDiscourseNodeSetting(node.type, ["index"], {
+          conditions: [
+            {
+              type: "clause",
+              source: DEFAULT_RETURN_NODE,
+              relation: "is a",
+              target: node.text,
+            },
+          ],
+          selections: [],
+        });
+
+        setShowQuery(true);
+      });
     }
-  }, [parentUid, initialQueryArgs, showQuery]);
+  }, [parentUid, initialQueryArgs, showQuery, node.text, node.type]);
   return (
     <ExtensionApiContextProvider {...onloadArgs}>
-      {showQuery ? <QueryBuilder pageUid={parentUid} /> : <Spinner />}
+      {showQuery ? (
+        <QueryBuilder pageUid={parentUid} discourseNodeType={node.type} />
+      ) : (
+        <Spinner />
+      )}
     </ExtensionApiContextProvider>
   );
 };

--- a/apps/roam/src/components/settings/utils/zodSchema.example.ts
+++ b/apps/roam/src/components/settings/utils/zodSchema.example.ts
@@ -75,6 +75,7 @@ const discourseNodeSettings: DiscourseNodeSettings = {
       },
     ],
     selections: [],
+    custom: "",
   },
   suggestiveRules,
   backedBy: "user",

--- a/apps/roam/src/components/settings/utils/zodSchema.ts
+++ b/apps/roam/src/components/settings/utils/zodSchema.ts
@@ -52,6 +52,7 @@ export const SelectionSchema = z.object({
 export const IndexSchema = z.object({
   conditions: z.array(ConditionSchema).default([]),
   selections: z.array(SelectionSchema).default([]),
+  custom: z.string().default(""),
 });
 
 type RoamNode = {


### PR DESCRIPTION
https://www.loom.com/share/92b399a36f4d4e3f8e49a95e5c65661b
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/764" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic query state synchronization to discourse nodes, preserving query configurations and selections.
  * Introduced a new "custom" field to query settings for extended configuration options.
  * Enhanced query builder to support discourse node type associations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->