### PR TITLE
ENG-1435 Use database views rather than tables for performance

### DIFF
--- a/apps/obsidian/src/utils/importNodes.ts
+++ b/apps/obsidian/src/utils/importNodes.ts
@@ -8,6 +8,8 @@ import { getLoggedInClient, getSupabaseContext } from "./supabaseContext";
 import type { DiscourseNode, ImportableNode } from "~/types";
 import { QueryEngine } from "~/services/QueryEngine";
 import { spaceUriAndLocalIdToRid, ridToSpaceUriAndLocalId } from "./rid";
+import type { PostgrestResponse } from "@supabase/supabase-js";
+import type { Tables } from "@repo/database/dbTypes";
 
 export const getAvailableGroupIds = async (
   client: DGSupabaseClient,
@@ -191,10 +193,10 @@ export const getSpaceNameFromIds = async (
     return new Map();
   }
 
-  const { data, error } = await client
-    .from("Space")
+  const { data, error } = (await client
+    .from("my_spaces")
     .select("id, name")
-    .in("id", spaceIds);
+    .in("id", spaceIds)) as PostgrestResponse<Tables<"Space">>;
 
   if (error) {
     console.error("Error fetching space names:", error);
@@ -217,10 +219,10 @@ export const getSpaceUris = async (
     return new Map();
   }
 
-  const { data, error } = await client
-    .from("Space")
+  const { data, error } = (await client
+    .from("my_spaces")
     .select("id, url")
-    .in("id", spaceIds);
+    .in("id", spaceIds)) as PostgrestResponse<Tables<"Space">>;
 
   if (error) {
     console.error("Error fetching space urls:", error);
@@ -422,11 +424,13 @@ const fetchFileReferences = async ({
     last_modified: number;
   }>
 > => {
-  const { data, error } = await client
-    .from("FileReference")
+  const { data, error } = (await client
+    .from("my_file_references")
     .select("filepath, filehash, created, last_modified")
     .eq("space_id", spaceId)
-    .eq("source_local_id", nodeInstanceId);
+    .eq("source_local_id", nodeInstanceId)) as PostgrestResponse<
+    Tables<"FileReference">
+  >;
 
   if (error) {
     console.error("Error fetching file references:", error);

--- a/apps/obsidian/src/utils/publishNode.ts
+++ b/apps/obsidian/src/utils/publishNode.ts
@@ -273,7 +273,7 @@ export const publishNodeToGroup = async ({
     (frontmatter.publishedToGroups as undefined | string[]) || [];
 
   const idResponse = await client
-    .from("Content")
+    .from("my_contents")
     .select("last_modified")
     .eq("source_local_id", nodeId)
     .eq("space_id", spaceId)
@@ -356,7 +356,7 @@ export const publishNodeToGroup = async ({
   // Always sync non-text assets when node is published to this group
   const existingFiles: string[] = [];
   const existingReferencesReq = await client
-    .from("FileReference")
+    .from("my_file_references")
     .select("*")
     .eq("space_id", spaceId)
     .eq("source_local_id", nodeId);

--- a/apps/obsidian/src/utils/syncDgNodesToSupabase.ts
+++ b/apps/obsidian/src/utils/syncDgNodesToSupabase.ts
@@ -51,7 +51,7 @@ const getAllNodeInstanceIdsFromSupabase = async (
 ): Promise<string[]> => {
   try {
     const { data, error } = await supabaseClient
-      .from("Content")
+      .from("my_contents")
       .select("source_local_id")
       .eq("space_id", spaceId)
       .eq("scale", "document")
@@ -161,7 +161,7 @@ const getLastContentSyncTime = async (
   spaceId: number,
 ): Promise<Date> => {
   const { data } = await supabaseClient
-    .from("Content")
+    .from("my_contents")
     .select("last_modified")
     .eq("space_id", spaceId)
     .order("last_modified", { ascending: false })
@@ -175,7 +175,7 @@ const getLastNodeSchemaSyncTime = async (
   spaceId: number,
 ): Promise<Date> => {
   const { data } = await supabaseClient
-    .from("Concept")
+    .from("my_concepts")
     .select("last_modified")
     .eq("space_id", spaceId)
     .eq("is_schema", true)
@@ -191,7 +191,7 @@ const getLastRelationSchemaSyncTime = async (
   spaceId: number,
 ): Promise<Date> => {
   const { data } = await supabaseClient
-    .from("Concept")
+    .from("my_concepts")
     .select("last_modified")
     .eq("space_id", spaceId)
     .eq("is_schema", true)
@@ -207,7 +207,7 @@ const getLastRelationSyncTime = async (
   spaceId: number,
 ): Promise<Date> => {
   const { data } = await supabaseClient
-    .from("Concept")
+    .from("my_concepts")
     .select("last_modified")
     .eq("space_id", spaceId)
     .eq("is_schema", false)
@@ -265,7 +265,7 @@ const getExistingTitlesFromDatabase = async (
 ): Promise<Map<string, string>> => {
   const { data: existingDirectContent, error: directError } =
     await supabaseClient
-      .from("Content")
+      .from("my_contents")
       .select("source_local_id, text")
       .eq("space_id", spaceId)
       .eq("variant", "direct")

--- a/apps/roam/src/utils/cleanupOrphanedNodes.ts
+++ b/apps/roam/src/utils/cleanupOrphanedNodes.ts
@@ -1,5 +1,7 @@
+import type { PostgrestResponse } from "@supabase/supabase-js";
 import type { SupabaseContext } from "./supabaseContext";
 import type { DGSupabaseClient } from "@repo/database/lib/client";
+import type { Tables } from "@repo/database/dbTypes";
 import internalError from "./internalError";
 
 const getAllNodesFromSupabase = async (
@@ -7,12 +9,12 @@ const getAllNodesFromSupabase = async (
   spaceId: number,
 ): Promise<string[]> => {
   try {
-    const { data: schemas, error: schemasError } = await supabaseClient
-      .from("Concept")
+    const { data: schemas, error: schemasError } = (await supabaseClient
+      .from("my_concepts")
       .select("id")
       .eq("space_id", spaceId)
       .eq("is_schema", true)
-      .eq("arity", 0);
+      .eq("arity", 0)) as PostgrestResponse<Tables<"Concept">>;
 
     if (schemasError) {
       internalError({
@@ -27,7 +29,7 @@ const getAllNodesFromSupabase = async (
 
     if (schemaIds.length > 0) {
       const conceptResponse = await supabaseClient
-        .from("Concept")
+        .from("my_concepts")
         .select("source_local_id")
         .eq("space_id", spaceId)
         .eq("is_schema", false)
@@ -52,7 +54,7 @@ const getAllNodesFromSupabase = async (
     }
 
     const blockContentResponse = await supabaseClient
-      .from("Content")
+      .from("my_contents")
       .select("source_local_id")
       .eq("space_id", spaceId)
       .eq("scale", "block")
@@ -86,7 +88,7 @@ const getAllNodeSchemasFromSupabase = async (
 ): Promise<string[]> => {
   try {
     const { data, error } = await supabaseClient
-      .from("Concept")
+      .from("my_concepts")
       .select("source_local_id")
       .eq("space_id", spaceId)
       .eq("is_schema", true)
@@ -189,12 +191,12 @@ const deleteNodeSchemasFromSupabase = async (
     if (uids.length === 0) return;
 
     const { data: schemaConceptData, error: schemaConceptError } =
-      await supabaseClient
-        .from("Concept")
+      (await supabaseClient
+        .from("my_concepts")
         .select("id")
         .eq("space_id", spaceId)
         .eq("is_schema", true)
-        .in("source_local_id", uids);
+        .in("source_local_id", uids)) as PostgrestResponse<Tables<"Concept">>;
 
     if (schemaConceptError) {
       internalError({
@@ -211,7 +213,7 @@ const deleteNodeSchemasFromSupabase = async (
     if (schemaConceptIds.length > 0) {
       const { data: instanceConceptData, error: instanceConceptError } =
         await supabaseClient
-          .from("Concept")
+          .from("my_concepts")
           .select("source_local_id")
           .eq("space_id", spaceId)
           .eq("is_schema", false)


### PR DESCRIPTION
https://linear.app/discourse-graphs/issue/ENG-1435/use-database-views-rather-than-tables-for-performance

This mostly affects the sync functions; Hyde etc. was already using a database function which uses the view.

https://www.loom.com/share/3b04f5396b724e9ea2b6a772788f64db


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/831" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
