### PR TITLE
ENG-1418 - Add file size validation for asset props in Tldraw component

### DIFF
--- a/apps/roam/package.json
+++ b/apps/roam/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roam",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Discourse Graph Plugin for roamresearch.com",
   "scripts": {
     "dev": "tsx scripts/dev.ts",

--- a/apps/roam/src/components/canvas/Tldraw.tsx
+++ b/apps/roam/src/components/canvas/Tldraw.tsx
@@ -127,6 +127,15 @@ export const MAX_WIDTH = "400px";
 
 const ICON_URL = `data:image/svg+xml;utf8,${encodeURIComponent(WHITE_LOGO_SVG)}`;
 
+/** Valid file size for asset props; undefined when unknown (e.g. Roam/file API not a real File) to avoid persisting null. */
+const getValidFileSize = (file: { size?: number }): number | undefined =>
+  typeof file.size === "number" && Number.isFinite(file.size) && file.size > 0
+    ? file.size
+    : undefined;
+
+const fileSizeProps = (size: number | undefined): { fileSize?: number } =>
+  size !== undefined ? { fileSize: size } : {};
+
 export const isPageUid = (uid: string) =>
   !!window.roamAlphaAPI.pull("[:node/title]", [":block/uid", uid])?.[
     ":node/title"
@@ -954,7 +963,7 @@ const InsideEditorAndUiContext = ({
             src: dataUrl,
             w: size.w,
             h: size.h,
-            fileSize: file.size,
+            ...fileSizeProps(getValidFileSize(file)),
             mimeType: file.type,
             isAnimated,
           },
@@ -1025,7 +1034,7 @@ const InsideEditorAndUiContext = ({
             src: dataUrl,
             w: width,
             h: height,
-            fileSize: file.size,
+            ...fileSizeProps(getValidFileSize(file)),
             mimeType: "image/svg+xml",
             isAnimated: false,
           },


### PR DESCRIPTION
- Introduced `getValidFileSize` function to validate file size, ensuring it is a finite number greater than zero.
- Updated `fileSizeProps` to conditionally include `fileSize` based on validation.
- Refactored asset handling in `InsideEditorAndUiContext` to utilize the new validation logic for file sizes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/768" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
