### PR TITLE
ENG-1428 Add eslint check to ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,13 +65,27 @@ jobs:
         shell: bash
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE_REF: ${{ github.base_ref }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
 
-          git fetch origin "${{ github.base_ref }}" --depth=1
+          BASE_SHA=""
+          for fetch_depth in 1 10 50 200; do
+            git fetch origin "$BASE_REF" --depth="$fetch_depth"
+            BASE_SHA="$(git merge-base "origin/$BASE_REF" "$PR_HEAD_SHA" || true)"
+            if [ -n "$BASE_SHA" ]; then
+              break
+            fi
+          done
 
-          BASE_SHA="$(git merge-base "origin/${{ github.base_ref }}" "${{ github.event.pull_request.head.sha }}")"
-          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          if [ -z "$BASE_SHA" ]; then
+            echo "Unable to determine merge-base within depth limit (max depth: 200) for base ref '$BASE_REF'."
+            echo "Increase the depth sequence in CI for unusually long-lived branches."
+            exit 1
+          fi
+
+          HEAD_SHA="$PR_HEAD_SHA"
 
           mapfile -t changed_files < <(git diff --name-only --diff-filter=ACMR "$BASE_SHA" "$HEAD_SHA")
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -117,13 +117,17 @@ jobs:
             exit 0
           fi
 
+          lint_failed=0
           for workspace in "${!workspace_to_files[@]}"; do
             echo "Linting changed files in ${workspace}"
             mapfile -t files < <(printf '%s' "${workspace_to_files[$workspace]}" | sed '/^$/d')
-            pnpm --dir "$workspace" exec eslint --max-warnings 0 "${files[@]}" | reviewdog \
+            if ! pnpm --dir "$workspace" exec eslint --max-warnings 0 "${files[@]}" | reviewdog \
               -f=eslint \
               -name="eslint (${workspace})" \
               -reporter=github-pr-check \
               -filter-mode=added \
-              -level=warning
+              -level=warning; then
+              lint_failed=1
+            fi
           done
+          exit $lint_failed

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,8 @@
 name: CI
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
 on:
   pull_request:
     types: [opened, synchronize, reopened]
@@ -30,6 +34,96 @@ jobs:
       - name: Check TypeScript Types
         run: npx turbo check-types
 
-        # TODO: Add future linting, testing, style checks, etc.
-        # name: Lint
-        # run: pnpm run lint
+  lint-changed-files:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+        with:
+          version: 10.15.1
+          run_install: false
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "pnpm"
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Setup Reviewdog
+        uses: reviewdog/action-setup@v1
+
+      - name: Lint Changed Files
+        shell: bash
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          git fetch origin "${{ github.base_ref }}" --depth=1
+
+          BASE_SHA="$(git merge-base "origin/${{ github.base_ref }}" "${{ github.event.pull_request.head.sha }}")"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+
+          mapfile -t changed_files < <(git diff --name-only --diff-filter=ACMR "$BASE_SHA" "$HEAD_SHA")
+
+          if [ ${#changed_files[@]} -eq 0 ]; then
+            echo "No files changed in this pull request."
+            exit 0
+          fi
+
+          declare -A workspace_to_files
+          lintable_count=0
+
+          for file in "${changed_files[@]}"; do
+            case "$file" in
+              *.js|*.jsx|*.ts|*.tsx|*.mjs|*.cjs) ;;
+              *) continue ;;
+            esac
+
+            if [ ! -f "$file" ]; then
+              continue
+            fi
+
+            IFS='/' read -r top_level workspace_name _ <<< "$file"
+            if [ -z "${top_level:-}" ] || [ -z "${workspace_name:-}" ]; then
+              continue
+            fi
+
+            workspace="${top_level}/${workspace_name}"
+            if [ ! -f "${workspace}/eslint.config.mjs" ]; then
+              continue
+            fi
+
+            relative_file="${file#${workspace}/}"
+            if [ "$relative_file" = "$file" ]; then
+              continue
+            fi
+
+            workspace_to_files["$workspace"]+="${relative_file}"$'\n'
+            lintable_count=$((lintable_count + 1))
+          done
+
+          if [ "$lintable_count" -eq 0 ]; then
+            echo "No changed lintable files in workspaces with ESLint configs."
+            exit 0
+          fi
+
+          for workspace in "${!workspace_to_files[@]}"; do
+            echo "Linting changed files in ${workspace}"
+            mapfile -t files < <(printf '%s' "${workspace_to_files[$workspace]}" | sed '/^$/d')
+            pnpm --dir "$workspace" exec eslint --max-warnings 0 "${files[@]}" | reviewdog \
+              -f=eslint \
+              -name="eslint (${workspace})" \
+              -reporter=github-pr-check \
+              -filter-mode=added \
+              -level=warning
+          done

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,6 +61,7 @@ jobs:
       - name: Setup Reviewdog
         uses: reviewdog/action-setup@v1
 
+      # Lint only files changed in the PR and annotate results in the PR check.
       - name: Lint Changed Files
         shell: bash
         env:
@@ -70,6 +71,7 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Compute a stable merge-base for the PR diff while keeping fetch depth bounded.
           BASE_SHA=""
           for fetch_depth in 1 10 50 200; do
             git fetch origin "$BASE_REF" --depth="$fetch_depth"
@@ -94,6 +96,8 @@ jobs:
             exit 0
           fi
 
+          # Keep only lintable files and group them by workspace so each file is linted
+          # from the directory that owns its ESLint flat config.
           declare -A workspace_to_files
           lintable_count=0
 
@@ -131,6 +135,7 @@ jobs:
             exit 0
           fi
 
+          # Lint every touched workspace and fail once at the end so all findings are reported.
           lint_failed=0
           for workspace in "${!workspace_to_files[@]}"; do
             echo "Linting changed files in ${workspace}"

--- a/apps/website/app/utils/lintWarningProbe.ts
+++ b/apps/website/app/utils/lintWarningProbe.ts
@@ -1,3 +1,0 @@
-export function lintWarningProbe(): string {
-  return "lint-warning-probe";
-}

--- a/apps/website/app/utils/lintWarningProbe.ts
+++ b/apps/website/app/utils/lintWarningProbe.ts
@@ -1,0 +1,3 @@
+export function lintWarningProbe(): string {
+  return "lint-warning-probe";
+}


### PR DESCRIPTION
- We are intentionally keeping separate CI check names for now while we validate behavior.
- Future improvements:
  - [ENG-1429: Consolidate setup so dependency install runs once per workflow run instead of once per job.](https://linear.app/discourse-graphs/issue/ENG-1429/consolidate-setup-so-dependency-install-runs-once-per-workflow-run)
  - [ENG-1430: move the changed-files lint logic out of inline workflow YAML into a dedicated TypeScript script for maintainability and easier testing.](https://linear.app/discourse-graphs/issue/ENG-1430/move-the-changed-files-lint-logic-out-of-inline-workflow-yaml-into-a)
  - [ENG-1431: Standardize ESLint Invocation for Shared Use (Turbo + GitHub Actions)](https://linear.app/discourse-graphs/issue/ENG-1431/standardize-eslint-invocation-for-shared-use-turbo-github-actions)

<img width="1508" height="1058" alt="image" src="https://github.com/user-attachments/assets/35537c6b-3443-442a-b904-9969cda05c51" />

<img width="469" height="311" alt="image" src="https://github.com/user-attachments/assets/09ccbe73-1f1b-43e2-8b21-941e572d6a89" />

<img width="1385" height="429" alt="image" src="https://github.com/user-attachments/assets/b419829d-a8a6-4278-9018-3c895fe7b6fa" />

<!-- devin-review-badge-begin -->




---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/781" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
