### PR TITLE
Context view publish status

### DIFF
--- a/apps/obsidian/src/components/DiscourseContextView.tsx
+++ b/apps/obsidian/src/components/DiscourseContextView.tsx
@@ -44,7 +44,7 @@ const DiscourseContext = ({ activeFile }: DiscourseContextProps) => {
       Array.isArray(publishedToGroups) &&
       publishedToGroups.length > 0;
     setIsPublished(published);
-  }, [activeFile?.path, plugin]);
+  }, [activeFile, plugin]);
 
   const extractContentFromTitle = (format: string, title: string): string => {
     if (!format) return "";

--- a/apps/obsidian/src/components/DiscourseContextView.tsx
+++ b/apps/obsidian/src/components/DiscourseContextView.tsx
@@ -18,6 +18,7 @@ const DiscourseContext = ({ activeFile }: DiscourseContextProps) => {
   const plugin = usePlugin();
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [isPublishing, setIsPublishing] = useState(false);
+  const [, forceUpdate] = useState({});
 
   const extractContentFromTitle = (format: string, title: string): string => {
     if (!format) return "";
@@ -62,6 +63,8 @@ const DiscourseContext = ({ activeFile }: DiscourseContextProps) => {
     try {
       await publishNode({ plugin, file: activeFile, frontmatter });
       new Notice("Published successfully", 3000);
+      // Force re-render to update button state after frontmatter changes
+      forceUpdate({});
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : String(error);
@@ -149,18 +152,24 @@ const DiscourseContext = ({ activeFile }: DiscourseContextProps) => {
                   void handlePublish(frontmatter);
                 }}
                 disabled={isPublishing}
-                className="ml-auto rounded border px-2 py-1 text-xs"
+                className={`ml-auto rounded px-2 py-1 text-xs ${
+                  isPublished
+                    ? "border-green-600 bg-green-600 text-white hover:bg-green-700"
+                    : "border hover:bg-gray-100"
+                }`}
                 title={
                   isPublished
                     ? "Re-publish to lab space"
                     : "Publish to lab space"
                 }
               >
-                {isPublishing
-                  ? "Publishing..."
-                  : isPublished
-                    ? "Published"
-                    : "Publish"}
+                {isPublishing ? (
+                  "Publishing..."
+                ) : isPublished ? (
+                  <>✓ Published</>
+                ) : (
+                  "Publish"
+                )}
               </button>
             )}
           </div>

--- a/apps/obsidian/src/components/DiscourseContextView.tsx
+++ b/apps/obsidian/src/components/DiscourseContextView.tsx
@@ -1,4 +1,10 @@
-import { ItemView, TFile, WorkspaceLeaf, Notice, FrontMatterCache } from "obsidian";
+import {
+  ItemView,
+  TFile,
+  WorkspaceLeaf,
+  Notice,
+  FrontMatterCache,
+} from "obsidian";
 import { createRoot, Root } from "react-dom/client";
 import DiscourseGraphPlugin from "~/index";
 import { getDiscourseNodeFormatExpression } from "~/utils/getDiscourseNodeFormatExpression";


### PR DESCRIPTION
Add a "Publish" button to the Discourse Context View for local vault nodes to enable easy publishing and display of publish status.

---
Linear Issue: [ENG-1449](https://linear.app/discourse-graphs/issue/ENG-1449/add-publish-button-to-discourse-context-view)

<p><a href="https://cursor.com/background-agent?bcId=bc-ae301fff-124d-4c40-aa35-4f1b3d877b58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ae301fff-124d-4c40-aa35-4f1b3d877b58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/799" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
