### PR TITLE
ENG-1447 - Add sentence case to agents.md and style guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,7 @@ This repository uses Turborepo.
 - Add comments only when necessary; descriptive names should minimize the need for comments
 - Explain the why, not the what, focusing on reasoning, trade-offs, and approaches
 - Document limitations, known bugs, or edge cases where behavior may not align with expectations
+- Prefer sentence case in documentation and feature descriptions; capitalize official product/plugin names and exact UI labels, buttons, or titles, but keep generic feature terms lowercase to emphasize user actions
 
 ### Testing
 

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -25,7 +25,7 @@ This document outlines the coding standards and best practices for contributing 
   - camelCase for variables and functions
   - UPPERCASE for constants
 
-## Documentation
+## Code Documentation
 
 - Use Comments Strategically:
   - Add comments only when necessary. Well-written code with descriptive names should minimize the need for comments.
@@ -87,6 +87,10 @@ const processData = (data: Data) => {
   return formatForDisplay(transformedData);
 };
 ```
+
+## Documentation
+
+- Use sentence case by default in docs and UI copy. Capitalize official product/plugin names and exact UI labels, buttons, or page titles, but keep generic feature terms lowercase.
 
 ## Testing
 

--- a/apps/website/AGENTS.md
+++ b/apps/website/AGENTS.md
@@ -2,3 +2,6 @@ You are working on the public-facing website for Discourse Graph.
 
 ## Dependencies
 Prefer existing dependencies from package.json.
+
+## Documentation Style
+Use sentence case for documentation copy by default. Capitalize official product/plugin names and exact UI labels, buttons, or titles, but keep generic feature terms lowercase.


### PR DESCRIPTION
- Added a preference for sentence case in documentation and feature descriptions.
- Clarified capitalization rules for official product/plugin names and UI elements.
- Renamed the "Documentation" section to "Code Documentation" in STYLE_GUIDE.md for better clarity.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/797" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
