### PR TITLE
ENG-1465: Add "Use new settings store" feature flag 

### DIFF
--- a/apps/roam/src/components/settings/AdminPanel.tsx
+++ b/apps/roam/src/components/settings/AdminPanel.tsx
@@ -39,6 +39,7 @@ import deleteBlock from "roamjs-components/writes/deleteBlock";
 import { USE_REIFIED_RELATIONS } from "~/data/userSettings";
 import posthog from "posthog-js";
 import { setFeatureFlag } from "~/components/settings/utils/accessors";
+import { FeatureFlagPanel } from "./components/BlockPropSettingPanels";
 
 const NodeRow = ({ node }: { node: PConceptFull }) => {
   return (
@@ -465,6 +466,12 @@ const FeatureFlagsTab = (): React.ReactElement => {
             />
           </>
         }
+      />
+
+      <FeatureFlagPanel
+        title="Enable dual read"
+        description="When enabled, accessor getters read from block props instead of the old system. Surfaces dual-write gaps during development."
+        featureKey="Enable dual read"
       />
 
       <Button

--- a/apps/roam/src/components/settings/AdminPanel.tsx
+++ b/apps/roam/src/components/settings/AdminPanel.tsx
@@ -40,6 +40,7 @@ import { USE_REIFIED_RELATIONS } from "~/data/userSettings";
 import posthog from "posthog-js";
 import { setFeatureFlag } from "~/components/settings/utils/accessors";
 import { FeatureFlagPanel } from "./components/BlockPropSettingPanels";
+import { getFeatureFlag } from "./utils/accessors";
 
 const NodeRow = ({ node }: { node: PConceptFull }) => {
   return (
@@ -469,9 +470,10 @@ const FeatureFlagsTab = (): React.ReactElement => {
       />
 
       <FeatureFlagPanel
-        title="Enable dual read"
+        title="Use new settings store"
         description="When enabled, accessor getters read from block props instead of the old system. Surfaces dual-write gaps during development."
-        featureKey="Enable dual read"
+        featureKey="Use new settings store"
+        initialValue={getFeatureFlag("Use new settings store")}
       />
 
       <Button

--- a/apps/roam/src/components/settings/utils/accessors.ts
+++ b/apps/roam/src/components/settings/utils/accessors.ts
@@ -285,6 +285,10 @@ export const getFeatureFlag = (key: keyof FeatureFlags): boolean => {
   return flags[key];
 };
 
+export const isDualReadEnabled = (): boolean => {
+  return getFeatureFlag("Enable dual read");
+};
+
 export const setFeatureFlag = (
   key: keyof FeatureFlags,
   value: boolean,

--- a/apps/roam/src/components/settings/utils/accessors.ts
+++ b/apps/roam/src/components/settings/utils/accessors.ts
@@ -285,8 +285,8 @@ export const getFeatureFlag = (key: keyof FeatureFlags): boolean => {
   return flags[key];
 };
 
-export const isDualReadEnabled = (): boolean => {
-  return getFeatureFlag("Enable dual read");
+export const isNewSettingsStoreEnabled = (): boolean => {
+  return getFeatureFlag("Use new settings store");
 };
 
 export const setFeatureFlag = (

--- a/apps/roam/src/components/settings/utils/pullWatchers.ts
+++ b/apps/roam/src/components/settings/utils/pullWatchers.ts
@@ -90,10 +90,13 @@ export const featureFlagHandlers: Partial<
     (newValue: boolean, oldValue: boolean, allFlags: FeatureFlags) => void
   >
 > = {
-  // Add handlers as needed:
-  // "Enable Left Sidebar": (newValue) => { ... },
-  // "Suggestive Mode Enabled": (newValue) => { ... },
-  // "Reified Relation Triples": (newValue) => { ... },
+  /* eslint-disable @typescript-eslint/naming-convention */
+  "Enable dual read": (newValue, oldValue) => {
+    console.log(
+      `[DG] Enable dual read: ${String(oldValue)} → ${String(newValue)}`,
+    );
+  },
+  /* eslint-enable @typescript-eslint/naming-convention */
 };
 
 type GlobalSettingsHandlers = {

--- a/apps/roam/src/components/settings/utils/pullWatchers.ts
+++ b/apps/roam/src/components/settings/utils/pullWatchers.ts
@@ -90,13 +90,10 @@ export const featureFlagHandlers: Partial<
     (newValue: boolean, oldValue: boolean, allFlags: FeatureFlags) => void
   >
 > = {
-  /* eslint-disable @typescript-eslint/naming-convention */
-  "Enable dual read": (newValue, oldValue) => {
-    console.log(
-      `[DG] Enable dual read: ${String(oldValue)} → ${String(newValue)}`,
-    );
-  },
-  /* eslint-enable @typescript-eslint/naming-convention */
+  // Add handlers as needed:
+  // "Enable Left Sidebar": (newValue) => { ... },
+  // "Suggestive Mode Enabled": (newValue) => { ... },
+  // "Reified Relation Triples": (newValue) => { ... },
 };
 
 type GlobalSettingsHandlers = {

--- a/apps/roam/src/components/settings/utils/zodSchema.example.ts
+++ b/apps/roam/src/components/settings/utils/zodSchema.example.ts
@@ -90,12 +90,14 @@ const featureFlags: FeatureFlags = {
   "Enable left sidebar": true,
   "Suggestive mode enabled": true,
   "Reified relation triples": false,
+  "Use new settings store": false,
 };
 
 const defaultFeatureFlags: FeatureFlags = {
   "Enable left sidebar": false,
   "Suggestive mode enabled": false,
   "Reified relation triples": false,
+  "Use new settings store": false,
 };
 
 const exportSettings: ExportSettings = {

--- a/apps/roam/src/components/settings/utils/zodSchema.ts
+++ b/apps/roam/src/components/settings/utils/zodSchema.ts
@@ -157,7 +157,7 @@ export const FeatureFlagsSchema = z.object({
   "Enable left sidebar": z.boolean().default(false),
   "Suggestive mode enabled": z.boolean().default(false),
   "Reified relation triples": z.boolean().default(false),
-  "Enable dual read": z.boolean().default(false),
+  "Use new settings store": z.boolean().default(false),
 });
 
 export const ExportSettingsSchema = z.object({

--- a/apps/roam/src/components/settings/utils/zodSchema.ts
+++ b/apps/roam/src/components/settings/utils/zodSchema.ts
@@ -157,6 +157,7 @@ export const FeatureFlagsSchema = z.object({
   "Enable left sidebar": z.boolean().default(false),
   "Suggestive mode enabled": z.boolean().default(false),
   "Reified relation triples": z.boolean().default(false),
+  "Enable dual read": z.boolean().default(false),
 });
 
 export const ExportSettingsSchema = z.object({

--- a/apps/roam/src/index.ts
+++ b/apps/roam/src/index.ts
@@ -155,7 +155,6 @@ export default runExtension(async (onloadArgs) => {
     });
   }
 
-
   const { blockUids } = await initSchema();
   const cleanupPullWatchers = setupPullWatchOnSettingsPage(blockUids);
 

--- a/apps/roam/src/index.ts
+++ b/apps/roam/src/index.ts
@@ -42,7 +42,7 @@ import {
   DISALLOW_DIAGNOSTICS,
 } from "./data/userSettings";
 import { initSchema } from "./components/settings/utils/init";
-
+import { setupPullWatchOnSettingsPage } from "./components/settings/utils/pullWatchers";
 export const DEFAULT_CANVAS_PAGE_FORMAT = "Canvas/*";
 
 export default runExtension(async (onloadArgs) => {
@@ -155,7 +155,10 @@ export default runExtension(async (onloadArgs) => {
     });
   }
 
-  await initSchema();
+
+  const { blockUids } = await initSchema();
+  const cleanupPullWatchers = setupPullWatchOnSettingsPage(blockUids);
+
   return {
     elements: [
       style,
@@ -166,6 +169,7 @@ export default runExtension(async (onloadArgs) => {
     ],
     observers: observers,
     unload: () => {
+      cleanupPullWatchers();
       setSyncActivity(false);
       window.roamjs.extension?.smartblocks?.unregisterCommand("QUERYBUILDER");
       // @ts-expect-error - tldraw throws a warning on multiple loads

--- a/apps/roam/src/index.ts
+++ b/apps/roam/src/index.ts
@@ -42,7 +42,6 @@ import {
   DISALLOW_DIAGNOSTICS,
 } from "./data/userSettings";
 import { initSchema } from "./components/settings/utils/init";
-import { setupPullWatchOnSettingsPage } from "./components/settings/utils/pullWatchers";
 export const DEFAULT_CANVAS_PAGE_FORMAT = "Canvas/*";
 
 export default runExtension(async (onloadArgs) => {
@@ -155,8 +154,7 @@ export default runExtension(async (onloadArgs) => {
     });
   }
 
-  const { blockUids } = await initSchema();
-  const cleanupPullWatchers = setupPullWatchOnSettingsPage(blockUids);
+  await initSchema();
 
   return {
     elements: [
@@ -168,7 +166,6 @@ export default runExtension(async (onloadArgs) => {
     ],
     observers: observers,
     unload: () => {
-      cleanupPullWatchers();
       setSyncActivity(false);
       window.roamjs.extension?.smartblocks?.unregisterCommand("QUERYBUILDER");
       // @ts-expect-error - tldraw throws a warning on multiple loads


### PR DESCRIPTION
https://www.loom.com/share/ada47787b17b48c78d46ecbf1e44c0c6


add caller
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/811" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Use new settings store" feature flag to the admin panel. When enabled, the settings system reads from block properties, surfacing any dual-write gaps during development.
  * Implemented change tracking infrastructure for the settings system.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->