### PR TITLE
Relations json type triplet

### DIFF
--- a/apps/obsidian/src/components/canvas/utils/relationJsonUtils.ts
+++ b/apps/obsidian/src/components/canvas/utils/relationJsonUtils.ts
@@ -10,18 +10,19 @@ import {
  * Persists a relation between two files to the relations store (relations.json).
  * Uses addRelation (checks for existing relation by default).
  *
+ * @param relationTripletId - The relation triplet id (DiscourseRelation.id, typically has prefix rel3_)
  * @returns Object indicating whether the relation already existed and the relation instance id.
  */
 export const addRelationToRelationsJson = async ({
   plugin,
   sourceFile,
   targetFile,
-  relationTypeId,
+  relationTripletId,
 }: {
   plugin: DiscourseGraphPlugin;
   sourceFile: TFile;
   targetFile: TFile;
-  relationTypeId: string;
+  relationTripletId: string;
 }): Promise<{ alreadyExisted: boolean; relationInstanceId?: string }> => {
   const sourceId = await getNodeInstanceIdForFile(plugin, sourceFile);
   const destId = await getNodeInstanceIdForFile(plugin, targetFile);
@@ -42,7 +43,7 @@ export const addRelationToRelationsJson = async ({
   }
 
   const { id, alreadyExisted } = await addRelation(plugin, {
-    type: relationTypeId,
+    type: relationTripletId,
     source: sourceId,
     destination: destId,
   });
@@ -102,6 +103,6 @@ export const addRelationIfRequested = async (
     plugin,
     sourceFile,
     targetFile,
-    relationTypeId: relation.relationshipTypeId,
+    relationTypeId: relation.id,
   });
 };

--- a/apps/obsidian/src/components/canvas/utils/relationJsonUtils.ts
+++ b/apps/obsidian/src/components/canvas/utils/relationJsonUtils.ts
@@ -103,6 +103,6 @@ export const addRelationIfRequested = async (
     plugin,
     sourceFile,
     targetFile,
-    relationTypeId: relation.id,
+    relationTripletId: relation.id,
   });
 };

--- a/apps/obsidian/src/utils/typeUtils.ts
+++ b/apps/obsidian/src/utils/typeUtils.ts
@@ -1,5 +1,5 @@
 import type DiscourseGraphPlugin from "~/index";
-import { DiscourseNode, DiscourseRelationType } from "~/types";
+import { DiscourseNode, DiscourseRelation, DiscourseRelationType } from "~/types";
 
 export const getNodeTypeById = (
   plugin: DiscourseGraphPlugin,
@@ -15,4 +15,32 @@ export const getRelationTypeById = (
   return plugin.settings.relationTypes.find(
     (relation) => relation.id === relationTypeId,
   );
+};
+
+export const getRelationById = (
+  plugin: DiscourseGraphPlugin,
+  relationId: string,
+): DiscourseRelation | undefined => {
+  return plugin.settings.discourseRelations.find(
+    (relation) => relation.id === relationId,
+  );
+};
+
+/**
+ * Finds a relation triplet (DiscourseRelation) by matching source node type, destination node type, and relation type.
+ * Returns the relation triplet id if found, otherwise undefined.
+ */
+export const findRelationTripletId = (
+  plugin: DiscourseGraphPlugin,
+  sourceNodeTypeId: string,
+  destinationNodeTypeId: string,
+  relationTypeId: string,
+): string | undefined => {
+  const relation = plugin.settings.discourseRelations.find(
+    (rel) =>
+      rel.sourceId === sourceNodeTypeId &&
+      rel.destinationId === destinationNodeTypeId &&
+      rel.relationshipTypeId === relationTypeId,
+  );
+  return relation?.id;
 };


### PR DESCRIPTION
Change the `type` field in `relations.json` to use the relation triplet ID instead of the relation type ID.

Previously, relations were stored using the generic `relationTypeId` (e.g., `rel_...`), which is not unique for specific subject-predicate-object combinations. This PR updates the storage and all related logic to use the unique `relation triplet id` (e.g., `rel3_...`), ensuring each relation instance is correctly identified.

---
Linear Issue: [ENG-1423](https://linear.app/discourse-graphs/issue/ENG-1423/bug-fix-change-the-type-in-relationsjson-to-use-triplet-id-instead-of)

<p><a href="https://cursor.com/background-agent?bcId=bc-6b59c373-bf7b-4c4f-b3f9-a61aae2b4b48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6b59c373-bf7b-4c4f-b3f9-a61aae2b4b48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

