### PR TITLE
ENG-1497 - Canvas editor/store instance stale hotfix

### DIFF
--- a/apps/roam/src/components/canvas/Tldraw.tsx
+++ b/apps/roam/src/components/canvas/Tldraw.tsx
@@ -695,146 +695,76 @@ const TldrawCanvasShared = ({
   };
 
   // COMPONENTS
-  const defaultEditorComponents: TLEditorComponents = useMemo(
-    () => ({
-      Scribble: TldrawScribble,
-      CollaboratorScribble: TldrawScribble,
-      SelectionForeground: TldrawSelectionForeground,
-      SelectionBackground: TldrawSelectionBackground,
-      Handles: TldrawHandles,
-    }),
-    [],
-  );
-  const editorComponents: TLEditorComponents = useMemo(
-    () => ({
-      ...defaultEditorComponents,
-      OnTheCanvas: ToastListener,
-    }),
-    [defaultEditorComponents],
-  );
-  const customUiComponents: TLUiComponents = useMemo(
-    () =>
-      createUiComponents({
-        allNodes,
-        allRelationNames,
-        allAddReferencedNodeActions,
-        canvasSyncMode,
-        onCanvasSyncModeChange,
-      }),
-    [
-      allNodes,
-      allRelationNames,
-      allAddReferencedNodeActions,
-      canvasSyncMode,
-      onCanvasSyncModeChange,
-    ],
-  );
+  const defaultEditorComponents: TLEditorComponents = {
+    Scribble: TldrawScribble,
+    CollaboratorScribble: TldrawScribble,
+    SelectionForeground: TldrawSelectionForeground,
+    SelectionBackground: TldrawSelectionBackground,
+    Handles: TldrawHandles,
+  };
+  const editorComponents: TLEditorComponents = {
+    ...defaultEditorComponents,
+    OnTheCanvas: ToastListener,
+  };
+  const customUiComponents: TLUiComponents = createUiComponents({
+    allNodes,
+    allRelationNames,
+    allAddReferencedNodeActions,
+    canvasSyncMode,
+    onCanvasSyncModeChange,
+  });
 
   // UTILS
-  const discourseNodeUtils = useMemo(
-    () => createNodeShapeUtils(allNodes),
-    [allNodes],
+  const discourseNodeUtils = createNodeShapeUtils(allNodes);
+  const discourseRelationUtils = createAllRelationShapeUtils(allRelationIds);
+  const referencedNodeUtils = createAllReferencedNodeUtils(
+    allAddReferencedNodeByAction,
   );
-  const discourseRelationUtils = useMemo(
-    () => createAllRelationShapeUtils(allRelationIds),
-    [allRelationIds],
-  );
-  const referencedNodeUtils = useMemo(
-    () => createAllReferencedNodeUtils(allAddReferencedNodeByAction),
-    [allAddReferencedNodeByAction],
-  );
-  const customShapeUtils = useMemo(
-    () => [
-      ...discourseNodeUtils,
-      ...discourseRelationUtils,
-      ...referencedNodeUtils,
-    ],
-    [discourseNodeUtils, discourseRelationUtils, referencedNodeUtils],
-  );
+  const customShapeUtils = [
+    ...discourseNodeUtils,
+    ...discourseRelationUtils,
+    ...referencedNodeUtils,
+  ];
 
   // TOOLS
-  const discourseGraphTool = useMemo(
-    () =>
-      class DiscourseGraphTool extends StateNode {
-        static override id = "discourse-tool";
-        static override initial = "idle";
-      },
-    [],
+  const discourseGraphTool = class DiscourseGraphTool extends StateNode {
+    static override id = "discourse-tool";
+    static override initial = "idle";
+  };
+  const discourseNodeTools = createNodeShapeTools(allNodes);
+  const discourseRelationTools = createAllRelationShapeTools(allRelationNames);
+  const referencedNodeTools = createAllReferencedNodeTools(
+    allAddReferencedNodeByAction,
   );
-  const discourseNodeTools = useMemo(
-    () => createNodeShapeTools(allNodes),
-    [allNodes],
-  );
-  const discourseRelationTools = useMemo(
-    () => createAllRelationShapeTools(allRelationNames),
-    [allRelationNames],
-  );
-  const referencedNodeTools = useMemo(
-    () => createAllReferencedNodeTools(allAddReferencedNodeByAction),
-    [allAddReferencedNodeByAction],
-  );
-  const customTools = useMemo(
-    () => [
-      discourseGraphTool,
-      ...discourseNodeTools,
-      ...discourseRelationTools,
-      ...referencedNodeTools,
-    ],
-    [
-      discourseGraphTool,
-      discourseNodeTools,
-      discourseRelationTools,
-      referencedNodeTools,
-    ],
-  );
+  const customTools = [
+    discourseGraphTool,
+    ...discourseNodeTools,
+    ...discourseRelationTools,
+    ...referencedNodeTools,
+  ];
 
   // BINDINGS
-  const relationBindings = useMemo(
-    () => createAllRelationBindings(allRelationIds),
-    [allRelationIds],
+  const relationBindings = createAllRelationBindings(allRelationIds);
+  const referencedNodeBindings = createAllReferencedNodeBindings(
+    allAddReferencedNodeByAction,
   );
-  const referencedNodeBindings = useMemo(
-    () => createAllReferencedNodeBindings(allAddReferencedNodeByAction),
-    [allAddReferencedNodeByAction],
-  );
-  const customBindingUtils = useMemo(
-    () => [...relationBindings, ...referencedNodeBindings],
-    [relationBindings, referencedNodeBindings],
-  );
-  const customShapeTypes = useMemo(
-    () =>
-      customShapeUtils
-        .map((s) => (s as unknown as { type?: string }).type)
-        .filter((t): t is string => !!t),
-    [customShapeUtils],
-  );
-  const customBindingTypes = useMemo(
-    () =>
-      customBindingUtils
-        .map((b) => (b as unknown as { type?: string }).type)
-        .filter((t): t is string => !!t),
-    [customBindingUtils],
-  );
+  const customBindingUtils = [...relationBindings, ...referencedNodeBindings];
+  const customShapeTypes = customShapeUtils
+    .map((s) => (s as unknown as { type?: string }).type)
+    .filter((t): t is string => !!t);
+  const customBindingTypes = customBindingUtils
+    .map((b) => (b as unknown as { type?: string }).type)
+    .filter((t): t is string => !!t);
 
   // UI OVERRIDES
-  const uiOverrides = useMemo(
-    () =>
-      createUiOverrides({
-        allNodes,
-        allRelationNames,
-        allAddReferencedNodeByAction,
-        toggleMaximized: handleMaximizedChange,
-        setConvertToDialogOpen,
-        discourseContext,
-      }),
-    [
-      allNodes,
-      allRelationNames,
-      allAddReferencedNodeByAction,
-      handleMaximizedChange,
-      setConvertToDialogOpen,
-    ],
-  );
+  const uiOverrides = createUiOverrides({
+    allNodes,
+    allRelationNames,
+    allAddReferencedNodeByAction,
+    toggleMaximized: handleMaximizedChange,
+    setConvertToDialogOpen,
+    discourseContext,
+  });
 
   // STORE
   useEffect(() => {
@@ -853,10 +783,7 @@ const TldrawCanvasShared = ({
     [allRelationIds, allAddReferencedNodeActions, allNodes],
   );
 
-  const migrations = useMemo(
-    () => [arrowShapeMigrations],
-    [arrowShapeMigrations],
-  );
+  const migrations = [arrowShapeMigrations];
   const { store, needsUpgrade, performUpgrade, error, isLoading } =
     useStoreAdapter({
       migrations,

--- a/apps/roam/src/components/canvas/uiOverrides.tsx
+++ b/apps/roam/src/components/canvas/uiOverrides.tsx
@@ -285,13 +285,13 @@ export const createUiComponents = ({
 
       return (
         <DefaultMainMenu>
-          <TldrawUiMenuGroup id="sync-mode">
-            {/* <SyncModeMenuSwitchItem
+          {/* <TldrawUiMenuGroup id="sync-mode"> */}
+          {/* <SyncModeMenuSwitchItem
               label="(Beta) Use cloud canvas"
               checked={canvasSyncMode === "sync"}
               onToggle={onToggleSyncMode}
             /> */}
-          </TldrawUiMenuGroup>
+          {/* </TldrawUiMenuGroup> */}
           <EditSubmenu />
           <CustomViewMenu /> {/* Replaced <ViewSubmenu /> */}
           <ExportFileContentSubMenu />

--- a/apps/roam/src/components/canvas/uiOverrides.tsx
+++ b/apps/roam/src/components/canvas/uiOverrides.tsx
@@ -16,10 +16,10 @@ import {
   TldrawUiMenuItem,
   DefaultMainMenu,
   TldrawUiMenuGroup,
-  TldrawUiDropdownMenuItem,
-  TldrawUiButton,
-  TldrawUiButtonLabel,
-  TldrawUiIcon,
+  // TldrawUiDropdownMenuItem,
+  // TldrawUiButton,
+  // TldrawUiButtonLabel,
+  // TldrawUiIcon,
   useActions,
   DefaultContextMenu,
   DefaultContextMenuContent,
@@ -52,39 +52,39 @@ import { CustomDefaultToolbar } from "./CustomDefaultToolbar";
 import { renderModifyNodeDialog } from "~/components/ModifyNodeDialog";
 import { CanvasSyncMode } from "./canvasSyncMode";
 
-const SyncModeMenuSwitchItem = ({
-  checked,
-  disabled,
-  label,
-  onToggle,
-}: {
-  checked: boolean;
-  disabled?: boolean;
-  label: string;
-  onToggle: () => void;
-}): React.ReactElement => {
-  return (
-    <TldrawUiDropdownMenuItem>
-      <TldrawUiButton
-        type="menu"
-        title={label}
-        disabled={disabled}
-        onClick={onToggle}
-      >
-        <TldrawUiButtonLabel>{label}</TldrawUiButtonLabel>
-        <span
-          style={{
-            marginLeft: "auto",
-            display: "inline-flex",
-            alignItems: "center",
-          }}
-        >
-          <TldrawUiIcon icon={checked ? "toggle-on" : "toggle-off"} small />
-        </span>
-      </TldrawUiButton>
-    </TldrawUiDropdownMenuItem>
-  );
-};
+// const SyncModeMenuSwitchItem = ({
+//   checked,
+//   disabled,
+//   label,
+//   onToggle,
+// }: {
+//   checked: boolean;
+//   disabled?: boolean;
+//   label: string;
+//   onToggle: () => void;
+// }): React.ReactElement => {
+//   return (
+//     <TldrawUiDropdownMenuItem>
+//       <TldrawUiButton
+//         type="menu"
+//         title={label}
+//         disabled={disabled}
+//         onClick={onToggle}
+//       >
+//         <TldrawUiButtonLabel>{label}</TldrawUiButtonLabel>
+//         <span
+//           style={{
+//             marginLeft: "auto",
+//             display: "inline-flex",
+//             alignItems: "center",
+//           }}
+//         >
+//           <TldrawUiIcon icon={checked ? "toggle-on" : "toggle-off"} small />
+//         </span>
+//       </TldrawUiButton>
+//     </TldrawUiDropdownMenuItem>
+//   );
+// };
 
 export const getOnSelectForShape = ({
   shape,
@@ -224,8 +224,8 @@ export const createUiComponents = ({
   allNodes,
   allAddReferencedNodeActions,
   allRelationNames,
-  canvasSyncMode,
-  onCanvasSyncModeChange,
+  // canvasSyncMode,
+  // onCanvasSyncModeChange,
 }: {
   allNodes: DiscourseNode[];
   allRelationNames: string[];
@@ -277,20 +277,20 @@ export const createUiComponents = ({
           </TldrawUiMenuSubmenu>
         );
       };
-      const onToggleSyncMode = (): void => {
-        const nextMode: CanvasSyncMode =
-          canvasSyncMode === "sync" ? "local" : "sync";
-        onCanvasSyncModeChange(nextMode);
-      };
+      // const onToggleSyncMode = (): void => {
+      //   const nextMode: CanvasSyncMode =
+      //     canvasSyncMode === "sync" ? "local" : "sync";
+      //   onCanvasSyncModeChange(nextMode);
+      // };
 
       return (
         <DefaultMainMenu>
           <TldrawUiMenuGroup id="sync-mode">
-            <SyncModeMenuSwitchItem
+            {/* <SyncModeMenuSwitchItem
               label="(Beta) Use cloud canvas"
               checked={canvasSyncMode === "sync"}
               onToggle={onToggleSyncMode}
-            />
+            /> */}
           </TldrawUiMenuGroup>
           <EditSubmenu />
           <CustomViewMenu /> {/* Replaced <ViewSubmenu /> */}


### PR DESCRIPTION
the `useMemo` on the tldraw specific functions cause the editor or store to be stale. Sync needs these because it needs stable references, but local, either in the way it's architectured currently or for another reason,

The first canvas loaded works fine, but the second and subsequent local canvases do not save.  This is a quick hot fix until we can address the root cause.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/841" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Removed the cloud-sync toggle from the menu interface.
  * Optimized component rendering and initialization performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->