### PR TITLE
ENG-1495 - Split 4 sync integration

### DIFF
--- a/apps/roam/package.json
+++ b/apps/roam/package.json
@@ -47,6 +47,7 @@
     "@tldraw/state": "2.4.6",
     "@tldraw/state-react": "2.4.6",
     "@tldraw/store": "2.4.6",
+    "@tldraw/sync": "2.4.6",
     "@tldraw/tlschema": "2.4.6",
     "@tldraw/utils": "2.4.6",
     "@tldraw/validate": "2.4.6",

--- a/apps/roam/src/components/canvas/Tldraw.tsx
+++ b/apps/roam/src/components/canvas/Tldraw.tsx
@@ -249,9 +249,11 @@ const TldrawCanvas = ({ title }: { title: string }) => {
 
   if (useCloudflareSync) {
     return (
-      <TldrawCanvasCloudflare
+      <TldrawCanvasShared
         title={title}
         pageUid={pageUid}
+        useStoreAdapter={useCloudflareCanvasStore}
+        isCloudflareSync={true}
         canvasSyncMode={canvasSyncMode}
         onCanvasSyncModeChange={onCanvasSyncModeChange}
       />
@@ -259,9 +261,11 @@ const TldrawCanvas = ({ title }: { title: string }) => {
   }
 
   return (
-    <TldrawCanvasRoam
+    <TldrawCanvasShared
       title={title}
       pageUid={pageUid}
+      useStoreAdapter={useRoamCanvasStore}
+      isCloudflareSync={false}
       canvasSyncMode={canvasSyncMode}
       onCanvasSyncModeChange={onCanvasSyncModeChange}
     />
@@ -330,52 +334,6 @@ const useCloudflareCanvasStore = ({
     needsUpgrade: false,
     performUpgrade: () => {},
   };
-};
-
-const TldrawCanvasRoam = ({
-  title,
-  pageUid,
-  canvasSyncMode,
-  onCanvasSyncModeChange,
-}: {
-  title: string;
-  pageUid: string;
-  canvasSyncMode: CanvasSyncMode;
-  onCanvasSyncModeChange: (mode: CanvasSyncMode) => void;
-}) => {
-  return (
-    <TldrawCanvasShared
-      title={title}
-      pageUid={pageUid}
-      useStoreAdapter={useRoamCanvasStore}
-      isCloudflareSync={false}
-      canvasSyncMode={canvasSyncMode}
-      onCanvasSyncModeChange={onCanvasSyncModeChange}
-    />
-  );
-};
-
-const TldrawCanvasCloudflare = ({
-  title,
-  pageUid,
-  canvasSyncMode,
-  onCanvasSyncModeChange,
-}: {
-  title: string;
-  pageUid: string;
-  canvasSyncMode: CanvasSyncMode;
-  onCanvasSyncModeChange: (mode: CanvasSyncMode) => void;
-}) => {
-  return (
-    <TldrawCanvasShared
-      title={title}
-      pageUid={pageUid}
-      useStoreAdapter={useCloudflareCanvasStore}
-      isCloudflareSync={true}
-      canvasSyncMode={canvasSyncMode}
-      onCanvasSyncModeChange={onCanvasSyncModeChange}
-    />
-  );
 };
 
 const TldrawCanvasShared = ({
@@ -1193,7 +1151,7 @@ const TldrawCanvasShared = ({
 
 // apps\examples\src\examples\exploded\ExplodedExample.tsx
 // We put these hooks into a component here so that they can run inside of the context provided by TldrawEditor and TldrawUi
-export const InsideEditorAndUiContext = ({
+const InsideEditorAndUiContext = ({
   extensionAPI,
   allNodes,
   // allRelationIds,

--- a/apps/roam/src/components/canvas/Tldraw.tsx
+++ b/apps/roam/src/components/canvas/Tldraw.tsx
@@ -249,11 +249,9 @@ const TldrawCanvas = ({ title }: { title: string }) => {
 
   if (useCloudflareSync) {
     return (
-      <TldrawCanvasShared
+      <TldrawCanvasCloudflare
         title={title}
         pageUid={pageUid}
-        useStoreAdapter={useCloudflareCanvasStore}
-        isCloudflareSync={true}
         canvasSyncMode={canvasSyncMode}
         onCanvasSyncModeChange={onCanvasSyncModeChange}
       />
@@ -261,11 +259,9 @@ const TldrawCanvas = ({ title }: { title: string }) => {
   }
 
   return (
-    <TldrawCanvasShared
+    <TldrawCanvasRoam
       title={title}
       pageUid={pageUid}
-      useStoreAdapter={useRoamCanvasStore}
-      isCloudflareSync={false}
       canvasSyncMode={canvasSyncMode}
       onCanvasSyncModeChange={onCanvasSyncModeChange}
     />
@@ -334,6 +330,51 @@ const useCloudflareCanvasStore = ({
     needsUpgrade: false,
     performUpgrade: () => {},
   };
+};
+const TldrawCanvasRoam = ({
+  title,
+  pageUid,
+  canvasSyncMode,
+  onCanvasSyncModeChange,
+}: {
+  title: string;
+  pageUid: string;
+  canvasSyncMode: CanvasSyncMode;
+  onCanvasSyncModeChange: (mode: CanvasSyncMode) => void;
+}) => {
+  return (
+    <TldrawCanvasShared
+      title={title}
+      pageUid={pageUid}
+      useStoreAdapter={useRoamCanvasStore}
+      isCloudflareSync={false}
+      canvasSyncMode={canvasSyncMode}
+      onCanvasSyncModeChange={onCanvasSyncModeChange}
+    />
+  );
+};
+
+const TldrawCanvasCloudflare = ({
+  title,
+  pageUid,
+  canvasSyncMode,
+  onCanvasSyncModeChange,
+}: {
+  title: string;
+  pageUid: string;
+  canvasSyncMode: CanvasSyncMode;
+  onCanvasSyncModeChange: (mode: CanvasSyncMode) => void;
+}) => {
+  return (
+    <TldrawCanvasShared
+      title={title}
+      pageUid={pageUid}
+      useStoreAdapter={useCloudflareCanvasStore}
+      isCloudflareSync={true}
+      canvasSyncMode={canvasSyncMode}
+      onCanvasSyncModeChange={onCanvasSyncModeChange}
+    />
+  );
 };
 
 const TldrawCanvasShared = ({

--- a/apps/roam/src/components/canvas/Tldraw.tsx
+++ b/apps/roam/src/components/canvas/Tldraw.tsx
@@ -6,6 +6,7 @@ import React, {
   useEffect,
   useCallback,
 } from "react";
+import { Icon } from "@blueprintjs/core";
 import ExtensionApiContextProvider, {
   useExtensionAPI,
 } from "roamjs-components/components/ExtensionApiContext";
@@ -38,6 +39,8 @@ import {
   getHashForString,
   TLShapeId,
   TLShape,
+  TLStore,
+  TLStoreWithStatus,
   useToasts,
   useTranslation,
   DEFAULT_SUPPORTED_IMAGE_TYPES,
@@ -49,6 +52,9 @@ import {
   StateNode,
   DefaultSpinner,
   Box,
+  MigrationSequence,
+  TLAnyBindingUtilConstructor,
+  TLAnyShapeUtilConstructor,
 } from "tldraw";
 import "tldraw/tldraw.css";
 import tldrawStyles from "./tldrawStyles";
@@ -68,6 +74,10 @@ import {
   createNodeShapeUtils,
 } from "./DiscourseNodeUtil";
 import { useRoamStore } from "./useRoamStore";
+import {
+  TLDRAW_CLOUDFLARE_SYNC_WS_BASE_URL,
+  useCloudflareSyncStore,
+} from "./TldrawCanvasCloudflareSync";
 import getPageUidByPageTitle from "roamjs-components/queries/getPageUidByPageTitle";
 import getTextByBlockUid from "roamjs-components/queries/getTextByBlockUid";
 import getUids from "roamjs-components/dom/getUids";
@@ -140,10 +150,10 @@ export const MAX_WIDTH = "400px";
 
 const ICON_URL = `data:image/svg+xml;utf8,${encodeURIComponent(WHITE_LOGO_SVG)}`;
 
+// hack for "cannot change atoms during reaction cycle" bug
 const isAtomReactionCycleError = (error: unknown): error is Error =>
   error instanceof Error &&
   /cannot change atoms during reaction cycle/i.test(error.message);
-
 const installSafeHintingSetter = ({
   app,
   title,
@@ -189,7 +199,9 @@ const installSafeHintingSetter = ({
               },
               sendEmail: false,
             });
+            return;
           }
+          // Ignore deferred hinting updates if the editor is gone or still reacting.
         }
       }, 0);
 
@@ -213,6 +225,174 @@ export const isPageUid = (uid: string) =>
   ];
 
 const TldrawCanvas = ({ title }: { title: string }) => {
+  // In Roam, canvas identity is currently keyed by the page UID.
+  // Room sync is graph/page encoded as an opaque base64url token.
+  const pageUid = useMemo(() => getPageUidByPageTitle(title), [title]);
+  const [canvasSyncMode, setCanvasSyncModeState] = useState<CanvasSyncMode>(
+    () => getEffectiveCanvasSyncMode({ pageUid }),
+  );
+
+  const useCloudflareSync =
+    canvasSyncMode === "sync" && !!TLDRAW_CLOUDFLARE_SYNC_WS_BASE_URL;
+
+  useEffect(() => {
+    setCanvasSyncModeState(ensureCanvasSyncMode({ pageUid }));
+  }, [pageUid]);
+
+  const onCanvasSyncModeChange = useCallback(
+    (mode: CanvasSyncMode) => {
+      setCanvasSyncMode({ pageUid, mode });
+      setCanvasSyncModeState(mode);
+    },
+    [pageUid],
+  );
+
+  if (useCloudflareSync) {
+    return (
+      <TldrawCanvasCloudflare
+        title={title}
+        pageUid={pageUid}
+        canvasSyncMode={canvasSyncMode}
+        onCanvasSyncModeChange={onCanvasSyncModeChange}
+      />
+    );
+  }
+
+  return (
+    <TldrawCanvasRoam
+      title={title}
+      pageUid={pageUid}
+      canvasSyncMode={canvasSyncMode}
+      onCanvasSyncModeChange={onCanvasSyncModeChange}
+    />
+  );
+};
+
+type CanvasStoreAdapterArgs = {
+  pageUid: string;
+  migrations: MigrationSequence[];
+  customShapeUtils: readonly TLAnyShapeUtilConstructor[];
+  customBindingUtils: readonly TLAnyBindingUtilConstructor[];
+  customShapeTypes: string[];
+  customBindingTypes: string[];
+};
+
+type CanvasStoreAdapterResult = {
+  store: TLStore | TLStoreWithStatus | null;
+  needsUpgrade: boolean;
+  performUpgrade: () => void;
+  error: Error | null;
+  isLoading: boolean;
+};
+
+const useRoamCanvasStore = ({
+  pageUid,
+  migrations,
+  customShapeUtils,
+  customBindingUtils,
+}: CanvasStoreAdapterArgs): CanvasStoreAdapterResult => {
+  const { store, needsUpgrade, performUpgrade, error } = useRoamStore({
+    migrations,
+    customShapeUtils,
+    customBindingUtils,
+    pageUid,
+  });
+
+  return {
+    store,
+    needsUpgrade,
+    performUpgrade,
+    error,
+    isLoading: false,
+  };
+};
+
+const useCloudflareCanvasStore = ({
+  pageUid,
+  migrations,
+  customShapeUtils,
+  customBindingUtils,
+  customShapeTypes,
+  customBindingTypes,
+}: CanvasStoreAdapterArgs): CanvasStoreAdapterResult => {
+  const { store, error, isLoading } = useCloudflareSyncStore({
+    pageUid,
+    migrations,
+    customShapeUtils,
+    customBindingUtils,
+    customShapeTypes,
+    customBindingTypes,
+  });
+  return {
+    store,
+    error,
+    isLoading,
+    needsUpgrade: false,
+    performUpgrade: () => {},
+  };
+};
+
+const TldrawCanvasRoam = ({
+  title,
+  pageUid,
+  canvasSyncMode,
+  onCanvasSyncModeChange,
+}: {
+  title: string;
+  pageUid: string;
+  canvasSyncMode: CanvasSyncMode;
+  onCanvasSyncModeChange: (mode: CanvasSyncMode) => void;
+}) => {
+  return (
+    <TldrawCanvasShared
+      title={title}
+      pageUid={pageUid}
+      useStoreAdapter={useRoamCanvasStore}
+      isCloudflareSync={false}
+      canvasSyncMode={canvasSyncMode}
+      onCanvasSyncModeChange={onCanvasSyncModeChange}
+    />
+  );
+};
+
+const TldrawCanvasCloudflare = ({
+  title,
+  pageUid,
+  canvasSyncMode,
+  onCanvasSyncModeChange,
+}: {
+  title: string;
+  pageUid: string;
+  canvasSyncMode: CanvasSyncMode;
+  onCanvasSyncModeChange: (mode: CanvasSyncMode) => void;
+}) => {
+  return (
+    <TldrawCanvasShared
+      title={title}
+      pageUid={pageUid}
+      useStoreAdapter={useCloudflareCanvasStore}
+      isCloudflareSync={true}
+      canvasSyncMode={canvasSyncMode}
+      onCanvasSyncModeChange={onCanvasSyncModeChange}
+    />
+  );
+};
+
+const TldrawCanvasShared = ({
+  title,
+  pageUid,
+  useStoreAdapter,
+  isCloudflareSync,
+  canvasSyncMode,
+  onCanvasSyncModeChange,
+}: {
+  title: string;
+  pageUid: string;
+  useStoreAdapter: (args: CanvasStoreAdapterArgs) => CanvasStoreAdapterResult;
+  isCloudflareSync: boolean;
+  canvasSyncMode: CanvasSyncMode;
+  onCanvasSyncModeChange: (mode: CanvasSyncMode) => void;
+}) => {
   const appRef = useRef<Editor | null>(null);
   const lastInsertRef = useRef<VecModel>();
   const containerRef = useRef<HTMLDivElement>(null);
@@ -221,8 +401,10 @@ const TldrawCanvas = ({ title }: { title: string }) => {
   );
 
   const [isConvertToDialogOpen, setConvertToDialogOpen] = useState(false);
+  // hack for "cannot change atoms during reaction cycle" bug
+  const [hasMountedEditor, setHasMountedEditor] = useState(false);
 
-  const updateViewportScreenBounds = (el: HTMLDivElement) => {
+  const updateViewportScreenBounds = useCallback((el: HTMLDivElement) => {
     // Use tldraw's built-in viewport bounds update with centering
     requestAnimationFrame(() => {
       const rect = el.getBoundingClientRect();
@@ -231,8 +413,8 @@ const TldrawCanvas = ({ title }: { title: string }) => {
         true,
       );
     });
-  };
-  const handleMaximizedChange = () => {
+  }, []);
+  const handleMaximizedChange = useCallback(() => {
     // Direct DOM manipulation to avoid React re-renders
     if (!containerRef.current) return;
     const tldrawEl = containerRef.current;
@@ -253,7 +435,7 @@ const TldrawCanvas = ({ title }: { title: string }) => {
       posthog.capture("Canvas: Fullscreen Toggled", { maximized: false });
       updateViewportScreenBounds(tldrawEl);
     }
-  };
+  }, [updateViewportScreenBounds]);
 
   // Workaround to avoid a race condition when loading a canvas page directly
   // Start false to avoid noisy warnings on first render if timer isn't initialized yet
@@ -513,87 +695,147 @@ const TldrawCanvas = ({ title }: { title: string }) => {
     });
   };
 
-  const pageUid = useMemo(() => getPageUidByPageTitle(title), [title]);
-  const [canvasSyncMode, setCanvasSyncModeState] = useState<CanvasSyncMode>(
-    () => getEffectiveCanvasSyncMode({ pageUid }),
-  );
-  useEffect(() => {
-    setCanvasSyncModeState(ensureCanvasSyncMode({ pageUid }));
-  }, [pageUid]);
-
-  const onCanvasSyncModeChange = useCallback(
-    (mode: CanvasSyncMode) => {
-      setCanvasSyncMode({ pageUid, mode });
-      setCanvasSyncModeState(mode);
-    },
-    [pageUid],
-  );
-
   // COMPONENTS
-  const defaultEditorComponents: TLEditorComponents = {
-    Scribble: TldrawScribble,
-    CollaboratorScribble: TldrawScribble,
-    SelectionForeground: TldrawSelectionForeground,
-    SelectionBackground: TldrawSelectionBackground,
-    Handles: TldrawHandles,
-  };
-  const editorComponents: TLEditorComponents = {
-    ...defaultEditorComponents,
-    OnTheCanvas: ToastListener,
-  };
-  const customUiComponents: TLUiComponents = createUiComponents({
-    allNodes,
-    allRelationNames,
-    allAddReferencedNodeActions,
-    canvasSyncMode,
-    onCanvasSyncModeChange,
-  });
+  const defaultEditorComponents: TLEditorComponents = useMemo(
+    () => ({
+      Scribble: TldrawScribble,
+      CollaboratorScribble: TldrawScribble,
+      SelectionForeground: TldrawSelectionForeground,
+      SelectionBackground: TldrawSelectionBackground,
+      Handles: TldrawHandles,
+    }),
+    [],
+  );
+  const editorComponents: TLEditorComponents = useMemo(
+    () => ({
+      ...defaultEditorComponents,
+      OnTheCanvas: ToastListener,
+    }),
+    [defaultEditorComponents],
+  );
+  const customUiComponents: TLUiComponents = useMemo(
+    () =>
+      createUiComponents({
+        allNodes,
+        allRelationNames,
+        allAddReferencedNodeActions,
+        canvasSyncMode,
+        onCanvasSyncModeChange,
+      }),
+    [
+      allNodes,
+      allRelationNames,
+      allAddReferencedNodeActions,
+      canvasSyncMode,
+      onCanvasSyncModeChange,
+    ],
+  );
 
   // UTILS
-  const discourseNodeUtils = createNodeShapeUtils(allNodes);
-  const discourseRelationUtils = createAllRelationShapeUtils(allRelationIds);
-  const referencedNodeUtils = createAllReferencedNodeUtils(
-    allAddReferencedNodeByAction,
+  const discourseNodeUtils = useMemo(
+    () => createNodeShapeUtils(allNodes),
+    [allNodes],
   );
-  const customShapeUtils = [
-    ...discourseNodeUtils,
-    ...discourseRelationUtils,
-    ...referencedNodeUtils,
-  ];
+  const discourseRelationUtils = useMemo(
+    () => createAllRelationShapeUtils(allRelationIds),
+    [allRelationIds],
+  );
+  const referencedNodeUtils = useMemo(
+    () => createAllReferencedNodeUtils(allAddReferencedNodeByAction),
+    [allAddReferencedNodeByAction],
+  );
+  const customShapeUtils = useMemo(
+    () => [
+      ...discourseNodeUtils,
+      ...discourseRelationUtils,
+      ...referencedNodeUtils,
+    ],
+    [discourseNodeUtils, discourseRelationUtils, referencedNodeUtils],
+  );
 
   // TOOLS
-  const discourseGraphTool = class DiscourseGraphTool extends StateNode {
-    static override id = "discourse-tool";
-    static override initial = "idle";
-  };
-  const discourseNodeTools = createNodeShapeTools(allNodes);
-  const discourseRelationTools = createAllRelationShapeTools(allRelationNames);
-  const referencedNodeTools = createAllReferencedNodeTools(
-    allAddReferencedNodeByAction,
+  const discourseGraphTool = useMemo(
+    () =>
+      class DiscourseGraphTool extends StateNode {
+        static override id = "discourse-tool";
+        static override initial = "idle";
+      },
+    [],
   );
-  const customTools = [
-    discourseGraphTool,
-    ...discourseNodeTools,
-    ...discourseRelationTools,
-    ...referencedNodeTools,
-  ];
+  const discourseNodeTools = useMemo(
+    () => createNodeShapeTools(allNodes),
+    [allNodes],
+  );
+  const discourseRelationTools = useMemo(
+    () => createAllRelationShapeTools(allRelationNames),
+    [allRelationNames],
+  );
+  const referencedNodeTools = useMemo(
+    () => createAllReferencedNodeTools(allAddReferencedNodeByAction),
+    [allAddReferencedNodeByAction],
+  );
+  const customTools = useMemo(
+    () => [
+      discourseGraphTool,
+      ...discourseNodeTools,
+      ...discourseRelationTools,
+      ...referencedNodeTools,
+    ],
+    [
+      discourseGraphTool,
+      discourseNodeTools,
+      discourseRelationTools,
+      referencedNodeTools,
+    ],
+  );
 
   // BINDINGS
-  const relationBindings = createAllRelationBindings(allRelationIds);
-  const referencedNodeBindings = createAllReferencedNodeBindings(
-    allAddReferencedNodeByAction,
+  const relationBindings = useMemo(
+    () => createAllRelationBindings(allRelationIds),
+    [allRelationIds],
   );
-  const customBindingUtils = [...relationBindings, ...referencedNodeBindings];
+  const referencedNodeBindings = useMemo(
+    () => createAllReferencedNodeBindings(allAddReferencedNodeByAction),
+    [allAddReferencedNodeByAction],
+  );
+  const customBindingUtils = useMemo(
+    () => [...relationBindings, ...referencedNodeBindings],
+    [relationBindings, referencedNodeBindings],
+  );
+  const customShapeTypes = useMemo(
+    () =>
+      customShapeUtils
+        .map((s) => (s as unknown as { type?: string }).type)
+        .filter((t): t is string => !!t),
+    [customShapeUtils],
+  );
+  const customBindingTypes = useMemo(
+    () =>
+      customBindingUtils
+        .map((b) => (b as unknown as { type?: string }).type)
+        .filter((t): t is string => !!t),
+    [customBindingUtils],
+  );
 
   // UI OVERRIDES
-  const uiOverrides = createUiOverrides({
-    allNodes,
-    allRelationNames,
-    allAddReferencedNodeByAction,
-    toggleMaximized: handleMaximizedChange,
-    setConvertToDialogOpen,
-    discourseContext,
-  });
+  const uiOverrides = useMemo(
+    () =>
+      createUiOverrides({
+        allNodes,
+        allRelationNames,
+        allAddReferencedNodeByAction,
+        toggleMaximized: handleMaximizedChange,
+        setConvertToDialogOpen,
+        discourseContext,
+      }),
+    [
+      allNodes,
+      allRelationNames,
+      allAddReferencedNodeByAction,
+      handleMaximizedChange,
+      setConvertToDialogOpen,
+    ],
+  );
 
   // STORE
   useEffect(() => {
@@ -612,13 +854,19 @@ const TldrawCanvas = ({ title }: { title: string }) => {
     [allRelationIds, allAddReferencedNodeActions, allNodes],
   );
 
-  const migrations = [arrowShapeMigrations];
-  const { store, needsUpgrade, performUpgrade, error } = useRoamStore({
-    migrations,
-    customShapeUtils,
-    customBindingUtils,
-    pageUid,
-  });
+  const migrations = useMemo(
+    () => [arrowShapeMigrations],
+    [arrowShapeMigrations],
+  );
+  const { store, needsUpgrade, performUpgrade, error, isLoading } =
+    useStoreAdapter({
+      migrations,
+      customShapeUtils,
+      customBindingUtils,
+      customShapeTypes,
+      customBindingTypes,
+      pageUid,
+    });
 
   // ASSETS
   const assetLoading = usePreloadAssets(defaultEditorAssetUrls);
@@ -707,6 +955,54 @@ const TldrawCanvas = ({ title }: { title: string }) => {
     };
   }, [title]);
 
+  const lastReportedStoreErrorRef = useRef<string>("");
+  useEffect(() => {
+    if (!error) return;
+    const errorKey = `${pageUid}:${error.message}`;
+    if (lastReportedStoreErrorRef.current === errorKey) return;
+    lastReportedStoreErrorRef.current = errorKey;
+
+    const isInvalidRecord = /invalidRecord/i.test(error.message);
+    console.error("[DG Canvas] Store error", {
+      title,
+      pageUid,
+      message: error.message,
+      stack: error.stack,
+      ...(isInvalidRecord
+        ? {
+            hint: "Cloudflare sync worker schema is rejecting one or more custom records.",
+            customShapeTypes,
+            customBindingTypes,
+          }
+        : {}),
+    });
+    internalError({
+      error,
+      type: "Canvas Store Error",
+      context: {
+        title,
+        pageUid,
+        ...(isInvalidRecord
+          ? {
+              customShapeTypes,
+              customBindingTypes,
+            }
+          : {}),
+      },
+    });
+  }, [error, pageUid, title, customShapeTypes, customBindingTypes]);
+
+  // Keep the mounted editor alive through transient reconnect errors,
+  // but still surface errors when the store is unavailable.
+  const blockingStoreError =
+    error && (!hasMountedEditor || !store) ? error : null;
+  const isCanvasBlocked =
+    !store ||
+    !assetLoading.done ||
+    !extensionAPI ||
+    !isPluginReady ||
+    (!hasMountedEditor && (isLoading || !!error));
+
   return (
     <div
       className="roamjs-tldraw-canvas-container relative z-10 h-full w-full overflow-hidden rounded-md border border-gray-300 bg-white"
@@ -715,6 +1011,14 @@ const TldrawCanvas = ({ title }: { title: string }) => {
       onDragOver={handleDragOver}
       onDrop={handleDrop}
     >
+      {isCloudflareSync && (
+        <div
+          className="absolute bottom-3 right-3 z-20 opacity-90"
+          title="Using cloud canvas"
+        >
+          <Icon icon="cloud" size={12} className="text-green-500" />
+        </div>
+      )}
       <style>{tldrawStyles}</style>
 
       {needsUpgrade ? (
@@ -742,17 +1046,24 @@ const TldrawCanvas = ({ title }: { title: string }) => {
             </button>
           </div>
         </div>
-      ) : !store || !assetLoading.done || !extensionAPI || !isPluginReady ? (
+      ) : isCanvasBlocked ? (
         <div className="flex h-full items-center justify-center">
           <div className="text-center">
             <h2 className="mb-2 text-2xl font-semibold">
-              {error || assetLoading.error
+              {blockingStoreError || assetLoading.error
                 ? "Error Loading Canvas"
                 : "Loading Canvas"}
             </h2>
             <p className="mb-4 text-gray-600">
-              {error || assetLoading.error ? (
-                "There was a problem loading the Tldraw canvas. Please try again later."
+              {blockingStoreError || assetLoading.error ? (
+                <span>
+                  {blockingStoreError?.message?.includes("invalidRecord")
+                    ? "Cloudflare sync rejected a custom Discourse Graph record (invalidRecord). The sync worker schema must include DG custom shapes and bindings."
+                    : "There was a problem loading the Tldraw canvas."}{" "}
+                  {blockingStoreError?.message
+                    ? `Details: ${blockingStoreError.message}`
+                    : ""}
+                </span>
               ) : (
                 <DefaultSpinner />
               )}
@@ -785,7 +1096,10 @@ const TldrawCanvas = ({ title }: { title: string }) => {
               }
 
               appRef.current = app;
+
+              // hack for "cannot change atoms during reaction cycle" bug
               installSafeHintingSetter({ app, title, pageUid });
+              setHasMountedEditor(true);
 
               app.on("change", (entry) => {
                 lastActionsRef.current.push(entry);
@@ -879,7 +1193,7 @@ const TldrawCanvas = ({ title }: { title: string }) => {
 
 // apps\examples\src\examples\exploded\ExplodedExample.tsx
 // We put these hooks into a component here so that they can run inside of the context provided by TldrawEditor and TldrawUi
-const InsideEditorAndUiContext = ({
+export const InsideEditorAndUiContext = ({
   extensionAPI,
   allNodes,
   // allRelationIds,

--- a/apps/roam/src/components/canvas/TldrawCanvasCloudflareSync.tsx
+++ b/apps/roam/src/components/canvas/TldrawCanvasCloudflareSync.tsx
@@ -1,0 +1,104 @@
+import { useSync } from "@tldraw/sync";
+import {
+  TLAnyBindingUtilConstructor,
+  TLAnyShapeUtilConstructor,
+  TLAssetStore,
+  TLStoreWithStatus,
+  defaultBindingUtils,
+  defaultShapeUtils,
+  MigrationSequence,
+} from "tldraw";
+import { useMemo } from "react";
+
+/** Base URL for tldraw-sync-cloudflare worker. Use https (not wss) - useSync upgrades to WebSocket. */
+export const TLDRAW_CLOUDFLARE_SYNC_WS_BASE_URL =
+  "https://multiplayer-dg-sync.discoursegraphs.workers.dev";
+
+export type CloudflareCanvasStoreAdapterResult = {
+  store: TLStoreWithStatus;
+  error: Error | null;
+  isLoading: boolean;
+};
+
+// TODO: this should be more secure, but using graphName/UID is probably fine for now
+export const getSyncRoomId = ({ pageUid }: { pageUid: string }): string => {
+  const graphName = window.roamAlphaAPI.graph.name;
+  const payload = JSON.stringify({ graphName, pageUid });
+  const bytes = new TextEncoder().encode(payload);
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+
+  return btoa(binary)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
+};
+
+const parseRoamUploadResponse = (value: string): string => {
+  return value.replace(/^!\[\]\(/, "").replace(/\)$/, "");
+};
+
+const createRoamAssetStore = (): TLAssetStore => {
+  return {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    upload: async (_asset, file) => {
+      const response = await window.roamAlphaAPI.file.upload({ file });
+      return parseRoamUploadResponse(response);
+    },
+    resolve: (asset) => asset.props.src,
+  };
+};
+
+export const useCloudflareSyncStore = ({
+  pageUid,
+  migrations,
+  customShapeUtils,
+  customBindingUtils,
+  customShapeTypes,
+  customBindingTypes,
+}: {
+  pageUid: string;
+  migrations: MigrationSequence[];
+  customShapeUtils: readonly TLAnyShapeUtilConstructor[];
+  customBindingUtils: readonly TLAnyBindingUtilConstructor[];
+  customShapeTypes: string[];
+  customBindingTypes: string[];
+}): CloudflareCanvasStoreAdapterResult => {
+  const assets = useMemo(() => createRoamAssetStore(), []);
+  const shapeUtils = useMemo(
+    () => [...defaultShapeUtils, ...customShapeUtils],
+    [customShapeUtils],
+  );
+  const bindingUtils = useMemo(
+    () => [...defaultBindingUtils, ...customBindingUtils],
+    [customBindingUtils],
+  );
+
+  const uri = useMemo(() => {
+    const roomId = getSyncRoomId({ pageUid });
+    const query = new URLSearchParams();
+    for (const shapeType of customShapeTypes) {
+      query.append("shapeType", shapeType);
+    }
+    for (const bindingType of customBindingTypes) {
+      query.append("bindingType", bindingType);
+    }
+    return `${TLDRAW_CLOUDFLARE_SYNC_WS_BASE_URL}/connect/${roomId}?${query.toString()}`;
+  }, [customShapeTypes, customBindingTypes, pageUid]);
+
+  const store = useSync({
+    uri,
+    assets,
+    migrations,
+    shapeUtils,
+    bindingUtils,
+  });
+
+  return {
+    store,
+    error: store.status === "error" ? store.error : null,
+    isLoading: store.status === "loading",
+  };
+};

--- a/apps/roam/src/components/canvas/uiOverrides.tsx
+++ b/apps/roam/src/components/canvas/uiOverrides.tsx
@@ -287,7 +287,7 @@ export const createUiComponents = ({
         <DefaultMainMenu>
           <TldrawUiMenuGroup id="sync-mode">
             <SyncModeMenuSwitchItem
-              label="Use cloud canvas"
+              label="(Beta) Use cloud canvas"
               checked={canvasSyncMode === "sync"}
               onToggle={onToggleSyncMode}
             />

--- a/apps/roam/src/components/canvas/uiOverrides.tsx
+++ b/apps/roam/src/components/canvas/uiOverrides.tsx
@@ -15,7 +15,6 @@ import {
   DefaultToolbarContent,
   TldrawUiMenuItem,
   DefaultMainMenu,
-  DefaultMainMenuContent,
   TldrawUiMenuGroup,
   TldrawUiDropdownMenuItem,
   TldrawUiButton,
@@ -25,7 +24,14 @@ import {
   DefaultContextMenu,
   DefaultContextMenuContent,
   TLUiComponents,
+  EditSubmenu,
+  ExportFileContentSubMenu,
+  ExtrasGroup,
+  PreferencesGroup,
   TldrawUiMenuSubmenu,
+  ZoomTo100MenuItem,
+  ZoomToFitMenuItem,
+  ZoomToSelectionMenuItem,
   useEditor,
   useValue,
   useToasts,
@@ -256,27 +262,41 @@ export const createUiComponents = ({
       );
     },
     MainMenu: () => {
+      const CustomViewMenu = () => {
+        const actions = useActions();
+        return (
+          <TldrawUiMenuSubmenu id="view" label="menu.view">
+            <TldrawUiMenuGroup id="view-actions">
+              <TldrawUiMenuItem {...actions["zoom-in"]} />
+              <TldrawUiMenuItem {...actions["zoom-out"]} />
+              <ZoomTo100MenuItem />
+              <ZoomToFitMenuItem />
+              <ZoomToSelectionMenuItem />
+              <TldrawUiMenuItem {...actions["toggle-full-screen"]} />
+            </TldrawUiMenuGroup>
+          </TldrawUiMenuSubmenu>
+        );
+      };
       const onToggleSyncMode = (): void => {
         const nextMode: CanvasSyncMode =
           canvasSyncMode === "sync" ? "local" : "sync";
         onCanvasSyncModeChange(nextMode);
       };
-      // const syncModeLabel = isCloudflareSyncAvailable
-      //   ? "Use cloud canvas"
-      //   : "Cloud canvas unavailable";
 
       return (
         <DefaultMainMenu>
           <TldrawUiMenuGroup id="sync-mode">
             <SyncModeMenuSwitchItem
-              // label={syncModeLabel}
               label="Use cloud canvas"
               checked={canvasSyncMode === "sync"}
-              // disabled={!isCloudflareSyncAvailable}
               onToggle={onToggleSyncMode}
             />
           </TldrawUiMenuGroup>
-          <DefaultMainMenuContent />
+          <EditSubmenu />
+          <CustomViewMenu /> {/* Replaced <ViewSubmenu /> */}
+          <ExportFileContentSubMenu />
+          <ExtrasGroup />
+          <PreferencesGroup />
         </DefaultMainMenu>
       );
     },

--- a/apps/roam/src/components/canvas/uiOverrides.tsx
+++ b/apps/roam/src/components/canvas/uiOverrides.tsx
@@ -15,6 +15,7 @@ import {
   DefaultToolbarContent,
   TldrawUiMenuItem,
   DefaultMainMenu,
+  DefaultMainMenuContent,
   TldrawUiMenuGroup,
   TldrawUiDropdownMenuItem,
   TldrawUiButton,
@@ -24,14 +25,7 @@ import {
   DefaultContextMenu,
   DefaultContextMenuContent,
   TLUiComponents,
-  EditSubmenu,
-  ExportFileContentSubMenu,
-  ExtrasGroup,
-  PreferencesGroup,
   TldrawUiMenuSubmenu,
-  ZoomTo100MenuItem,
-  ZoomToFitMenuItem,
-  ZoomToSelectionMenuItem,
   useEditor,
   useValue,
   useToasts,
@@ -262,41 +256,27 @@ export const createUiComponents = ({
       );
     },
     MainMenu: () => {
-      const CustomViewMenu = () => {
-        const actions = useActions();
-        return (
-          <TldrawUiMenuSubmenu id="view" label="menu.view">
-            <TldrawUiMenuGroup id="view-actions">
-              <TldrawUiMenuItem {...actions["zoom-in"]} />
-              <TldrawUiMenuItem {...actions["zoom-out"]} />
-              <ZoomTo100MenuItem />
-              <ZoomToFitMenuItem />
-              <ZoomToSelectionMenuItem />
-              <TldrawUiMenuItem {...actions["toggle-full-screen"]} />
-            </TldrawUiMenuGroup>
-          </TldrawUiMenuSubmenu>
-        );
-      };
       const onToggleSyncMode = (): void => {
         const nextMode: CanvasSyncMode =
           canvasSyncMode === "sync" ? "local" : "sync";
         onCanvasSyncModeChange(nextMode);
       };
+      // const syncModeLabel = isCloudflareSyncAvailable
+      //   ? "Use cloud canvas"
+      //   : "Cloud canvas unavailable";
 
       return (
         <DefaultMainMenu>
           <TldrawUiMenuGroup id="sync-mode">
             <SyncModeMenuSwitchItem
+              // label={syncModeLabel}
               label="Use cloud canvas"
               checked={canvasSyncMode === "sync"}
+              // disabled={!isCloudflareSyncAvailable}
               onToggle={onToggleSyncMode}
             />
           </TldrawUiMenuGroup>
-          <EditSubmenu />
-          <CustomViewMenu /> {/* Replaced <ViewSubmenu /> */}
-          <ExportFileContentSubMenu />
-          <ExtrasGroup />
-          <PreferencesGroup />
+          <DefaultMainMenuContent />
         </DefaultMainMenu>
       );
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -239,6 +239,9 @@ importers:
       '@tldraw/store':
         specifier: 2.4.6
         version: 2.4.6(react@18.2.0)
+      '@tldraw/sync':
+        specifier: 2.4.6
+        version: 2.4.6(@types/react-dom@18.2.17)(@types/react@18.2.21)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@tldraw/tlschema':
         specifier: 2.4.6
         version: 2.4.6(react@18.2.0)


### PR DESCRIPTION
Parent: [ENG-1402: review the implementation and prepare for merge to main](https://linear.app/discourse-graphs/issue/ENG-1402/review-the-implementation-and-prepare-for-merge-to-main)

Split from https://github.com/DiscourseGraphs/discourse-graph/pull/749
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/840" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cloud-based canvas sync mode now available via Cloudflare integration alongside traditional Roam-native canvas.
  * Cloud icon indicator displays when using cloud sync.

* **Improvements**
  * Enhanced error handling and user feedback for canvas synchronization.
  * Added upgrade path for legacy canvas formats.

* **UI Updates**
  * Cloud canvas toggle updated with beta label.

* **Chores**
  * Added @tldraw/sync dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->