### PR TITLE
Node selection focus

### DIFF
--- a/apps/roam/src/components/FuzzySelectInput.tsx
+++ b/apps/roam/src/components/FuzzySelectInput.tsx
@@ -21,6 +21,7 @@ type FuzzySelectInputProps<T extends Result = Result> = {
   placeholder?: string;
   autoFocus?: boolean;
   initialIsLocked?: boolean;
+  onSelectComplete?: () => void;
 };
 
 const FuzzySelectInput = <T extends Result = Result>({
@@ -33,6 +34,7 @@ const FuzzySelectInput = <T extends Result = Result>({
   placeholder = "Enter value",
   autoFocus,
   initialIsLocked,
+  onSelectComplete,
 }: FuzzySelectInputProps<T>) => {
   const [isLocked, setIsLocked] = useState(initialIsLocked || false);
   const [query, setQuery] = useState<string>(() => value?.text || "");
@@ -58,13 +60,15 @@ const FuzzySelectInput = <T extends Result = Result>({
         setValue(item);
         setIsOpen(false);
         onLockedChange?.(true);
+        onSelectComplete?.();
       } else {
         setQuery(item.text);
         setValue(item);
         setIsOpen(false);
+        onSelectComplete?.();
       }
     },
-    [mode, initialUid, setValue, onLockedChange],
+    [mode, initialUid, setValue, onLockedChange, onSelectComplete],
   );
 
   const handleClear = useCallback(() => {

--- a/apps/roam/src/components/FuzzySelectInput.tsx
+++ b/apps/roam/src/components/FuzzySelectInput.tsx
@@ -21,7 +21,6 @@ type FuzzySelectInputProps<T extends Result = Result> = {
   placeholder?: string;
   autoFocus?: boolean;
   initialIsLocked?: boolean;
-  onSelectComplete?: () => void;
 };
 
 const FuzzySelectInput = <T extends Result = Result>({
@@ -34,7 +33,6 @@ const FuzzySelectInput = <T extends Result = Result>({
   placeholder = "Enter value",
   autoFocus,
   initialIsLocked,
-  onSelectComplete,
 }: FuzzySelectInputProps<T>) => {
   const [isLocked, setIsLocked] = useState(initialIsLocked || false);
   const [query, setQuery] = useState<string>(() => value?.text || "");
@@ -60,15 +58,13 @@ const FuzzySelectInput = <T extends Result = Result>({
         setValue(item);
         setIsOpen(false);
         onLockedChange?.(true);
-        onSelectComplete?.();
       } else {
         setQuery(item.text);
         setValue(item);
         setIsOpen(false);
-        onSelectComplete?.();
       }
     },
-    [mode, initialUid, setValue, onLockedChange, onSelectComplete],
+    [mode, initialUid, setValue, onLockedChange],
   );
 
   const handleClear = useCallback(() => {

--- a/apps/roam/src/components/FuzzySelectInput.tsx
+++ b/apps/roam/src/components/FuzzySelectInput.tsx
@@ -62,7 +62,6 @@ const FuzzySelectInput = <T extends Result = Result>({
         setQuery(item.text);
         setValue(item);
         setIsOpen(false);
-        requestAnimationFrame(() => inputRef.current?.focus());
       }
     },
     [mode, initialUid, setValue, onLockedChange],

--- a/apps/roam/src/components/ModifyNodeDialog.tsx
+++ b/apps/roam/src/components/ModifyNodeDialog.tsx
@@ -102,6 +102,7 @@ const ModifyNodeDialog = ({
   const contentRequestIdRef = useRef(0);
   const referencedNodeRequestIdRef = useRef(0);
   const [error, setError] = useState("");
+  const confirmButtonRef = useRef<HTMLButtonElement>(null);
 
   const discourseNodes = useMemo(() => {
     const allNodes = getDiscourseNodes();
@@ -233,6 +234,10 @@ const ModifyNodeDialog = ({
 
   const setReferencedNodeValueCallback = useCallback((r: Result) => {
     setReferencedNodeValue(r);
+  }, []);
+
+  const handleSelectComplete = useCallback(() => {
+    confirmButtonRef.current?.focus();
   }, []);
 
   const onCancelClick = useCallback(() => {
@@ -540,6 +545,7 @@ const ModifyNodeDialog = ({
               mode={mode}
               initialUid={content.uid}
               autoFocus
+              onSelectComplete={handleSelectComplete}
             />
           </div>
 
@@ -556,6 +562,7 @@ const ModifyNodeDialog = ({
                 initialUid={referencedNodeValue.uid}
                 initialIsLocked={isReferencedNodeLocked}
                 autoFocus={false}
+                onSelectComplete={handleSelectComplete}
               />
             </div>
           )}
@@ -571,6 +578,7 @@ const ModifyNodeDialog = ({
               onClick={() => void onSubmit()}
               disabled={loading || !content.text.trim()}
               className="flex-shrink-0"
+              elementRef={confirmButtonRef}
             />
             <Button
               text="Cancel"

--- a/apps/roam/src/components/ModifyNodeDialog.tsx
+++ b/apps/roam/src/components/ModifyNodeDialog.tsx
@@ -491,6 +491,7 @@ const ModifyNodeDialog = ({
       onClose={onClose}
       canEscapeKeyClose
       autoFocus={false}
+      enforceFocus={false}
       className={"roamjs-canvas-dialog"}
     >
       <div

--- a/apps/roam/src/components/ModifyNodeDialog.tsx
+++ b/apps/roam/src/components/ModifyNodeDialog.tsx
@@ -230,15 +230,17 @@ const ModifyNodeDialog = ({
 
   const setValue = useCallback((r: Result) => {
     setContent(r);
-  }, []);
+    if (r.uid && r.uid !== initialValue.uid) {
+      confirmButtonRef.current?.focus();
+    }
+  }, [initialValue.uid]);
 
   const setReferencedNodeValueCallback = useCallback((r: Result) => {
     setReferencedNodeValue(r);
-  }, []);
-
-  const handleSelectComplete = useCallback(() => {
-    confirmButtonRef.current?.focus();
-  }, []);
+    if (r.uid && r.uid !== initialReferencedNode?.uid) {
+      confirmButtonRef.current?.focus();
+    }
+  }, [initialReferencedNode?.uid]);
 
   const onCancelClick = useCallback(() => {
     onClose();
@@ -545,7 +547,6 @@ const ModifyNodeDialog = ({
               mode={mode}
               initialUid={content.uid}
               autoFocus
-              onSelectComplete={handleSelectComplete}
             />
           </div>
 
@@ -562,7 +563,6 @@ const ModifyNodeDialog = ({
                 initialUid={referencedNodeValue.uid}
                 initialIsLocked={isReferencedNodeLocked}
                 autoFocus={false}
-                onSelectComplete={handleSelectComplete}
               />
             </div>
           )}


### PR DESCRIPTION
Fixes focus jumping to the Node Type dropdown after selecting a node with Enter by directing focus to the Confirm button.

---
Linear Issue: [ENG-1316](https://linear.app/discourse-graphs/issue/ENG-1316/when-selecting-node-using-enter-shouldnt-focus-on-node-select-dropdown)

<p><a href="https://cursor.com/background-agent?bcId=bc-2ec51ec5-dc1c-4a58-b1f9-4dffbce9facd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2ec51ec5-dc1c-4a58-b1f9-4dffbce9facd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

