### PR TITLE
Discourse node canvas drop

### DIFF
--- a/DRAG_DROP_TESTING.md
+++ b/DRAG_DROP_TESTING.md
@@ -1,0 +1,120 @@
+# Drag and Drop Testing Guide for ENG-1368
+
+This guide describes how to test the drag-and-drop functionality for Discourse Nodes into tldraw Canvas.
+
+## Feature Overview
+
+Users can now drag Discourse Nodes (files with `nodeTypeId` in frontmatter) from Obsidian's file system directly into a Canvas, which will create a corresponding DiscourseNodeShape.
+
+## Test Scenarios
+
+### 1. Drag from File Explorer (Sidebar)
+
+**Steps:**
+1. Open Obsidian with the Discourse Graphs plugin enabled
+2. Create or identify a Discourse Node (a file with `nodeTypeId` in its frontmatter)
+3. Open a Canvas file
+4. In the left sidebar file explorer, locate the Discourse Node
+5. Click and drag the file from the file explorer
+6. Drop it onto the Canvas
+
+**Expected Result:**
+- A DiscourseNodeShape should appear at the drop location
+- The shape should display the file's title
+- The shape should have the correct node type color
+- If the node type has `keyImage` enabled and the file contains an image, it should be displayed
+- A success toast should appear: "Node Added: [node type]: [filename]"
+
+**Error Cases:**
+- If you drag a regular markdown file (not a Discourse Node), nothing should happen (no error)
+- If the node type is not found, a warning toast should appear
+
+### 2. Drag from Base Query Results
+
+**Steps:**
+1. Open a page with base query results showing Discourse Nodes
+2. Open a Canvas file
+3. Drag a Discourse Node link from the query results
+4. Drop it onto the Canvas
+
+**Expected Result:**
+- Same as scenario 1
+
+### 3. Drag from Open Page/Sidebar Panel
+
+**Steps:**
+1. Open multiple Discourse Node pages in tabs or sidebar panels
+2. Open a Canvas file
+3. From the file explorer or sidebar, drag one of the open Discourse Node files
+4. Drop it onto the Canvas
+
+**Expected Result:**
+- Same as scenario 1
+
+### 4. Multiple Nodes
+
+**Steps:**
+1. Open a Canvas
+2. Drag and drop multiple different Discourse Nodes one by one
+3. Verify each creates its own shape
+
+**Expected Result:**
+- Each node should create a separate DiscourseNodeShape
+- Each should be positioned where it was dropped
+- All shapes should be properly styled according to their node types
+
+### 5. Edge Cases
+
+**Test dragging non-Discourse files:**
+- Drag a regular markdown file without `nodeTypeId`
+- Expected: Should be ignored (no shape created, no error)
+
+**Test dragging with invalid node type:**
+- Drag a file with a `nodeTypeId` that doesn't exist in settings
+- Expected: Warning toast about unknown node type
+
+**Test dragging from external sources:**
+- Try dragging from external file manager
+- Expected: Should be handled normally by tldraw (image/file handling)
+
+## Technical Details
+
+### Implementation Files
+- `/apps/obsidian/src/components/canvas/utils/dropHandler.ts` - Main drop handling logic
+- `/apps/obsidian/src/components/canvas/TldrawViewComponent.tsx` - Drop event listeners
+
+### Key Functions
+- `isDiscourseNode()` - Checks if a file has `nodeTypeId` in frontmatter
+- `handleCanvasDrop()` - Processes drop events and creates DiscourseNodeShapes
+- `extractFilePathFromDragData()` - Extracts file path from drag event data
+
+### Data Flow
+1. User drags file from Obsidian file system
+2. Drop event fires on canvas container
+3. `extractFilePathFromDragData()` extracts the file path (handles wikilink and plain path formats)
+4. File is resolved using `app.metadataCache.getFirstLinkpathDest()`
+5. `isDiscourseNode()` checks for `nodeTypeId` in frontmatter
+6. If valid, a block reference is created in the canvas file
+7. Node metadata is retrieved (type, image, size)
+8. DiscourseNodeShape is created at drop position
+9. Success/error toast is shown
+
+## Debugging
+
+If drag-and-drop doesn't work:
+
+1. Check browser console for errors
+2. Verify the file has `nodeTypeId` in frontmatter:
+   ```yaml
+   ---
+   nodeTypeId: some-node-type-id
+   ---
+   ```
+3. Check that the node type exists in plugin settings
+4. Verify the canvas file is properly loaded
+5. Check that event listeners are attached (inspect in DevTools)
+
+## Related Issues
+
+- Linear Issue: ENG-1368
+- Branch: `cursor/ENG-1368-discourse-node-canvas-drop-bf14`

--- a/apps/obsidian/src/components/canvas/TldrawViewComponent.tsx
+++ b/apps/obsidian/src/components/canvas/TldrawViewComponent.tsx
@@ -52,6 +52,7 @@ import {
   openFileInNewLeaf,
   resolveDiscourseNodeFile,
 } from "./utils/openFileUtils";
+import { handleCanvasDrop } from "./utils/dropHandler";
 type TldrawPreviewProps = {
   store: TLStore;
   file: TFile;
@@ -144,6 +145,40 @@ export const TldrawPreviewComponent = ({
 
     return () => {
       window.removeEventListener("keydown", handleKeyDown, true);
+    };
+  }, [isEditorMounted, file, plugin]);
+
+  // Add drag-and-drop event listeners when editor is mounted
+  useEffect(() => {
+    if (!isEditorMounted || !editorRef.current) return;
+
+    const editor = editorRef.current;
+    const container = editor.getContainer();
+    
+    const handleDragOver = (e: DragEvent) => {
+      // Prevent default to allow drop
+      e.preventDefault();
+      if (e.dataTransfer) {
+        e.dataTransfer.dropEffect = "copy";
+      }
+    };
+
+    const handleDrop = (e: DragEvent) => {
+      void handleCanvasDrop({
+        editor,
+        app: plugin.app,
+        plugin,
+        canvasFile: file,
+        event: e,
+      });
+    };
+
+    container.addEventListener("dragover", handleDragOver);
+    container.addEventListener("drop", handleDrop);
+
+    return () => {
+      container.removeEventListener("dragover", handleDragOver);
+      container.removeEventListener("drop", handleDrop);
     };
   }, [isEditorMounted, file, plugin]);
 

--- a/apps/obsidian/src/components/canvas/utils/dropHandler.ts
+++ b/apps/obsidian/src/components/canvas/utils/dropHandler.ts
@@ -1,0 +1,171 @@
+import type { App, TFile } from "obsidian";
+import type { Editor } from "tldraw";
+import type DiscourseGraphPlugin from "~/index";
+import { createShapeId } from "tldraw";
+import { addWikilinkBlockrefForFile } from "~/components/canvas/stores/assetStore";
+import { calcDiscourseNodeSize } from "~/utils/calcDiscourseNodeSize";
+import { showToast } from "./toastUtils";
+import { getFirstImageSrcForFile } from "~/components/canvas/shapes/discourseNodeShapeUtils";
+
+type HandleDropOptions = {
+  editor: Editor;
+  app: App;
+  plugin: DiscourseGraphPlugin;
+  canvasFile: TFile;
+  event: DragEvent;
+};
+
+/**
+ * Check if a file is a Discourse Node by verifying it has a nodeTypeId in frontmatter
+ */
+export const isDiscourseNode = (app: App, file: TFile): boolean => {
+  const fileCache = app.metadataCache.getFileCache(file);
+  const nodeTypeId = fileCache?.frontmatter?.nodeTypeId;
+  return typeof nodeTypeId === "string" && nodeTypeId.length > 0;
+};
+
+/**
+ * Extract file path from dropped data
+ * Obsidian drag-and-drop provides file paths in various formats
+ */
+const extractFilePathFromDragData = (
+  event: DragEvent,
+): string | null => {
+  const dataTransfer = event.dataTransfer;
+  if (!dataTransfer) return null;
+
+  // Try to get plain text data (usually contains wikilink or file path)
+  const textData = dataTransfer.getData("text/plain");
+  if (!textData) return null;
+
+  // Handle wikilink format [[filename]]
+  const wikilinkMatch = textData.match(/\[\[([^\]]+)\]\]/);
+  if (wikilinkMatch) {
+    return wikilinkMatch[1] ?? null;
+  }
+
+  // Handle plain file path
+  if (textData.endsWith(".md")) {
+    return textData;
+  }
+
+  return textData;
+};
+
+/**
+ * Handle drop events on the canvas to create DiscourseNodeShapes from dragged files
+ */
+export const handleCanvasDrop = async ({
+  editor,
+  app,
+  plugin,
+  canvasFile,
+  event,
+}: HandleDropOptions): Promise<void> => {
+  try {
+    const filePath = extractFilePathFromDragData(event);
+    if (!filePath) return;
+
+    // Resolve the file from the path
+    const file = app.metadataCache.getFirstLinkpathDest(filePath, canvasFile.path);
+    if (!file) {
+      console.log("Could not resolve file from drag data:", filePath);
+      return;
+    }
+
+    // Check if it's a Discourse Node
+    if (!isDiscourseNode(app, file)) {
+      console.log("Dropped file is not a Discourse Node:", file.path);
+      return;
+    }
+
+    // Prevent default handling
+    event.preventDefault();
+    event.stopPropagation();
+
+    // Get the drop position in canvas coordinates
+    const canvasRect = editor.getContainer().getBoundingClientRect();
+    const screenPoint = {
+      x: event.clientX - canvasRect.left,
+      y: event.clientY - canvasRect.top,
+    };
+    
+    const pagePoint = editor.screenToPage(screenPoint);
+
+    // Get node metadata
+    const fileCache = app.metadataCache.getFileCache(file);
+    const nodeTypeId = fileCache?.frontmatter?.nodeTypeId as string;
+    const nodeType = plugin.settings.nodeTypes.find(
+      (nt) => nt.id === nodeTypeId,
+    );
+
+    if (!nodeType) {
+      showToast({
+        severity: "warning",
+        title: "Unknown Node Type",
+        description: `Node type ID "${nodeTypeId}" not found`,
+        targetCanvasId: canvasFile.path,
+      });
+      return;
+    }
+
+    // Create block reference for the file
+    const src = await addWikilinkBlockrefForFile({
+      app,
+      canvasFile,
+      linkedFile: file,
+    });
+
+    // Get image if node type supports it
+    let imageSrc: string | undefined;
+    if (nodeType.keyImage) {
+      const img = await getFirstImageSrcForFile(app, file);
+      if (img) {
+        imageSrc = img;
+      }
+    }
+
+    // Calculate size based on content
+    const { w, h } = await calcDiscourseNodeSize({
+      title: file.basename,
+      nodeTypeId,
+      imageSrc,
+      plugin,
+    });
+
+    // Create the DiscourseNodeShape
+    const shapeId = createShapeId();
+    editor.createShape({
+      id: shapeId,
+      type: "discourse-node",
+      x: pagePoint.x - w / 2, // Center on drop point
+      y: pagePoint.y - h / 2,
+      props: {
+        w,
+        h,
+        src,
+        title: file.basename,
+        nodeTypeId,
+        imageSrc,
+      },
+    });
+
+    editor.setSelectedShapes([shapeId]);
+    editor.markHistoryStoppingPoint("create discourse node from drop");
+
+    showToast({
+      severity: "success",
+      title: "Node Added",
+      description: `Added ${nodeType.name}: ${file.basename}`,
+      targetCanvasId: canvasFile.path,
+    });
+  } catch (error) {
+    console.error("Error handling canvas drop:", error);
+    showToast({
+      severity: "error",
+      title: "Drop Failed",
+      description: `Could not create node from dropped file: ${error instanceof Error ? error.message : "Unknown error"}`,
+      targetCanvasId: canvasFile.path,
+    });
+  }
+};


### PR DESCRIPTION
Implement drag-and-drop functionality for Discourse Nodes onto the tldraw Canvas, allowing users to easily create shapes from files dragged from Obsidian's file system.

---
Linear Issue: [ENG-1368](https://linear.app/discourse-graphs/issue/ENG-1368/ability-to-drag-and-drop-files-from-obsidian-file-system-to-tldraw)

<p><a href="https://cursor.com/background-agent?bcId=bc-a1431e02-2aec-47e1-932f-2732864db645"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a1431e02-2aec-47e1-932f-2732864db645"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

