### PR TITLE
ENG-1440: Port page groups settings in suggestive mode

### DIFF
--- a/apps/roam/src/components/DiscourseNodeSearchMenu.tsx
+++ b/apps/roam/src/components/DiscourseNodeSearchMenu.tsx
@@ -26,10 +26,6 @@ import getDiscourseNodeFormatExpression from "~/utils/getDiscourseNodeFormatExpr
 import { Result } from "~/utils/types";
 import { getSetting } from "~/utils/extensionSettings";
 import MiniSearch from "minisearch";
-import {
-  getPersonalSetting,
-  setPersonalSetting,
-} from "~/components/settings/utils/accessors";
 
 type Props = {
   textarea: HTMLTextAreaElement;

--- a/apps/roam/src/components/settings/PageGroupPanel.tsx
+++ b/apps/roam/src/components/settings/PageGroupPanel.tsx
@@ -10,7 +10,7 @@ import { setGlobalSetting } from "~/components/settings/utils/accessors";
 
 const syncPageGroupsToBlockProps = (groups: PageGroup[]) => {
   setGlobalSetting(
-    ["Suggestive Mode", "Page Groups"],
+    ["Suggestive mode", "Page groups"],
     groups.map((g) => ({ name: g.name, pages: g.pages.map((p) => p.name) })),
   );
 };

--- a/apps/roam/src/components/settings/PageGroupPanel.tsx
+++ b/apps/roam/src/components/settings/PageGroupPanel.tsx
@@ -6,6 +6,14 @@ import createBlock from "roamjs-components/writes/createBlock";
 import deleteBlock from "roamjs-components/writes/deleteBlock";
 import getAllPageNames from "roamjs-components/queries/getAllPageNames";
 import { type PageGroup } from "~/utils/getSuggestiveModeConfigSettings";
+import { setGlobalSetting } from "~/components/settings/utils/accessors";
+
+const syncPageGroupsToBlockProps = (groups: PageGroup[]) => {
+  setGlobalSetting(
+    ["Suggestive Mode", "Page Groups"],
+    groups.map((g) => ({ name: g.name, pages: g.pages.map((p) => p.name) })),
+  );
+};
 
 const PageGroupsPanel = ({
   uid,
@@ -31,7 +39,12 @@ const PageGroupsPanel = ({
         parentUid: uid,
         node: { text: name },
       });
-      setPageGroups([...pageGroups, { uid: newGroupUid, name, pages: [] }]);
+      const updatedGroups = [
+        ...pageGroups,
+        { uid: newGroupUid, name, pages: [] },
+      ];
+      setPageGroups(updatedGroups);
+      syncPageGroupsToBlockProps(updatedGroups);
       setNewGroupName("");
       setGroupKeys((prev) => prev + 1);
     } catch (e) {
@@ -42,7 +55,9 @@ const PageGroupsPanel = ({
   const removeGroup = async (groupUid: string) => {
     try {
       await deleteBlock(groupUid);
-      setPageGroups(pageGroups.filter((g) => g.uid !== groupUid));
+      const updatedGroups = pageGroups.filter((g) => g.uid !== groupUid);
+      setPageGroups(updatedGroups);
+      syncPageGroupsToBlockProps(updatedGroups);
     } catch (e) {
       console.error("Error removing group", e);
     }
@@ -58,13 +73,13 @@ const PageGroupsPanel = ({
         parentUid: groupUid,
         node: { text: page },
       });
-      setPageGroups(
-        pageGroups.map((g) =>
-          g.uid === groupUid
-            ? { ...g, pages: [...g.pages, { uid: newPageUid, name: page }] }
-            : g,
-        ),
+      const updatedGroups = pageGroups.map((g) =>
+        g.uid === groupUid
+          ? { ...g, pages: [...g.pages, { uid: newPageUid, name: page }] }
+          : g,
       );
+      setPageGroups(updatedGroups);
+      syncPageGroupsToBlockProps(updatedGroups);
       setNewPageInputs((prev) => ({
         ...prev,
         [groupUid]: "",
@@ -81,13 +96,13 @@ const PageGroupsPanel = ({
   const removePageFromGroup = async (groupUid: string, pageUid: string) => {
     try {
       await deleteBlock(pageUid);
-      setPageGroups(
-        pageGroups.map((g) =>
-          g.uid === groupUid
-            ? { ...g, pages: g.pages.filter((p) => p.uid !== pageUid) }
-            : g,
-        ),
+      const updatedGroups = pageGroups.map((g) =>
+        g.uid === groupUid
+          ? { ...g, pages: g.pages.filter((p) => p.uid !== pageUid) }
+          : g,
       );
+      setPageGroups(updatedGroups);
+      syncPageGroupsToBlockProps(updatedGroups);
     } catch (e) {
       console.error("Error removing page from group", e);
     }

--- a/apps/roam/src/components/settings/utils/init.ts
+++ b/apps/roam/src/components/settings/utils/init.ts
@@ -4,17 +4,18 @@ import { createPage, createBlock } from "roamjs-components/writes";
 import setBlockProps from "~/utils/setBlockProps";
 import getBlockProps from "~/utils/getBlockProps";
 import type { json } from "~/utils/getBlockProps";
-import INITIAL_NODE_VALUES from "~/data/defaultDiscourseNodes";
 import DEFAULT_RELATIONS_BLOCK_PROPS from "~/components/settings/data/defaultRelationsBlockProps";
-import { getAllDiscourseNodes } from "./accessors";
 import {
-  DiscourseNodeSchema,
   getTopLevelBlockPropsConfig,
 } from "~/components/settings/utils/zodSchema";
 import {
   DG_BLOCK_PROP_SETTINGS_PAGE_TITLE,
-  DISCOURSE_NODE_PAGE_PREFIX,
 } from "./zodSchema";
+// TODO: Re-enable when initDiscourseNodePages is uncommented
+// import INITIAL_NODE_VALUES from "~/data/defaultDiscourseNodes";
+// import { getAllDiscourseNodes } from "./accessors";
+// import { DiscourseNodeSchema } from "~/components/settings/utils/zodSchema";
+// import { DISCOURSE_NODE_PAGE_PREFIX } from "./zodSchema";
 import toFlexRegex from "roamjs-components/util/toFlexRegex";
 
 const ensurePageExists = async (pageTitle: string): Promise<string> => {
@@ -113,61 +114,65 @@ const initSettingsPageBlocks = async (): Promise<Record<string, string>> => {
   return blockMap;
 };
 
-const hasNonDefaultNodes = (): boolean => {
-  return getAllDiscourseNodes().some((node) => node.backedBy !== "default");
-};
-
-const initSingleDiscourseNode = async (
-  node: (typeof INITIAL_NODE_VALUES)[number],
-): Promise<{ label: string; pageUid: string } | null> => {
-  if (!node.text) return null;
-
-  const pageUid = await ensurePageExists(
-    `${DISCOURSE_NODE_PAGE_PREFIX}${node.text}`,
-  );
-  const existingProps = getBlockProps(pageUid);
-
-  if (!existingProps || Object.keys(existingProps).length === 0) {
-    const nodeData = DiscourseNodeSchema.parse({
-      text: node.text,
-      type: node.type,
-      format: node.format || "",
-      shortcut: node.shortcut || "",
-      tag: node.tag || "",
-      graphOverview: node.graphOverview ?? false,
-      canvasSettings: node.canvasSettings || {},
-      backedBy: "default",
-    });
-
-    setBlockProps(pageUid, nodeData, false);
-  }
-
-  return { label: node.text, pageUid };
-};
-
-const initDiscourseNodePages = async (): Promise<Record<string, string>> => {
-  if (hasNonDefaultNodes()) {
-    const existingNodes = getAllDiscourseNodes();
-    const nodePageUids: Record<string, string> = {};
-    for (const node of existingNodes) {
-      nodePageUids[node.text] = node.type;
-    }
-    return nodePageUids;
-  }
-
-  const results = await Promise.all(
-    INITIAL_NODE_VALUES.map((node) => initSingleDiscourseNode(node)),
-  );
-
-  const nodePageUids: Record<string, string> = {};
-  for (const result of results) {
-    if (result) {
-      nodePageUids[result.label] = result.pageUid;
-    }
-  }
-
-  return nodePageUids;
-};
+// TODO: Enable once we start reading discourse nodes from block props.
+// Currently initializeDiscourseNodes() (called earlier in index.ts) already
+// creates the node pages, so these are unused.
+//
+// const hasNonDefaultNodes = (): boolean => {
+//   return getAllDiscourseNodes().some((node) => node.backedBy !== "default");
+// };
+//
+// const initSingleDiscourseNode = async (
+//   node: (typeof INITIAL_NODE_VALUES)[number],
+// ): Promise<{ label: string; pageUid: string } | null> => {
+//   if (!node.text) return null;
+//
+//   const pageUid = await ensurePageExists(
+//     `${DISCOURSE_NODE_PAGE_PREFIX}${node.text}`,
+//   );
+//   const existingProps = getBlockProps(pageUid);
+//
+//   if (!existingProps || Object.keys(existingProps).length === 0) {
+//     const nodeData = DiscourseNodeSchema.parse({
+//       text: node.text,
+//       type: node.type,
+//       format: node.format || "",
+//       shortcut: node.shortcut || "",
+//       tag: node.tag || "",
+//       graphOverview: node.graphOverview ?? false,
+//       canvasSettings: node.canvasSettings || {},
+//       backedBy: "default",
+//     });
+//
+//     setBlockProps(pageUid, nodeData, false);
+//   }
+//
+//   return { label: node.text, pageUid };
+// };
+//
+// const initDiscourseNodePages = async (): Promise<Record<string, string>> => {
+//   if (hasNonDefaultNodes()) {
+//     const existingNodes = getAllDiscourseNodes();
+//     const nodePageUids: Record<string, string> = {};
+//     for (const node of existingNodes) {
+//       nodePageUids[node.text] = node.type;
+//     }
+//     return nodePageUids;
+//   }
+//
+//   const results = await Promise.all(
+//     INITIAL_NODE_VALUES.map((node) => initSingleDiscourseNode(node)),
+//   );
+//
+//   const nodePageUids: Record<string, string> = {};
+//   for (const result of results) {
+//     if (result) {
+//       nodePageUids[result.label] = result.pageUid;
+//     }
+//   }
+//
+//   return nodePageUids;
+// };
 
 /**
  * Replace placeholder relation keys (_INFO-rel, etc.) in the Global blockprops
@@ -244,6 +249,9 @@ export type InitSchemaResult = {
 
 export const initSchema = async (): Promise<InitSchemaResult> => {
   const blockUids = await initSettingsPageBlocks();
-  const nodePageUids = await initDiscourseNodePages();
-  return { blockUids, nodePageUids };
+  // TODO: Enable once we start reading discourse nodes from block props.
+  // Currently initializeDiscourseNodes() (called earlier in index.ts) already
+  // creates the node pages, so this just duplicates work.
+  // const nodePageUids = await initDiscourseNodePages();
+  return { blockUids, nodePageUids: {} };
 };

--- a/apps/roam/src/components/settings/utils/init.ts
+++ b/apps/roam/src/components/settings/utils/init.ts
@@ -5,12 +5,8 @@ import setBlockProps from "~/utils/setBlockProps";
 import getBlockProps from "~/utils/getBlockProps";
 import type { json } from "~/utils/getBlockProps";
 import DEFAULT_RELATIONS_BLOCK_PROPS from "~/components/settings/data/defaultRelationsBlockProps";
-import {
-  getTopLevelBlockPropsConfig,
-} from "~/components/settings/utils/zodSchema";
-import {
-  DG_BLOCK_PROP_SETTINGS_PAGE_TITLE,
-} from "./zodSchema";
+import { getTopLevelBlockPropsConfig } from "~/components/settings/utils/zodSchema";
+import { DG_BLOCK_PROP_SETTINGS_PAGE_TITLE } from "./zodSchema";
 // TODO: Re-enable when initDiscourseNodePages is uncommented
 // import INITIAL_NODE_VALUES from "~/data/defaultDiscourseNodes";
 // import { getAllDiscourseNodes } from "./accessors";

--- a/apps/roam/src/index.ts
+++ b/apps/roam/src/index.ts
@@ -42,6 +42,7 @@ import {
   DISALLOW_DIAGNOSTICS,
 } from "./data/userSettings";
 import { initSchema } from "./components/settings/utils/init";
+
 export const DEFAULT_CANVAS_PAGE_FORMAT = "Canvas/*";
 
 export default runExtension(async (onloadArgs) => {
@@ -155,7 +156,6 @@ export default runExtension(async (onloadArgs) => {
   }
 
   await initSchema();
-
   return {
     elements: [
       style,


### PR DESCRIPTION
https://www.loom.com/share/dcdbb3b9441145fe94bf152f84fff80b
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/793" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Page group persistence improved. Groups now properly synchronize with global settings whenever changes occur—when groups are created, deleted, or when pages are added to or removed from groups. Changes are immediately saved.

* **New Features**
  * Schema initialization now runs automatically on extension startup, ensuring the extension is properly configured without requiring manual intervention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->