### PR TITLE
ENG-1426 Bug in permission functions

### DIFF
--- a/apps/roam/src/utils/syncDgNodesToSupabase.ts
+++ b/apps/roam/src/utils/syncDgNodesToSupabase.ts
@@ -349,7 +349,7 @@ const getAllUsers = async (): Promise<AccountLocalInput[]> => {
     email: null,
     email_trusted: null,
     space_editor: null,
-    permissions: "editor",
+    permissions: null,
   }));
 };
 

--- a/apps/roam/src/utils/syncDgNodesToSupabase.ts
+++ b/apps/roam/src/utils/syncDgNodesToSupabase.ts
@@ -349,6 +349,7 @@ const getAllUsers = async (): Promise<AccountLocalInput[]> => {
     email: null,
     email_trusted: null,
     space_editor: null,
+    permissions: "editor",
   }));
 };
 

--- a/packages/database/src/dbTypes.ts
+++ b/packages/database/src/dbTypes.ts
@@ -1542,10 +1542,10 @@ export type Database = {
       create_account_in_space: {
         Args: {
           account_local_id_: string
-          editor_?: boolean
           email_?: string
           email_trusted?: boolean
           name_: string
+          permissions_?: Database["public"]["Enums"]["SpaceAccessPermissions"]
           space_id_: number
         }
         Returns: number
@@ -1659,6 +1659,10 @@ export type Database = {
           similarity: number
           text_content: string
         }[]
+      }
+      my_permissions_in_space: {
+        Args: { space_id_: number }
+        Returns: Database["public"]["Enums"]["SpaceAccessPermissions"]
       }
       my_space_ids: {
         Args: {
@@ -1798,6 +1802,9 @@ export type Database = {
         email: string | null
         email_trusted: boolean | null
         space_editor: boolean | null
+        permissions:
+          | Database["public"]["Enums"]["SpaceAccessPermissions"]
+          | null
       }
       concept_local_input: {
         epistemic_status: Database["public"]["Enums"]["EpistemicStatus"] | null

--- a/packages/database/supabase/migrations/20260213155959_upsert_user_permissions.sql
+++ b/packages/database/supabase/migrations/20260213155959_upsert_user_permissions.sql
@@ -38,11 +38,11 @@ BEGIN
             CASE WHEN local_account.space_editor IS true THEN 'editor'  -- legacy
                  WHEN local_account.space_editor IS false THEN 'reader' END);
         INSERT INTO public."SpaceAccess" as sa (space_id, account_uid, permissions)
-            VALUES (space_id_, user_uid, greatest(my_permissions_in_space(space_id_), COALESCE(permissions_, 'editor')))
+            VALUES (space_id_, user_uid, least(my_permissions_in_space(space_id_), COALESCE(permissions_, 'editor')))
             ON CONFLICT (space_id, account_uid)
             DO UPDATE SET permissions = CASE
                 WHEN permissions_ IS NULL THEN permissions
-                ELSE greatest(my_permissions_in_space(space_id_), permissions_)
+                ELSE least(my_permissions_in_space(space_id_), permissions_)
                 END;
     END IF;
     INSERT INTO public."LocalAccess" (space_id, account_id) values (space_id_, account_id_)

--- a/packages/database/supabase/migrations/20260213155959_upsert_user_permissions.sql
+++ b/packages/database/supabase/migrations/20260213155959_upsert_user_permissions.sql
@@ -32,14 +32,18 @@ BEGIN
             name = COALESCE(NULLIF(TRIM(EXCLUDED.name), ''), pa.name)
         RETURNING id, dg_account INTO STRICT account_id_, user_uid;
     IF user_uid IS NOT NULL THEN
-        permissions_ := max(
-            my_permissions_in_space(space_id_),
-            COALESCE(local_account.permissions,
-                CASE WHEN local_account.space_editor THEN 'editor' ELSE 'reader' END));
+        -- is any permission specified in the input?
+        permissions_ := COALESCE(
+            local_account.permissions,
+            CASE WHEN local_account.space_editor IS true THEN 'editor'  -- legacy
+                 WHEN local_account.space_editor IS false THEN 'reader' END);
         INSERT INTO public."SpaceAccess" as sa (space_id, account_uid, permissions)
-            VALUES (space_id_, user_uid, permissions_)
+            VALUES (space_id_, user_uid, max(my_permissions_in_space(space_id_), COALESCE(permissions_, 'editor')))
             ON CONFLICT (space_id, account_uid)
-            DO UPDATE SET permissions = permissions_;
+            DO UPDATE SET permissions = CASE
+                WHEN permissions_ IS NULL THEN permissions
+                ELSE max(my_permissions_in_space(space_id_), permissions_)
+                END;
     END IF;
     INSERT INTO public."LocalAccess" (space_id, account_id) values (space_id_, account_id_)
         ON CONFLICT (space_id, account_id)
@@ -53,6 +57,7 @@ BEGIN
     RETURN account_id_;
 END;
 $$;
+
 
 DROP FUNCTION create_account_in_space;
 

--- a/packages/database/supabase/migrations/20260213155959_upsert_user_permissions.sql
+++ b/packages/database/supabase/migrations/20260213155959_upsert_user_permissions.sql
@@ -38,11 +38,11 @@ BEGIN
             CASE WHEN local_account.space_editor IS true THEN 'editor'  -- legacy
                  WHEN local_account.space_editor IS false THEN 'reader' END);
         INSERT INTO public."SpaceAccess" as sa (space_id, account_uid, permissions)
-            VALUES (space_id_, user_uid, max(my_permissions_in_space(space_id_), COALESCE(permissions_, 'editor')))
+            VALUES (space_id_, user_uid, greatest(my_permissions_in_space(space_id_), COALESCE(permissions_, 'editor')))
             ON CONFLICT (space_id, account_uid)
             DO UPDATE SET permissions = CASE
                 WHEN permissions_ IS NULL THEN permissions
-                ELSE max(my_permissions_in_space(space_id_), permissions_)
+                ELSE greatest(my_permissions_in_space(space_id_), permissions_)
                 END;
     END IF;
     INSERT INTO public."LocalAccess" (space_id, account_id) values (space_id_, account_id_)

--- a/packages/database/supabase/migrations/20260213155959_upsert_user_permissions.sql
+++ b/packages/database/supabase/migrations/20260213155959_upsert_user_permissions.sql
@@ -1,0 +1,72 @@
+ALTER TYPE public.account_local_input ADD ATTRIBUTE permissions public."SpaceAccessPermissions";
+
+CREATE OR REPLACE FUNCTION public.my_permissions_in_space(
+    space_id_ BIGINT
+) RETURNS public."SpaceAccessPermissions"
+SET search_path = ''
+LANGUAGE sql
+AS $$
+    SELECT permissions FROM public."SpaceAccess" WHERE space_id=space_id_ AND account_uid = auth.uid();
+$$;
+
+CREATE OR REPLACE FUNCTION public.upsert_account_in_space(
+    space_id_ BIGINT,
+    local_account public.account_local_input
+) RETURNS BIGINT
+SECURITY DEFINER
+SET search_path = ''
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    platform_ public."Platform";
+    account_id_ BIGINT;
+    user_uid UUID;
+    permissions_ public."SpaceAccessPermissions";
+BEGIN
+    SELECT platform INTO STRICT platform_ FROM public."Space" WHERE id = space_id_;
+    INSERT INTO public."PlatformAccount" AS pa (
+            account_local_id, name, platform
+        ) VALUES (
+            local_account.account_local_id, local_account.name, platform_
+        ) ON CONFLICT (account_local_id, platform) DO UPDATE SET
+            name = COALESCE(NULLIF(TRIM(EXCLUDED.name), ''), pa.name)
+        RETURNING id, dg_account INTO STRICT account_id_, user_uid;
+    IF user_uid IS NOT NULL THEN
+        permissions_ := max(
+            my_permissions_in_space(space_id_),
+            COALESCE(local_account.permissions,
+                CASE WHEN local_account.space_editor THEN 'editor' ELSE 'reader' END));
+        INSERT INTO public."SpaceAccess" as sa (space_id, account_uid, permissions)
+            VALUES (space_id_, user_uid, permissions_)
+            ON CONFLICT (space_id, account_uid)
+            DO UPDATE SET permissions = permissions_;
+    END IF;
+    INSERT INTO public."LocalAccess" (space_id, account_id) values (space_id_, account_id_)
+        ON CONFLICT (space_id, account_id)
+        DO NOTHING;
+    IF local_account.email IS NOT NULL THEN
+        -- TODO: how to distinguish basic untrusted from platform placeholder email?
+        INSERT INTO public."AgentIdentifier" as ai (account_id, value, identifier_type, trusted) VALUES (account_id_, local_account.email, 'email', COALESCE(local_account.email_trusted, false))
+        ON CONFLICT (value, identifier_type, account_id)
+        DO UPDATE SET trusted = COALESCE(local_account.email_trusted, ai.trusted, false);
+    END IF;
+    RETURN account_id_;
+END;
+$$;
+
+DROP FUNCTION create_account_in_space;
+
+CREATE OR REPLACE FUNCTION create_account_in_space(
+    space_id_ BIGINT,
+    account_local_id_ varchar,
+    name_ varchar,
+    email_ varchar = null,
+    email_trusted boolean = true,
+    permissions_ public."SpaceAccessPermissions" = 'editor'
+) RETURNS BIGINT
+SECURITY DEFINER
+SET search_path = ''
+LANGUAGE sql
+AS $$
+    SELECT public.upsert_account_in_space(space_id_, ROW(name_, account_local_id_ ,email_, email_trusted, null, permissions_)::public.account_local_input);
+$$;

--- a/packages/database/supabase/migrations/20260213155959_upsert_user_permissions.sql
+++ b/packages/database/supabase/migrations/20260213155959_upsert_user_permissions.sql
@@ -75,3 +75,14 @@ LANGUAGE sql
 AS $$
     SELECT public.upsert_account_in_space(space_id_, ROW(name_, account_local_id_ ,email_, email_trusted, null, permissions_)::public.account_local_input);
 $$;
+
+CREATE OR REPLACE FUNCTION public.my_permissions_in_space(
+    space_id_ BIGINT
+) RETURNS public."SpaceAccessPermissions"
+SET search_path = ''
+LANGUAGE sql
+AS $$
+    SELECT max(permissions) FROM public."SpaceAccess"
+    JOIN public.my_user_accounts() ON (account_uid = my_user_accounts)
+    WHERE space_id=space_id_;
+$$;

--- a/packages/database/supabase/schemas/account.sql
+++ b/packages/database/supabase/schemas/account.sql
@@ -222,11 +222,11 @@ BEGIN
             CASE WHEN local_account.space_editor IS true THEN 'editor'  -- legacy
                  WHEN local_account.space_editor IS false THEN 'reader' END);
         INSERT INTO public."SpaceAccess" as sa (space_id, account_uid, permissions)
-            VALUES (space_id_, user_uid, greatest(my_permissions_in_space(space_id_), COALESCE(permissions_, 'editor')))
+            VALUES (space_id_, user_uid, least(my_permissions_in_space(space_id_), COALESCE(permissions_, 'editor')))
             ON CONFLICT (space_id, account_uid)
             DO UPDATE SET permissions = CASE
                 WHEN permissions_ IS NULL THEN permissions
-                ELSE greatest(my_permissions_in_space(space_id_), permissions_)
+                ELSE least(my_permissions_in_space(space_id_), permissions_)
                 END;
     END IF;
     INSERT INTO public."LocalAccess" (space_id, account_id) values (space_id_, account_id_)

--- a/packages/database/supabase/schemas/account.sql
+++ b/packages/database/supabase/schemas/account.sql
@@ -169,9 +169,9 @@ GRANT ALL ON TABLE public.group_membership TO authenticated;
 GRANT ALL ON TABLE public.group_membership TO service_role;
 
 CREATE OR REPLACE VIEW public.my_groups AS
-SELECT id, split_part(email,'@',1) AS name FROM auth.users
-    JOIN public.group_membership ON (group_id=id)
-    WHERE member_id = auth.uid();
+SELECT id, split_part(email, '@', 1) AS name FROM auth.users
+    JOIN public.group_membership ON (group_id = id)
+WHERE member_id = auth.uid();
 
 CREATE TYPE public.account_local_input AS (
     -- PlatformAccount columns

--- a/packages/database/supabase/schemas/account.sql
+++ b/packages/database/supabase/schemas/account.sql
@@ -222,11 +222,11 @@ BEGIN
             CASE WHEN local_account.space_editor IS true THEN 'editor'  -- legacy
                  WHEN local_account.space_editor IS false THEN 'reader' END);
         INSERT INTO public."SpaceAccess" as sa (space_id, account_uid, permissions)
-            VALUES (space_id_, user_uid, max(my_permissions_in_space(space_id_), COALESCE(permissions_, 'editor')))
+            VALUES (space_id_, user_uid, greatest(my_permissions_in_space(space_id_), COALESCE(permissions_, 'editor')))
             ON CONFLICT (space_id, account_uid)
             DO UPDATE SET permissions = CASE
                 WHEN permissions_ IS NULL THEN permissions
-                ELSE max(my_permissions_in_space(space_id_), permissions_)
+                ELSE greatest(my_permissions_in_space(space_id_), permissions_)
                 END;
     END IF;
     INSERT INTO public."LocalAccess" (space_id, account_id) values (space_id_, account_id_)


### PR DESCRIPTION
https://linear.app/discourse-graphs/issue/ENG-1426/bug-in-permission-functions

Pointed out by Devin in the group-test branch: there was still an issue with using the obsolete editor field of the SpaceAccess structure in that code. 
Surprisingly the bug did not make the function fail, probably because the value is rarely set.
Corrected, and generalized the use of permissions as an input parameter to create_account_in_space.
Also, make sure that one cannot give permissions higher than one's own this way;
but also do not lower the permissions if no change was requested.

https://www.loom.com/share/a7089d0681c84d659c1220a70dbb0c0e

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/778" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
