### PR TITLE
ENG-1378 automatic source appending for evd incorrectly pre pends

### DIFF
--- a/apps/roam/src/components/FuzzySelectInput.tsx
+++ b/apps/roam/src/components/FuzzySelectInput.tsx
@@ -24,7 +24,7 @@ type FuzzySelectInputProps<T extends Result = Result> = {
   options?: T[];
   placeholder?: string;
   autoFocus?: boolean;
-  isLocked?: boolean;
+  isLocked: boolean;
 };
 
 const FuzzySelectInput = <T extends Result = Result>({
@@ -34,13 +34,12 @@ const FuzzySelectInput = <T extends Result = Result>({
   options = [],
   placeholder = "Enter value",
   autoFocus,
-  isLocked: isLockedProp,
+  isLocked,
 }: FuzzySelectInputProps<T>) => {
   const [query, setQuery] = useState<string>(() => value?.text || "");
   const [isOpen, setIsOpen] = useState(false);
   const [activeIndex, setActiveIndex] = useState(0);
   const [isFocused, setIsFocused] = useState(false);
-  const isLocked = isLockedProp ?? (mode === "create" && Boolean(value?.uid));
 
   const menuRef = useRef<HTMLUListElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);

--- a/apps/roam/src/components/FuzzySelectInput.tsx
+++ b/apps/roam/src/components/FuzzySelectInput.tsx
@@ -24,6 +24,7 @@ type FuzzySelectInputProps<T extends Result = Result> = {
   options?: T[];
   placeholder?: string;
   autoFocus?: boolean;
+  isLocked?: boolean;
 };
 
 const FuzzySelectInput = <T extends Result = Result>({
@@ -33,12 +34,13 @@ const FuzzySelectInput = <T extends Result = Result>({
   options = [],
   placeholder = "Enter value",
   autoFocus,
+  isLocked: isLockedProp,
 }: FuzzySelectInputProps<T>) => {
   const [query, setQuery] = useState<string>(() => value?.text || "");
   const [isOpen, setIsOpen] = useState(false);
   const [activeIndex, setActiveIndex] = useState(0);
   const [isFocused, setIsFocused] = useState(false);
-  const isLocked = mode === "create" && Boolean(value?.uid);
+  const isLocked = isLockedProp ?? (mode === "create" && Boolean(value?.uid));
 
   const menuRef = useRef<HTMLUListElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);

--- a/apps/roam/src/components/FuzzySelectInput.tsx
+++ b/apps/roam/src/components/FuzzySelectInput.tsx
@@ -68,6 +68,16 @@ const FuzzySelectInput = <T extends Result = Result>({
     setValue({ ...value, text: "", uid: "" } as T);
   }, [value, setValue]);
 
+  const handleInputChange = useCallback(
+    (text: string) => {
+      setQuery(text);
+      if (mode === "create" && !isLocked) {
+        setValue({ text, uid: "" } as T);
+      }
+    },
+    [mode, isLocked, setValue],
+  );
+
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
       if (e.key === "ArrowDown") {
@@ -93,10 +103,9 @@ const FuzzySelectInput = <T extends Result = Result>({
   );
 
   useEffect(() => {
-    if (mode === "create" && !isLocked) {
-      setValue({ text: query, uid: "" } as T);
-    }
-  }, [query, mode, isLocked, setValue]);
+    if (isLocked) return;
+    setQuery(value?.text ?? "");
+  }, [isLocked, value?.text]);
 
   useEffect(() => {
     if (isFocused && filteredItems.length > 0 && query) {
@@ -199,7 +208,7 @@ const FuzzySelectInput = <T extends Result = Result>({
           inputRef={inputRef}
           className="w-full"
           value={query}
-          onChange={(e) => setQuery(e.target.value)}
+          onChange={(e) => handleInputChange(e.target.value)}
           onKeyDown={handleKeyDown}
           autoFocus={autoFocus}
           placeholder={placeholder}

--- a/apps/roam/src/components/FuzzySelectInput.tsx
+++ b/apps/roam/src/components/FuzzySelectInput.tsx
@@ -1,4 +1,10 @@
-import React, { useState, useCallback, useMemo, useRef, useEffect } from "react";
+import React, {
+  useState,
+  useCallback,
+  useMemo,
+  useRef,
+  useEffect,
+} from "react";
 import {
   Button,
   TextArea,
@@ -16,7 +22,6 @@ type FuzzySelectInputProps<T extends Result = Result> = {
   setValue: (q: T) => void;
   onLockedChange?: (isLocked: boolean) => void;
   mode: "create" | "edit";
-  initialUid: string;
   options?: T[];
   placeholder?: string;
   autoFocus?: boolean;
@@ -28,7 +33,6 @@ const FuzzySelectInput = <T extends Result = Result>({
   setValue,
   onLockedChange,
   mode,
-  initialUid,
   options = [],
   placeholder = "Enter value",
   autoFocus,
@@ -52,7 +56,7 @@ const FuzzySelectInput = <T extends Result = Result>({
 
   const handleSelect = useCallback(
     (item: T) => {
-      if (mode === "create" && item.uid && item.uid !== initialUid) {
+      if (mode === "create" && item.uid) {
         setIsLocked(true);
         setQuery(item.text);
         setValue(item);
@@ -65,7 +69,7 @@ const FuzzySelectInput = <T extends Result = Result>({
         requestAnimationFrame(() => inputRef.current?.focus());
       }
     },
-    [mode, initialUid, setValue, onLockedChange],
+    [mode, setValue, onLockedChange],
   );
 
   const handleClear = useCallback(() => {
@@ -104,6 +108,12 @@ const FuzzySelectInput = <T extends Result = Result>({
       setValue({ text: query, uid: "" } as T);
     }
   }, [query, mode, isLocked, setValue]);
+
+  useEffect(() => {
+    if (typeof initialIsLocked === "boolean") {
+      setIsLocked(initialIsLocked);
+    }
+  }, [initialIsLocked]);
 
   useEffect(() => {
     if (isFocused && filteredItems.length > 0 && query) {

--- a/apps/roam/src/components/ModifyNodeDialog.tsx
+++ b/apps/roam/src/components/ModifyNodeDialog.tsx
@@ -84,12 +84,8 @@ const ModifyNodeDialog = ({
     [content.uid, initialValue.uid, mode],
   );
   const isReferencedNodeLocked = useMemo(
-    () =>
-      Boolean(
-        referencedNodeValue.uid &&
-          referencedNodeValue.uid !== initialReferencedNode?.uid,
-      ),
-    [referencedNodeValue.uid, initialReferencedNode?.uid],
+    () => Boolean(referencedNodeValue.uid),
+    [referencedNodeValue.uid],
   );
 
   const [options, setOptions] = useState<{
@@ -537,7 +533,6 @@ const ModifyNodeDialog = ({
                   : `Enter a ${selectedNodeType.text.toLowerCase()} ...`
               }
               mode={mode}
-              initialUid={content.uid}
               autoFocus
             />
           </div>
@@ -552,7 +547,6 @@ const ModifyNodeDialog = ({
                 options={options.referencedNode}
                 placeholder={loading ? "..." : "Select a referenced node"}
                 mode={"create"}
-                initialUid={referencedNodeValue.uid}
                 initialIsLocked={isReferencedNodeLocked}
                 autoFocus={false}
               />

--- a/apps/roam/src/components/ModifyNodeDialog.tsx
+++ b/apps/roam/src/components/ModifyNodeDialog.tsx
@@ -533,6 +533,7 @@ const ModifyNodeDialog = ({
                   : `Enter a ${selectedNodeType.text.toLowerCase()} ...`
               }
               mode={mode}
+              isLocked={isContentLocked}
               autoFocus
             />
           </div>
@@ -547,6 +548,7 @@ const ModifyNodeDialog = ({
                 options={options.referencedNode}
                 placeholder={loading ? "..." : "Select a referenced node"}
                 mode={"create"}
+                isLocked={isReferencedNodeLocked}
                 autoFocus={false}
               />
             </div>

--- a/apps/roam/src/components/ModifyNodeDialog.tsx
+++ b/apps/roam/src/components/ModifyNodeDialog.tsx
@@ -547,7 +547,6 @@ const ModifyNodeDialog = ({
                 options={options.referencedNode}
                 placeholder={loading ? "..." : "Select a referenced node"}
                 mode={"create"}
-                initialIsLocked={isReferencedNodeLocked}
                 autoFocus={false}
               />
             </div>


### PR DESCRIPTION
https://www.loom.com/share/12276fa951e14a1d824e8da9e5f6ab7d

## Summary

  Fixes the EVD create flow so a prefilled Source is visibly locked and treated as an existing node, instead of being silently converted  into a “new source” input path.

  ## Problem

  In the create-node modal, the referenced Source could appear prefilled but still behave as unlocked. In that state, the input update path  could clear the referenced uid, which then caused submit logic to treat it as a new source and re-run source formatting.

  ## Root Cause

  FuzzySelectInput kept a separate local isLocked state that could drift from the actual source-of-truth (value.uid), and lock behavior  relied on prop-sync logic.

  ## What Changed

  - Refactored lock behavior to be derived, not stored:
      - isLocked = mode === "create" && Boolean(value?.uid)
      - File: apps/roam/src/components/FuzzySelectInput.tsx
  - Removed prop-sync lock mechanism and related props:
      - Removed initialIsLocked
      - Removed onLockedChange
      - Removed the useEffect that copied prop state into local lock state
      - File: apps/roam/src/components/FuzzySelectInput.tsx
  - Updated selection/clear behavior to drive lock purely via value.uid:
      - Selecting existing item (uid present) locks automatically
      - Clearing resets uid and unlocks automatically
      - File: apps/roam/src/components/FuzzySelectInput.tsx
  - Removed obsolete prop usage in dialog:
      - File: apps/roam/src/components/ModifyNodeDialog.tsx

  ## Why This Approach

  This removes duplicated state and makes lock behavior deterministic from a single source of truth. It is simpler, more React-idiomatic, and avoids stale lock transitions.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/788" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal state management in the fuzzy select component, reducing dependencies and redundant props while preserving all user-facing functionality and UI behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->