### PR TITLE
ENG-1328: Port small blueprint based misc settings into props based

### DIFF
--- a/apps/roam/src/components/settings/AdminPanel.tsx
+++ b/apps/roam/src/components/settings/AdminPanel.tsx
@@ -38,6 +38,7 @@ import createBlock from "roamjs-components/writes/createBlock";
 import deleteBlock from "roamjs-components/writes/deleteBlock";
 import { USE_REIFIED_RELATIONS } from "~/data/userSettings";
 import posthog from "posthog-js";
+import { setFeatureFlag } from "~/components/settings/utils/accessors";
 
 const NodeRow = ({ node }: { node: PConceptFull }) => {
   return (
@@ -377,6 +378,7 @@ const FeatureFlagsTab = (): React.ReactElement => {
               setSuggestiveModeUid(undefined);
             }
             setSuggestiveModeEnabled(false);
+            setFeatureFlag("Suggestive mode enabled", false);
           }
         }}
         labelElement={
@@ -399,6 +401,7 @@ const FeatureFlagsTab = (): React.ReactElement => {
           }).then((uid) => {
             setSuggestiveModeUid(uid);
             setSuggestiveModeEnabled(true);
+            setFeatureFlag("Suggestive mode enabled", true);
             setIsAlertOpen(false);
             setIsInstructionOpen(true);
           });
@@ -447,6 +450,7 @@ const FeatureFlagsTab = (): React.ReactElement => {
           void setSetting(USE_REIFIED_RELATIONS, target.checked).catch(
             () => undefined,
           );
+          setFeatureFlag("Reified relation triples", target.checked);
           posthog.capture("Reified Relations: Toggled", {
             enabled: target.checked,
           });

--- a/apps/roam/src/components/settings/DefaultFilters.tsx
+++ b/apps/roam/src/components/settings/DefaultFilters.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from "react";
 import type { OnloadArgs } from "roamjs-components/types";
 import type { Filters } from "roamjs-components/components/Filter";
 import posthog from "posthog-js";
+import { setPersonalSetting } from "~/components/settings/utils/accessors";
 
 //
 // TODO - REWORK THIS COMPONENT
@@ -124,28 +125,27 @@ const DefaultFilters = ({
   );
 
   useEffect(() => {
-    extensionAPI.settings.set(
-      "default-filters",
-      Object.fromEntries(
-        Object.entries(filters).map(([k, v]) => [
-          k,
-          {
-            includes: Object.fromEntries(
-              Object.entries(v.includes || {}).map(([k, v]) => [
-                k,
-                Array.from(v),
-              ]),
-            ),
-            excludes: Object.fromEntries(
-              Object.entries(v.excludes || {}).map(([k, v]) => [
-                k,
-                Array.from(v),
-              ]),
-            ),
-          },
-        ]),
-      ),
+    const serialized = Object.fromEntries(
+      Object.entries(filters).map(([k, v]) => [
+        k,
+        {
+          includes: Object.fromEntries(
+            Object.entries(v.includes || {}).map(([k, v]) => [
+              k,
+              Array.from(v),
+            ]),
+          ),
+          excludes: Object.fromEntries(
+            Object.entries(v.excludes || {}).map(([k, v]) => [
+              k,
+              Array.from(v),
+            ]),
+          ),
+        },
+      ]),
     );
+    void extensionAPI.settings.set("default-filters", serialized);
+    setPersonalSetting(["Query", "Default filters"], serialized);
   }, [filters]);
   return (
     <div

--- a/apps/roam/src/components/settings/DiscourseNodeAttributes.tsx
+++ b/apps/roam/src/components/settings/DiscourseNodeAttributes.tsx
@@ -63,7 +63,13 @@ const NodeAttribute = ({
 const toRecord = (attrs: Attribute[]): Record<string, string> =>
   Object.fromEntries(attrs.map((a) => [a.label, a.value]));
 
-const NodeAttributes = ({ uid, nodeType }: { uid: string; nodeType: string }) => {
+const NodeAttributes = ({
+  uid,
+  nodeType,
+}: {
+  uid: string;
+  nodeType: string;
+}) => {
   const [attributes, setAttributes] = useState<Attribute[]>(() =>
     getBasicTreeByParentUid(uid).map((t) => ({
       uid: t.uid,
@@ -74,7 +80,11 @@ const NodeAttributes = ({ uid, nodeType }: { uid: string; nodeType: string }) =>
   const attributesRef = useRef(attributes);
   attributesRef.current = attributes;
   const syncToBlockProps = () =>
-    setDiscourseNodeSetting(nodeType, ["attributes"], toRecord(attributesRef.current));
+    setDiscourseNodeSetting(
+      nodeType,
+      ["attributes"],
+      toRecord(attributesRef.current),
+    );
   const [newAttribute, setNewAttribute] = useState("");
   return (
     <div>
@@ -94,7 +104,11 @@ const NodeAttributes = ({ uid, nodeType }: { uid: string; nodeType: string }) =>
               deleteBlock(a.uid).then(() => {
                 const updated = attributes.filter((aa) => a.uid !== aa.uid);
                 setAttributes(updated);
-                setDiscourseNodeSetting(nodeType, ["attributes"], toRecord(updated));
+                setDiscourseNodeSetting(
+                  nodeType,
+                  ["attributes"],
+                  toRecord(updated),
+                );
               })
             }
             onSync={syncToBlockProps}
@@ -128,7 +142,11 @@ const NodeAttributes = ({ uid, nodeType }: { uid: string; nodeType: string }) =>
                 ];
                 setAttributes(updated);
                 setNewAttribute("");
-                setDiscourseNodeSetting(nodeType, ["attributes"], toRecord(updated));
+                setDiscourseNodeSetting(
+                  nodeType,
+                  ["attributes"],
+                  toRecord(updated),
+                );
               });
             }}
           />

--- a/apps/roam/src/components/settings/DiscourseNodeAttributes.tsx
+++ b/apps/roam/src/components/settings/DiscourseNodeAttributes.tsx
@@ -79,12 +79,13 @@ const NodeAttributes = ({
   );
   const attributesRef = useRef(attributes);
   attributesRef.current = attributes;
-  const syncToBlockProps = () =>
+  const syncToBlockProps = () => {
     setDiscourseNodeSetting(
       nodeType,
       ["attributes"],
       toRecord(attributesRef.current),
     );
+  };
   const [newAttribute, setNewAttribute] = useState("");
   return (
     <div>

--- a/apps/roam/src/components/settings/DiscourseNodeCanvasSettings.tsx
+++ b/apps/roam/src/components/settings/DiscourseNodeCanvasSettings.tsx
@@ -11,7 +11,10 @@ import React, { useState, useMemo } from "react";
 import getBasicTreeByParentUid from "roamjs-components/queries/getBasicTreeByParentUid";
 import getSettingValueFromTree from "roamjs-components/util/getSettingValueFromTree";
 import setInputSetting from "roamjs-components/util/setInputSetting";
-import { DiscourseNodeFlagPanel, DiscourseNodeTextPanel } from "./components/BlockPropSettingPanels";
+import {
+  DiscourseNodeFlagPanel,
+  DiscourseNodeTextPanel,
+} from "./components/BlockPropSettingPanels";
 import { setDiscourseNodeSetting } from "~/components/settings/utils/accessors";
 
 export const formatHexColor = (color: string) => {
@@ -66,7 +69,11 @@ const DiscourseNodeCanvasSettings = ({
                 key: "color",
                 value: colorValue,
               });
-              setDiscourseNodeSetting(nodeType, ["canvasSettings", "color"], colorValue);
+              setDiscourseNodeSetting(
+                nodeType,
+                ["canvasSettings", "color"],
+                colorValue,
+              );
             }}
           />
           <Tooltip content={color ? "Unset" : "Color not set"}>
@@ -80,7 +87,11 @@ const DiscourseNodeCanvasSettings = ({
                   key: "color",
                   value: "",
                 });
-                setDiscourseNodeSetting(nodeType, ["canvasSettings", "color"], "");
+                setDiscourseNodeSetting(
+                  nodeType,
+                  ["canvasSettings", "color"],
+                  "",
+                );
               }}
             />
           </Tooltip>
@@ -128,7 +139,11 @@ const DiscourseNodeCanvasSettings = ({
             key: "key-image-option",
             value,
           });
-          setDiscourseNodeSetting(nodeType, ["canvasSettings", "key-image-option"], value);
+          setDiscourseNodeSetting(
+            nodeType,
+            ["canvasSettings", "key-image-option"],
+            value,
+          );
         }}
       >
         <Radio label="First image on page" value="first-image" />
@@ -155,7 +170,11 @@ const DiscourseNodeCanvasSettings = ({
             key: "query-builder-alias",
             value: val,
           });
-          setDiscourseNodeSetting(nodeType, ["canvasSettings", "query-builder-alias"], val);
+          setDiscourseNodeSetting(
+            nodeType,
+            ["canvasSettings", "query-builder-alias"],
+            val,
+          );
         }}
       />
     </div>

--- a/apps/roam/src/components/settings/DiscourseNodeCanvasSettings.tsx
+++ b/apps/roam/src/components/settings/DiscourseNodeCanvasSettings.tsx
@@ -11,7 +11,8 @@ import React, { useState, useMemo } from "react";
 import getBasicTreeByParentUid from "roamjs-components/queries/getBasicTreeByParentUid";
 import getSettingValueFromTree from "roamjs-components/util/getSettingValueFromTree";
 import setInputSetting from "roamjs-components/util/setInputSetting";
-import { DiscourseNodeFlagPanel } from "./components/BlockPropSettingPanels";
+import { DiscourseNodeFlagPanel, DiscourseNodeTextPanel } from "./components/BlockPropSettingPanels";
+import { setDiscourseNodeSetting } from "~/components/settings/utils/accessors";
 
 export const formatHexColor = (color: string) => {
   if (!color) return "";
@@ -37,9 +38,7 @@ const DiscourseNodeCanvasSettings = ({
     const color = getSettingValueFromTree({ tree, key: "color" });
     return formatHexColor(color);
   });
-  const [alias, setAlias] = useState<string>(() =>
-    getSettingValueFromTree({ tree, key: "alias" }),
-  );
+  const alias = getSettingValueFromTree({ tree, key: "alias" });
   const [queryBuilderAlias, setQueryBuilderAlias] = useState<string>(() =>
     getSettingValueFromTree({ tree, key: "query-builder-alias" }),
   );
@@ -60,12 +59,14 @@ const DiscourseNodeCanvasSettings = ({
             type={"color"}
             value={color}
             onChange={(e) => {
+              const colorValue = e.target.value.replace("#", ""); // remove hash to not create roam link
               setColor(e.target.value);
               void setInputSetting({
                 blockUid: uid,
                 key: "color",
-                value: e.target.value.replace("#", ""), // remove hash to not create roam link
+                value: colorValue,
               });
+              setDiscourseNodeSetting(nodeType, ["canvasSettings", "color"], colorValue);
             }}
           />
           <Tooltip content={color ? "Unset" : "Color not set"}>
@@ -79,25 +80,26 @@ const DiscourseNodeCanvasSettings = ({
                   key: "color",
                   value: "",
                 });
+                setDiscourseNodeSetting(nodeType, ["canvasSettings", "color"], "");
               }}
             />
           </Tooltip>
         </ControlGroup>
       </div>
-      <Label style={{ width: 240 }}>
-        Display alias
-        <InputGroup
-          value={alias}
-          onChange={(e) => {
-            setAlias(e.target.value);
-            void setInputSetting({
-              blockUid: uid,
-              key: "alias",
-              value: e.target.value,
-            });
-          }}
-        />
-      </Label>
+      <DiscourseNodeTextPanel
+        nodeType={nodeType}
+        title="Display alias"
+        description=""
+        settingKeys={["canvasSettings", "alias"]}
+        initialValue={alias}
+        onChange={(val) => {
+          void setInputSetting({
+            blockUid: uid,
+            key: "alias",
+            value: val,
+          });
+        }}
+      />
       <DiscourseNodeFlagPanel
         nodeType={nodeType}
         title="Key image"
@@ -126,6 +128,7 @@ const DiscourseNodeCanvasSettings = ({
             key: "key-image-option",
             value,
           });
+          setDiscourseNodeSetting(nodeType, ["canvasSettings", "key-image-option"], value);
         }}
       >
         <Radio label="First image on page" value="first-image" />
@@ -145,12 +148,14 @@ const DiscourseNodeCanvasSettings = ({
         disabled={keyImageOption !== "query-builder" || !isKeyImage}
         value={queryBuilderAlias}
         onChange={(e) => {
-          setQueryBuilderAlias(e.target.value);
+          const val = e.target.value;
+          setQueryBuilderAlias(val);
           void setInputSetting({
             blockUid: uid,
             key: "query-builder-alias",
-            value: e.target.value,
+            value: val,
           });
+          setDiscourseNodeSetting(nodeType, ["canvasSettings", "query-builder-alias"], val);
         }}
       />
     </div>

--- a/apps/roam/src/components/settings/DiscourseNodeConfigPanel.tsx
+++ b/apps/roam/src/components/settings/DiscourseNodeConfigPanel.tsx
@@ -13,7 +13,9 @@ import refreshConfigTree from "~/utils/refreshConfigTree";
 import createPage from "roamjs-components/writes/createPage";
 import type { CustomField } from "roamjs-components/components/ConfigPanels/types";
 import posthog from "posthog-js";
-import getDiscourseRelations from "~/utils/getDiscourseRelations";
+import getDiscourseRelations, {
+  type DiscourseRelation,
+} from "~/utils/getDiscourseRelations";
 import { deleteBlock } from "roamjs-components/writes";
 import { formatHexColor } from "./DiscourseNodeCanvasSettings";
 import setBlockProps from "~/utils/setBlockProps";
@@ -41,7 +43,7 @@ const DiscourseNodeConfigPanel: React.FC<DiscourseNodeConfigPanelProps> = ({
 
   const [isAlertOpen, setIsAlertOpen] = useState(false);
   const [alertMessage, setAlertMessage] = useState("");
-  const [affectedRelations, setAffectedRelations] = useState<any[]>([]);
+  const [affectedRelations, setAffectedRelations] = useState<DiscourseRelation[]>([]);
   const [nodeTypeIdToDelete, setNodeTypeIdToDelete] = useState<string>("");
   const navigateToNode = (uid: string) => {
     if (isPopup) {

--- a/apps/roam/src/components/settings/DiscourseNodeConfigPanel.tsx
+++ b/apps/roam/src/components/settings/DiscourseNodeConfigPanel.tsx
@@ -43,7 +43,9 @@ const DiscourseNodeConfigPanel: React.FC<DiscourseNodeConfigPanelProps> = ({
 
   const [isAlertOpen, setIsAlertOpen] = useState(false);
   const [alertMessage, setAlertMessage] = useState("");
-  const [affectedRelations, setAffectedRelations] = useState<DiscourseRelation[]>([]);
+  const [affectedRelations, setAffectedRelations] = useState<
+    DiscourseRelation[]
+  >([]);
   const [nodeTypeIdToDelete, setNodeTypeIdToDelete] = useState<string>("");
   const navigateToNode = (uid: string) => {
     if (isPopup) {
@@ -97,13 +99,16 @@ const DiscourseNodeConfigPanel: React.FC<DiscourseNodeConfigPanelProps> = ({
                 },
               ],
             }).then((valueUid) => {
-              setBlockProps(valueUid, DiscourseNodeSchema.parse({
-                text: label,
-                type: valueUid,
-                shortcut,
-                format,
-                backedBy: "user",
-              }));
+              setBlockProps(
+                valueUid,
+                DiscourseNodeSchema.parse({
+                  text: label,
+                  type: valueUid,
+                  shortcut,
+                  format,
+                  backedBy: "user",
+                }),
+              );
               setNodes([
                 ...nodes,
                 {

--- a/apps/roam/src/components/settings/NodeConfig.tsx
+++ b/apps/roam/src/components/settings/NodeConfig.tsx
@@ -25,6 +25,7 @@ import refreshConfigTree from "~/utils/refreshConfigTree";
 import {
   DiscourseNodeTextPanel,
   DiscourseNodeFlagPanel,
+  DiscourseNodeSelectPanel,
 } from "./components/BlockPropSettingPanels";
 
 const TEMPLATE_SETTING_KEYS = ["template"];
@@ -360,15 +361,16 @@ const NodeConfig = ({
           panel={
             <div className="flex flex-col gap-4 p-1">
               <DiscourseNodeAttributes uid={attributeNode.uid} />
-              <SelectPanel
+              <DiscourseNodeSelectPanel
+                nodeType={node.type}
                 title="Overlay"
                 description="Select which attribute is used for the discourse overlay"
+                settingKeys={["overlay"]}
+                options={attributeNode.children.map((c) => c.text)}
+                initialValue={getBasicTreeByParentUid(overlayUid)[0]?.text}
                 order={0}
                 parentUid={node.type}
                 uid={overlayUid}
-                options={{
-                  items: () => attributeNode.children.map((c) => c.text),
-                }}
               />
             </div>
           }

--- a/apps/roam/src/components/settings/NodeConfig.tsx
+++ b/apps/roam/src/components/settings/NodeConfig.tsx
@@ -1,9 +1,4 @@
-import React, {
-  useState,
-  useCallback,
-  useEffect,
-  useMemo,
-} from "react";
+import React, { useState, useCallback, useEffect, useMemo } from "react";
 import { DiscourseNode } from "~/utils/getDiscourseNodes";
 import DualWriteBlocksPanel from "./components/EphemeralBlocksPanel";
 import { getSubTree } from "roamjs-components/util";
@@ -261,7 +256,10 @@ const NodeConfig = ({
           title="Attributes"
           panel={
             <div className="flex flex-col gap-4 p-1">
-              <DiscourseNodeAttributes uid={attributeNode.uid} nodeType={node.type} />
+              <DiscourseNodeAttributes
+                uid={attributeNode.uid}
+                nodeType={node.type}
+              />
               <DiscourseNodeSelectPanel
                 nodeType={node.type}
                 title="Overlay"

--- a/apps/roam/src/components/settings/NodeConfig.tsx
+++ b/apps/roam/src/components/settings/NodeConfig.tsx
@@ -1,24 +1,20 @@
 import React, {
   useState,
   useCallback,
-  useRef,
   useEffect,
   useMemo,
 } from "react";
 import { DiscourseNode } from "~/utils/getDiscourseNodes";
-import SelectPanel from "roamjs-components/components/ConfigPanels/SelectPanel";
 import DualWriteBlocksPanel from "./components/EphemeralBlocksPanel";
 import { getSubTree } from "roamjs-components/util";
 import Description from "roamjs-components/components/Description";
-import { Label, Tabs, Tab, TabId, InputGroup } from "@blueprintjs/core";
+import { Label, Tabs, Tab, TabId } from "@blueprintjs/core";
 import DiscourseNodeSpecification from "./DiscourseNodeSpecification";
 import DiscourseNodeAttributes from "./DiscourseNodeAttributes";
 import DiscourseNodeCanvasSettings from "./DiscourseNodeCanvasSettings";
 import DiscourseNodeIndex from "./DiscourseNodeIndex";
 import { OnloadArgs } from "roamjs-components/types";
 import getBasicTreeByParentUid from "roamjs-components/queries/getBasicTreeByParentUid";
-import createBlock from "roamjs-components/writes/createBlock";
-import updateBlock from "roamjs-components/writes/updateBlock";
 import DiscourseNodeSuggestiveRules from "./DiscourseNodeSuggestiveRules";
 import { getFormattedConfigTree } from "~/utils/discourseConfigRef";
 import refreshConfigTree from "~/utils/refreshConfigTree";
@@ -32,91 +28,6 @@ const TEMPLATE_SETTING_KEYS = ["template"];
 
 export const getCleanTagText = (tag: string): string => {
   return tag.replace(/^#+/, "").trim().toUpperCase();
-};
-
-const ValidatedInputPanel = ({
-  label,
-  description,
-  value,
-  onChange,
-  onBlur,
-  error,
-  placeholder,
-}: {
-  label: string;
-  description: string;
-  value: string;
-  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  onBlur: () => void;
-  error: string;
-  placeholder?: string;
-}) => (
-  <div className="flex flex-col">
-    <Label>
-      {label}
-      <Description description={description} />
-      <InputGroup
-        value={value}
-        onChange={onChange}
-        onBlur={onBlur}
-        placeholder={placeholder}
-      />
-    </Label>
-    {error && (
-      <div className="mt-1 text-sm font-medium text-red-600">{error}</div>
-    )}
-  </div>
-);
-
-const useDebouncedRoamUpdater = <
-  T extends HTMLInputElement | HTMLTextAreaElement,
->(
-  uid: string,
-  initialValue: string,
-  isValid: boolean,
-) => {
-  const [value, setValue] = useState(initialValue);
-  const debounceRef = useRef(0);
-  const isValidRef = useRef(isValid);
-  isValidRef.current = isValid;
-
-  const saveToRoam = useCallback(
-    (text: string, timeout: boolean) => {
-      window.clearTimeout(debounceRef.current);
-      debounceRef.current = window.setTimeout(
-        () => {
-          if (!isValidRef.current) {
-            return;
-          }
-          const existingBlock = getBasicTreeByParentUid(uid)[0];
-          if (existingBlock) {
-            if (existingBlock.text !== text) {
-              void updateBlock({ uid: existingBlock.uid, text });
-            }
-          } else if (text) {
-            void createBlock({ parentUid: uid, node: { text } });
-          }
-        },
-        timeout ? 500 : 0,
-      );
-    },
-    [uid],
-  );
-
-  const handleChange = useCallback(
-    (e: React.ChangeEvent<T>) => {
-      const newValue = e.target.value;
-      setValue(newValue);
-      saveToRoam(newValue, true);
-    },
-    [saveToRoam],
-  );
-
-  const handleBlur = useCallback(() => {
-    saveToRoam(value, false);
-  }, [value, saveToRoam]);
-
-  return { value, handleChange, handleBlur };
 };
 
 const generateTagPlaceholder = (node: DiscourseNode): string => {
@@ -167,18 +78,9 @@ const NodeConfig = ({
   const [selectedTabId, setSelectedTabId] = useState<TabId>("general");
   const [tagError, setTagError] = useState("");
   const [formatError, setFormatError] = useState("");
-  const isConfigurationValid = !tagError && !formatError;
 
   const [tagValue, setTagValue] = useState(node.tag || "");
-  const {
-    value: formatValue,
-    handleChange: handleFormatChange,
-    handleBlur: handleFormatBlurFromHook,
-  } = useDebouncedRoamUpdater<HTMLInputElement>(
-    formatUid,
-    node.format,
-    isConfigurationValid,
-  );
+  const [formatValue, setFormatValue] = useState(node.format || "");
   const validate = useCallback(
     ({
       tag,
@@ -237,11 +139,6 @@ const NodeConfig = ({
   useEffect(() => {
     validate({ tag: tagValue, format: formatValue });
   }, [tagValue, formatValue, validate]);
-
-  const handleFormatBlur = useCallback(() => {
-    handleFormatBlurFromHook();
-    validate({ tag: tagValue, format: formatValue });
-  }, [handleFormatBlurFromHook, tagValue, formatValue, validate]);
 
   return (
     <>
@@ -310,13 +207,17 @@ const NodeConfig = ({
           title="Format"
           panel={
             <div className="flex flex-col gap-4 p-1">
-              <ValidatedInputPanel
-                label="Format"
+              <DiscourseNodeTextPanel
+                nodeType={node.type}
+                title="Format"
                 description={`DEPRECATED - Use specification instead. The format ${node.text} pages should have.`}
-                value={formatValue}
-                onChange={handleFormatChange}
-                onBlur={handleFormatBlur}
+                settingKeys={["format"]}
+                initialValue={node.format}
                 error={formatError}
+                onChange={setFormatValue}
+                order={3}
+                parentUid={node.type}
+                uid={formatUid}
               />
               <Label>
                 Specification
@@ -360,7 +261,7 @@ const NodeConfig = ({
           title="Attributes"
           panel={
             <div className="flex flex-col gap-4 p-1">
-              <DiscourseNodeAttributes uid={attributeNode.uid} />
+              <DiscourseNodeAttributes uid={attributeNode.uid} nodeType={node.type} />
               <DiscourseNodeSelectPanel
                 nodeType={node.type}
                 title="Overlay"


### PR DESCRIPTION
https://www.loom.com/share/612bb20332b1445c977547b14b08b42a


Ported the following:

Queries -> Default filters

Grammar -> Nodes

Nodes -> type -> Format

Nodes -> type -> Attributes

Nodes -> type -> Attributes -> Overlay

Nodes -> type -> Canvas -> Color picker

Nodes -> type -> Canvas -> Display alias

Nodes -> type -> Canvas -> Key image location

Nodes -> type -> Canvas -> Query builder alias

Admin -> (BETA) Suggestive mode enabled

Admin -> Reified relation triples


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/805" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced feature flag management for Suggestive Mode and Reified relations.

* **Bug Fixes**
  * Improved settings persistence and synchronization across discourse node configurations, default filters, and attribute management.
  * Fixed color and alias handling in node canvas settings.

* **Improvements**
  * Strengthened node type creation and deletion workflows with better data validation and persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->