### PR TITLE
ENG-1461 Use full Rid instead of just spaceUri as marker of import

### DIFF
--- a/apps/obsidian/src/components/DiscourseContextView.tsx
+++ b/apps/obsidian/src/components/DiscourseContextView.tsx
@@ -37,7 +37,7 @@ const DiscourseContext = ({ activeFile }: DiscourseContextProps) => {
       setIsPublished(false);
       return;
     }
-    const isImported = !!frontmatter.importedFromSpaceUri;
+    const isImported = !!frontmatter.importedFromRid;
     const publishedToGroups = frontmatter.publishedToGroups as unknown;
     const published =
       !isImported &&
@@ -125,7 +125,7 @@ const DiscourseContext = ({ activeFile }: DiscourseContextProps) => {
       return <div>Unknown node type: {frontmatter.nodeTypeId}</div>;
     }
 
-    const isImported = !!frontmatter.importedFromSpaceUri;
+    const isImported = !!frontmatter.importedFromRid;
     const modifiedAt =
       typeof frontmatter.lastModified === "number"
         ? frontmatter.lastModified

--- a/apps/obsidian/src/components/NodeTypeSettings.tsx
+++ b/apps/obsidian/src/components/NodeTypeSettings.tsx
@@ -27,7 +27,7 @@ const generateTagPlaceholder = (format: string, nodeName?: string): string => {
 
 type EditableFieldKey = keyof Omit<
   DiscourseNode,
-  "id" | "shortcut" | "modified" | "created"
+  "id" | "shortcut" | "modified" | "created" | "importedFromRid"
 >;
 
 type BaseFieldConfig = {

--- a/apps/obsidian/src/components/RelationshipSettings.tsx
+++ b/apps/obsidian/src/components/RelationshipSettings.tsx
@@ -21,7 +21,7 @@ const RelationshipSettings = () => {
 
   type EditableFieldKey = keyof Omit<
     DiscourseRelation,
-    "id" | "modified" | "created"
+    "id" | "modified" | "created" | "importedFromRid"
   >;
 
   const handleRelationChange = async (

--- a/apps/obsidian/src/components/RelationshipTypeSettings.tsx
+++ b/apps/obsidian/src/components/RelationshipTypeSettings.tsx
@@ -99,7 +99,7 @@ const RelationshipTypeSettings = () => {
 
   type EditableFieldKey = keyof Omit<
     DiscourseRelationType,
-    "id" | "modified" | "created"
+    "id" | "modified" | "created" | "importedFromRid"
   >;
 
   const handleRelationTypeChange = (

--- a/apps/obsidian/src/services/QueryEngine.ts
+++ b/apps/obsidian/src/services/QueryEngine.ts
@@ -297,17 +297,17 @@ export class QueryEngine {
    */
   findExistingImportedFile = (
     nodeInstanceId: string,
-    importedFromSpaceUri: string,
+    importedFromRid: string,
   ): TFile | null => {
     if (this.dc) {
       try {
         const safeId = nodeInstanceId
           .replace(/\\/g, "\\\\")
           .replace(/"/g, '\\"');
-        const safeUri = importedFromSpaceUri
+        const safeUri = importedFromRid
           .replace(/\\/g, "\\\\")
           .replace(/"/g, '\\"');
-        const dcQuery = `@page and nodeInstanceId = "${safeId}" and importedFromSpaceUri = "${safeUri}"`;
+        const dcQuery = `@page and nodeInstanceId = "${safeId}" and importedFromRid = "${safeUri}"`;
         const results = this.dc.query(dcQuery);
 
         for (const page of results) {
@@ -329,7 +329,7 @@ export class QueryEngine {
       const fm = this.app.metadataCache.getFileCache(f)?.frontmatter;
       if (
         fm?.nodeInstanceId === nodeInstanceId &&
-        fm.importedFromSpaceUri === importedFromSpaceUri
+        fm.importedFromRid === importedFromRid
       ) {
         return f;
       }

--- a/apps/obsidian/src/services/QueryEngine.ts
+++ b/apps/obsidian/src/services/QueryEngine.ts
@@ -291,7 +291,7 @@ export class QueryEngine {
   }
 
   /**
-   * Find an existing imported file by nodeInstanceId and importedFromSpaceUri
+   * Find an existing imported file by nodeInstanceId and importedFromRid
    * Uses DataCore when available; falls back to vault iteration otherwise
    * Returns the file if found, null otherwise
    */

--- a/apps/obsidian/src/types.ts
+++ b/apps/obsidian/src/types.ts
@@ -13,6 +13,7 @@ export type DiscourseNode = {
   keyImage?: boolean;
   created: number;
   modified: number;
+  importedFromRid?: string;
 };
 
 export type DiscourseRelationType = {
@@ -22,6 +23,7 @@ export type DiscourseRelationType = {
   color: TldrawColorName;
   created: number;
   modified: number;
+  importedFromRid?: string;
 };
 
 export type DiscourseRelation = {
@@ -31,6 +33,19 @@ export type DiscourseRelation = {
   relationshipTypeId: string;
   created: number;
   modified: number;
+  importedFromRid?: string;
+};
+
+export type RelationInstance = {
+  id: string;
+  type: string;
+  source: string;
+  destination: string;
+  created: number;
+  author: string;
+  lastModified?: number;
+  publishedToGroupId?: string[];
+  importedFromRid?: string;
 };
 
 export type Settings = {

--- a/apps/obsidian/src/utils/fileChangeListener.ts
+++ b/apps/obsidian/src/utils/fileChangeListener.ts
@@ -98,7 +98,7 @@ export class FileChangeListener {
       return false;
     }
 
-    if (frontmatter?.importedFromSpaceUri) {
+    if (frontmatter?.importedFromRid) {
       return false;
     }
 

--- a/apps/obsidian/src/utils/getDiscourseNodes.ts
+++ b/apps/obsidian/src/utils/getDiscourseNodes.ts
@@ -29,7 +29,11 @@ export const collectDiscourseNodesFromVault = async (
       continue;
     }
 
-    if (frontmatter.importedFromRid && includeImported !== true) {
+    if (
+      // note: importedFromSpaceUri is legacy
+      (frontmatter.importedFromRid || frontmatter.importedFromSpaceUri) &&
+      includeImported !== true
+    ) {
       continue;
     }
 

--- a/apps/obsidian/src/utils/getDiscourseNodes.ts
+++ b/apps/obsidian/src/utils/getDiscourseNodes.ts
@@ -1,0 +1,56 @@
+import type { TFile } from "obsidian";
+import type DiscourseGraphPlugin from "~/index";
+import { ensureNodeInstanceId } from "./nodeInstanceId";
+
+export type DiscourseNodeInVault = {
+  file: TFile;
+  frontmatter: Record<string, unknown>;
+  nodeTypeId: string;
+  nodeInstanceId: string;
+};
+
+/**
+ * Step 1: Collect all discourse nodes from the vault
+ * Filters markdown files that have nodeTypeId in frontmatter
+ */
+export const collectDiscourseNodesFromVault = async (
+  plugin: DiscourseGraphPlugin,
+  includeImported?: boolean,
+): Promise<DiscourseNodeInVault[]> => {
+  const allFiles = plugin.app.vault.getMarkdownFiles();
+  const dgNodes: DiscourseNodeInVault[] = [];
+
+  for (const file of allFiles) {
+    const cache = plugin.app.metadataCache.getFileCache(file);
+    const frontmatter = cache?.frontmatter;
+
+    // Not a discourse node
+    if (!frontmatter?.nodeTypeId) {
+      continue;
+    }
+
+    if (frontmatter.importedFromRid && includeImported !== true) {
+      continue;
+    }
+
+    const nodeTypeId = frontmatter.nodeTypeId as string;
+    if (!nodeTypeId) {
+      continue;
+    }
+
+    const nodeInstanceId = await ensureNodeInstanceId(
+      plugin,
+      file,
+      frontmatter as Record<string, unknown>,
+    );
+
+    dgNodes.push({
+      file,
+      frontmatter: frontmatter as Record<string, unknown>,
+      nodeTypeId,
+      nodeInstanceId,
+    });
+  }
+
+  return dgNodes;
+};

--- a/apps/obsidian/src/utils/importNodes.ts
+++ b/apps/obsidian/src/utils/importNodes.ts
@@ -1021,7 +1021,7 @@ const mapNodeTypeIdToLocal = async ({
   const importedFromRid = spaceUriAndLocalIdToRid(
     sourceSpaceUri,
     sourceNodeTypeId,
-    "nodeSchema",
+    "schema",
   );
 
   const newNodeType: DiscourseNode = {

--- a/apps/obsidian/src/utils/importNodes.ts
+++ b/apps/obsidian/src/utils/importNodes.ts
@@ -1057,7 +1057,9 @@ const processFileContent = async ({
   filePath: string;
   importedCreatedAt?: number;
   importedModifiedAt?: number;
-}): Promise<{ file: TFile } | { error: string }> => {
+}): Promise<
+  { file: TFile; error?: never } | { file?: never; error: string }
+> => {
   // 1. Create or update the file with the fetched content first.
   // On create, set file metadata (ctime/mtime) to original vault dates via vault adapter.
   let file: TFile | null = plugin.app.vault.getFileByPath(filePath);
@@ -1249,7 +1251,8 @@ export const importSelectedNodes = async ({
           continue;
         }
 
-        const processedFile = result.file;
+        // typescript should not need this assertion?
+        const processedFile = result.file!;
 
         // Import assets for this node (use originalNodePath so assets go under import/{space}/ relative to note)
         const assetImportResult = await importAssetsForNode({

--- a/apps/obsidian/src/utils/importNodes.ts
+++ b/apps/obsidian/src/utils/importNodes.ts
@@ -972,11 +972,13 @@ const mapNodeTypeIdToLocal = async ({
   plugin,
   client,
   sourceSpaceId,
+  sourceSpaceUri,
   sourceNodeTypeId,
 }: {
   plugin: DiscourseGraphPlugin;
   client: DGSupabaseClient;
   sourceSpaceId: number;
+  sourceSpaceUri: string;
   sourceNodeTypeId: string;
 }): Promise<string> => {
   // Find the schema in the source space with this nodeTypeId (my_concepts applies RLS)
@@ -1028,6 +1030,7 @@ const mapNodeTypeIdToLocal = async ({
     keyImage: parsed.keyImage,
     created: now,
     modified: now,
+    importedFromRid: `${sourceSpaceUri}/${sourceNodeTypeId}`,
   };
   plugin.settings.nodeTypes = [...plugin.settings.nodeTypes, newNodeType];
   await plugin.saveSettings();
@@ -1089,6 +1092,7 @@ const processFileContent = async ({
     plugin,
     client,
     sourceSpaceId,
+    sourceSpaceUri,
     sourceNodeTypeId,
   });
 

--- a/apps/obsidian/src/utils/importNodes.ts
+++ b/apps/obsidian/src/utils/importNodes.ts
@@ -1084,15 +1084,19 @@ const processFileContent = async ({
   //    often empty immediately after create/modify), then map nodeTypeId and update frontmatter.
   const { frontmatter } = parseFrontmatter(rawContent);
   const sourceNodeTypeId = frontmatter.nodeTypeId;
-  if (typeof sourceNodeTypeId !== "string")
+  if (typeof sourceNodeTypeId !== "string") {
+    await plugin.app.vault.delete(file);
     return {
       error: "importedNode missing sourceNodeTypeId",
     };
+  }
   const sourceNodeId = frontmatter.nodeInstanceId;
-  if (typeof sourceNodeId !== "string")
+  if (typeof sourceNodeId !== "string") {
+    await plugin.app.vault.delete(file);
     return {
       error: "importedNode missing nodeInstanceId",
     };
+  }
 
   const mappedNodeTypeId = await mapNodeTypeIdToLocal({
     plugin,
@@ -1109,7 +1113,11 @@ const processFileContent = async ({
       if (mappedNodeTypeId !== undefined) {
         record.nodeTypeId = mappedNodeTypeId;
       }
-      record.importedFromRid = `${sourceSpaceUri}/${sourceNodeId}`;
+      record.importedFromRid = spaceUriAndLocalIdToRid(
+        sourceSpaceUri,
+        sourceNodeId,
+        "note",
+      );
       record.lastModified = importedModifiedAt;
     },
     stat,

--- a/apps/obsidian/src/utils/importNodes.ts
+++ b/apps/obsidian/src/utils/importNodes.ts
@@ -1021,7 +1021,7 @@ const mapNodeTypeIdToLocal = async ({
   const importedFromRid = spaceUriAndLocalIdToRid(
     sourceSpaceUri,
     sourceNodeTypeId,
-    "note",
+    "nodeSchema",
   );
 
   const newNodeType: DiscourseNode = {
@@ -1180,7 +1180,11 @@ export const importSelectedNodes = async ({
     // Process each node in this space
     for (const node of nodes) {
       try {
-        const importedFromRid = `${spaceUri}/${node.nodeInstanceId}`;
+        const importedFromRid = spaceUriAndLocalIdToRid(
+          spaceUri,
+          node.nodeInstanceId,
+          "note",
+        );
         // Check if file already exists by nodeInstanceId + importedFromRid
         const existingFile = queryEngine.findExistingImportedFile(
           node.nodeInstanceId,

--- a/apps/obsidian/src/utils/relationsStore.ts
+++ b/apps/obsidian/src/utils/relationsStore.ts
@@ -4,6 +4,7 @@ import type DiscourseGraphPlugin from "~/index";
 import { ensureNodeInstanceId } from "~/utils/nodeInstanceId";
 import { checkAndCreateFolder } from "~/utils/file";
 import { getVaultId } from "./supabaseContext";
+import { RelationInstance } from "../types";
 
 const RELATIONS_FILE_NAME = "relations.json";
 const RELATIONS_FILE_VERSION = 1;
@@ -14,18 +15,6 @@ export const getRelationsFilePath = (plugin: DiscourseGraphPlugin): string => {
   return folderPath
     ? normalizePath(`${folderPath}/${RELATIONS_FILE_NAME}`)
     : normalizePath(RELATIONS_FILE_NAME);
-};
-
-export type RelationInstance = {
-  id: string;
-  type: string;
-  source: string;
-  destination: string;
-  created: number;
-  author: string;
-  lastModified?: number;
-  importedFromSpaceId?: number;
-  publishedToGroupId?: string[];
 };
 
 export type RelationsFile = {
@@ -96,7 +85,7 @@ export type AddRelationParams = {
   source: string;
   destination: string;
   author?: string;
-  importedFromSpaceId?: number;
+  importedFromRid?: string;
   publishedToGroupId?: string[];
 };
 
@@ -119,7 +108,7 @@ export const addRelationNoCheck = async (
     destination: params.destination,
     created: now,
     author,
-    importedFromSpaceId: params.importedFromSpaceId,
+    importedFromRid: params.importedFromRid,
     publishedToGroupId: params.publishedToGroupId,
   };
   const data = await loadRelations(plugin);
@@ -162,7 +151,7 @@ export const removeRelationById = async (
   delete data.relations[relationInstanceId];
   await saveRelations(plugin, data);
   return true;
-}
+};
 
 export const getRelationsForNodeInstanceId = async (
   plugin: DiscourseGraphPlugin,
@@ -174,7 +163,7 @@ export const getRelationsForNodeInstanceId = async (
   return Object.values(relations).filter(
     (r) => r.source === nodeInstanceId || r.destination === nodeInstanceId,
   );
-}
+};
 
 const DEFAULT_CACHE_WAIT_MS = 500;
 const CACHE_POLL_INTERVAL_MS = 30;
@@ -215,7 +204,7 @@ export const getNodeInstanceIdForFile = async (
     return null;
   }
   return await ensureNodeInstanceId(plugin, file, frontmatter);
-}
+};
 
 /**
  * Returns the node type id from a file's frontmatter (nodeTypeId).
@@ -252,7 +241,7 @@ export const getFileForNodeInstanceId = async (
     }
   }
   return null;
-}
+};
 
 /**
  * Find a relation instance by source, destination, and type. Returns the first match.
@@ -313,7 +302,11 @@ export const removeRelationBySourceDestinationType = async (
   const data = await loadRelations(plugin);
   let removed = 0;
   for (const [id, r] of Object.entries(data.relations)) {
-    if (r.source === source && r.destination === destination && r.type === type) {
+    if (
+      r.source === source &&
+      r.destination === destination &&
+      r.type === type
+    ) {
       delete data.relations[id];
       removed++;
     }
@@ -322,7 +315,7 @@ export const removeRelationBySourceDestinationType = async (
     await saveRelations(plugin, data);
   }
   return removed;
-}
+};
 
 /**
  * Returns true if the frontmatter link (e.g. "[[path]]" or "[[path.md]]") resolves to the same file as targetFile.
@@ -334,7 +327,9 @@ const frontmatterLinkPointsToFile = (
   sourceFilePath: string,
   targetFile: TFile,
 ): boolean => {
-  const match = String(linkStr).trim().match(/\[\[(.*?)\]\]/);
+  const match = String(linkStr)
+    .trim()
+    .match(/\[\[(.*?)\]\]/);
   const linkpath = match?.[1]?.trim();
   if (!linkpath) return false;
   const resolved = plugin.app.metadataCache.getFirstLinkpathDest(
@@ -476,4 +471,4 @@ export const migrateFrontmatterRelationsToRelationsJson = async (
       );
     }
   }
-}
+};

--- a/apps/obsidian/src/utils/rid.ts
+++ b/apps/obsidian/src/utils/rid.ts
@@ -15,9 +15,13 @@ export const spaceUriAndLocalIdToRid = (
 export const ridToSpaceUriAndLocalId = (
   rid: string,
 ): { spaceUri: string; sourceLocalId: string } => {
-  const m = rid.match(/^orn:(\w+).(\w+):(.*)\/([^/]+)$/);
+  const m = rid.match(/^orn:(\w+)\.(\w+):(.*)\/([^/]+)$/);
   if (m) {
     return { spaceUri: `${m[1]}:${m[3]}`, sourceLocalId: m[4]! };
+  }
+  const m2 = rid.match(/^orn:(\w+):(.*)\/([^/]+)$/);
+  if (m2) {
+    return { spaceUri: `${m2[1]}:${m2[2]}`, sourceLocalId: m2[3]! };
   }
   const parts = rid.split("/");
   const sourceLocalId = parts.pop()!;

--- a/apps/obsidian/src/utils/rid.ts
+++ b/apps/obsidian/src/utils/rid.ts
@@ -1,0 +1,25 @@
+export const spaceUriAndLocalIdToRid = (
+  spaceUri: string,
+  localId: string,
+  subtype?: string,
+): string => {
+  if (spaceUri.startsWith("http")) return `${spaceUri}/${localId}`;
+  const parts = spaceUri.split(":");
+  if (parts.length === 2)
+    return subtype
+      ? `orn:${parts[0]}.${subtype}:${parts[1]}/${localId}`
+      : `orn:${parts[0]}:${parts[1]}/${localId}`;
+  throw new Error("Unrecognized spaceUri");
+};
+
+export const ridToSpaceUriAndLocalId = (
+  rid: string,
+): { spaceUri: string; sourceLocalId: string } => {
+  const m = rid.match(/^orn:(\w+).(\w+):(.*)\/([^/]+)$/);
+  if (m) {
+    return { spaceUri: `${m[1]}:${m[3]}`, sourceLocalId: m[4]! };
+  }
+  const parts = rid.split("/");
+  const sourceLocalId = parts.pop()!;
+  return { spaceUri: parts.join("/"), sourceLocalId };
+};

--- a/apps/obsidian/src/utils/rid.ts
+++ b/apps/obsidian/src/utils/rid.ts
@@ -1,3 +1,10 @@
+// Functions to express a pair of spaceUri, sourceLocalId as a single string, and back.
+// We're following https://github.com/BlockScience/rid-lib:
+// Either a Web URL, with the last segment as the sourceLocalId;
+// OR the format `orn:<platform>.<subtype>:<source identifier>/<sourceLocalId>`
+// With the assumption that the sourceUri has the form <platform>:<source identifier>
+// The subtype may be omitted.
+
 export const spaceUriAndLocalIdToRid = (
   spaceUri: string,
   localId: string,

--- a/apps/obsidian/src/utils/supabaseContext.ts
+++ b/apps/obsidian/src/utils/supabaseContext.ts
@@ -62,7 +62,7 @@ export const getVaultId = (app: DiscourseGraphPlugin["app"]): string => {
 };
 
 const canonicalObsidianUrl = (vaultId: string): string => {
-  return `orn:obsidian.note:${vaultId}`;
+  return `obsidian:${vaultId}`;
 };
 
 export const getSupabaseContext = async (

--- a/apps/obsidian/src/utils/supabaseContext.ts
+++ b/apps/obsidian/src/utils/supabaseContext.ts
@@ -62,7 +62,7 @@ export const getVaultId = (app: DiscourseGraphPlugin["app"]): string => {
 };
 
 const canonicalObsidianUrl = (vaultId: string): string => {
-  return `obsidian:${vaultId}`;
+  return `orn:obsidian.note:${vaultId}`;
 };
 
 export const getSupabaseContext = async (

--- a/apps/obsidian/src/utils/syncDgNodesToSupabase.ts
+++ b/apps/obsidian/src/utils/syncDgNodesToSupabase.ts
@@ -21,7 +21,6 @@ import {
   type DiscourseNodeInVault,
   collectDiscourseNodesFromVault,
 } from "./getDiscourseNodes";
-import { spaceUriAndLocalIdToRid } from "./rid";
 
 const DEFAULT_TIME = "1970-01-01";
 export type ChangeType = "title" | "content";
@@ -781,35 +780,6 @@ export const cleanupOrphanedNodes = async (
   }
 };
 
-const migrateImportedFromFrontMatter = async (plugin: DiscourseGraphPlugin) => {
-  const nodes = await collectDiscourseNodesFromVault(plugin, true);
-  for (const node of nodes) {
-    if (typeof node.frontmatter.importedFromSpaceUri === "string") {
-      await plugin.app.fileManager.processFrontMatter(
-        node.file,
-        (frontmatter: Record<string, unknown>) => {
-          const spaceUri = frontmatter.importedFromSpaceUri as string;
-          // note: we fortunately reused the original Id here.
-          const nodeId = frontmatter.nodeInstanceId;
-          if (typeof nodeId !== "string") {
-            console.error(
-              `error: missing nodeInstanceId on node ${node.file.path}`,
-            );
-            return;
-          }
-          try {
-            const rid = spaceUriAndLocalIdToRid(spaceUri, nodeId, "note");
-            frontmatter.importedFromRid = rid;
-            delete frontmatter.importedFromSpaceUri;
-          } catch (error) {
-            console.error(error);
-          }
-        },
-      );
-    }
-  }
-};
-
 export const initializeSupabaseSync = async (
   plugin: DiscourseGraphPlugin,
 ): Promise<void> => {
@@ -819,10 +789,6 @@ export const initializeSupabaseSync = async (
       "Failed to initialize Supabase sync: could not create context",
     );
   }
-
-  await migrateImportedFromFrontMatter(plugin).catch((error) => {
-    console.error("Failed to migrate frontmatter:", error);
-  });
 
   await createOrUpdateDiscourseEmbedding(plugin, context).catch((error) => {
     new Notice(`Initial sync failed: ${error}`);


### PR DESCRIPTION
https://linear.app/discourse-graphs/issue/ENG-1461/use-full-rid-instead-of-just-spaceuri-as-marker-of-import

This PR migrates imported node frontmatter from using `importedFromSpaceUri` to using `importedFromRid`, which contains both the original node's spaceUri and the original sourceLocalId, in the form of a koi-compliant Rid. 
(See [Rid specs](https://github.com/BlockScience/rid-lib)

Previously imported nodes are migrated accordingly.

Also, the sourceRid is added to the schema types, so we have provenance for schemas.

https://www.loom.com/share/b5dc1662b79e4b56a7ff0e3bf74b7039

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/808" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
