### PR TITLE
ENG-1432 Error in date manipulation

### DIFF
--- a/apps/obsidian/src/utils/syncDgNodesToSupabase.ts
+++ b/apps/obsidian/src/utils/syncDgNodesToSupabase.ts
@@ -18,7 +18,7 @@ import {
 } from "./conceptConversion";
 import type { LocalConceptDataInput } from "@repo/database/inputTypes";
 
-const DEFAULT_TIME = "1970-01-01";
+const DEFAULT_TIME = "1970-01-01Z";
 export type ChangeType = "title" | "content";
 
 export type ObsidianDiscourseNodeData = {
@@ -159,7 +159,7 @@ const getLastContentSyncTime = async (
     .order("last_modified", { ascending: false })
     .limit(1)
     .maybeSingle();
-  return new Date((data?.last_modified || DEFAULT_TIME) + "Z");
+  return new Date(data?.last_modified || DEFAULT_TIME);
 };
 
 const getLastSchemaSyncTime = async (
@@ -174,7 +174,7 @@ const getLastSchemaSyncTime = async (
     .order("last_modified", { ascending: false })
     .limit(1)
     .maybeSingle();
-  return new Date((data?.last_modified || DEFAULT_TIME) + "Z");
+  return new Date(data?.last_modified || DEFAULT_TIME);
 };
 
 type DiscourseNodeInVault = {


### PR DESCRIPTION
https://linear.app/discourse-graphs/issue/ENG-1432/error-in-date-manipulation

This is a silly mistake I introduced while handling time zones: the date in this case can be either a string or a number, and adding "Z" will fail in the latter case. It's easier to add the Z in the original string.

(I tested the code still runs.)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/782" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
