### PR TITLE
ENG-1486 - Fix canvas filesize error

### DIFF
--- a/apps/roam/src/components/canvas/DiscourseRelationShape/discourseRelationMigrations.ts
+++ b/apps/roam/src/components/canvas/DiscourseRelationShape/discourseRelationMigrations.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
@@ -33,6 +34,7 @@ export const createMigrations = ({
     ExtractBindings: 1,
     "2.3.0": 2,
     AddSizeAndFontFamily: 3,
+    RemoveNullAssetFileSize: 4,
   });
   return createMigrationSequence({
     sequenceId: `${SEQUENCE_ID_BASE}`,
@@ -141,6 +143,17 @@ export const createMigrations = ({
         up: (shape: any) => {
           shape.props.size = "m";
           shape.props.fontFamily = "draw";
+        },
+      },
+      {
+        id: versions["RemoveNullAssetFileSize"],
+        scope: "record",
+        filter: (r: any) =>
+          r.typeName === "asset" &&
+          (r.type === "image" || r.type === "video") &&
+          r.props?.fileSize === null,
+        up: (asset: any) => {
+          delete asset.props.fileSize;
         },
       },
     ],

--- a/apps/roam/src/components/canvas/useRoamStore.ts
+++ b/apps/roam/src/components/canvas/useRoamStore.ts
@@ -208,7 +208,13 @@ export const useRoamStore = ({
           typeof props["roamjs-query-builder"] === "object"
             ? (props["roamjs-query-builder"] as Record<string, unknown>)
             : {};
-        const schema = _store.schema.serialize();
+        const propSchema = isTLStoreSnapshot(rjsqb.tldraw)
+          ? rjsqb.tldraw.schema
+          : {};
+        const schema =
+          Object.keys(propSchema).length === 0
+            ? _store.schema.serialize()
+            : propSchema;
         await setInputSetting({
           blockUid: pageUid,
           key: "timestamp",

--- a/apps/roam/src/components/canvas/useRoamStore.ts
+++ b/apps/roam/src/components/canvas/useRoamStore.ts
@@ -208,13 +208,7 @@ export const useRoamStore = ({
           typeof props["roamjs-query-builder"] === "object"
             ? (props["roamjs-query-builder"] as Record<string, unknown>)
             : {};
-        const propSchema = isTLStoreSnapshot(rjsqb.tldraw)
-          ? rjsqb.tldraw.schema
-          : {};
-        const schema =
-          Object.keys(propSchema).length === 0
-            ? _store.schema.serialize()
-            : propSchema;
+        const schema = _store.schema.serialize();
         await setInputSetting({
           blockUid: pageUid,
           key: "timestamp",


### PR DESCRIPTION
- Introduced a new migration step to delete the fileSize property from assets of type image or video when its value is null.
- Updated migration versioning to include this new step.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/836" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of image and video assets with missing file size information—these corrupted entries will now be properly cleaned up in the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->