### PR TITLE
ENG-1425 Bump sync timeout duration

### DIFF
--- a/apps/roam/src/utils/syncDgNodesToSupabase.ts
+++ b/apps/roam/src/utils/syncDgNodesToSupabase.ts
@@ -31,7 +31,7 @@ const SYNC_FUNCTION = "embedding";
 const SYNC_INTERVAL = "45s";
 // Interval between syncs for each client individually
 const BASE_SYNC_INTERVAL = 5 * 60 * 1000; // 5 minutes
-const SYNC_TIMEOUT = "20s";
+const SYNC_TIMEOUT = "120s"; // must be less than half the interval.
 const BATCH_SIZE = 200;
 const DEFAULT_TIME = new Date("1970-01-01");
 

--- a/apps/roam/src/utils/syncDgNodesToSupabase.ts
+++ b/apps/roam/src/utils/syncDgNodesToSupabase.ts
@@ -28,10 +28,10 @@ import { FatalError } from "@repo/database/lib/contextFunctions";
 
 const SYNC_FUNCTION = "embedding";
 // Minimal interval between syncs of all clients for this task.
-const SYNC_INTERVAL = "45s";
+const SYNC_INTERVAL = "130s";
 // Interval between syncs for each client individually
 const BASE_SYNC_INTERVAL = 5 * 60 * 1000; // 5 minutes
-const SYNC_TIMEOUT = "120s"; // must be less than half the interval.
+const SYNC_TIMEOUT = "60s"; // must be less than half the SYNC_INTERVAL.
 const BATCH_SIZE = 200;
 const DEFAULT_TIME = new Date("1970-01-01");
 


### PR DESCRIPTION
https://linear.app/discourse-graphs/issue/ENG-1425/bump-sync-timeout-duration

Changed the timeout value from 20s to 60s. Let us see the impact on Wrong worker.
This is just a change of value, skipping the loom.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/776" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
