### PR TITLE
ENG-1492 - Split 1 Atom safety

### DIFF
--- a/apps/roam/src/components/canvas/Tldraw.tsx
+++ b/apps/roam/src/components/canvas/Tldraw.tsx
@@ -134,6 +134,64 @@ export const MAX_WIDTH = "400px";
 
 const ICON_URL = `data:image/svg+xml;utf8,${encodeURIComponent(WHITE_LOGO_SVG)}`;
 
+const isAtomReactionCycleError = (error: unknown): error is Error =>
+  error instanceof Error &&
+  /cannot change atoms during reaction cycle/i.test(error.message);
+
+const installSafeHintingSetter = ({
+  app,
+  title,
+  pageUid,
+}: {
+  app: Editor;
+  title?: string;
+  pageUid?: string;
+}): void => {
+  const originalSetHintingShapes = app.setHintingShapes.bind(app);
+
+  app.setHintingShapes = ((shapeIds: TLShapeId[]) => {
+    try {
+      return originalSetHintingShapes(shapeIds);
+    } catch (error) {
+      if (!isAtomReactionCycleError(error)) {
+        throw error;
+      }
+
+      internalError({
+        error,
+        type: "Canvas Atom Reaction Cycle Error",
+        context: {
+          phase: "setHintingShapes.sync",
+          title,
+          pageUid,
+        },
+        sendEmail: false,
+      });
+
+      app.timers.setTimeout(() => {
+        try {
+          originalSetHintingShapes(shapeIds);
+        } catch (deferredError) {
+          if (isAtomReactionCycleError(deferredError)) {
+            internalError({
+              error: deferredError,
+              type: "Canvas Atom Reaction Cycle Error",
+              context: {
+                phase: "setHintingShapes.deferred",
+                title,
+                pageUid,
+              },
+              sendEmail: false,
+            });
+          }
+        }
+      }, 0);
+
+      return app;
+    }
+  }) as Editor["setHintingShapes"];
+};
+
 /** Valid file size for asset props; undefined when unknown (e.g. Roam/file API not a real File) to avoid persisting null. */
 const getValidFileSize = (file: { size?: number }): number | undefined =>
   typeof file.size === "number" && Number.isFinite(file.size) && file.size > 0
@@ -704,6 +762,7 @@ const TldrawCanvas = ({ title }: { title: string }) => {
               }
 
               appRef.current = app;
+              installSafeHintingSetter({ app, title, pageUid });
 
               app.on("change", (entry) => {
                 lastActionsRef.current.push(entry);


### PR DESCRIPTION
Parent: [ENG-1402: review the implementation and prepare for merge to main](https://linear.app/discourse-graphs/issue/ENG-1402/review-the-implementation-and-prepare-for-merge-to-main)

Split from https://github.com/DiscourseGraphs/discourse-graph/pull/749
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/837" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved canvas editor reliability with enhanced error handling and automatic recovery for complex operations
  * Better asset file sizing validation with graceful handling of edge cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->