### PR TITLE
ENG-1448 - Add PostHog capture events for broader Roam feature usage telemetry

### DIFF
--- a/apps/roam/src/components/CreateRelationDialog.tsx
+++ b/apps/roam/src/components/CreateRelationDialog.tsx
@@ -24,6 +24,7 @@ import type { Result } from "~/utils/types";
 import internalError from "~/utils/internalError";
 import getDiscourseNodes from "~/utils/getDiscourseNodes";
 import { USE_REIFIED_RELATIONS } from "~/data/userSettings";
+import posthog from "posthog-js";
 
 export type CreateRelationDialogProps = {
   onClose: () => void;
@@ -162,6 +163,10 @@ const CreateRelationDialog = ({
   };
 
   const onCreateSync = (): void => {
+    posthog.capture("Create Relation Dialog: Create Triggered", {
+      relationName: selectedRelationName,
+      hasTarget: !!selectedTarget.uid,
+    });
     onCreate()
       .then((result: boolean) => {
         if (result) {

--- a/apps/roam/src/components/DiscourseFloatingMenu.tsx
+++ b/apps/roam/src/components/DiscourseFloatingMenu.tsx
@@ -12,6 +12,7 @@ import {
 } from "@blueprintjs/core";
 import { FeedbackWidget } from "./BirdEatsBugs";
 import { render as renderSettings } from "~/components/settings/Settings";
+import posthog from "posthog-js";
 
 type DiscourseFloatingMenuProps = {
   // CSS placement class
@@ -36,6 +37,7 @@ export const DiscourseFloatingMenu = (props: DiscourseFloatingMenuProps) => (
             text="Send feedback"
             icon="send-message"
             onClick={() => {
+              posthog.capture("Floating Menu: Feedback Clicked");
               try {
                 (window.birdeatsbug as FeedbackWidget | undefined)?.trigger?.();
               } catch (error) {
@@ -46,6 +48,7 @@ export const DiscourseFloatingMenu = (props: DiscourseFloatingMenuProps) => (
           <MenuItem
             text="Docs"
             icon="book"
+            onClick={() => posthog.capture("Floating Menu: Docs Clicked")}
             href="https://discoursegraphs.com/docs/roam"
             rel="noopener noreferrer"
             target="_blank"
@@ -53,6 +56,7 @@ export const DiscourseFloatingMenu = (props: DiscourseFloatingMenuProps) => (
           <MenuItem
             text="Community"
             icon="social-media"
+            onClick={() => posthog.capture("Floating Menu: Community Clicked")}
             href="https://join.slack.com/t/discoursegraphs/shared_invite/zt-37xklatti-cpEjgPQC0YyKYQWPNgAkEg"
             rel="noopener noreferrer"
             target="_blank"
@@ -60,12 +64,18 @@ export const DiscourseFloatingMenu = (props: DiscourseFloatingMenuProps) => (
           <MenuItem
             text="Settings"
             icon="cog"
-            onClick={() => renderSettings({ onloadArgs: props.onloadArgs! })}
+            onClick={() => {
+              posthog.capture("Floating Menu: Settings Clicked");
+              renderSettings({ onloadArgs: props.onloadArgs! });
+            }}
             rel="noopener noreferrer"
             target="_blank"
           />
         </Menu>
       }
+      onOpened={() => {
+        posthog.capture("Floating Menu: Opened");
+      }}
       onClosed={() => {
         document.getElementById("dg-floating-menu-button")?.blur();
       }}

--- a/apps/roam/src/components/DiscourseSuggestionsPanel.tsx
+++ b/apps/roam/src/components/DiscourseSuggestionsPanel.tsx
@@ -7,6 +7,7 @@ import {
   Collapse,
 } from "@blueprintjs/core";
 import React, { useState, useCallback, useEffect } from "react";
+import posthog from "posthog-js";
 import SuggestionsBody from "./SuggestionsBody";
 
 export const DiscourseSuggestionsPanel = ({
@@ -31,6 +32,9 @@ export const DiscourseSuggestionsPanel = ({
   const handleToggle = useCallback(() => {
     setIsOpen((prev) => {
       const next = !prev;
+      posthog.capture("Suggestive Mode Panel: Toggled", {
+        isOpen: next,
+      });
       onToggle(next);
       return next;
     });

--- a/apps/roam/src/components/Export.tsx
+++ b/apps/roam/src/components/Export.tsx
@@ -748,12 +748,12 @@ const ExportDialog: ExportDialogComponent = ({
       if (download) {
         const blob = new Blob([download], { type: "application/zip" });
         saveAs(blob, `${filename}.zip`);
-      }
       posthog.capture("Export Dialog: Export Completed", {
         exportType: "PDF",
         destination: activeExportDestination,
         fileCount: files.length,
       });
+
       onClose();
     } catch (e) {
       setError("Failed to export files.");

--- a/apps/roam/src/components/Export.tsx
+++ b/apps/roam/src/components/Export.tsx
@@ -154,15 +154,10 @@ const ExportDialog: ExportDialogComponent = ({
   const exportId = useMemo(() => nanoid(), []);
   useEffect(() => {
     setDialogOpen(isOpen);
-    if (isOpen) {
-      posthog.capture("Export Dialog: Opened", {
-        title,
-        resultCount: results.length,
-        initialPanel: initialPanel ?? "sendTo",
-        isExportDiscourseGraph,
-      });
-    }
-  }, [initialPanel, isExportDiscourseGraph, isOpen, results.length, title]);
+  }, [isOpen]);
+
+  // TODO: maybe add posthog capture here for isOpen
+
   const [dialogOpen, setDialogOpen] = useState(isOpen);
   const exportTypes = useMemo(
     () => getExportTypes({ results, exportId, isExportDiscourseGraph }),

--- a/apps/roam/src/components/Export.tsx
+++ b/apps/roam/src/components/Export.tsx
@@ -748,12 +748,12 @@ const ExportDialog: ExportDialogComponent = ({
       if (download) {
         const blob = new Blob([download], { type: "application/zip" });
         saveAs(blob, `${filename}.zip`);
-      posthog.capture("Export Dialog: Export Completed", {
-        exportType: "PDF",
-        destination: activeExportDestination,
-        fileCount: files.length,
-      });
-
+        posthog.capture("Export Dialog: Export Completed", {
+          exportType: "PDF",
+          destination: activeExportDestination,
+          fileCount: files.length,
+        });
+      }
       onClose();
     } catch (e) {
       setError("Failed to export files.");

--- a/apps/roam/src/components/ImportDialog.tsx
+++ b/apps/roam/src/components/ImportDialog.tsx
@@ -11,6 +11,7 @@ import React, { useMemo, useState } from "react";
 import createBlock from "roamjs-components/writes/createBlock";
 import getChildrenLengthByPageUid from "roamjs-components/queries/getChildrenLengthByPageUid";
 import createOverlayRender from "roamjs-components/util/createOverlayRender";
+import posthog from "posthog-js";
 import importDiscourseGraph from "~/utils/importDiscourseGraph";
 
 const ImportDialog = ({ onClose }: { onClose: () => void }) => {
@@ -49,6 +50,10 @@ const ImportDialog = ({ onClose }: { onClose: () => void }) => {
             disabled={loading}
             onClick={() => {
               setLoading(true);
+              posthog.capture("Import Dialog: Import Started", {
+                hasFile: !!file,
+                title,
+              });
               setTimeout(() => {
                 const reader = new FileReader();
                 reader.onload = (event) => {

--- a/apps/roam/src/components/LeftSidebarView.tsx
+++ b/apps/roam/src/components/LeftSidebarView.tsx
@@ -42,6 +42,7 @@ import getBasicTreeByParentUid from "roamjs-components/queries/getBasicTreeByPar
 import { DISCOURSE_CONFIG_PAGE_TITLE } from "~/utils/renderNodeConfigPage";
 import getPageTitleByPageUid from "roamjs-components/queries/getPageTitleByPageUid";
 import { migrateLeftSidebarSettings } from "~/utils/migrateLeftSidebarSettings";
+import posthog from "posthog-js";
 
 const parseReference = (text: string) => {
   const extracted = extractRef(text);
@@ -61,6 +62,10 @@ const openTarget = async (e: React.MouseEvent, targetUid: string) => {
   e.preventDefault();
   e.stopPropagation();
   const target = parseReference(targetUid);
+  posthog.capture("Left Sidebar: Target Opened", {
+    targetType: target.type,
+    openInSidebar: e.shiftKey,
+  });
   if (target.type === "block") {
     if (e.shiftKey) {
       await openBlockInSidebar(target.uid);

--- a/apps/roam/src/components/ModifyNodeDialog.tsx
+++ b/apps/roam/src/components/ModifyNodeDialog.tsx
@@ -35,6 +35,7 @@ import { render as renderToast } from "roamjs-components/components/Toast";
 import getPageUidByPageTitle from "roamjs-components/queries/getPageUidByPageTitle";
 import resolveQueryBuilderRef from "~/utils/resolveQueryBuilderRef";
 import runQuery from "~/utils/runQuery";
+import posthog from "posthog-js";
 
 export type ModifyNodeDialogMode = "create" | "edit";
 export type ModifyNodeDialogProps = {
@@ -301,6 +302,10 @@ const ModifyNodeDialog = ({
 
   const onSubmit = async () => {
     if (!content.text.trim()) return;
+    posthog.capture("Modify Node Dialog: Submit Triggered", {
+      mode,
+      nodeType: selectedNodeType.type,
+    });
     try {
       if (mode === "create") {
         // If content is locked (user selected existing node), just insert it

--- a/apps/roam/src/components/QueryDrawer.tsx
+++ b/apps/roam/src/components/QueryDrawer.tsx
@@ -380,7 +380,7 @@ const QueryDrawer = ({
 );
 
 export const openQueryDrawer = (onloadArgs: OnloadArgs) => {
-  posthog.capture("Query Drawer: Opened", {});
+  posthog.capture("Query Drawer: Opened");
   return Promise.resolve(
     getPageUidByPageTitle("roam/js/query-builder/drawer") ||
       createPage({

--- a/apps/roam/src/components/SuggestionsBody.tsx
+++ b/apps/roam/src/components/SuggestionsBody.tsx
@@ -29,6 +29,7 @@ import { render as renderToast } from "roamjs-components/components/Toast";
 import { getSetting } from "~/utils/extensionSettings";
 import { USE_REIFIED_RELATIONS } from "~/data/userSettings";
 import { createReifiedRelation } from "~/utils/createReifiedBlock";
+import posthog from "posthog-js";
 
 export type DiscourseData = {
   results: Awaited<ReturnType<typeof getDiscourseContextResults>>;
@@ -369,6 +370,12 @@ const SuggestionsBody = ({
         node: { text: `[[${node.text}]]` },
       });
     }
+    posthog.capture("Suggestive Mode: Suggestion Adopted", {
+      tag,
+      nodeType: node.type,
+      nodeText: node.text,
+      useReifiedRelations: getSetting<boolean>(USE_REIFIED_RELATIONS, false),
+    });
     setHydeFilteredNodes((prev) => prev.filter((n) => n.uid !== node.uid));
   };
 

--- a/apps/roam/src/components/VectorDuplicateMatches.tsx
+++ b/apps/roam/src/components/VectorDuplicateMatches.tsx
@@ -109,13 +109,8 @@ export const VectorDuplicateMatches = ({
       <div
         className="flex cursor-pointer items-center justify-between p-2"
         onClick={() => {
-          setIsOpen((prev) => {
-            const next = !prev;
-            posthog.capture("Possible Duplicates: Toggled", {
-              isOpen: next,
-            });
-            return next;
-          });
+          setIsOpen(!isOpen);
+          posthog.capture("Possible Duplicates: Toggled");
         }}
       >
         <div className="flex items-center gap-2">

--- a/apps/roam/src/components/VectorDuplicateMatches.tsx
+++ b/apps/roam/src/components/VectorDuplicateMatches.tsx
@@ -8,6 +8,7 @@ import getPageUidByPageTitle from "roamjs-components/queries/getPageUidByPageTit
 import { DiscourseNode } from "~/utils/getDiscourseNodes";
 import extractContentFromTitle from "~/utils/extractContentFromTitle";
 import { handleTitleAdditions } from "~/utils/handleTitleAdditions";
+import posthog from "posthog-js";
 
 export const VectorDuplicateMatches = ({
   pageTitle,
@@ -108,7 +109,13 @@ export const VectorDuplicateMatches = ({
       <div
         className="flex cursor-pointer items-center justify-between p-2"
         onClick={() => {
-          setIsOpen(!isOpen);
+          setIsOpen((prev) => {
+            const next = !prev;
+            posthog.capture("Possible Duplicates: Toggled", {
+              isOpen: next,
+            });
+            return next;
+          });
         }}
       >
         <div className="flex items-center gap-2">

--- a/apps/roam/src/components/canvas/CanvasDrawer.tsx
+++ b/apps/roam/src/components/canvas/CanvasDrawer.tsx
@@ -20,6 +20,7 @@ import getCurrentPageUid from "roamjs-components/dom/getCurrentPageUid";
 import getDiscourseNodes from "~/utils/getDiscourseNodes";
 import { DiscourseNodeShape } from "./DiscourseNodeUtil";
 import { formatHexColor } from "~/components/settings/DiscourseNodeCanvasSettings";
+import posthog from "posthog-js";
 
 export type GroupedShapes = Record<string, DiscourseNodeShape[]>;
 
@@ -389,7 +390,13 @@ export const CanvasDrawerContent = ({
 export const CanvasDrawerPanel = () => {
   const editor = useEditor();
   const toggleDrawer = useCallback(() => {
-    setIsOpen((prev) => !prev);
+    setIsOpen((prev) => {
+      const next = !prev;
+      posthog.capture("Canvas Drawer: Toggled", {
+        isOpen: next,
+      });
+      return next;
+    });
   }, []);
   const [isOpen, setIsOpen] = useState(false);
   const pageUid = getCurrentPageUid();

--- a/apps/roam/src/components/canvas/CanvasDrawer.tsx
+++ b/apps/roam/src/components/canvas/CanvasDrawer.tsx
@@ -390,13 +390,8 @@ export const CanvasDrawerContent = ({
 export const CanvasDrawerPanel = () => {
   const editor = useEditor();
   const toggleDrawer = useCallback(() => {
-    setIsOpen((prev) => {
-      const next = !prev;
-      posthog.capture("Canvas Drawer: Toggled", {
-        isOpen: next,
-      });
-      return next;
-    });
+    setIsOpen((prev) => !prev);
+    posthog.capture("Canvas Drawer: Toggled");
   }, []);
   const [isOpen, setIsOpen] = useState(false);
   const pageUid = getCurrentPageUid();

--- a/apps/roam/src/components/canvas/Clipboard.tsx
+++ b/apps/roam/src/components/canvas/Clipboard.tsx
@@ -217,17 +217,10 @@ export const ClipboardProvider = ({
 
   const openClipboard = useCallback(() => setIsOpen(true), []);
   const closeClipboard = useCallback(() => setIsOpen(false), []);
-  const toggleClipboard = useCallback(
-    () =>
-      setIsOpen((prev) => {
-        const next = !prev;
-        posthog.capture("Canvas Clipboard: Toggled", {
-          isOpen: next,
-        });
-        return next;
-      }),
-    [],
-  );
+  const toggleClipboard = useCallback(() => {
+    setIsOpen((prev) => !prev);
+    posthog.capture("Canvas Clipboard: Toggled");
+  }, []);
 
   const addPage = useCallback((page: ClipboardPage) => {
     setPages((prev) => {

--- a/apps/roam/src/components/canvas/Clipboard.tsx
+++ b/apps/roam/src/components/canvas/Clipboard.tsx
@@ -61,6 +61,7 @@ import getBlockProps from "~/utils/getBlockProps";
 import setBlockProps from "~/utils/setBlockProps";
 import { measureCanvasNodeText } from "~/utils/measureCanvasNodeText";
 import internalError from "~/utils/internalError";
+import posthog from "posthog-js";
 
 export type ClipboardPage = {
   uid: string;
@@ -216,7 +217,17 @@ export const ClipboardProvider = ({
 
   const openClipboard = useCallback(() => setIsOpen(true), []);
   const closeClipboard = useCallback(() => setIsOpen(false), []);
-  const toggleClipboard = useCallback(() => setIsOpen((prev) => !prev), []);
+  const toggleClipboard = useCallback(
+    () =>
+      setIsOpen((prev) => {
+        const next = !prev;
+        posthog.capture("Canvas Clipboard: Toggled", {
+          isOpen: next,
+        });
+        return next;
+      }),
+    [],
+  );
 
   const addPage = useCallback((page: ClipboardPage) => {
     setPages((prev) => {

--- a/apps/roam/src/components/canvas/ConvertToDialog.tsx
+++ b/apps/roam/src/components/canvas/ConvertToDialog.tsx
@@ -4,6 +4,7 @@ import { Editor } from "tldraw";
 import { DiscourseNode } from "~/utils/getDiscourseNodes";
 import { getOnSelectForShape } from "./uiOverrides";
 import { Dialog, Button, Classes } from "@blueprintjs/core";
+import posthog from "posthog-js";
 
 const ConvertToDialog = ({
   extensionAPI,
@@ -62,6 +63,13 @@ const ConvertToDialog = ({
                         className="flex-grow justify-start p-2 px-7 focus:bg-gray-300 focus:outline-none"
                         style={{ caretColor: "transparent" }}
                         onClick={() => {
+                          posthog.capture(
+                            "Canvas Convert To Dialog: Node Type Selected",
+                            {
+                              nodeType: node.type,
+                              shapeType: selectedShapes[0]?.type || "unknown",
+                            },
+                          );
                           getOnSelectForShape({
                             shape: selectedShapes[0],
                             nodeType: node.type,

--- a/apps/roam/src/components/canvas/Tldraw.tsx
+++ b/apps/roam/src/components/canvas/Tldraw.tsx
@@ -1,5 +1,11 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import React, { useState, useRef, useMemo, useEffect, useCallback } from "react";
+import React, {
+  useState,
+  useRef,
+  useMemo,
+  useEffect,
+  useCallback,
+} from "react";
 import ExtensionApiContextProvider, {
   useExtensionAPI,
 } from "roamjs-components/components/ExtensionApiContext";

--- a/apps/roam/src/components/settings/DefaultFilters.tsx
+++ b/apps/roam/src/components/settings/DefaultFilters.tsx
@@ -2,6 +2,7 @@ import { Button, Intent, InputGroup } from "@blueprintjs/core";
 import React, { useEffect, useState } from "react";
 import type { OnloadArgs } from "roamjs-components/types";
 import type { Filters } from "roamjs-components/components/Filter";
+import posthog from "posthog-js";
 
 //
 // TODO - REWORK THIS COMPONENT
@@ -190,6 +191,9 @@ const DefaultFilters = ({
           minimal
           disabled={!newColumn}
           onClick={() => {
+            posthog.capture("Default Filters: Column Added", {
+              column: newColumn,
+            });
             const newFilters = {
               ...filters,
               [newColumn]: {

--- a/apps/roam/src/components/settings/GeneralSettings.tsx
+++ b/apps/roam/src/components/settings/GeneralSettings.tsx
@@ -7,6 +7,7 @@ import {
   GlobalTextPanel,
   FeatureFlagPanel,
 } from "./components/BlockPropSettingPanels";
+import posthog from "posthog-js";
 
 const DiscourseGraphHome = () => {
   const settings = useMemo(() => {
@@ -51,6 +52,9 @@ const DiscourseGraphHome = () => {
           if (checked) {
             setIsAlertOpen(true);
           }
+          posthog.capture("General Settings: Left Sidebar Toggled", {
+            enabled: checked,
+          });
         }}
       />
       <Alert

--- a/apps/roam/src/components/settings/HomePersonalSettings.tsx
+++ b/apps/roam/src/components/settings/HomePersonalSettings.tsx
@@ -28,6 +28,7 @@ import KeyboardShortcutInput from "./KeyboardShortcutInput";
 import streamlineStyling from "~/styles/streamlineStyling";
 import { getFormattedConfigTree } from "~/utils/discourseConfigRef";
 import { PersonalFlagPanel } from "./components/BlockPropSettingPanels";
+import posthog from "posthog-js";
 
 const HomePersonalSettings = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
   const extensionAPI = onloadArgs.extensionAPI;
@@ -69,6 +70,9 @@ const HomePersonalSettings = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
         onChange={(checked) => {
           void setSetting("discourse-context-overlay", checked);
           onPageRefObserverChange(overlayHandler)(checked);
+          posthog.capture("Personal Settings: Overlay Toggled", {
+            enabled: checked,
+          });
         }}
       />
       {settings.suggestiveModeEnabled?.value && (

--- a/apps/roam/src/components/settings/LeftSidebarGlobalSettings.tsx
+++ b/apps/roam/src/components/settings/LeftSidebarGlobalSettings.tsx
@@ -17,6 +17,7 @@ import refreshConfigTree from "~/utils/refreshConfigTree";
 import { refreshAndNotify } from "~/components/LeftSidebarView";
 import getPageTitleByPageUid from "roamjs-components/queries/getPageTitleByPageUid";
 import getTextByBlockUid from "roamjs-components/queries/getTextByBlockUid";
+import posthog from "posthog-js";
 
 const PageItem = memo(
   ({
@@ -203,6 +204,9 @@ const LeftSidebarGlobalSectionsContent = ({
         setPages((prev) => [...prev, newPage]);
         setNewPageInput("");
         setAutocompleteKey((prev) => prev + 1);
+        posthog.capture("Left Sidebar Global Settings: Page Added", {
+          pageName,
+        });
         refreshAndNotify();
       } catch (error) {
         renderToast({

--- a/apps/roam/src/components/settings/LeftSidebarPersonalSettings.tsx
+++ b/apps/roam/src/components/settings/LeftSidebarPersonalSettings.tsx
@@ -35,6 +35,7 @@ import refreshConfigTree from "~/utils/refreshConfigTree";
 import { refreshAndNotify } from "~/components/LeftSidebarView";
 import { memo, Dispatch, SetStateAction } from "react";
 import getPageTitleByPageUid from "roamjs-components/queries/getPageTitleByPageUid";
+import posthog from "posthog-js";
 
 const SectionItem = memo(
   ({
@@ -586,6 +587,9 @@ const LeftSidebarPersonalSectionsContent = ({
           } as LeftSidebarPersonalSectionConfig,
         ]);
 
+        posthog.capture("Left Sidebar Personal Settings: Section Added", {
+          sectionName,
+        });
         setNewSectionInput("");
         refreshAndNotify();
       } catch (error) {

--- a/apps/roam/src/components/settings/QuerySettings.tsx
+++ b/apps/roam/src/components/settings/QuerySettings.tsx
@@ -10,6 +10,7 @@ import {
   PersonalNumberPanel,
   PersonalMultiTextPanel,
 } from "./components/BlockPropSettingPanels";
+import posthog from "posthog-js";
 
 const QuerySettings = ({
   extensionAPI,
@@ -27,6 +28,9 @@ const QuerySettings = ({
         }
         onChange={(checked) => {
           void extensionAPI.settings.set(HIDE_METADATA_KEY, checked);
+          posthog.capture("Query Settings: Hide Metadata Toggled", {
+            hidden: checked,
+          });
         }}
       />
       <PersonalNumberPanel
@@ -38,6 +42,9 @@ const QuerySettings = ({
         }
         onChange={(value) => {
           void extensionAPI.settings.set(DEFAULT_PAGE_SIZE_KEY, value);
+          posthog.capture("Query Settings: Default Page Size Changed", {
+            value,
+          });
         }}
       />
       <PersonalMultiTextPanel

--- a/apps/roam/src/components/settings/Settings.tsx
+++ b/apps/roam/src/components/settings/Settings.tsx
@@ -28,6 +28,7 @@ import { FeedbackWidget } from "~/components/BirdEatsBugs";
 import { getVersionWithDate } from "~/utils/getVersion";
 import { LeftSidebarPersonalSections } from "./LeftSidebarPersonalSettings";
 import { LeftSidebarGlobalSections } from "./LeftSidebarGlobalSettings";
+import posthog from "posthog-js";
 
 type SectionHeaderProps = {
   children: React.ReactNode;
@@ -48,6 +49,7 @@ export const SettingsPanel = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
     <div className="m-4">
       <Button
         onClick={() => {
+          posthog.capture("Settings: Opened from Roam Settings Panel");
           render({
             onloadArgs,
           });
@@ -81,12 +83,19 @@ export const SettingsDialog = ({
   );
 
   useEffect(() => {
+    posthog.capture("Settings: Dialog Opened", {
+      initialTabId: String(selectedTabId ?? "discourse-graph-home-personal"),
+    });
+  }, [selectedTabId]);
+
+  useEffect(() => {
     const handleKeyPress = (e: KeyboardEvent) => {
       if (e.ctrlKey && e.shiftKey && e.key === "A") {
         e.stopPropagation();
         e.preventDefault();
         setShowAdminPanel(true);
         setActiveTabId("secret-admin-panel");
+        posthog.capture("Settings: Admin Panel Opened via Shortcut");
       }
     };
 
@@ -134,7 +143,12 @@ export const SettingsDialog = ({
         `}</style>
         <Tabs
           className="dg-settings-tabs flex h-full"
-          onChange={(id) => setActiveTabId(id)}
+          onChange={(id) => {
+            setActiveTabId(id);
+            posthog.capture("Settings: Tab Opened", {
+              tabId: String(id),
+            });
+          }}
           selectedTabId={activeTabId}
           vertical={true}
           renderActiveTabPanelOnly={true}
@@ -235,6 +249,7 @@ export const SettingsDialog = ({
           icon="send-message"
           intent={Intent.PRIMARY}
           onClick={() => {
+            posthog.capture("Feedback: Triggered from Settings");
             const birdeatsbug = window.birdeatsbug as FeedbackWidget;
             birdeatsbug.trigger?.();
           }}

--- a/apps/roam/src/components/settings/SuggestiveModeSettings.tsx
+++ b/apps/roam/src/components/settings/SuggestiveModeSettings.tsx
@@ -9,6 +9,7 @@ import { DISCOURSE_CONFIG_PAGE_TITLE } from "~/utils/renderNodeConfigPage";
 import { createOrUpdateDiscourseEmbedding } from "~/utils/syncDgNodesToSupabase";
 import { render as renderToast } from "roamjs-components/components/Toast";
 import { GlobalFlagPanel } from "./components/BlockPropSettingPanels";
+import posthog from "posthog-js";
 
 const SuggestiveModeSettings = () => {
   const settings = getFormattedConfigTree();
@@ -41,7 +42,12 @@ const SuggestiveModeSettings = () => {
   return (
     <>
       <Tabs
-        onChange={(id) => setSelectedTabId(id)}
+        onChange={(id) => {
+          setSelectedTabId(id);
+          posthog.capture("Suggestive Mode Settings: Tab Opened", {
+            tabId: String(id),
+          });
+        }}
         selectedTabId={selectedTabId}
         renderActiveTabPanelOnly={true}
       >

--- a/apps/roam/src/utils/renderImageToolsMenu.tsx
+++ b/apps/roam/src/utils/renderImageToolsMenu.tsx
@@ -4,6 +4,7 @@ import { Button, IconName } from "@blueprintjs/core";
 import getUids from "roamjs-components/dom/getUids";
 import NodeMenu from "~/components/DiscourseNodeMenu";
 import { OnloadArgs } from "roamjs-components/types";
+import posthog from "posthog-js";
 
 type ImageToolsMenuProps = {
   blockUid: string;
@@ -17,6 +18,7 @@ const ImageToolsMenu = ({
   const [menuKey, setMenuKey] = useState(0);
 
   const handleEditBlock = useCallback((): void => {
+    posthog.capture("Image Tools Menu: Edit Block Clicked");
     // eslint-disable-next-line @typescript-eslint/naming-convention
     void window.roamAlphaAPI.ui.setBlockFocusAndSelection({
       // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/apps/roam/src/utils/renderTextSelectionPopup.tsx
+++ b/apps/roam/src/utils/renderTextSelectionPopup.tsx
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom";
 import { TextSelectionNodeMenu } from "~/components/DiscourseNodeMenu";
 import { getCoordsFromTextarea } from "roamjs-components/components/CursorMenu";
 import { OnloadArgs } from "roamjs-components/types";
+import posthog from "posthog-js";
 
 let currentPopupContainer: HTMLDivElement | null = null;
 
@@ -48,6 +49,7 @@ export const renderTextSelectionPopup = ({
   blockElement: Element;
   textarea: HTMLTextAreaElement;
 }) => {
+  posthog.capture("Text Selection Popup: Opened");
   removeTextSelectionPopup();
   const coords = getCoordsFromTextarea(textarea);
   currentPopupContainer = document.createElement("div");


### PR DESCRIPTION
Codex:
 Added In This PR

  1. Import discourse graph flow (Import Dialog: Import Started)
  2. Suggestive mode settings tab interaction (Suggestive Mode Settings: Tab Opened)
  3. Suggestions panel open/close toggle (Suggestive Mode Panel: Toggled)
  4. Possible duplicates panel open/close toggle (Possible Duplicates: Toggled)
  5. Left sidebar target open interaction (Left Sidebar: Target Opened)
  6. Left sidebar personal settings add section (Left Sidebar Personal Settings: Section Added)
  7. Left sidebar global settings add page (Left Sidebar Global Settings: Page Added)
  8. Personal settings overlay toggle (Personal Settings: Overlay Toggled)
  9. General settings left sidebar toggle (General Settings: Left Sidebar Toggled)
  10. Default filters add column (Default Filters: Column Added)
  11. Create relation dialog submit (Create Relation Dialog: Create Triggered)
  12. Modify node dialog submit (Modify Node Dialog: Submit Triggered)
  13. Canvas clipboard open/close toggle (Canvas Clipboard: Toggled)
  14. Canvas drawer open/close toggle (Canvas Drawer: Toggled)
  15. Canvas convert-to selection (Canvas Convert To Dialog: Node Type Selected)
  16. Image tools menu edit action (Image Tools Menu: Edit Block Clicked)
  17. Text selection popup open (Text Selection Popup: Opened)

  Already Had PostHog Before This PR

  1. Discourse node menu create/tag actions
  2. Floating menu interactions/open event
  3. Discourse context show results event
  4. Query drawer usage/error/open events
  5. Query block/page render events
  6. Graph overview export event
  7. Export dialog/send-to-destination/tab/open flow events
  8. Results view layout/column/share interactions
  9. Discourse node search menu selection event
  10. Reified relations migration/toggle events
  11. Discourse node type creation event
  12. Discourse relation creation event
  13. Query page format add event
  14. Query settings toggles/changes
  15. Settings dialog/tab/admin/feedback/open events
  16. Canvas telemetry (opened/fullscreen/relation/open-node/drop/add-asset/add-node)
  17. Discourse node creation utility event
  18. Extension loaded event
  19. Command palette usage events (query/export/settings/overlay/metadata toggles)
  20. Sync completion/error events
---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/798" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added analytics instrumentation across the app to record user interactions in settings, export flows, canvas features, sidebars, dialogs, command palette, import/export, and suggestion panels.
  * Telemetry now captures opens, toggles, dialog actions, export milestones, and other UI events to improve product insights without changing user-facing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->