### PR TITLE
[ENG-1419] Remove redundant info in Relationship setting section

### DIFF
--- a/apps/obsidian/src/components/RelationshipSettings.tsx
+++ b/apps/obsidian/src/components/RelationshipSettings.tsx
@@ -205,41 +205,6 @@ const RelationshipSettings = () => {
                     Delete
                   </button>
                 </div>
-
-                {relation.sourceId &&
-                  relation.relationshipTypeId &&
-                  relation.destinationId && (
-                    <div className="text-normal mt-2 p-2">
-                      <div className="flex items-center justify-between">
-                        <div className="flex-1">
-                          {getNodeTypeById(plugin, relation.sourceId)?.name ||
-                            "Unknown Node"}
-                        </div>
-
-                        <div className="flex flex-1 flex-col items-center gap-2 px-4">
-                          <div className="flex items-center">
-                            <div className="text-accent-text text-sm">
-                              {findRelationTypeById(relation.relationshipTypeId)
-                                ?.label || "Unknown Relation"}
-                            </div>
-                            <div className="text-accent-text mx-1">→</div>
-                          </div>
-                          <div className="text-muted text-sm">
-                            ←{" "}
-                            <span className="text-accent-text">
-                              {findRelationTypeById(relation.relationshipTypeId)
-                                ?.complement || "Unknown Complement"}
-                            </span>
-                          </div>
-                        </div>
-
-                        <div className="flex-1 text-right">
-                          {getNodeTypeById(plugin, relation.destinationId)
-                            ?.name || "Unknown Node"}
-                        </div>
-                      </div>
-                    </div>
-                  )}
               </div>
             </div>
           ))}


### PR DESCRIPTION
Before
<img width="800" height="536" alt="image" src="https://github.com/user-attachments/assets/ecde51be-39c3-4b19-a2fa-895b2b85cb3b" />


After
<img width="825" height="557" alt="Screenshot 2026-02-23 at 14 54 18" src="https://github.com/user-attachments/assets/5cd44a4c-231d-4cb6-8823-a16591fd3b90" />

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/819" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
