### PR TITLE
Land orphaned Graphite stack PRs (#764, #765, #769, #793, #794, #805)

### DIFF
--- a/apps/roam/src/components/DiscourseNodeSearchMenu.tsx
+++ b/apps/roam/src/components/DiscourseNodeSearchMenu.tsx
@@ -26,6 +26,7 @@ import getDiscourseNodeFormatExpression from "~/utils/getDiscourseNodeFormatExpr
 import { Result } from "~/utils/types";
 import { getSetting } from "~/utils/extensionSettings";
 import MiniSearch from "minisearch";
+import { setPersonalSetting } from "~/components/settings/utils/accessors";
 
 type Props = {
   textarea: HTMLTextAreaElement;
@@ -724,7 +725,8 @@ export const NodeSearchMenuTriggerSetting = ({
       .trim();
 
     setNodeSearchTrigger(trigger);
-    extensionAPI.settings.set("node-search-trigger", trigger);
+    void extensionAPI.settings.set("node-search-trigger", trigger);
+    setPersonalSetting(["Node search menu trigger"], trigger);
   };
   return (
     <InputGroup

--- a/apps/roam/src/components/QueryBuilder.tsx
+++ b/apps/roam/src/components/QueryBuilder.tsx
@@ -31,11 +31,21 @@ type QueryPageComponent = (props: {
   pageUid: string;
   isEditBlock?: boolean;
   showAlias?: boolean;
+  discourseNodeType?: string;
+  settingKey?: "index" | "specification";
+  returnNode?: string;
 }) => JSX.Element;
 
 type Props = Parameters<QueryPageComponent>[0];
 
-const QueryBuilder = ({ pageUid, isEditBlock, showAlias }: Props) => {
+const QueryBuilder = ({
+  pageUid,
+  isEditBlock,
+  showAlias,
+  discourseNodeType,
+  settingKey,
+  returnNode,
+}: Props) => {
   const extensionAPI = useExtensionAPI();
   const hideMetadata = useMemo(
     () =>
@@ -158,6 +168,9 @@ const QueryBuilder = ({ pageUid, isEditBlock, showAlias }: Props) => {
           <>
             <QueryEditor
               parentUid={pageUid}
+              discourseNodeType={discourseNodeType}
+              settingKey={settingKey}
+              returnNode={returnNode}
               onQuery={() => {
                 setHasResults(true);
                 setIsEdit(false);

--- a/apps/roam/src/components/QueryEditor.tsx
+++ b/apps/roam/src/components/QueryEditor.tsx
@@ -447,7 +447,7 @@ const QueryEditor: QueryEditorComponent = ({
   setHasResults,
   hideCustomSwitch,
   showAlias,
-  discourseNodeType,// eslint-disable-line react/prop-types
+  discourseNodeType, // eslint-disable-line react/prop-types
   settingKey, // eslint-disable-line react/prop-types
   returnNode, // eslint-disable-line react/prop-types
 }) => {

--- a/apps/roam/src/components/QueryEditor.tsx
+++ b/apps/roam/src/components/QueryEditor.tsx
@@ -44,6 +44,8 @@ import {
 import getShallowTreeByParentUid from "roamjs-components/queries/getShallowTreeByParentUid";
 import { ALL_SELECTION_SUGGESTIONS } from "~/utils/predefinedSelections";
 import { getAlias } from "~/utils/parseResultSettings";
+import { setDiscourseNodeSetting } from "~/components/settings/utils/accessors";
+import { IndexSchema } from "~/components/settings/utils/zodSchema";
 
 const getSourceCandidates = (cs: Condition[]): string[] =>
   cs.flatMap((c) =>
@@ -434,6 +436,9 @@ type QueryEditorComponent = (props: {
   setHasResults?: () => void;
   hideCustomSwitch?: boolean;
   showAlias?: boolean;
+  discourseNodeType?: string;
+  settingKey?: "index" | "specification";
+  returnNode?: string;
 }) => JSX.Element;
 
 const QueryEditor: QueryEditorComponent = ({
@@ -442,6 +447,9 @@ const QueryEditor: QueryEditorComponent = ({
   setHasResults,
   hideCustomSwitch,
   showAlias,
+  discourseNodeType,
+  settingKey, // eslint-disable-line react/prop-types
+  returnNode, // eslint-disable-line react/prop-types
 }) => {
   useEffect(() => {
     const previewQuery = ((e: CustomEvent) => {
@@ -476,6 +484,53 @@ const QueryEditor: QueryEditorComponent = ({
   const [conditions, _setConditions] = useState(initialConditions);
   const [selections, setSelections] = useState(initialSelections);
   const [custom, setCustom] = useState(initialCustom);
+
+  const blockPropSyncTimeoutRef = useRef(0);
+  const lastSyncedIndexRef = useRef("");
+  useEffect(() => {
+    return () => window.clearTimeout(blockPropSyncTimeoutRef.current);
+  }, []);
+  useEffect(() => {
+    if (!discourseNodeType || !settingKey) return;
+
+    const stripped: unknown = JSON.parse(
+      JSON.stringify(
+        { conditions, selections, custom, returnNode },
+        (key, value: unknown) => (key === "uid" ? undefined : value),
+      ),
+    );
+
+    const serialized = JSON.stringify(stripped);
+    if (serialized === lastSyncedIndexRef.current) return;
+
+    const result = IndexSchema.safeParse(stripped);
+    if (!result.success) {
+      console.error(
+        `${settingKey} blockprop sync failed validation:`,
+        result.error,
+      );
+      return;
+    }
+
+    const path =
+      settingKey === "index" ? ["index"] : ["specification", "query"];
+
+    window.clearTimeout(blockPropSyncTimeoutRef.current);
+    blockPropSyncTimeoutRef.current = window.setTimeout(() => {
+      setDiscourseNodeSetting(discourseNodeType, path, result.data);
+      lastSyncedIndexRef.current = serialized;
+    }, 250);
+
+    return () => window.clearTimeout(blockPropSyncTimeoutRef.current);
+  }, [
+    conditions,
+    selections,
+    custom,
+    discourseNodeType,
+    settingKey,
+    returnNode,
+  ]);
+
   const customNodeOnChange = (value: string) => {
     window.clearTimeout(debounceRef.current);
     setCustom(value);

--- a/apps/roam/src/components/QueryEditor.tsx
+++ b/apps/roam/src/components/QueryEditor.tsx
@@ -447,7 +447,7 @@ const QueryEditor: QueryEditorComponent = ({
   setHasResults,
   hideCustomSwitch,
   showAlias,
-  discourseNodeType,
+  discourseNodeType,// eslint-disable-line react/prop-types
   settingKey, // eslint-disable-line react/prop-types
   returnNode, // eslint-disable-line react/prop-types
 }) => {

--- a/apps/roam/src/components/settings/AdminPanel.tsx
+++ b/apps/roam/src/components/settings/AdminPanel.tsx
@@ -38,6 +38,7 @@ import createBlock from "roamjs-components/writes/createBlock";
 import deleteBlock from "roamjs-components/writes/deleteBlock";
 import { USE_REIFIED_RELATIONS } from "~/data/userSettings";
 import posthog from "posthog-js";
+import { setFeatureFlag } from "~/components/settings/utils/accessors";
 
 const NodeRow = ({ node }: { node: PConceptFull }) => {
   return (
@@ -377,6 +378,7 @@ const FeatureFlagsTab = (): React.ReactElement => {
               setSuggestiveModeUid(undefined);
             }
             setSuggestiveModeEnabled(false);
+            setFeatureFlag("Suggestive mode enabled", false);
           }
         }}
         labelElement={
@@ -399,6 +401,7 @@ const FeatureFlagsTab = (): React.ReactElement => {
           }).then((uid) => {
             setSuggestiveModeUid(uid);
             setSuggestiveModeEnabled(true);
+            setFeatureFlag("Suggestive mode enabled", true);
             setIsAlertOpen(false);
             setIsInstructionOpen(true);
           });
@@ -447,6 +450,7 @@ const FeatureFlagsTab = (): React.ReactElement => {
           void setSetting(USE_REIFIED_RELATIONS, target.checked).catch(
             () => undefined,
           );
+          setFeatureFlag("Reified relation triples", target.checked);
           posthog.capture("Reified Relations: Toggled", {
             enabled: target.checked,
           });

--- a/apps/roam/src/components/settings/DefaultFilters.tsx
+++ b/apps/roam/src/components/settings/DefaultFilters.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from "react";
 import type { OnloadArgs } from "roamjs-components/types";
 import type { Filters } from "roamjs-components/components/Filter";
 import posthog from "posthog-js";
+import { setPersonalSetting } from "~/components/settings/utils/accessors";
 
 //
 // TODO - REWORK THIS COMPONENT
@@ -124,28 +125,27 @@ const DefaultFilters = ({
   );
 
   useEffect(() => {
-    extensionAPI.settings.set(
-      "default-filters",
-      Object.fromEntries(
-        Object.entries(filters).map(([k, v]) => [
-          k,
-          {
-            includes: Object.fromEntries(
-              Object.entries(v.includes || {}).map(([k, v]) => [
-                k,
-                Array.from(v),
-              ]),
-            ),
-            excludes: Object.fromEntries(
-              Object.entries(v.excludes || {}).map(([k, v]) => [
-                k,
-                Array.from(v),
-              ]),
-            ),
-          },
-        ]),
-      ),
+    const serialized = Object.fromEntries(
+      Object.entries(filters).map(([k, v]) => [
+        k,
+        {
+          includes: Object.fromEntries(
+            Object.entries(v.includes || {}).map(([k, v]) => [
+              k,
+              Array.from(v),
+            ]),
+          ),
+          excludes: Object.fromEntries(
+            Object.entries(v.excludes || {}).map(([k, v]) => [
+              k,
+              Array.from(v),
+            ]),
+          ),
+        },
+      ]),
     );
+    void extensionAPI.settings.set("default-filters", serialized);
+    setPersonalSetting(["Query", "Default filters"], serialized);
   }, [filters]);
   return (
     <div

--- a/apps/roam/src/components/settings/DiscourseNodeAttributes.tsx
+++ b/apps/roam/src/components/settings/DiscourseNodeAttributes.tsx
@@ -5,6 +5,7 @@ import getBasicTreeByParentUid from "roamjs-components/queries/getBasicTreeByPar
 import getFirstChildUidByBlockUid from "roamjs-components/queries/getFirstChildUidByBlockUid";
 import updateBlock from "roamjs-components/writes/updateBlock";
 import deleteBlock from "roamjs-components/writes/deleteBlock";
+import { setDiscourseNodeSetting } from "~/components/settings/utils/accessors";
 
 type Attribute = {
   uid: string;
@@ -18,7 +19,12 @@ const NodeAttribute = ({
   value,
   onChange,
   onDelete,
-}: Attribute & { onChange: (v: string) => void; onDelete: () => void }) => {
+  onSync,
+}: Attribute & {
+  onChange: (v: string) => void;
+  onDelete: () => void;
+  onSync?: () => void;
+}) => {
   const timeoutRef = useRef(0);
   return (
     <div
@@ -40,6 +46,7 @@ const NodeAttribute = ({
               text: e.target.value,
               uid: getFirstChildUidByBlockUid(uid),
             });
+            onSync?.();
           }, 500);
         }}
       />
@@ -53,7 +60,16 @@ const NodeAttribute = ({
   );
 };
 
-const NodeAttributes = ({ uid }: { uid: string }) => {
+const toRecord = (attrs: Attribute[]): Record<string, string> =>
+  Object.fromEntries(attrs.map((a) => [a.label, a.value]));
+
+const NodeAttributes = ({
+  uid,
+  nodeType,
+}: {
+  uid: string;
+  nodeType: string;
+}) => {
   const [attributes, setAttributes] = useState<Attribute[]>(() =>
     getBasicTreeByParentUid(uid).map((t) => ({
       uid: t.uid,
@@ -61,6 +77,15 @@ const NodeAttributes = ({ uid }: { uid: string }) => {
       value: t.children[0]?.text,
     })),
   );
+  const attributesRef = useRef(attributes);
+  attributesRef.current = attributes;
+  const syncToBlockProps = () => {
+    setDiscourseNodeSetting(
+      nodeType,
+      ["attributes"],
+      toRecord(attributesRef.current),
+    );
+  };
   const [newAttribute, setNewAttribute] = useState("");
   return (
     <div>
@@ -77,10 +102,17 @@ const NodeAttributes = ({ uid }: { uid: string }) => {
               )
             }
             onDelete={() =>
-              deleteBlock(a.uid).then(() =>
-                setAttributes(attributes.filter((aa) => a.uid !== aa.uid)),
-              )
+              deleteBlock(a.uid).then(() => {
+                const updated = attributes.filter((aa) => a.uid !== aa.uid);
+                setAttributes(updated);
+                setDiscourseNodeSetting(
+                  nodeType,
+                  ["attributes"],
+                  toRecord(updated),
+                );
+              })
             }
+            onSync={syncToBlockProps}
           />
         ))}
       </div>
@@ -105,11 +137,17 @@ const NodeAttributes = ({ uid }: { uid: string }) => {
                 parentUid: uid,
                 order: attributes.length,
               }).then((uid) => {
-                setAttributes([
+                const updated = [
                   ...attributes,
                   { uid, label: newAttribute, value: DEFAULT },
-                ]);
+                ];
+                setAttributes(updated);
                 setNewAttribute("");
+                setDiscourseNodeSetting(
+                  nodeType,
+                  ["attributes"],
+                  toRecord(updated),
+                );
               });
             }}
           />

--- a/apps/roam/src/components/settings/DiscourseNodeCanvasSettings.tsx
+++ b/apps/roam/src/components/settings/DiscourseNodeCanvasSettings.tsx
@@ -11,7 +11,11 @@ import React, { useState, useMemo } from "react";
 import getBasicTreeByParentUid from "roamjs-components/queries/getBasicTreeByParentUid";
 import getSettingValueFromTree from "roamjs-components/util/getSettingValueFromTree";
 import setInputSetting from "roamjs-components/util/setInputSetting";
-import { DiscourseNodeFlagPanel } from "./components/BlockPropSettingPanels";
+import {
+  DiscourseNodeFlagPanel,
+  DiscourseNodeTextPanel,
+} from "./components/BlockPropSettingPanels";
+import { setDiscourseNodeSetting } from "~/components/settings/utils/accessors";
 
 export const formatHexColor = (color: string) => {
   if (!color) return "";
@@ -37,9 +41,7 @@ const DiscourseNodeCanvasSettings = ({
     const color = getSettingValueFromTree({ tree, key: "color" });
     return formatHexColor(color);
   });
-  const [alias, setAlias] = useState<string>(() =>
-    getSettingValueFromTree({ tree, key: "alias" }),
-  );
+  const alias = getSettingValueFromTree({ tree, key: "alias" });
   const [queryBuilderAlias, setQueryBuilderAlias] = useState<string>(() =>
     getSettingValueFromTree({ tree, key: "query-builder-alias" }),
   );
@@ -60,12 +62,18 @@ const DiscourseNodeCanvasSettings = ({
             type={"color"}
             value={color}
             onChange={(e) => {
+              const colorValue = e.target.value.replace("#", ""); // remove hash to not create roam link
               setColor(e.target.value);
               void setInputSetting({
                 blockUid: uid,
                 key: "color",
-                value: e.target.value.replace("#", ""), // remove hash to not create roam link
+                value: colorValue,
               });
+              setDiscourseNodeSetting(
+                nodeType,
+                ["canvasSettings", "color"],
+                colorValue,
+              );
             }}
           />
           <Tooltip content={color ? "Unset" : "Color not set"}>
@@ -79,25 +87,30 @@ const DiscourseNodeCanvasSettings = ({
                   key: "color",
                   value: "",
                 });
+                setDiscourseNodeSetting(
+                  nodeType,
+                  ["canvasSettings", "color"],
+                  "",
+                );
               }}
             />
           </Tooltip>
         </ControlGroup>
       </div>
-      <Label style={{ width: 240 }}>
-        Display alias
-        <InputGroup
-          value={alias}
-          onChange={(e) => {
-            setAlias(e.target.value);
-            void setInputSetting({
-              blockUid: uid,
-              key: "alias",
-              value: e.target.value,
-            });
-          }}
-        />
-      </Label>
+      <DiscourseNodeTextPanel
+        nodeType={nodeType}
+        title="Display alias"
+        description=""
+        settingKeys={["canvasSettings", "alias"]}
+        initialValue={alias}
+        onChange={(val) => {
+          void setInputSetting({
+            blockUid: uid,
+            key: "alias",
+            value: val,
+          });
+        }}
+      />
       <DiscourseNodeFlagPanel
         nodeType={nodeType}
         title="Key image"
@@ -126,6 +139,11 @@ const DiscourseNodeCanvasSettings = ({
             key: "key-image-option",
             value,
           });
+          setDiscourseNodeSetting(
+            nodeType,
+            ["canvasSettings", "key-image-option"],
+            value,
+          );
         }}
       >
         <Radio label="First image on page" value="first-image" />
@@ -145,12 +163,18 @@ const DiscourseNodeCanvasSettings = ({
         disabled={keyImageOption !== "query-builder" || !isKeyImage}
         value={queryBuilderAlias}
         onChange={(e) => {
-          setQueryBuilderAlias(e.target.value);
+          const val = e.target.value;
+          setQueryBuilderAlias(val);
           void setInputSetting({
             blockUid: uid,
             key: "query-builder-alias",
-            value: e.target.value,
+            value: val,
           });
+          setDiscourseNodeSetting(
+            nodeType,
+            ["canvasSettings", "query-builder-alias"],
+            val,
+          );
         }}
       />
     </div>

--- a/apps/roam/src/components/settings/DiscourseNodeConfigPanel.tsx
+++ b/apps/roam/src/components/settings/DiscourseNodeConfigPanel.tsx
@@ -13,9 +13,14 @@ import refreshConfigTree from "~/utils/refreshConfigTree";
 import createPage from "roamjs-components/writes/createPage";
 import type { CustomField } from "roamjs-components/components/ConfigPanels/types";
 import posthog from "posthog-js";
-import getDiscourseRelations from "~/utils/getDiscourseRelations";
+import getDiscourseRelations, {
+  type DiscourseRelation,
+} from "~/utils/getDiscourseRelations";
 import { deleteBlock } from "roamjs-components/writes";
 import { formatHexColor } from "./DiscourseNodeCanvasSettings";
+import setBlockProps from "~/utils/setBlockProps";
+import { DiscourseNodeSchema } from "./utils/zodSchema";
+import { getGlobalSettings, setGlobalSetting } from "./utils/accessors";
 
 type DiscourseNodeConfigPanelProps = React.ComponentProps<
   CustomField["options"]["component"]
@@ -38,7 +43,9 @@ const DiscourseNodeConfigPanel: React.FC<DiscourseNodeConfigPanelProps> = ({
 
   const [isAlertOpen, setIsAlertOpen] = useState(false);
   const [alertMessage, setAlertMessage] = useState("");
-  const [affectedRelations, setAffectedRelations] = useState<any[]>([]);
+  const [affectedRelations, setAffectedRelations] = useState<
+    DiscourseRelation[]
+  >([]);
   const [nodeTypeIdToDelete, setNodeTypeIdToDelete] = useState<string>("");
   const navigateToNode = (uid: string) => {
     if (isPopup) {
@@ -72,13 +79,15 @@ const DiscourseNodeConfigPanel: React.FC<DiscourseNodeConfigPanelProps> = ({
           className="select-none"
           disabled={!label}
           onClick={() => {
+            const shortcut = label.slice(0, 1).toUpperCase();
+            const format = `[[${label.slice(0, 3).toUpperCase()}]] - {content}`;
             posthog.capture("Discourse Node: Type Created", { label: label });
-            createPage({
+            void createPage({
               title: `discourse-graph/nodes/${label}`,
               tree: [
                 {
                   text: "Shortcut",
-                  children: [{ text: label.slice(0, 1).toUpperCase() }],
+                  children: [{ text: shortcut }],
                 },
                 {
                   text: "Tag",
@@ -86,14 +95,20 @@ const DiscourseNodeConfigPanel: React.FC<DiscourseNodeConfigPanelProps> = ({
                 },
                 {
                   text: "Format",
-                  children: [
-                    {
-                      text: `[[${label.slice(0, 3).toUpperCase()}]] - {content}`,
-                    },
-                  ],
+                  children: [{ text: format }],
                 },
               ],
             }).then((valueUid) => {
+              setBlockProps(
+                valueUid,
+                DiscourseNodeSchema.parse({
+                  text: label,
+                  type: valueUid,
+                  shortcut,
+                  format,
+                  backedBy: "user",
+                }),
+              );
               setNodes([
                 ...nodes,
                 {
@@ -222,6 +237,9 @@ const DiscourseNodeConfigPanel: React.FC<DiscourseNodeConfigPanelProps> = ({
                   throw error;
                 });
               }
+              const relations = { ...getGlobalSettings().Relations };
+              for (const rel of affectedRelations) delete relations[rel.id];
+              setGlobalSetting(["Relations"], relations);
               deleteNodeType(nodeTypeIdToDelete);
             } catch (error) {
               console.error(

--- a/apps/roam/src/components/settings/DiscourseNodeIndex.tsx
+++ b/apps/roam/src/components/settings/DiscourseNodeIndex.tsx
@@ -6,6 +6,7 @@ import type { DiscourseNode } from "~/utils/getDiscourseNodes";
 import QueryBuilder from "~/components/QueryBuilder";
 import parseQuery, { DEFAULT_RETURN_NODE } from "~/utils/parseQuery";
 import createBlock from "roamjs-components/writes/createBlock";
+import { setDiscourseNodeSetting } from "~/components/settings/utils/accessors";
 
 const NodeIndex = ({
   parentUid,
@@ -25,7 +26,7 @@ const NodeIndex = ({
   );
   useEffect(() => {
     if (!showQuery) {
-      createBlock({
+      void createBlock({
         parentUid: initialQueryArgs.conditionsNodesUid,
         node: {
           text: "clause",
@@ -48,12 +49,37 @@ const NodeIndex = ({
             },
           ],
         },
-      }).then(() => setShowQuery(true));
+      }).then(() => {
+        setDiscourseNodeSetting(node.type, ["index"], {
+          conditions: [
+            {
+              type: "clause",
+              source: DEFAULT_RETURN_NODE,
+              relation: "is a",
+              target: node.text,
+            },
+          ],
+          selections: [],
+          custom: "",
+          returnNode: DEFAULT_RETURN_NODE,
+        });
+
+        setShowQuery(true);
+      });
     }
-  }, [parentUid, initialQueryArgs, showQuery]);
+  }, [parentUid, initialQueryArgs, showQuery, node.text, node.type]);
   return (
     <ExtensionApiContextProvider {...onloadArgs}>
-      {showQuery ? <QueryBuilder pageUid={parentUid} /> : <Spinner />}
+      {showQuery ? (
+        <QueryBuilder
+          pageUid={parentUid}
+          discourseNodeType={node.type}
+          settingKey="index"
+          returnNode={DEFAULT_RETURN_NODE}
+        />
+      ) : (
+        <Spinner />
+      )}
     </ExtensionApiContextProvider>
   );
 };

--- a/apps/roam/src/components/settings/DiscourseNodeSpecification.tsx
+++ b/apps/roam/src/components/settings/DiscourseNodeSpecification.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import getSubTree from "roamjs-components/util/getSubTree";
 import createBlock from "roamjs-components/writes/createBlock";
-import { Checkbox } from "@blueprintjs/core";
 import getBasicTreeByParentUid from "roamjs-components/queries/getBasicTreeByParentUid";
 import deleteBlock from "roamjs-components/writes/deleteBlock";
 import refreshConfigTree from "~/utils/refreshConfigTree";
@@ -9,6 +8,8 @@ import getDiscourseNodes from "~/utils/getDiscourseNodes";
 import getDiscourseNodeFormatExpression from "~/utils/getDiscourseNodeFormatExpression";
 import QueryEditor from "~/components/QueryEditor";
 import internalError from "~/utils/internalError";
+import { setDiscourseNodeSetting } from "~/components/settings/utils/accessors";
+import { DiscourseNodeFlagPanel } from "~/components/settings/components/BlockPropSettingPanels";
 
 const NodeSpecification = ({
   parentUid,
@@ -20,11 +21,14 @@ const NodeSpecification = ({
   parentSetEnabled?: (enabled: boolean) => void;
 }) => {
   const [migrated, setMigrated] = React.useState(false);
-  const [enabled, setEnabled] = React.useState<string>(
+  const enabledBlockUid = React.useMemo(
     () =>
       getSubTree({ tree: getBasicTreeByParentUid(parentUid), key: "enabled" })
         ?.uid,
+    [parentUid],
   );
+  const [enabled, setEnabled] = React.useState(!!enabledBlockUid);
+
   React.useEffect(() => {
     if (enabled) {
       const scratchNode = getSubTree({ parentUid, key: "scratch" });
@@ -69,7 +73,22 @@ const NodeSpecification = ({
               },
             }),
           )
-          .then(() => setMigrated(true))
+          .then(() => {
+            setDiscourseNodeSetting(node.type, ["specification", "query"], {
+              conditions: [
+                {
+                  type: "clause" as const,
+                  source: node.text,
+                  relation: "has title",
+                  target: `/${getDiscourseNodeFormatExpression(node.format).source}/`,
+                },
+              ],
+              selections: [],
+              custom: "",
+              returnNode: node.text,
+            });
+            setMigrated(true);
+          })
           .catch((error) => {
             internalError({ error });
           });
@@ -77,11 +96,18 @@ const NodeSpecification = ({
     } else {
       const tree = getBasicTreeByParentUid(parentUid);
       const scratchNode = getSubTree({ tree, key: "scratch" });
-      Promise.all(scratchNode.children.map((c) => deleteBlock(c.uid))).catch(
-        (error) => {
+      Promise.all(scratchNode.children.map((c) => deleteBlock(c.uid)))
+        .then(() => {
+          setDiscourseNodeSetting(node.type, ["specification", "query"], {
+            conditions: [],
+            selections: [],
+            custom: "",
+            returnNode: "",
+          });
+        })
+        .catch((error) => {
           internalError({ error });
-        },
-      );
+        });
     }
     return () => {
       refreshConfigTree();
@@ -90,40 +116,24 @@ const NodeSpecification = ({
   return (
     <div className={"roamjs-node-specification"}>
       <style>
-        {`.roamjs-node-specification .bp3-button.bp3-intent-primary { display: none; }`}
+        {`.roamjs-node-specification .bp3-button.bp3-intent-primary { display: none; }
+.roamjs-node-specification .bp3-checkbox { visibility: hidden; }
+.roamjs-node-specification .bp3-checkbox .bp3-control-indicator { visibility: visible; }`}
       </style>
-      <p>
-        <Checkbox
-          checked={!!enabled}
-          className={"ml-8 inline-block"}
-          onChange={(e) => {
-            const flag = (e.target as HTMLInputElement).checked;
-            if (flag) {
-              createBlock({
-                parentUid,
-                order: 2,
-                node: { text: "enabled" },
-              })
-                .then((uid: string) => {
-                  setEnabled(uid);
-                  if (parentSetEnabled) parentSetEnabled(true);
-                })
-                .catch((error) => {
-                  internalError({ error });
-                });
-            } else {
-              deleteBlock(enabled)
-                .then(() => {
-                  setEnabled("");
-                  if (parentSetEnabled) parentSetEnabled(false);
-                })
-                .catch((error) => {
-                  internalError({ error });
-                });
-            }
-          }}
-        />
-      </p>
+      <DiscourseNodeFlagPanel
+        nodeType={node.type}
+        title="enabled"
+        description=""
+        settingKeys={["specification", "enabled"]}
+        initialValue={enabled}
+        parentUid={parentUid}
+        uid={enabledBlockUid}
+        order={2}
+        onChange={(checked) => {
+          setEnabled(checked);
+          parentSetEnabled?.(checked);
+        }}
+      />
       <div
         className={`${enabled ? "" : "bg-gray-200 opacity-75"} overflow-auto`}
       >
@@ -131,6 +141,9 @@ const NodeSpecification = ({
           parentUid={parentUid}
           key={Number(migrated)}
           hideCustomSwitch
+          discourseNodeType={node.type}
+          settingKey="specification"
+          returnNode={node.text}
         />
       </div>
     </div>

--- a/apps/roam/src/components/settings/DiscourseRelationConfigPanel.tsx
+++ b/apps/roam/src/components/settings/DiscourseRelationConfigPanel.tsx
@@ -51,6 +51,10 @@ import { formatHexColor } from "./DiscourseNodeCanvasSettings";
 import posthog from "posthog-js";
 import { getSetting, setSetting } from "~/utils/extensionSettings";
 import { USE_REIFIED_RELATIONS } from "~/data/userSettings";
+import {
+  setGlobalSetting,
+  getGlobalSettings,
+} from "~/components/settings/utils/accessors";
 
 const DEFAULT_SELECTED_RELATION = {
   display: "none",
@@ -568,108 +572,147 @@ export const RelationEditPanel = ({
           className="select-none"
           onClick={() => {
             setLoading(true);
-            setTimeout(async () => {
-              const rootUid = editingRelationInfo.uid;
-              setInputSetting({
-                blockUid: rootUid,
-                key: "source",
-                value: source,
-              });
-              setInputSetting({
-                blockUid: rootUid,
-                key: "destination",
-                value: destination,
-                index: 1,
-              });
-              setInputSetting({
-                blockUid: rootUid,
-                key: "complement",
-                value: complement,
-                index: 2,
-              });
-              updateBlock({
-                uid: rootUid,
-                text: label,
-              });
-              const ifUid =
-                editingRelationInfo.children.find((t) =>
-                  toFlexRegex("if").test(t.text),
-                )?.uid ||
-                (await createBlock({
-                  node: { text: "If" },
-                  parentUid: rootUid,
-                  order: 3,
-                }));
-              saveCyToElementRef(tab);
-              const blocks = tabs
-                .map((t) => elementsRef.current[t])
-                .map((elements) => ({
-                  text: "And",
-                  children: elements
-                    .filter((e) => e.data.id.includes("-"))
-                    .map((e) => {
-                      const { source, target, relation } = e.data as {
-                        source: string;
-                        target: string;
-                        relation: string;
-                      };
-                      return {
-                        text: (
-                          elements.find((e) => e.data.id === source)?.data as {
-                            node: string;
-                          }
-                        )?.node,
-                        children: [
-                          {
-                            text: relation,
+            setTimeout(
+              () =>
+                void (async () => {
+                  const rootUid = editingRelationInfo.uid;
+                  await setInputSetting({
+                    blockUid: rootUid,
+                    key: "source",
+                    value: source,
+                  });
+                  await setInputSetting({
+                    blockUid: rootUid,
+                    key: "destination",
+                    value: destination,
+                    index: 1,
+                  });
+                  await setInputSetting({
+                    blockUid: rootUid,
+                    key: "complement",
+                    value: complement,
+                    index: 2,
+                  });
+                  await updateBlock({
+                    uid: rootUid,
+                    text: label,
+                  });
+                  const ifUid =
+                    editingRelationInfo.children.find((t) =>
+                      toFlexRegex("if").test(t.text),
+                    )?.uid ||
+                    (await createBlock({
+                      node: { text: "If" },
+                      parentUid: rootUid,
+                      order: 3,
+                    }));
+                  saveCyToElementRef(tab);
+                  const blocks = tabs
+                    .map((t) => elementsRef.current[t])
+                    .map((elements) => ({
+                      text: "And",
+                      children: elements
+                        .filter((e) => e.data.id.includes("-"))
+                        .map((e) => {
+                          const { source, target, relation } = e.data as {
+                            source: string;
+                            target: string;
+                            relation: string;
+                          };
+                          return {
+                            text: (
+                              elements.find((e) => e.data.id === source)
+                                ?.data as {
+                                node: string;
+                              }
+                            )?.node,
                             children: [
                               {
-                                text: ["source", "destination"].includes(target)
-                                  ? target
-                                  : (
-                                      elements.find((e) => e.data.id === target)
-                                        ?.data as { node: string }
-                                    )?.node,
+                                text: relation,
+                                children: [
+                                  {
+                                    text: ["source", "destination"].includes(
+                                      target,
+                                    )
+                                      ? target
+                                      : (
+                                          elements.find(
+                                            (e) => e.data.id === target,
+                                          )?.data as { node: string }
+                                        )?.node,
+                                  },
+                                ],
                               },
                             ],
+                          };
+                        })
+                        .concat([
+                          {
+                            text: "node positions",
+                            children: elements
+                              .filter(
+                                (
+                                  e,
+                                ): e is {
+                                  data: { id: string; node: unknown };
+                                  position: { x: number; y: number };
+                                } => Object.keys(e).includes("position"),
+                              )
+                              .map((e) => ({
+                                text: e.data.id,
+                                children: [
+                                  { text: `${e.position.x} ${e.position.y}` },
+                                ],
+                              })),
                           },
-                        ],
-                      };
-                    })
-                    .concat([
-                      {
-                        text: "node positions",
-                        children: elements
-                          .filter(
-                            (
-                              e,
-                            ): e is {
-                              data: { id: string; node: unknown };
-                              position: { x: number; y: number };
-                            } => Object.keys(e).includes("position"),
-                          )
-                          .map((e) => ({
-                            text: e.data.id,
-                            children: [
-                              { text: `${e.position.x} ${e.position.y}` },
-                            ],
-                          })),
-                      },
-                    ]),
-                }));
-              await Promise.all(
-                getShallowTreeByParentUid(ifUid).map(({ uid }) =>
-                  deleteBlock(uid),
-                ),
-              );
-              await Promise.all(
-                blocks.map((block, order) =>
-                  createBlock({ parentUid: ifUid, node: block, order }),
-                ),
-              );
-              refreshConfigTree();
-              back();
-            }, 1);
+                        ]),
+                    }));
+                  await Promise.all(
+                    getShallowTreeByParentUid(ifUid).map(({ uid }) =>
+                      deleteBlock(uid),
+                    ),
+                  );
+                  await Promise.all(
+                    blocks.map((block, order) =>
+                      createBlock({ parentUid: ifUid, node: block, order }),
+                    ),
+                  );
+                  refreshConfigTree();
+
+                  const ifConditions = blocks.map((block) => {
+                    const positionsChild = block.children.find(
+                      (c) => c.text === "node positions",
+                    );
+                    const triples = block.children
+                      .filter((c) => c.text !== "node positions")
+                      .map(
+                        (c) =>
+                          [
+                            c.text,
+                            c.children[0].text,
+                            c.children[0].children[0].text,
+                          ] as [string, string, string],
+                      );
+                    const nodePositions = Object.fromEntries(
+                      (positionsChild?.children ?? []).map((c) => [
+                        c.text,
+                        c.children[0].text,
+                      ]),
+                    );
+                    return { triples, nodePositions };
+                  });
+                  setGlobalSetting(["Relations", rootUid], {
+                    label,
+                    source,
+                    destination,
+                    complement,
+                    ifConditions,
+                  });
+
+                  back();
+                })(),
+              1,
+            );
           }}
         />
       </div>
@@ -1030,6 +1073,10 @@ const DiscourseRelationConfigPanel: CustomField["options"]["component"] = ({
   const handleDelete = (rel: Relation) => {
     deleteBlock(rel.uid);
     setRelations(relations.filter((r) => r.uid !== rel.uid));
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/naming-convention
+    const { [rel.uid]: _, ...remaining } = getGlobalSettings().Relations;
+    setGlobalSetting(["Relations"], remaining);
   };
   const handleDuplicate = (rel: Relation) => {
     const baseText = rel.text
@@ -1059,7 +1106,15 @@ const DiscourseRelationConfigPanel: CustomField["options"]["component"] = ({
         text,
         children: stripUid(copyTree),
       },
-    }).then((newUid) =>
+    }).then((newUid) => {
+      const originalRelation = getGlobalSettings().Relations[rel.uid];
+      if (originalRelation) {
+        setGlobalSetting(["Relations", newUid], {
+          ...originalRelation,
+          label: text,
+        });
+      }
+
       setRelations([
         ...relations,
         {
@@ -1068,8 +1123,8 @@ const DiscourseRelationConfigPanel: CustomField["options"]["component"] = ({
           destination: rel.destination,
           text,
         },
-      ]),
-    );
+      ]);
+    });
   };
   const handleBack = () => {
     setEditingRelation("");

--- a/apps/roam/src/components/settings/HomePersonalSettings.tsx
+++ b/apps/roam/src/components/settings/HomePersonalSettings.tsx
@@ -58,6 +58,7 @@ const HomePersonalSettings = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
       <KeyboardShortcutInput
         onloadArgs={onloadArgs}
         settingKey={DISCOURSE_TOOL_SHORTCUT_KEY}
+        blockPropKey="Discourse tool shortcut"
         label="Discourse tool keyboard shortcut"
         description="Set a single key to activate the discourse tool in tldraw. Only single keys (no modifiers) are supported. Leave empty for no shortcut."
         placeholder="Click to set single key"

--- a/apps/roam/src/components/settings/LeftSidebarGlobalSettings.tsx
+++ b/apps/roam/src/components/settings/LeftSidebarGlobalSettings.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState, memo } from "react";
 import { Button, ButtonGroup, Collapse } from "@blueprintjs/core";
-import FlagPanel from "roamjs-components/components/ConfigPanels/FlagPanel";
+import { GlobalFlagPanel } from "~/components/settings/components/BlockPropSettingPanels";
+import { setGlobalSetting } from "~/components/settings/utils/accessors";
 import AutocompleteInput from "roamjs-components/components/AutocompleteInput";
 import getAllPageNames from "roamjs-components/queries/getAllPageNames";
 import createBlock from "roamjs-components/writes/createBlock";
@@ -18,6 +19,8 @@ import { refreshAndNotify } from "~/components/LeftSidebarView";
 import getPageTitleByPageUid from "roamjs-components/queries/getPageTitleByPageUid";
 import getTextByBlockUid from "roamjs-components/queries/getTextByBlockUid";
 import posthog from "posthog-js";
+
+const pagesToUids = (pages: RoamBasicNode[]) => pages.map((p) => p.text);
 
 const PageItem = memo(
   ({
@@ -160,6 +163,7 @@ const LeftSidebarGlobalSectionsContent = ({
       newPages.splice(newIndex, 0, removed);
 
       setPages(newPages);
+      setGlobalSetting(["Left sidebar", "Children"], pagesToUids(newPages));
 
       if (childrenUid) {
         const order = direction === "down" ? newIndex + 1 : newIndex;
@@ -201,7 +205,13 @@ const LeftSidebarGlobalSectionsContent = ({
           children: [],
         };
 
-        setPages((prev) => [...prev, newPage]);
+        const updatedPages = [...pages, newPage];
+        setPages(updatedPages);
+        setGlobalSetting(
+          ["Left sidebar", "Children"],
+          pagesToUids(updatedPages),
+        );
+
         setNewPageInput("");
         setAutocompleteKey((prev) => prev + 1);
         posthog.capture("Left Sidebar Global Settings: Page Added", {
@@ -219,19 +229,28 @@ const LeftSidebarGlobalSectionsContent = ({
     [childrenUid, pages],
   );
 
-  const removePage = useCallback(async (page: RoamBasicNode) => {
-    try {
-      await deleteBlock(page.uid);
-      setPages((prev) => prev.filter((p) => p.uid !== page.uid));
-      refreshAndNotify();
-    } catch (error) {
-      renderToast({
-        content: "Failed to remove page",
-        intent: "danger",
-        id: "remove-page-error",
-      });
-    }
-  }, []);
+  const removePage = useCallback(
+    async (page: RoamBasicNode) => {
+      try {
+        await deleteBlock(page.uid);
+        const updatedPages = pages.filter((p) => p.uid !== page.uid);
+        setPages(updatedPages);
+        setGlobalSetting(
+          ["Left sidebar", "Children"],
+          pagesToUids(updatedPages),
+        );
+
+        refreshAndNotify();
+      } catch (error) {
+        renderToast({
+          content: "Failed to remove page",
+          intent: "danger",
+          id: "remove-page-error",
+        });
+      }
+    },
+    [pages],
+  );
 
   const handlePageInputChange = useCallback((value: string) => {
     setNewPageInput(value);
@@ -263,21 +282,24 @@ const LeftSidebarGlobalSectionsContent = ({
           border: "1px solid rgba(51, 51, 51, 0.2)",
         }}
       >
-        <FlagPanel
+        <GlobalFlagPanel
           title="Folded"
           description="If children are present, start with global section collapsed in left sidebar"
+          settingKeys={["Left sidebar", "Settings", "Folded"]}
+          initialValue={globalSection.settings?.folded?.value || false}
           order={0}
           uid={globalSection.settings?.folded?.uid || ""}
           parentUid={globalSection.settings?.uid || ""}
           disabled={!globalSection.children?.length}
         />
-        <FlagPanel
+        <GlobalFlagPanel
           title="Collapsable"
           description="Make global section collapsable"
+          settingKeys={["Left sidebar", "Settings", "Collapsable"]}
+          initialValue={globalSection.settings?.collapsable?.value || false}
           order={1}
           uid={globalSection.settings?.collapsable?.uid || ""}
           parentUid={globalSection.settings?.uid || ""}
-          value={globalSection.settings?.collapsable?.value || false}
         />
       </div>
 

--- a/apps/roam/src/components/settings/LeftSidebarPersonalSettings.tsx
+++ b/apps/roam/src/components/settings/LeftSidebarPersonalSettings.tsx
@@ -19,8 +19,11 @@ import createBlock from "roamjs-components/writes/createBlock";
 import deleteBlock from "roamjs-components/writes/deleteBlock";
 import updateBlock from "roamjs-components/writes/updateBlock";
 import type { RoamBasicNode } from "roamjs-components/types";
-import NumberPanel from "roamjs-components/components/ConfigPanels/NumberPanel";
-import TextPanel from "roamjs-components/components/ConfigPanels/TextPanel";
+import { setPersonalSetting } from "~/components/settings/utils/accessors";
+import {
+  PersonalNumberPanel,
+  PersonalTextPanel,
+} from "~/components/settings/components/BlockPropSettingPanels";
 import {
   LeftSidebarPersonalSectionConfig,
   getLeftSidebarPersonalSectionConfig,
@@ -37,12 +40,34 @@ import { memo, Dispatch, SetStateAction } from "react";
 import getPageTitleByPageUid from "roamjs-components/queries/getPageTitleByPageUid";
 import posthog from "posthog-js";
 
+/* eslint-disable @typescript-eslint/naming-convention */
+const sectionsToBlockProps = (sections: LeftSidebarPersonalSectionConfig[]) =>
+  sections.map((s) => ({
+    name: s.text,
+    Children: (s.children || []).map((c) => ({
+      uid: c.text,
+      Alias: c.alias?.value || "",
+    })),
+    Settings: {
+      "Truncate-result?": s.settings?.truncateResult?.value ?? 75,
+      Folded: s.settings?.folded?.value ?? false,
+    },
+  }));
+/* eslint-enable @typescript-eslint/naming-convention */
+
+const syncAllSectionsToBlockProps = (
+  sections: LeftSidebarPersonalSectionConfig[],
+) => {
+  setPersonalSetting(["Left sidebar"], sectionsToBlockProps(sections));
+};
+
 const SectionItem = memo(
   ({
     section,
     setSettingsDialogSectionUid,
     pageNames,
     setSections,
+    sectionsRef,
     index,
     isFirst,
     isLast,
@@ -50,6 +75,7 @@ const SectionItem = memo(
   }: {
     section: LeftSidebarPersonalSectionConfig;
     setSections: Dispatch<SetStateAction<LeftSidebarPersonalSectionConfig[]>>;
+    sectionsRef: React.MutableRefObject<LeftSidebarPersonalSectionConfig[]>;
     setSettingsDialogSectionUid: (uid: string | null) => void;
     pageNames: string[];
     index: number;
@@ -125,6 +151,22 @@ const SectionItem = memo(
             }),
           );
 
+          syncAllSectionsToBlockProps(
+            sectionsRef.current.map((s) =>
+              s.uid === section.uid
+                ? {
+                    ...s,
+                    settings: {
+                      uid: settingsUid,
+                      folded: { uid: foldedUid, value: false },
+                      truncateResult: { uid: truncateSettingUid, value: 75 },
+                    },
+                    children: [],
+                  }
+                : s,
+            ),
+          );
+
           setExpandedChildLists((prev) => new Set([...prev, section.uid]));
           refreshAndNotify();
         } catch (error) {
@@ -135,7 +177,7 @@ const SectionItem = memo(
           });
         }
       },
-      [setSections],
+      [setSections, sectionsRef],
     );
 
     const removeSection = useCallback(
@@ -143,7 +185,11 @@ const SectionItem = memo(
         try {
           await deleteBlock(section.uid);
 
-          setSections((prev) => prev.filter((s) => s.uid !== section.uid));
+          const updatedSections = sectionsRef.current.filter(
+            (s) => s.uid !== section.uid,
+          );
+          setSections(updatedSections);
+          syncAllSectionsToBlockProps(updatedSections);
           refreshAndNotify();
         } catch (error) {
           renderToast({
@@ -153,7 +199,7 @@ const SectionItem = memo(
           });
         }
       },
-      [setSections],
+      [setSections, sectionsRef],
     );
 
     const addChildToSection = useCallback(
@@ -173,25 +219,25 @@ const SectionItem = memo(
             node: { text: targetUid },
           });
 
-          setSections((prev) =>
-            prev.map((s) => {
-              if (s.uid === section.uid) {
-                return {
-                  ...s,
-                  children: [
-                    ...(s.children || []),
-                    {
-                      text: targetUid,
-                      uid: newChild,
-                      children: [],
-                      alias: { value: "" },
-                    },
-                  ],
-                };
-              }
-              return s;
-            }),
-          );
+          const updatedSections = sectionsRef.current.map((s) => {
+            if (s.uid === section.uid) {
+              return {
+                ...s,
+                children: [
+                  ...(s.children || []),
+                  {
+                    text: targetUid,
+                    uid: newChild,
+                    children: [],
+                    alias: { value: "" },
+                  },
+                ],
+              };
+            }
+            return s;
+          });
+          setSections(updatedSections);
+          syncAllSectionsToBlockProps(updatedSections);
           refreshAndNotify();
         } catch (error) {
           renderToast({
@@ -201,7 +247,7 @@ const SectionItem = memo(
           });
         }
       },
-      [setSections],
+      [setSections, sectionsRef],
     );
     const removeChild = useCallback(
       async (
@@ -211,17 +257,17 @@ const SectionItem = memo(
         try {
           await deleteBlock(child.uid);
 
-          setSections((prev) =>
-            prev.map((s) => {
-              if (s.uid === section.uid) {
-                return {
-                  ...s,
-                  children: s.children?.filter((c) => c.uid !== child.uid),
-                };
-              }
-              return s;
-            }),
-          );
+          const updatedSections = sectionsRef.current.map((s) => {
+            if (s.uid === section.uid) {
+              return {
+                ...s,
+                children: s.children?.filter((c) => c.uid !== child.uid),
+              };
+            }
+            return s;
+          });
+          setSections(updatedSections);
+          syncAllSectionsToBlockProps(updatedSections);
           refreshAndNotify();
         } catch (error) {
           renderToast({
@@ -231,7 +277,7 @@ const SectionItem = memo(
           });
         }
       },
-      [setSections],
+      [setSections, sectionsRef],
     );
 
     const moveChild = useCallback(
@@ -250,17 +296,17 @@ const SectionItem = memo(
         const newIndex = direction === "up" ? index - 1 : index + 1;
         newChildren.splice(newIndex, 0, removed);
 
-        setSections((prev) =>
-          prev.map((s) => {
-            if (s.uid === section.uid) {
-              return {
-                ...s,
-                children: newChildren,
-              };
-            }
-            return s;
-          }),
-        );
+        const updatedSections = sectionsRef.current.map((s) => {
+          if (s.uid === section.uid) {
+            return {
+              ...s,
+              children: newChildren,
+            };
+          }
+          return s;
+        });
+        setSections(updatedSections);
+        syncAllSectionsToBlockProps(updatedSections);
 
         if (section.childrenUid) {
           const order = direction === "down" ? newIndex + 1 : newIndex;
@@ -276,7 +322,7 @@ const SectionItem = memo(
             });
         }
       },
-      [setSections],
+      [setSections, sectionsRef],
     );
 
     const handleAddChild = useCallback(async () => {
@@ -458,39 +504,36 @@ const SectionItem = memo(
                           style={{ width: "400px" }}
                         >
                           <div className="p-4">
-                            <TextPanel
+                            <PersonalTextPanel
                               title="Alias"
                               description="Display name for this item"
+                              settingKeys={["Left sidebar"]}
+                              initialValue={child.alias?.value ?? ""}
                               order={0}
                               uid={child.alias?.uid}
                               parentUid={child.uid}
-                              defaultValue=""
-                              options={{
-                                onChange: (
-                                  event: React.ChangeEvent<HTMLInputElement>,
-                                ) => {
-                                  const nextValue = event.target.value;
-                                  setSections((prev) =>
-                                    prev.map((s) =>
-                                      s.uid === section.uid
-                                        ? {
-                                            ...s,
-                                            children: s.children?.map((c) =>
-                                              c.uid === child.uid
-                                                ? {
-                                                    ...c,
-                                                    alias: {
-                                                      ...c.alias,
-                                                      value: nextValue,
-                                                    },
-                                                  }
-                                                : c,
-                                            ),
-                                          }
-                                        : s,
-                                    ),
-                                  );
-                                },
+                              setter={(_keys, value) => {
+                                const updatedSections = sectionsRef.current.map(
+                                  (s) =>
+                                    s.uid === section.uid
+                                      ? {
+                                          ...s,
+                                          children: s.children?.map((c) =>
+                                            c.uid === child.uid
+                                              ? {
+                                                  ...c,
+                                                  alias: {
+                                                    ...c.alias,
+                                                    value,
+                                                  },
+                                                }
+                                              : c,
+                                          ),
+                                        }
+                                      : s,
+                                );
+                                setSections(updatedSections);
+                                syncAllSectionsToBlockProps(updatedSections);
                               }}
                             />
                           </div>
@@ -532,6 +575,8 @@ const LeftSidebarPersonalSectionsContent = ({
     string | null
   >(null);
   const sectionTitleUpdateTimeoutRef = useRef<ReturnType<typeof setTimeout>>();
+  const sectionsRef = useRef(sections);
+  sectionsRef.current = sections;
 
   useEffect(() => {
     const initialize = async () => {
@@ -567,7 +612,7 @@ const LeftSidebarPersonalSectionsContent = ({
   const addSection = useCallback(
     async (sectionName: string) => {
       if (!sectionName || !personalSectionUid) return;
-      if (sections.some((s) => s.text === sectionName)) return;
+      if (sectionsRef.current.some((s) => s.text === sectionName)) return;
 
       try {
         const newBlock = await createBlock({
@@ -576,16 +621,16 @@ const LeftSidebarPersonalSectionsContent = ({
           node: { text: sectionName },
         });
 
-        setSections((prev) => [
-          ...prev,
-          {
-            text: sectionName,
-            uid: newBlock,
-            settings: undefined,
-            children: undefined,
-            childrenUid: undefined,
-          } as LeftSidebarPersonalSectionConfig,
-        ]);
+        const newSection = {
+          text: sectionName,
+          uid: newBlock,
+          settings: undefined,
+          children: undefined,
+          childrenUid: undefined,
+        } as LeftSidebarPersonalSectionConfig;
+        const updatedSections = [...sectionsRef.current, newSection];
+        setSections(updatedSections);
+        syncAllSectionsToBlockProps(updatedSections);
 
         posthog.capture("Left Sidebar Personal Settings: Section Added", {
           sectionName,
@@ -600,7 +645,7 @@ const LeftSidebarPersonalSectionsContent = ({
         });
       }
     },
-    [personalSectionUid, sections],
+    [personalSectionUid],
   );
 
   const handleNewSectionInputChange = useCallback((value: string) => {
@@ -618,6 +663,7 @@ const LeftSidebarPersonalSectionsContent = ({
       newSections.splice(newIndex, 0, removed);
 
       setSections(newSections);
+      syncAllSectionsToBlockProps(newSections);
 
       if (personalSectionUid) {
         const order = direction === "down" ? newIndex + 1 : newIndex;
@@ -685,6 +731,7 @@ const LeftSidebarPersonalSectionsContent = ({
               setSettingsDialogSectionUid={setSettingsDialogSectionUid}
               pageNames={pageNames}
               setSections={setSections}
+              sectionsRef={sectionsRef}
               index={index}
               isFirst={index === 0}
               isLast={index === sections.length - 1}
@@ -697,7 +744,9 @@ const LeftSidebarPersonalSectionsContent = ({
       {activeDialogSection && activeDialogSection.settings && (
         <Dialog
           isOpen={true}
-          onClose={() => setSettingsDialogSectionUid(null)}
+          onClose={() => {
+            setSettingsDialogSectionUid(null);
+          }}
           title={`Settings for "${activeDialogSection.text}"`}
           style={{ width: "500px" }}
         >
@@ -729,17 +778,41 @@ const LeftSidebarPersonalSectionsContent = ({
                       }).then(() => {
                         refreshAndNotify();
                       });
+                      syncAllSectionsToBlockProps(sectionsRef.current);
                     }, 300);
                   }}
                 />
               </div>
-              <NumberPanel
+              <PersonalNumberPanel
                 title="Truncate-result?"
                 description="Maximum characters to display"
+                settingKeys={["Left sidebar"]}
+                initialValue={
+                  activeDialogSection.settings.truncateResult?.value ?? 75
+                }
                 order={1}
                 uid={activeDialogSection.settings.truncateResult?.uid}
-                parentUid={activeDialogSection.settings.uid}
-                value={activeDialogSection.settings.truncateResult?.value}
+                parentUid={activeDialogSection.settings.uid || ""}
+                setter={(_keys, value) => {
+                  const updatedSections = sectionsRef.current.map((s) =>
+                    s.uid === activeDialogSection.uid
+                      ? {
+                          ...s,
+                          settings: s.settings
+                            ? {
+                                ...s.settings,
+                                truncateResult: {
+                                  ...s.settings.truncateResult,
+                                  value,
+                                },
+                              }
+                            : s.settings,
+                        }
+                      : s,
+                  );
+                  setSections(updatedSections);
+                  syncAllSectionsToBlockProps(updatedSections);
+                }}
               />
             </div>
           </div>

--- a/apps/roam/src/components/settings/NodeConfig.tsx
+++ b/apps/roam/src/components/settings/NodeConfig.tsx
@@ -1,121 +1,28 @@
-import React, {
-  useState,
-  useCallback,
-  useRef,
-  useEffect,
-  useMemo,
-} from "react";
+import React, { useState, useCallback, useEffect, useMemo } from "react";
 import { DiscourseNode } from "~/utils/getDiscourseNodes";
-import SelectPanel from "roamjs-components/components/ConfigPanels/SelectPanel";
 import DualWriteBlocksPanel from "./components/EphemeralBlocksPanel";
 import { getSubTree } from "roamjs-components/util";
 import Description from "roamjs-components/components/Description";
-import { Label, Tabs, Tab, TabId, InputGroup } from "@blueprintjs/core";
+import { Label, Tabs, Tab, TabId } from "@blueprintjs/core";
 import DiscourseNodeSpecification from "./DiscourseNodeSpecification";
 import DiscourseNodeAttributes from "./DiscourseNodeAttributes";
 import DiscourseNodeCanvasSettings from "./DiscourseNodeCanvasSettings";
 import DiscourseNodeIndex from "./DiscourseNodeIndex";
 import { OnloadArgs } from "roamjs-components/types";
 import getBasicTreeByParentUid from "roamjs-components/queries/getBasicTreeByParentUid";
-import createBlock from "roamjs-components/writes/createBlock";
-import updateBlock from "roamjs-components/writes/updateBlock";
 import DiscourseNodeSuggestiveRules from "./DiscourseNodeSuggestiveRules";
 import { getFormattedConfigTree } from "~/utils/discourseConfigRef";
 import refreshConfigTree from "~/utils/refreshConfigTree";
 import {
   DiscourseNodeTextPanel,
   DiscourseNodeFlagPanel,
+  DiscourseNodeSelectPanel,
 } from "./components/BlockPropSettingPanels";
 
 const TEMPLATE_SETTING_KEYS = ["template"];
 
 export const getCleanTagText = (tag: string): string => {
   return tag.replace(/^#+/, "").trim().toUpperCase();
-};
-
-const ValidatedInputPanel = ({
-  label,
-  description,
-  value,
-  onChange,
-  onBlur,
-  error,
-  placeholder,
-}: {
-  label: string;
-  description: string;
-  value: string;
-  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  onBlur: () => void;
-  error: string;
-  placeholder?: string;
-}) => (
-  <div className="flex flex-col">
-    <Label>
-      {label}
-      <Description description={description} />
-      <InputGroup
-        value={value}
-        onChange={onChange}
-        onBlur={onBlur}
-        placeholder={placeholder}
-      />
-    </Label>
-    {error && (
-      <div className="mt-1 text-sm font-medium text-red-600">{error}</div>
-    )}
-  </div>
-);
-
-const useDebouncedRoamUpdater = <
-  T extends HTMLInputElement | HTMLTextAreaElement,
->(
-  uid: string,
-  initialValue: string,
-  isValid: boolean,
-) => {
-  const [value, setValue] = useState(initialValue);
-  const debounceRef = useRef(0);
-  const isValidRef = useRef(isValid);
-  isValidRef.current = isValid;
-
-  const saveToRoam = useCallback(
-    (text: string, timeout: boolean) => {
-      window.clearTimeout(debounceRef.current);
-      debounceRef.current = window.setTimeout(
-        () => {
-          if (!isValidRef.current) {
-            return;
-          }
-          const existingBlock = getBasicTreeByParentUid(uid)[0];
-          if (existingBlock) {
-            if (existingBlock.text !== text) {
-              void updateBlock({ uid: existingBlock.uid, text });
-            }
-          } else if (text) {
-            void createBlock({ parentUid: uid, node: { text } });
-          }
-        },
-        timeout ? 500 : 0,
-      );
-    },
-    [uid],
-  );
-
-  const handleChange = useCallback(
-    (e: React.ChangeEvent<T>) => {
-      const newValue = e.target.value;
-      setValue(newValue);
-      saveToRoam(newValue, true);
-    },
-    [saveToRoam],
-  );
-
-  const handleBlur = useCallback(() => {
-    saveToRoam(value, false);
-  }, [value, saveToRoam]);
-
-  return { value, handleChange, handleBlur };
 };
 
 const generateTagPlaceholder = (node: DiscourseNode): string => {
@@ -166,18 +73,9 @@ const NodeConfig = ({
   const [selectedTabId, setSelectedTabId] = useState<TabId>("general");
   const [tagError, setTagError] = useState("");
   const [formatError, setFormatError] = useState("");
-  const isConfigurationValid = !tagError && !formatError;
 
   const [tagValue, setTagValue] = useState(node.tag || "");
-  const {
-    value: formatValue,
-    handleChange: handleFormatChange,
-    handleBlur: handleFormatBlurFromHook,
-  } = useDebouncedRoamUpdater<HTMLInputElement>(
-    formatUid,
-    node.format,
-    isConfigurationValid,
-  );
+  const [formatValue, setFormatValue] = useState(node.format || "");
   const validate = useCallback(
     ({
       tag,
@@ -236,11 +134,6 @@ const NodeConfig = ({
   useEffect(() => {
     validate({ tag: tagValue, format: formatValue });
   }, [tagValue, formatValue, validate]);
-
-  const handleFormatBlur = useCallback(() => {
-    handleFormatBlurFromHook();
-    validate({ tag: tagValue, format: formatValue });
-  }, [handleFormatBlurFromHook, tagValue, formatValue, validate]);
 
   return (
     <>
@@ -309,13 +202,17 @@ const NodeConfig = ({
           title="Format"
           panel={
             <div className="flex flex-col gap-4 p-1">
-              <ValidatedInputPanel
-                label="Format"
+              <DiscourseNodeTextPanel
+                nodeType={node.type}
+                title="Format"
                 description={`DEPRECATED - Use specification instead. The format ${node.text} pages should have.`}
-                value={formatValue}
-                onChange={handleFormatChange}
-                onBlur={handleFormatBlur}
+                settingKeys={["format"]}
+                initialValue={node.format}
                 error={formatError}
+                onChange={setFormatValue}
+                order={3}
+                parentUid={node.type}
+                uid={formatUid}
               />
               <Label>
                 Specification
@@ -359,16 +256,20 @@ const NodeConfig = ({
           title="Attributes"
           panel={
             <div className="flex flex-col gap-4 p-1">
-              <DiscourseNodeAttributes uid={attributeNode.uid} />
-              <SelectPanel
+              <DiscourseNodeAttributes
+                uid={attributeNode.uid}
+                nodeType={node.type}
+              />
+              <DiscourseNodeSelectPanel
+                nodeType={node.type}
                 title="Overlay"
                 description="Select which attribute is used for the discourse overlay"
+                settingKeys={["overlay"]}
+                options={attributeNode.children.map((c) => c.text)}
+                initialValue={getBasicTreeByParentUid(overlayUid)[0]?.text}
                 order={0}
                 parentUid={node.type}
                 uid={overlayUid}
-                options={{
-                  items: () => attributeNode.children.map((c) => c.text),
-                }}
               />
             </div>
           }

--- a/apps/roam/src/components/settings/PageGroupPanel.tsx
+++ b/apps/roam/src/components/settings/PageGroupPanel.tsx
@@ -6,6 +6,14 @@ import createBlock from "roamjs-components/writes/createBlock";
 import deleteBlock from "roamjs-components/writes/deleteBlock";
 import getAllPageNames from "roamjs-components/queries/getAllPageNames";
 import { type PageGroup } from "~/utils/getSuggestiveModeConfigSettings";
+import { setGlobalSetting } from "~/components/settings/utils/accessors";
+
+const syncPageGroupsToBlockProps = (groups: PageGroup[]) => {
+  setGlobalSetting(
+    ["Suggestive mode", "Page groups"],
+    groups.map((g) => ({ name: g.name, pages: g.pages.map((p) => p.name) })),
+  );
+};
 
 const PageGroupsPanel = ({
   uid,
@@ -31,7 +39,12 @@ const PageGroupsPanel = ({
         parentUid: uid,
         node: { text: name },
       });
-      setPageGroups([...pageGroups, { uid: newGroupUid, name, pages: [] }]);
+      const updatedGroups = [
+        ...pageGroups,
+        { uid: newGroupUid, name, pages: [] },
+      ];
+      setPageGroups(updatedGroups);
+      syncPageGroupsToBlockProps(updatedGroups);
       setNewGroupName("");
       setGroupKeys((prev) => prev + 1);
     } catch (e) {
@@ -42,7 +55,9 @@ const PageGroupsPanel = ({
   const removeGroup = async (groupUid: string) => {
     try {
       await deleteBlock(groupUid);
-      setPageGroups(pageGroups.filter((g) => g.uid !== groupUid));
+      const updatedGroups = pageGroups.filter((g) => g.uid !== groupUid);
+      setPageGroups(updatedGroups);
+      syncPageGroupsToBlockProps(updatedGroups);
     } catch (e) {
       console.error("Error removing group", e);
     }
@@ -58,13 +73,13 @@ const PageGroupsPanel = ({
         parentUid: groupUid,
         node: { text: page },
       });
-      setPageGroups(
-        pageGroups.map((g) =>
-          g.uid === groupUid
-            ? { ...g, pages: [...g.pages, { uid: newPageUid, name: page }] }
-            : g,
-        ),
+      const updatedGroups = pageGroups.map((g) =>
+        g.uid === groupUid
+          ? { ...g, pages: [...g.pages, { uid: newPageUid, name: page }] }
+          : g,
       );
+      setPageGroups(updatedGroups);
+      syncPageGroupsToBlockProps(updatedGroups);
       setNewPageInputs((prev) => ({
         ...prev,
         [groupUid]: "",
@@ -81,13 +96,13 @@ const PageGroupsPanel = ({
   const removePageFromGroup = async (groupUid: string, pageUid: string) => {
     try {
       await deleteBlock(pageUid);
-      setPageGroups(
-        pageGroups.map((g) =>
-          g.uid === groupUid
-            ? { ...g, pages: g.pages.filter((p) => p.uid !== pageUid) }
-            : g,
-        ),
+      const updatedGroups = pageGroups.map((g) =>
+        g.uid === groupUid
+          ? { ...g, pages: g.pages.filter((p) => p.uid !== pageUid) }
+          : g,
       );
+      setPageGroups(updatedGroups);
+      syncPageGroupsToBlockProps(updatedGroups);
     } catch (e) {
       console.error("Error removing page from group", e);
     }

--- a/apps/roam/src/components/settings/components/BlockPropSettingPanels.tsx
+++ b/apps/roam/src/components/settings/components/BlockPropSettingPanels.tsx
@@ -457,9 +457,13 @@ const BaseMultiTextPanel = ({
   );
 };
 
-type TextWrapperProps = Omit<BaseTextPanelProps, "setter">;
+type TextWrapperProps = Omit<BaseTextPanelProps, "setter"> & {
+  setter?: TextSetter;
+};
 type FlagWrapperProps = Omit<BaseFlagPanelProps, "setter">;
-type NumberWrapperProps = Omit<BaseNumberPanelProps, "setter">;
+type NumberWrapperProps = Omit<BaseNumberPanelProps, "setter"> & {
+  setter?: NumberSetter;
+};
 type SelectWrapperProps = Omit<BaseSelectPanelProps, "setter">;
 type MultiTextWrapperProps = Omit<BaseMultiTextPanelProps, "setter">;
 
@@ -557,16 +561,22 @@ export const GlobalMultiTextPanel = (props: MultiTextWrapperProps) => (
   <BaseMultiTextPanel {...props} {...globalAccessors.multiText} />
 );
 
-export const PersonalTextPanel = (props: TextWrapperProps) => (
-  <BaseTextPanel {...props} {...personalAccessors.text} />
+export const PersonalTextPanel = ({ setter, ...props }: TextWrapperProps) => (
+  <BaseTextPanel {...props} setter={setter ?? personalAccessors.text.setter} />
 );
 
 export const PersonalFlagPanel = (props: FlagWrapperProps) => (
   <BaseFlagPanel {...props} {...personalAccessors.flag} />
 );
 
-export const PersonalNumberPanel = (props: NumberWrapperProps) => (
-  <BaseNumberPanel {...props} {...personalAccessors.number} />
+export const PersonalNumberPanel = ({
+  setter,
+  ...props
+}: NumberWrapperProps) => (
+  <BaseNumberPanel
+    {...props}
+    setter={setter ?? personalAccessors.number.setter}
+  />
 );
 
 export const PersonalSelectPanel = (props: SelectWrapperProps) => (

--- a/apps/roam/src/components/settings/utils/init.ts
+++ b/apps/roam/src/components/settings/utils/init.ts
@@ -3,6 +3,7 @@ import getShallowTreeByParentUid from "roamjs-components/queries/getShallowTreeB
 import { createPage, createBlock } from "roamjs-components/writes";
 import setBlockProps from "~/utils/setBlockProps";
 import getBlockProps from "~/utils/getBlockProps";
+
 import INITIAL_NODE_VALUES from "~/data/defaultDiscourseNodes";
 import { getAllDiscourseNodes } from "./accessors";
 import {

--- a/apps/roam/src/components/settings/utils/init.ts
+++ b/apps/roam/src/components/settings/utils/init.ts
@@ -3,8 +3,9 @@ import getShallowTreeByParentUid from "roamjs-components/queries/getShallowTreeB
 import { createPage, createBlock } from "roamjs-components/writes";
 import setBlockProps from "~/utils/setBlockProps";
 import getBlockProps from "~/utils/getBlockProps";
-
+import type { json } from "~/utils/getBlockProps";
 import INITIAL_NODE_VALUES from "~/data/defaultDiscourseNodes";
+import DEFAULT_RELATIONS_BLOCK_PROPS from "~/components/settings/data/defaultRelationsBlockProps";
 import { getAllDiscourseNodes } from "./accessors";
 import {
   DiscourseNodeSchema,
@@ -14,6 +15,7 @@ import {
   DG_BLOCK_PROP_SETTINGS_PAGE_TITLE,
   DISCOURSE_NODE_PAGE_PREFIX,
 } from "./zodSchema";
+import toFlexRegex from "roamjs-components/util/toFlexRegex";
 
 const ensurePageExists = async (pageTitle: string): Promise<string> => {
   let pageUid = getPageUidByPageTitle(pageTitle);
@@ -67,6 +69,7 @@ const buildBlockMap = (pageUid: string): Record<string, string> => {
 };
 
 const initializeSettingsBlockProps = (
+  pageUid: string,
   blockMap: Record<string, string>,
 ): void => {
   const configs = getTopLevelBlockPropsConfig();
@@ -75,9 +78,30 @@ const initializeSettingsBlockProps = (
     const uid = blockMap[key];
     if (uid) {
       const existingProps = getBlockProps(uid);
-      if (!existingProps || Object.keys(existingProps).length === 0) {
-        const defaults = schema.parse({});
+      const defaults = schema.parse({});
+
+      // TODO: Overwriting on safeParse failure is a temporary fix for schema shape changes
+      // (e.g. specification: [] -> {enabled, query}). Replace with proper versioned migrations.
+      if (
+        !existingProps ||
+        Object.keys(existingProps).length === 0 ||
+        !schema.safeParse(existingProps).success
+      ) {
         setBlockProps(uid, defaults, false);
+      }
+
+      // Reconcile placeholder relation keys with real block UIDs.
+      // TODO: remove this when fully migrated to blockprops, as the keys won't need to match block UIDs anymore and the defaults can use any stable IDs.
+      if (key === "Global") {
+        const relations = ((existingProps as Record<string, json> | null)?.[
+          "Relations"
+        ] ?? (defaults as Record<string, json>)["Relations"]) as Record<
+          string,
+          json
+        >;
+        if (relations) {
+          reconcileRelationKeys(pageUid, uid, relations);
+        }
       }
     }
   }
@@ -90,7 +114,7 @@ const initSettingsPageBlocks = async (): Promise<Record<string, string>> => {
   const topLevelBlocks = getTopLevelBlockPropsConfig().map(({ key }) => key);
   await ensureBlocksExist(pageUid, topLevelBlocks, blockMap);
 
-  initializeSettingsBlockProps(blockMap);
+  initializeSettingsBlockProps(pageUid, blockMap);
 
   return blockMap;
 };
@@ -109,7 +133,12 @@ const initSingleDiscourseNode = async (
   );
   const existingProps = getBlockProps(pageUid);
 
-  if (!existingProps || Object.keys(existingProps).length === 0) {
+  // TODO: Same temporary fix as initializeSettingsBlockProps — replace with proper migrations.
+  if (
+    !existingProps ||
+    Object.keys(existingProps).length === 0 ||
+    !DiscourseNodeSchema.safeParse(existingProps).success
+  ) {
     const nodeData = DiscourseNodeSchema.parse({
       text: node.text,
       type: node.type,
@@ -149,6 +178,75 @@ const initDiscourseNodePages = async (): Promise<Record<string, string>> => {
   }
 
   return nodePageUids;
+};
+
+/**
+ * Replace placeholder relation keys (_INFO-rel, etc.) in the Global blockprops
+ * with the actual block UIDs from the grammar > relations block tree.
+ *
+ * TODO: Remove this when fully migrated to blockprops. Once relations are read
+ * exclusively from blockprops, the keys won't need to match block UIDs anymore
+ * and the defaults can use any stable IDs.
+ */
+const reconcileRelationKeys = (
+  pageUid: string,
+  globalBlockUid: string,
+  relations: Record<string, json>,
+): void => {
+  const placeholderKeys = Object.keys(DEFAULT_RELATIONS_BLOCK_PROPS);
+  const hasPlaceholders = placeholderKeys.some((k) => k in relations);
+  if (!hasPlaceholders) {
+    return;
+  }
+
+  const pageChildren = getShallowTreeByParentUid(pageUid);
+  const grammarBlock = pageChildren.find((c) =>
+    toFlexRegex("grammar").test(c.text),
+  );
+  if (!grammarBlock) {
+    return;
+  }
+
+  const grammarChildren = getShallowTreeByParentUid(grammarBlock.uid);
+  const relationsBlock = grammarChildren.find((c) =>
+    toFlexRegex("relations").test(c.text),
+  );
+  if (!relationsBlock) {
+    return;
+  }
+
+  const relationBlocks = getShallowTreeByParentUid(relationsBlock.uid);
+
+  const labelToUid: Record<string, string> = {};
+  for (const block of relationBlocks) {
+    labelToUid[block.text] = block.uid;
+  }
+
+  const placeholderToLabel: Record<string, string> = {};
+  for (const [key, value] of Object.entries(DEFAULT_RELATIONS_BLOCK_PROPS)) {
+    placeholderToLabel[key] = value.label;
+  }
+
+  const reconciledRelations: Record<string, json> = {};
+  let changed = false;
+
+  for (const [key, value] of Object.entries(relations)) {
+    if (placeholderKeys.includes(key)) {
+      const label = placeholderToLabel[key];
+      const realUid = label ? labelToUid[label] : undefined;
+      if (realUid) {
+        reconciledRelations[realUid] = value;
+        changed = true;
+        continue;
+      }
+    }
+    reconciledRelations[key] = value;
+  }
+
+  if (changed) {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    setBlockProps(globalBlockUid, { Relations: reconciledRelations }, false);
+  }
 };
 
 export type InitSchemaResult = {

--- a/apps/roam/src/components/settings/utils/zodSchema.example.ts
+++ b/apps/roam/src/components/settings/utils/zodSchema.example.ts
@@ -345,9 +345,9 @@ const personalSettings: PersonalSettings = {
       },
     },
   },
-  "Personal node menu trigger": ";;",
+  "Personal node menu trigger": { modifiers: 0, key: ";;" },
   "Node search menu trigger": "//",
-  "Discourse tool shortcut": "d",
+  "Discourse tool shortcut": { modifiers: 0, key: "d" },
   "Discourse context overlay": true,
   "Suggestive mode overlay": true,
   "Overlay in canvas": false,
@@ -373,9 +373,9 @@ const personalSettings: PersonalSettings = {
 
 const defaultPersonalSettings: PersonalSettings = {
   "Left sidebar": {},
-  "Personal node menu trigger": "",
+  "Personal node menu trigger": { modifiers: 0, key: "" },
   "Node search menu trigger": "",
-  "Discourse tool shortcut": "",
+  "Discourse tool shortcut": { modifiers: 0, key: "" },
   "Discourse context overlay": false,
   "Suggestive mode overlay": false,
   "Overlay in canvas": false,

--- a/apps/roam/src/components/settings/utils/zodSchema.example.ts
+++ b/apps/roam/src/components/settings/utils/zodSchema.example.ts
@@ -266,10 +266,11 @@ const defaultGlobalSettings: GlobalSettings = {
 };
 
 const personalSection: PersonalSection = {
+  name: "My Workspace",
   Children: [
-    { Page: "daily-notes-uid", Alias: "Daily Notes" },
-    { Page: "inbox-uid", Alias: "Inbox" },
-    { Page: "projects-uid", Alias: "" },
+    { uid: "daily-notes-uid", Alias: "Daily Notes" },
+    { uid: "inbox-uid", Alias: "Inbox" },
+    { uid: "projects-uid", Alias: "" },
   ],
   Settings: {
     "Truncate-result?": 100,
@@ -277,29 +278,31 @@ const personalSection: PersonalSection = {
   },
 };
 
-const leftSidebarPersonalSettings: LeftSidebarPersonalSettings = {
-  "My Workspace": {
+const leftSidebarPersonalSettings: LeftSidebarPersonalSettings = [
+  {
+    name: "My Workspace",
     Children: [
-      { Page: "daily-notes-uid", Alias: "Daily Notes" },
-      { Page: "inbox-uid", Alias: "Inbox" },
+      { uid: "daily-notes-uid", Alias: "Daily Notes" },
+      { uid: "inbox-uid", Alias: "Inbox" },
     ],
     Settings: {
       "Truncate-result?": 75,
       Folded: false,
     },
   },
-  Research: {
+  {
+    name: "Research",
     Children: [
-      { Page: "papers-uid", Alias: "Papers" },
-      { Page: "notes-uid", Alias: "Notes" },
-      { Page: "ideas-uid", Alias: "Ideas" },
+      { uid: "papers-uid", Alias: "Papers" },
+      { uid: "notes-uid", Alias: "Notes" },
+      { uid: "ideas-uid", Alias: "Ideas" },
     ],
     Settings: {
       "Truncate-result?": 50,
       Folded: true,
     },
   },
-};
+];
 
 const storedFilters: StoredFilters = {
   includes: { values: ["Claim", "Evidence"] },
@@ -323,28 +326,30 @@ const querySettings: QuerySettings = {
 };
 
 const personalSettings: PersonalSettings = {
-  "Left sidebar": {
-    "My Workspace": {
+  "Left sidebar": [
+    {
+      name: "My Workspace",
       Children: [
-        { Page: "daily-notes-uid", Alias: "Daily Notes" },
-        { Page: "inbox-uid", Alias: "Inbox" },
+        { uid: "daily-notes-uid", Alias: "Daily Notes" },
+        { uid: "inbox-uid", Alias: "Inbox" },
       ],
       Settings: {
         "Truncate-result?": 75,
         Folded: false,
       },
     },
-    Research: {
+    {
+      name: "Research",
       Children: [
-        { Page: "papers-uid", Alias: "Papers" },
-        { Page: "notes-uid", Alias: "Notes" },
+        { uid: "papers-uid", Alias: "Papers" },
+        { uid: "notes-uid", Alias: "Notes" },
       ],
       Settings: {
         "Truncate-result?": 50,
         Folded: true,
       },
     },
-  },
+  ],
   "Personal node menu trigger": { modifiers: 0, key: ";;" },
   "Node search menu trigger": "//",
   "Discourse tool shortcut": { modifiers: 0, key: "d" },
@@ -372,7 +377,7 @@ const personalSettings: PersonalSettings = {
 };
 
 const defaultPersonalSettings: PersonalSettings = {
-  "Left sidebar": {},
+  "Left sidebar": [],
   "Personal node menu trigger": { modifiers: 0, key: "" },
   "Node search menu trigger": "",
   "Discourse tool shortcut": { modifiers: 0, key: "" },

--- a/apps/roam/src/components/settings/utils/zodSchema.example.ts
+++ b/apps/roam/src/components/settings/utils/zodSchema.example.ts
@@ -41,14 +41,22 @@ const discourseNodeSettings: DiscourseNodeSettings = {
   shortcut: "C",
   tag: "#claim",
   description: "A statement or assertion that can be supported or refuted",
-  specification: [
-    {
-      type: "clause",
-      source: "Claim",
-      relation: "has title",
-      target: "/^\\[\\[CLM\\]\\]/",
+  specification: {
+    enabled: true,
+    query: {
+      conditions: [
+        {
+          type: "clause",
+          source: "Claim",
+          relation: "has title",
+          target: "/^\\[\\[CLM\\]\\]/",
+        },
+      ],
+      selections: [],
+      custom: "",
+      returnNode: "Claim",
     },
-  ],
+  },
   template: [
     { text: "Summary::", heading: 2 },
     { text: "Evidence::", heading: 2, children: [{ text: "" }] },
@@ -71,6 +79,8 @@ const discourseNodeSettings: DiscourseNodeSettings = {
       },
     ],
     selections: [],
+    custom: "",
+    returnNode: "node",
   },
   suggestiveRules,
   backedBy: "user",

--- a/apps/roam/src/components/settings/utils/zodSchema.ts
+++ b/apps/roam/src/components/settings/utils/zodSchema.ts
@@ -225,9 +225,16 @@ export const QuerySettingsSchema = z.object({
 
 export const PersonalSettingsSchema = z.object({
   "Left sidebar": LeftSidebarPersonalSettingsSchema,
-  "Personal node menu trigger": z.string().default(""),
+  "Personal node menu trigger": z
+    .union([
+      z.object({ modifiers: z.number(), key: z.string() }),
+      z.literal(""),
+    ])
+    .default({ modifiers: 0, key: "" }),
   "Node search menu trigger": z.string().default("@"),
-  "Discourse tool shortcut": z.string().default(""),
+  "Discourse tool shortcut": z
+    .object({ modifiers: z.number(), key: z.string() })
+    .default({ modifiers: 0, key: "" }),
   "Discourse context overlay": z.boolean().default(false),
   "Suggestive mode overlay": z.boolean().default(false),
   "Overlay in canvas": z.boolean().default(false),

--- a/apps/roam/src/components/settings/utils/zodSchema.ts
+++ b/apps/roam/src/components/settings/utils/zodSchema.ts
@@ -52,6 +52,8 @@ export const SelectionSchema = z.object({
 export const IndexSchema = z.object({
   conditions: z.array(ConditionSchema).default([]),
   selections: z.array(SelectionSchema).default([]),
+  custom: z.string().default(""),
+  returnNode: z.string().default("node"),
 });
 
 type RoamNode = {
@@ -101,10 +103,19 @@ export const DiscourseNodeSchema = z.object({
   tag: stringWithDefault(""),
   description: stringWithDefault(""),
   specification: z
-    .array(ConditionSchema)
+    .object({
+      enabled: z.boolean().default(false),
+      query: IndexSchema.default({}),
+    })
     .nullable()
     .optional()
-    .transform((val) => val ?? []),
+    .transform(
+      (val) =>
+        val ?? {
+          enabled: false,
+          query: { conditions: [], selections: [], custom: "", returnNode: "" },
+        },
+    ),
   template: z
     .array(RoamNodeSchema)
     .nullable()

--- a/apps/roam/src/components/settings/utils/zodSchema.ts
+++ b/apps/roam/src/components/settings/utils/zodSchema.ts
@@ -191,10 +191,11 @@ export const GlobalSettingsSchema = z.object({
 });
 
 export const PersonalSectionSchema = z.object({
+  name: z.string(),
   Children: z
     .array(
       z.object({
-        Page: z.string(),
+        uid: z.string(),
         Alias: z.string().default(""),
       }),
     )
@@ -208,8 +209,8 @@ export const PersonalSectionSchema = z.object({
 });
 
 export const LeftSidebarPersonalSettingsSchema = z
-  .record(z.string(), PersonalSectionSchema)
-  .default({});
+  .array(PersonalSectionSchema)
+  .default([]);
 
 export const StoredFiltersSchema = z.object({
   includes: z.object({ values: z.array(z.string()).default([]) }).default({}),

--- a/apps/roam/src/index.ts
+++ b/apps/roam/src/index.ts
@@ -42,6 +42,7 @@ import {
   DISALLOW_DIAGNOSTICS,
 } from "./data/userSettings";
 import { initSchema } from "./components/settings/utils/init";
+
 export const DEFAULT_CANVAS_PAGE_FORMAT = "Canvas/*";
 
 export default runExtension(async (onloadArgs) => {
@@ -155,7 +156,6 @@ export default runExtension(async (onloadArgs) => {
   }
 
   await initSchema();
-
   return {
     elements: [
       style,


### PR DESCRIPTION
**No new code was written.** This PR recovers 7
  already-reviewed-and-approved PRs whose changes never landed on
  main due to a Graphite stack merge race condition.             
   
  ## What happened                                               
  These PRs were part of a 22-PR Graphite stack. When Graphite
  merged the stack bottom-up, the base PR (#696) was
  squash-merged to main before the upstack PRs finished merging
  into their parent branches. The upstack PRs ended
  up squash-merged into now-dead parent branches instead of being
   rebased onto main first. Graphite shows them
  as "merged", but their changes are orphaned.

  The 7 orphaned PRs formed two independent chains:
  - **Chain 2** (#793 → #794 → #805 → #804): above #784 on main
  - **Chain 1** (#764 → #765 → #769): between #696 and #784 on
  main

  ## How this PR was created

  **Chain 2 (4 PRs):** Identified the topmost orphaned branch
  (`origin/eng-1217-section-components-in-left-sidebarv2`) which
  contains all Chain 2 changes.
  Ran `git merge --squash` of that branch into a fresh branch off
   main.
  Resolved conflicts in NodeConfig.tsx (due to #784 which did
  land on main) and zodSchema.example.ts
  (Left sidebar type change from `{}` to `[]`).

  **Chain 1 (3 PRs):** Chain 1 was on completely separate
  branches not included in Chain 2's merge source
  (Graphite had rebased Chain 2 onto main after #784 landed,
  losing Chain 1).
  Applied each PR's exact diff from GitHub in order using `gh pr
  diff`:
  1. `gh pr diff 764 | git apply`
  2. `gh pr diff 765 | git apply`
  3. `gh pr diff 769 | git apply --exclude='*/init.ts'` (init.ts
  applied manually — #765 and #769
     both modified it from the same base; merged both: #765's
  safeParse checks + #769's
     `reconcileRelationKeys` restructuring)

  All code was previously reviewed and approved in these PRs.

  | PR | Title |
  |---|---|
  | #764 | ENG-1280: Port query builder/editor for block props |
  | #765 | ENG-1291: Port discourse node specification |
  | #769 | ENG-1290: Port discourse node config panel |
  | #793 | ENG-1440: Port page groups suggestive mode |
  | #794 | ENG-1438: Port keyboard shortcuts |
  | #805 | ENG-1328: Port small blueprint misc settings |
  | #804 | ENG-1217: Port section component in left sidebar |


## Testing 


  ## Personal Settings                                                                                              
  
  ### Home                                                                                                          
  - [x] Overlay                                                                                                  
  - [x] Suggestive mode overlay  - works as it was coded but wrong, noted down in [ENG-1479: Port suggestive mode settings to dual-read](https://linear.app/discourse-graphs/issue/ENG-1479/port-suggestive-mode-settings-to-dual-read)                                                                                 
  - [x] Text selection popup                                                                                     
  - [x] Disable sidebar open
  - [x] Page preview
  - [x] Hide feedback button
  - [x] Auto canvas relations
  - [x] Overlay in canvas
  - [x] Streamline styling
  - [x] Disable product diagnostics
  - [x] Personal node menu trigger (set)
  - [x] Personal node menu trigger (clear)
  - [x] Node search menu trigger
  - [x] Discourse tool shortcut (set)
  - [x] Discourse tool shortcut (clear)

  ### Queries
  - [x] Hide query metadata
  - [x] Default page size
  - [x] Query pages
  - [x] Default filters - have to check with main, clicking on a child removed it. Checked in main same behaviour

  ### Left sidebar
  - [x] Add section
  - [x] Remove section
  - [x] Move section
  - [x] Add child
  - [x] Remove child
  - [x] Move child
  - [x] Edit section title
  - [x] Edit child alias
  - [x] Edit truncate-result

  ## Global Settings

  ### Home
  - [x] Trigger
  - [x] Canvas page format
  - [x] (BETA) Left Sidebar

  ### Export
  - [x] Remove special characters
  - [x] Resolve block references
  - [x] Resolve block embeds
  - [x] Append referenced node
  - [x] Link type
  - [x] Max filename length
  - [x] Frontmatter

  ### Left sidebar
  - [x] Folded
  - [x] Collapsable
  - [x] Add page
  - [x] Move page
  - [x] Remove page

  ## Grammar

  ### Relations
  - [x] Save relation
  - [x] Delete relation
  - [x] Duplicate relation

  ### Nodes
  - [x] Delete node with relations

  ## Nodes > [any node]

  ### General
  - [x] Description
  - [x] Shortcut
  - [x] Tag
  - [x] Format
  - [x] Overlay
  - [x] Graph Overview

  ### Canvas
  - [x] Color (set)
  - [x] Color (unset)
  - [x] Display alias
  - [x] Key image
  - [x] Key image option
  - [x] Query builder alias

  ### Attributes
  - [x] Add attribute
  - [x] Edit attribute value
  - [x] Delete attribute

  ### Index
  - [x] Index init (auto on first visit)
  - [x] Edit index query

  ### Format > Specification
  - [x] Specification enabled
  - [x] Specification enable (query init)
  - [x] Edit specification query
  - [x] Specification disable

  ### Suggestive rules
  - [x] Embedding Block Ref
  - [x] First Child

  ## Admin (Ctrl+Shift+A)

  ### Feature Flags
  - [x] Suggestive mode ON
  - [x] Suggestive mode OFF
  - [x] Reified relation triples

  ### Suggestive mode
  - [x] Include current page relations
  - [x] Include parent and child blocks
  - [x] Add/remove page group
  - [x] Add/remove page in group

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/826" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
