### PR TITLE
Arrow bend translation

### DIFF
--- a/apps/obsidian/src/components/canvas/shapes/DiscourseRelationShape.tsx
+++ b/apps/obsidian/src/components/canvas/shapes/DiscourseRelationShape.tsx
@@ -474,8 +474,13 @@ export class DiscourseRelationUtil extends ShapeUtil<DiscourseRelationShape> {
 
     const bindings = getArrowBindings(this.editor, shape);
 
-    // If both ends are bound, convert translation to bend changes instead of moving the arrow
-    if (bindings.start && bindings.end) {
+    // Check if other shapes are also being translated
+    const selectedShapeIds = this.editor.getSelectedShapeIds();
+    const onlyRelationSelected = selectedShapeIds.length === 1 && selectedShapeIds[0] === shape.id;
+
+    // If both ends are bound AND only the relation is selected, convert translation to bend changes
+    // If other shapes are also selected, do a simple translation instead
+    if (bindings.start && bindings.end && onlyRelationSelected) {
       const shapePageTransform = this.editor.getShapePageTransform(shape.id);
       const pageDelta = Vec.Sub(
         shapePageTransform.applyToPoint(shape),


### PR DESCRIPTION
https://www.loom.com/share/49c3b4960dbb4baf8a5e1a7a2a1391e3

Fixes DiscourseRelationShape's `onTranslate` to prevent unexpected bend changes when moving multiple selected shapes.

Previously, when both ends of a `DiscourseRelationShape` were bound, its `onTranslate` method would always convert translation into bend changes. This was incorrect when the relation was moved as part of a larger selection of shapes (e.g., nodes and the connecting arrow). The change ensures that bend changes only occur if *only* the relation shape is selected, allowing for simple translation when moved with other shapes, aligning with tldraw's native arrow behavior.

---
Linear Issue: [ENG-1366](https://linear.app/discourse-graphs/issue/ENG-1366/selecting-and-moving-multiple-connected-nodes-has-unexpected-side)

<p><a href="https://cursor.com/background-agent?bcId=bc-d42fd571-e424-43b2-a641-68845e91c20a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d42fd571-e424-43b2-a641-68845e91c20a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/770" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
