### PR TITLE
ENG-1478: Port left sidebar to dual-readers + reactivity

### DIFF
--- a/apps/roam/src/components/LeftSidebarView.tsx
+++ b/apps/roam/src/components/LeftSidebarView.tsx
@@ -22,7 +22,10 @@ import getPageUidByPageTitle from "roamjs-components/queries/getPageUidByPageTit
 import openBlockInSidebar from "roamjs-components/writes/openBlockInSidebar";
 import extractRef from "roamjs-components/util/extractRef";
 import { getFormattedConfigTree, notify } from "~/utils/discourseConfigRef";
-import { onSettingChange } from "~/components/settings/utils/settingsEmitter";
+import {
+  onSettingChange,
+  settingKeys,
+} from "~/components/settings/utils/settingsEmitter";
 import {
   type LeftSidebarConfig,
   type LeftSidebarPersonalSectionConfig,
@@ -343,9 +346,12 @@ export const useConfig = () => {
       refreshConfigTree();
       setConfig(buildConfig());
     };
-    const unsubGlobal = onSettingChange("global:Left sidebar", handleUpdate);
+    const unsubGlobal = onSettingChange(
+      settingKeys.globalLeftSidebar,
+      handleUpdate,
+    );
     const unsubPersonal = onSettingChange(
-      "personal:Left sidebar",
+      settingKeys.personalLeftSidebar,
       handleUpdate,
     );
     return () => {
@@ -356,9 +362,9 @@ export const useConfig = () => {
   return { config, setConfig };
 };
 
-// TODO(ENG-1471): refreshAndNotify still needed for other subscribe() consumers
-// (PanelManager, Canvas). Left sidebar reactivity now uses emitter, but other
-// components still depend on notify(). Remove when all consumers migrate to emitter.
+// TODO(ENG-1471): refreshAndNotify still needed by settings panels
+// (LeftSidebarGlobalSettings, LeftSidebarPersonalSettings) for old-system CRUD.
+// Remove when settings panels also read via accessors + emitter.
 export const refreshAndNotify = () => {
   refreshConfigTree();
   notify();

--- a/apps/roam/src/components/LeftSidebarView.tsx
+++ b/apps/roam/src/components/LeftSidebarView.tsx
@@ -30,6 +30,16 @@ import type {
   LeftSidebarConfig,
   LeftSidebarPersonalSectionConfig,
 } from "~/utils/getLeftSidebarSettings";
+import {
+  getGlobalSetting,
+  getPersonalSetting,
+  setGlobalSetting,
+  setPersonalSetting,
+} from "~/components/settings/utils/accessors";
+import type {
+  LeftSidebarGlobalSettings,
+  PersonalSection,
+} from "~/components/settings/utils/zodSchema";
 import { createBlock } from "roamjs-components/writes";
 import deleteBlock from "roamjs-components/writes/deleteBlock";
 import getTextByBlockUid from "roamjs-components/queries/getTextByBlockUid";
@@ -95,12 +105,18 @@ const toggleFoldedState = ({
   setIsOpen,
   folded,
   parentUid,
+  isGlobal,
+  sectionIndex,
 }: {
   isOpen: boolean;
   setIsOpen: Dispatch<SetStateAction<boolean>>;
   folded: { uid?: string; value: boolean };
   parentUid: string;
+  isGlobal?: boolean;
+  sectionIndex?: number;
 }) => {
+  const newFolded = !isOpen;
+
   if (isOpen) {
     setIsOpen(false);
     if (folded.uid) {
@@ -117,6 +133,18 @@ const toggleFoldedState = ({
     });
     folded.uid = newUid;
     folded.value = true;
+  }
+
+  // Dual-write to block props
+  if (isGlobal) {
+    setGlobalSetting(["Left sidebar", "Settings", "Folded"], newFolded);
+  } else if (sectionIndex !== undefined) {
+    const sections =
+      getPersonalSetting<PersonalSection[]>(["Left sidebar"]) || [];
+    if (sections[sectionIndex]) {
+      sections[sectionIndex].Settings.Folded = newFolded;
+      setPersonalSetting(["Left sidebar"], sections);
+    }
   }
 };
 
@@ -160,8 +188,10 @@ const SectionChildren = ({
 
 const PersonalSectionItem = ({
   section,
+  sectionIndex,
 }: {
   section: LeftSidebarPersonalSectionConfig;
+  sectionIndex: number;
 }) => {
   const titleRef = parseReference(section.text);
   const blockText = useMemo(
@@ -182,6 +212,7 @@ const PersonalSectionItem = ({
       setIsOpen,
       folded: section.settings.folded,
       parentUid: section.settings.uid || "",
+      sectionIndex,
     });
   };
 
@@ -226,9 +257,9 @@ const PersonalSections = ({ config }: { config: LeftSidebarConfig }) => {
 
   return (
     <div className="personal-left-sidebar-sections">
-      {sections.map((section) => (
+      {sections.map((section, index) => (
         <div key={section.uid}>
-          <PersonalSectionItem section={section} />
+          <PersonalSectionItem section={section} sectionIndex={index} />
         </div>
       ))}
     </div>
@@ -253,6 +284,7 @@ const GlobalSection = ({ config }: { config: LeftSidebarConfig["global"] }) => {
             setIsOpen,
             folded: config.settings.folded,
             parentUid: config.settings.uid,
+            isGlobal: true,
           });
         }}
       >
@@ -276,13 +308,81 @@ const GlobalSection = ({ config }: { config: LeftSidebarConfig["global"] }) => {
   );
 };
 
+// TODO(ENG-1471): Remove old-system merge when migration complete — just use accessor values directly
+const buildConfig = (): LeftSidebarConfig => {
+  // Read VALUES from accessor (handles flag routing + mismatch detection)
+  const globalValues = getGlobalSetting<LeftSidebarGlobalSettings>([
+    "Left sidebar",
+  ]);
+  const personalValues = getPersonalSetting<PersonalSection[]>([
+    "Left sidebar",
+  ]);
+
+  // Read UIDs from old system (needed for fold CRUD during dual-write)
+  const oldConfig = getFormattedConfigTree().leftSidebar;
+
+  // Merge: accessor values + old-system UIDs
+  return {
+    uid: oldConfig.uid,
+    favoritesMigrated: oldConfig.favoritesMigrated,
+    sidebarMigrated: oldConfig.sidebarMigrated,
+    global: {
+      uid: oldConfig.global.uid,
+      childrenUid: oldConfig.global.childrenUid,
+      children: oldConfig.global.children,
+      settings: oldConfig.global.settings
+        ? {
+            uid: oldConfig.global.settings.uid,
+            collapsable: {
+              uid: oldConfig.global.settings.collapsable.uid,
+              value:
+                globalValues?.Settings.Collapsable ??
+                oldConfig.global.settings.collapsable.value,
+            },
+            folded: {
+              uid: oldConfig.global.settings.folded.uid,
+              value:
+                globalValues?.Settings.Folded ??
+                oldConfig.global.settings.folded.value,
+            },
+          }
+        : undefined,
+    },
+    personal: {
+      uid: oldConfig.personal.uid,
+      sections: oldConfig.personal.sections.map((oldSection, i) => {
+        const newSection = personalValues?.[i];
+        return {
+          ...oldSection,
+          settings: oldSection.settings
+            ? {
+                ...oldSection.settings,
+                truncateResult: {
+                  ...oldSection.settings.truncateResult,
+                  value:
+                    newSection?.Settings?.["Truncate-result?"] ??
+                    oldSection.settings.truncateResult.value,
+                },
+                folded: {
+                  ...oldSection.settings.folded,
+                  value:
+                    newSection?.Settings?.Folded ??
+                    oldSection.settings.folded.value,
+                },
+              }
+            : oldSection.settings,
+        };
+      }),
+    },
+    allPersonalSections: oldConfig.allPersonalSections,
+  };
+};
+
 export const useConfig = () => {
-  const [config, setConfig] = useState(
-    () => getFormattedConfigTree().leftSidebar,
-  );
+  const [config, setConfig] = useState(() => buildConfig());
   useEffect(() => {
     const handleUpdate = () => {
-      setConfig(getFormattedConfigTree().leftSidebar);
+      setConfig(buildConfig());
     };
     const unsubscribe = subscribe(handleUpdate);
     return () => {

--- a/apps/roam/src/components/LeftSidebarView.tsx
+++ b/apps/roam/src/components/LeftSidebarView.tsx
@@ -340,6 +340,7 @@ export const useConfig = () => {
   const [config, setConfig] = useState(() => buildConfig());
   useEffect(() => {
     const handleUpdate = () => {
+      refreshConfigTree();
       setConfig(buildConfig());
     };
     const unsubGlobal = onSettingChange("global:Left sidebar", handleUpdate);

--- a/apps/roam/src/components/LeftSidebarView.tsx
+++ b/apps/roam/src/components/LeftSidebarView.tsx
@@ -21,14 +21,13 @@ import {
 import getPageUidByPageTitle from "roamjs-components/queries/getPageUidByPageTitle";
 import openBlockInSidebar from "roamjs-components/writes/openBlockInSidebar";
 import extractRef from "roamjs-components/util/extractRef";
+import { getFormattedConfigTree, notify } from "~/utils/discourseConfigRef";
+import { onSettingChange } from "~/components/settings/utils/settingsEmitter";
 import {
-  getFormattedConfigTree,
-  notify,
-  subscribe,
-} from "~/utils/discourseConfigRef";
-import type {
-  LeftSidebarConfig,
-  LeftSidebarPersonalSectionConfig,
+  type LeftSidebarConfig,
+  type LeftSidebarPersonalSectionConfig,
+  mergeGlobalSectionWithAccessor,
+  mergePersonalSectionsWithAccessor,
 } from "~/utils/getLeftSidebarSettings";
 import {
   getGlobalSetting,
@@ -135,7 +134,6 @@ const toggleFoldedState = ({
     folded.value = true;
   }
 
-  // Dual-write to block props
   if (isGlobal) {
     setGlobalSetting(["Left sidebar", "Settings", "Folded"], newFolded);
   } else if (sectionIndex !== undefined) {
@@ -308,7 +306,8 @@ const GlobalSection = ({ config }: { config: LeftSidebarConfig["global"] }) => {
   );
 };
 
-// TODO(ENG-1471): Remove old-system merge when migration complete — just use accessor values directly
+// TODO(ENG-1471): Remove old-system merge when migration complete — just use accessor values directly.
+// See mergeGlobalSectionWithAccessor/mergePersonalSectionsWithAccessor for why the merge exists.
 const buildConfig = (): LeftSidebarConfig => {
   // Read VALUES from accessor (handles flag routing + mismatch detection)
   const globalValues = getGlobalSetting<LeftSidebarGlobalSettings>([
@@ -321,58 +320,17 @@ const buildConfig = (): LeftSidebarConfig => {
   // Read UIDs from old system (needed for fold CRUD during dual-write)
   const oldConfig = getFormattedConfigTree().leftSidebar;
 
-  // Merge: accessor values + old-system UIDs
   return {
     uid: oldConfig.uid,
     favoritesMigrated: oldConfig.favoritesMigrated,
     sidebarMigrated: oldConfig.sidebarMigrated,
-    global: {
-      uid: oldConfig.global.uid,
-      childrenUid: oldConfig.global.childrenUid,
-      children: oldConfig.global.children,
-      settings: oldConfig.global.settings
-        ? {
-            uid: oldConfig.global.settings.uid,
-            collapsable: {
-              uid: oldConfig.global.settings.collapsable.uid,
-              value:
-                globalValues?.Settings.Collapsable ??
-                oldConfig.global.settings.collapsable.value,
-            },
-            folded: {
-              uid: oldConfig.global.settings.folded.uid,
-              value:
-                globalValues?.Settings.Folded ??
-                oldConfig.global.settings.folded.value,
-            },
-          }
-        : undefined,
-    },
+    global: mergeGlobalSectionWithAccessor(oldConfig.global, globalValues),
     personal: {
       uid: oldConfig.personal.uid,
-      sections: oldConfig.personal.sections.map((oldSection, i) => {
-        const newSection = personalValues?.[i];
-        return {
-          ...oldSection,
-          settings: oldSection.settings
-            ? {
-                ...oldSection.settings,
-                truncateResult: {
-                  ...oldSection.settings.truncateResult,
-                  value:
-                    newSection?.Settings?.["Truncate-result?"] ??
-                    oldSection.settings.truncateResult.value,
-                },
-                folded: {
-                  ...oldSection.settings.folded,
-                  value:
-                    newSection?.Settings?.Folded ??
-                    oldSection.settings.folded.value,
-                },
-              }
-            : oldSection.settings,
-        };
-      }),
+      sections: mergePersonalSectionsWithAccessor(
+        oldConfig.personal.sections,
+        personalValues,
+      ),
     },
     allPersonalSections: oldConfig.allPersonalSections,
   };
@@ -384,14 +342,22 @@ export const useConfig = () => {
     const handleUpdate = () => {
       setConfig(buildConfig());
     };
-    const unsubscribe = subscribe(handleUpdate);
+    const unsubGlobal = onSettingChange("global:Left sidebar", handleUpdate);
+    const unsubPersonal = onSettingChange(
+      "personal:Left sidebar",
+      handleUpdate,
+    );
     return () => {
-      unsubscribe();
+      unsubGlobal();
+      unsubPersonal();
     };
   }, []);
   return { config, setConfig };
 };
 
+// TODO(ENG-1471): refreshAndNotify still needed for other subscribe() consumers
+// (PanelManager, Canvas). Left sidebar reactivity now uses emitter, but other
+// components still depend on notify(). Remove when all consumers migrate to emitter.
 export const refreshAndNotify = () => {
   refreshConfigTree();
   notify();

--- a/apps/roam/src/components/settings/GeneralSettings.tsx
+++ b/apps/roam/src/components/settings/GeneralSettings.tsx
@@ -6,6 +6,7 @@ import {
   GlobalTextPanel,
   FeatureFlagPanel,
 } from "./components/BlockPropSettingPanels";
+import { isNewSettingsStoreEnabled } from "./utils/accessors";
 import posthog from "posthog-js";
 
 const DiscourseGraphHome = () => {
@@ -43,7 +44,7 @@ const DiscourseGraphHome = () => {
         uid={settings.leftSidebarEnabled.uid}
         parentUid={settings.settingsUid}
         onAfterChange={(checked: boolean) => {
-          if (checked) {
+          if (checked && !isNewSettingsStoreEnabled()) {
             setIsAlertOpen(true);
           }
           posthog.capture("General Settings: Left Sidebar Toggled", {

--- a/apps/roam/src/components/settings/LeftSidebarGlobalSettings.tsx
+++ b/apps/roam/src/components/settings/LeftSidebarGlobalSettings.tsx
@@ -1,7 +1,11 @@
 import React, { useCallback, useEffect, useMemo, useState, memo } from "react";
 import { Button, ButtonGroup, Collapse } from "@blueprintjs/core";
 import { GlobalFlagPanel } from "~/components/settings/components/BlockPropSettingPanels";
-import { setGlobalSetting } from "~/components/settings/utils/accessors";
+import {
+  setGlobalSetting,
+  getGlobalSetting,
+} from "~/components/settings/utils/accessors";
+import type { LeftSidebarGlobalSettings } from "~/components/settings/utils/zodSchema";
 import AutocompleteInput from "roamjs-components/components/AutocompleteInput";
 import getAllPageNames from "roamjs-components/queries/getAllPageNames";
 import createBlock from "roamjs-components/writes/createBlock";
@@ -98,6 +102,10 @@ const LeftSidebarGlobalSectionsContent = ({
     const initialize = async () => {
       setIsInitializing(true);
       const globalSectionText = "Global-Section";
+      // Dual-read: accessor validates values and logs mismatches when flag ON
+      getGlobalSetting<LeftSidebarGlobalSettings>(["Left sidebar"]);
+
+      // Use old system data (has UIDs needed for CRUD operations)
       const config = getLeftSidebarGlobalSectionConfig(leftSidebar.children);
 
       const existingGlobalSection = leftSidebar.children.find(

--- a/apps/roam/src/components/settings/LeftSidebarGlobalSettings.tsx
+++ b/apps/roam/src/components/settings/LeftSidebarGlobalSettings.tsx
@@ -15,8 +15,11 @@ import { extractRef, getSubTree } from "roamjs-components/util";
 import getPageUidByPageTitle from "roamjs-components/queries/getPageUidByPageTitle";
 import discourseConfigRef from "~/utils/discourseConfigRef";
 import { DISCOURSE_CONFIG_PAGE_TITLE } from "~/utils/renderNodeConfigPage";
-import { getLeftSidebarGlobalSectionConfig } from "~/utils/getLeftSidebarSettings";
-import { LeftSidebarGlobalSectionConfig } from "~/utils/getLeftSidebarSettings";
+import {
+  getLeftSidebarGlobalSectionConfig,
+  mergeGlobalSectionWithAccessor,
+  type LeftSidebarGlobalSectionConfig,
+} from "~/utils/getLeftSidebarSettings";
 import { render as renderToast } from "roamjs-components/components/Toast";
 import refreshConfigTree from "~/utils/refreshConfigTree";
 import { refreshAndNotify } from "~/components/LeftSidebarView";
@@ -102,10 +105,9 @@ const LeftSidebarGlobalSectionsContent = ({
     const initialize = async () => {
       setIsInitializing(true);
       const globalSectionText = "Global-Section";
-      // Dual-read: accessor validates values and logs mismatches when flag ON
-      getGlobalSetting<LeftSidebarGlobalSettings>(["Left sidebar"]);
-
-      // Use old system data (has UIDs needed for CRUD operations)
+      const globalValues = getGlobalSetting<LeftSidebarGlobalSettings>([
+        "Left sidebar",
+      ]);
       const config = getLeftSidebarGlobalSectionConfig(leftSidebar.children);
 
       const existingGlobalSection = leftSidebar.children.find(
@@ -150,9 +152,10 @@ const LeftSidebarGlobalSectionsContent = ({
           });
         }
       } else {
-        setChildrenUid(config.childrenUid || null);
-        setPages(config.children || []);
-        setGlobalSection(config);
+        const merged = mergeGlobalSectionWithAccessor(config, globalValues);
+        setChildrenUid(merged.childrenUid || null);
+        setPages(merged.children || []);
+        setGlobalSection(merged);
       }
       setIsInitializing(false);
     };

--- a/apps/roam/src/components/settings/LeftSidebarPersonalSettings.tsx
+++ b/apps/roam/src/components/settings/LeftSidebarPersonalSettings.tsx
@@ -31,6 +31,7 @@ import {
 import {
   LeftSidebarPersonalSectionConfig,
   getLeftSidebarPersonalSectionConfig,
+  mergePersonalSectionsWithAccessor,
   PersonalSectionChild,
 } from "~/utils/getLeftSidebarSettings";
 import { extractRef, getSubTree } from "roamjs-components/util";
@@ -604,14 +605,15 @@ const LeftSidebarPersonalSectionsContent = ({
       } else {
         setPersonalSectionUid(personalSection.uid);
 
-        // Dual-read: accessor validates values and logs mismatches when flag ON
-        getPersonalSetting<PersonalSection[]>(["Left sidebar"]);
-
-        // Use old system data (has UIDs needed for CRUD operations)
+        const personalValues = getPersonalSetting<PersonalSection[]>([
+          "Left sidebar",
+        ]);
         const loadedSections = getLeftSidebarPersonalSectionConfig(
           leftSidebar.children,
         ).sections;
-        setSections(loadedSections);
+        setSections(
+          mergePersonalSectionsWithAccessor(loadedSections, personalValues),
+        );
       }
     };
 

--- a/apps/roam/src/components/settings/LeftSidebarPersonalSettings.tsx
+++ b/apps/roam/src/components/settings/LeftSidebarPersonalSettings.tsx
@@ -19,7 +19,11 @@ import createBlock from "roamjs-components/writes/createBlock";
 import deleteBlock from "roamjs-components/writes/deleteBlock";
 import updateBlock from "roamjs-components/writes/updateBlock";
 import type { RoamBasicNode } from "roamjs-components/types";
-import { setPersonalSetting } from "~/components/settings/utils/accessors";
+import {
+  setPersonalSetting,
+  getPersonalSetting,
+} from "~/components/settings/utils/accessors";
+import type { PersonalSection } from "~/components/settings/utils/zodSchema";
 import {
   PersonalNumberPanel,
   PersonalTextPanel,
@@ -599,6 +603,11 @@ const LeftSidebarPersonalSectionsContent = ({
         setSections([]);
       } else {
         setPersonalSectionUid(personalSection.uid);
+
+        // Dual-read: accessor validates values and logs mismatches when flag ON
+        getPersonalSetting<PersonalSection[]>(["Left sidebar"]);
+
+        // Use old system data (has UIDs needed for CRUD operations)
         const loadedSections = getLeftSidebarPersonalSectionConfig(
           leftSidebar.children,
         ).sections;

--- a/apps/roam/src/components/settings/LeftSidebarPersonalSettings.tsx
+++ b/apps/roam/src/components/settings/LeftSidebarPersonalSettings.tsx
@@ -512,7 +512,7 @@ const SectionItem = memo(
                             <PersonalTextPanel
                               title="Alias"
                               description="Display name for this item"
-                              settingKeys={["Left sidebar"]}
+                              settingKeys={[]}
                               initialValue={child.alias?.value ?? ""}
                               order={0}
                               uid={child.alias?.uid}
@@ -797,7 +797,7 @@ const LeftSidebarPersonalSectionsContent = ({
               <PersonalNumberPanel
                 title="Truncate-result?"
                 description="Maximum characters to display"
-                settingKeys={["Left sidebar"]}
+                settingKeys={[]}
                 initialValue={
                   activeDialogSection.settings.truncateResult?.value ?? 75
                 }

--- a/apps/roam/src/components/settings/utils/accessors.ts
+++ b/apps/roam/src/components/settings/utils/accessors.ts
@@ -198,7 +198,7 @@ const getLegacyPersonalLeftSidebarSetting = (): unknown[] => {
   return settings.leftSidebar.personal.sections.map((section) => ({
     name: section.text,
     Children: (section.children || []).map((child) => ({
-      uid: child.uid,
+      uid: child.text,
       Alias: child.alias?.value || "",
     })),
     Settings: {

--- a/apps/roam/src/components/settings/utils/accessors.ts
+++ b/apps/roam/src/components/settings/utils/accessors.ts
@@ -724,6 +724,8 @@ export const getGlobalSettings = (): GlobalSettings => {
 export const getGlobalSetting = <T = unknown>(
   keys: string[],
 ): T | undefined => {
+  if (keys.length === 0) return undefined;
+
   if (!isNewSettingsStoreEnabled()) {
     return getLegacyGlobalSetting(keys) as T | undefined;
   }
@@ -788,6 +790,8 @@ export const getPersonalSettings = (): PersonalSettings => {
 export const getPersonalSetting = <T = unknown>(
   keys: string[],
 ): T | undefined => {
+  if (keys.length === 0) return undefined;
+
   if (!isNewSettingsStoreEnabled()) {
     return getLegacyPersonalSetting(keys) as T | undefined;
   }

--- a/apps/roam/src/components/settings/utils/pullWatchers.ts
+++ b/apps/roam/src/components/settings/utils/pullWatchers.ts
@@ -12,7 +12,7 @@ import {
   type PersonalSettings,
   type DiscourseNodeSettings,
 } from "./zodSchema";
-import { emitSettingChange } from "./settingsEmitter";
+import { emitSettingChange, settingKeys } from "./settingsEmitter";
 
 type PullWatchCallback = Parameters<AddPullWatch>[2];
 
@@ -93,7 +93,7 @@ export const featureFlagHandlers: Partial<
 > = {
   /* eslint-disable @typescript-eslint/naming-convention */
   "Enable left sidebar": (newValue, oldValue) => {
-    emitSettingChange("Enable left sidebar", newValue, oldValue);
+    emitSettingChange(settingKeys.leftSidebarFlag, newValue, oldValue);
   },
   /* eslint-enable @typescript-eslint/naming-convention */
 };
@@ -109,7 +109,7 @@ type GlobalSettingsHandlers = {
 export const globalSettingsHandlers: GlobalSettingsHandlers = {
   /* eslint-disable @typescript-eslint/naming-convention */
   "Left sidebar": (newValue, oldValue) => {
-    emitSettingChange("global:Left sidebar", newValue, oldValue);
+    emitSettingChange(settingKeys.globalLeftSidebar, newValue, oldValue);
   },
   /* eslint-enable @typescript-eslint/naming-convention */
 };
@@ -125,7 +125,7 @@ type PersonalSettingsHandlers = {
 export const personalSettingsHandlers: PersonalSettingsHandlers = {
   /* eslint-disable @typescript-eslint/naming-convention */
   "Left sidebar": (newValue, oldValue) => {
-    emitSettingChange("personal:Left sidebar", newValue, oldValue);
+    emitSettingChange(settingKeys.personalLeftSidebar, newValue, oldValue);
   },
   /* eslint-enable @typescript-eslint/naming-convention */
 };

--- a/apps/roam/src/components/settings/utils/pullWatchers.ts
+++ b/apps/roam/src/components/settings/utils/pullWatchers.ts
@@ -84,16 +84,25 @@ const addPullWatch = (
   watches.push([pattern, entityId, callback]);
 };
 
+let leftSidebarFlagHandler: ((newValue: boolean) => void) | null = null;
+export const setLeftSidebarFlagHandler = (
+  handler: (newValue: boolean) => void,
+) => {
+  leftSidebarFlagHandler = handler;
+};
+
 export const featureFlagHandlers: Partial<
   Record<
     keyof FeatureFlags,
     (newValue: boolean, oldValue: boolean, allFlags: FeatureFlags) => void
   >
 > = {
-  // Add handlers as needed:
-  // "Enable Left Sidebar": (newValue) => { ... },
-  // "Suggestive Mode Enabled": (newValue) => { ... },
-  // "Reified Relation Triples": (newValue) => { ... },
+  /* eslint-disable @typescript-eslint/naming-convention */
+  "Enable left sidebar": (newValue, oldValue) => {
+    if (newValue === oldValue) return;
+    leftSidebarFlagHandler?.(newValue);
+  },
+  /* eslint-enable @typescript-eslint/naming-convention */
 };
 
 type GlobalSettingsHandlers = {
@@ -122,30 +131,8 @@ type PersonalSettingsHandlers = {
 };
 
 export const personalSettingsHandlers: PersonalSettingsHandlers = {
-  // "Left Sidebar" stub for testing with stubSetLeftSidebarPersonalSections() in accessors.ts
-  /* eslint-disable @typescript-eslint/naming-convention */
-  "Left sidebar": (newValue, oldValue) => {
-    const oldSections = Object.keys(oldValue || {});
-    const newSections = Object.keys(newValue || {});
-
-    if (newSections.length === 0 && oldSections.length === 0) return;
-
-    console.group("👤 [PullWatch] Personal Settings Changed: Left Sidebar");
-    console.log("Old value:", JSON.stringify(oldValue, null, 2));
-    console.log("New value:", JSON.stringify(newValue, null, 2));
-
-    const addedSections = newSections.filter((s) => !oldSections.includes(s));
-    const removedSections = oldSections.filter((s) => !newSections.includes(s));
-
-    if (addedSections.length > 0) {
-      console.log("  → Sections added:", addedSections);
-    }
-    if (removedSections.length > 0) {
-      console.log("  → Sections removed:", removedSections);
-    }
-    console.groupEnd();
-  },
-  /* eslint-enable @typescript-eslint/naming-convention */
+  // Add handlers as needed:
+  // "Left sidebar": (newValue) => { ... },
 };
 
 export const discourseNodeHandlers: Array<

--- a/apps/roam/src/components/settings/utils/pullWatchers.ts
+++ b/apps/roam/src/components/settings/utils/pullWatchers.ts
@@ -12,6 +12,7 @@ import {
   type PersonalSettings,
   type DiscourseNodeSettings,
 } from "./zodSchema";
+import { emitSettingChange } from "./settingsEmitter";
 
 type PullWatchCallback = Parameters<AddPullWatch>[2];
 
@@ -84,13 +85,6 @@ const addPullWatch = (
   watches.push([pattern, entityId, callback]);
 };
 
-let leftSidebarFlagHandler: ((newValue: boolean) => void) | null = null;
-export const setLeftSidebarFlagHandler = (
-  handler: (newValue: boolean) => void,
-) => {
-  leftSidebarFlagHandler = handler;
-};
-
 export const featureFlagHandlers: Partial<
   Record<
     keyof FeatureFlags,
@@ -99,8 +93,7 @@ export const featureFlagHandlers: Partial<
 > = {
   /* eslint-disable @typescript-eslint/naming-convention */
   "Enable left sidebar": (newValue, oldValue) => {
-    if (newValue === oldValue) return;
-    leftSidebarFlagHandler?.(newValue);
+    emitSettingChange("Enable left sidebar", newValue, oldValue);
   },
   /* eslint-enable @typescript-eslint/naming-convention */
 };
@@ -114,12 +107,11 @@ type GlobalSettingsHandlers = {
 };
 
 export const globalSettingsHandlers: GlobalSettingsHandlers = {
-  // Add handlers as needed:
-  // "Trigger": (newValue) => { ... },
-  // "Canvas Page Format": (newValue) => { ... },
-  // "Left Sidebar": (newValue) => { ... },
-  // "Export": (newValue) => { ... },
-  // "Suggestive Mode": (newValue) => { ... },
+  /* eslint-disable @typescript-eslint/naming-convention */
+  "Left sidebar": (newValue, oldValue) => {
+    emitSettingChange("global:Left sidebar", newValue, oldValue);
+  },
+  /* eslint-enable @typescript-eslint/naming-convention */
 };
 
 type PersonalSettingsHandlers = {
@@ -131,8 +123,11 @@ type PersonalSettingsHandlers = {
 };
 
 export const personalSettingsHandlers: PersonalSettingsHandlers = {
-  // Add handlers as needed:
-  // "Left sidebar": (newValue) => { ... },
+  /* eslint-disable @typescript-eslint/naming-convention */
+  "Left sidebar": (newValue, oldValue) => {
+    emitSettingChange("personal:Left sidebar", newValue, oldValue);
+  },
+  /* eslint-enable @typescript-eslint/naming-convention */
 };
 
 export const discourseNodeHandlers: Array<

--- a/apps/roam/src/components/settings/utils/settingsEmitter.ts
+++ b/apps/roam/src/components/settings/utils/settingsEmitter.ts
@@ -1,0 +1,24 @@
+type SettingChangeCallback = (newValue: unknown, oldValue: unknown) => void;
+
+const listeners = new Map<string, Set<SettingChangeCallback>>();
+
+export const onSettingChange = (
+  key: string,
+  callback: SettingChangeCallback,
+): (() => void) => {
+  if (!listeners.has(key)) {
+    listeners.set(key, new Set());
+  }
+  listeners.get(key)!.add(callback);
+  return () => {
+    listeners.get(key)?.delete(callback);
+  };
+};
+
+export const emitSettingChange = (
+  key: string,
+  newValue: unknown,
+  oldValue: unknown,
+): void => {
+  listeners.get(key)?.forEach((cb) => cb(newValue, oldValue));
+};

--- a/apps/roam/src/components/settings/utils/settingsEmitter.ts
+++ b/apps/roam/src/components/settings/utils/settingsEmitter.ts
@@ -1,5 +1,11 @@
 type SettingChangeCallback = (newValue: unknown, oldValue: unknown) => void;
 
+export const settingKeys = {
+  leftSidebarFlag: "Enable left sidebar",
+  globalLeftSidebar: "global:Left sidebar",
+  personalLeftSidebar: "personal:Left sidebar",
+} as const;
+
 const listeners = new Map<string, Set<SettingChangeCallback>>();
 
 export const onSettingChange = (

--- a/apps/roam/src/index.ts
+++ b/apps/roam/src/index.ts
@@ -39,7 +39,10 @@ import {
   getPersonalSetting,
 } from "./components/settings/utils/accessors";
 import { setupPullWatchOnSettingsPage } from "./components/settings/utils/pullWatchers";
-import { onSettingChange } from "./components/settings/utils/settingsEmitter";
+import {
+  onSettingChange,
+  settingKeys,
+} from "./components/settings/utils/settingsEmitter";
 import { mountLeftSidebar } from "./components/LeftSidebarView";
 
 export const DEFAULT_CANVAS_PAGE_FORMAT = "Canvas/*";
@@ -154,7 +157,7 @@ export default runExtension(async (onloadArgs) => {
   }
 
   const unsubLeftSidebarFlag = onSettingChange(
-    "Enable left sidebar",
+    settingKeys.leftSidebarFlag,
     (newValue) => {
       const enabled = Boolean(newValue);
       const wrapper = document.querySelector<HTMLDivElement>(

--- a/apps/roam/src/index.ts
+++ b/apps/roam/src/index.ts
@@ -38,10 +38,8 @@ import {
   getFeatureFlag,
   getPersonalSetting,
 } from "./components/settings/utils/accessors";
-import {
-  setupPullWatchOnSettingsPage,
-  setLeftSidebarFlagHandler,
-} from "./components/settings/utils/pullWatchers";
+import { setupPullWatchOnSettingsPage } from "./components/settings/utils/pullWatchers";
+import { onSettingChange } from "./components/settings/utils/settingsEmitter";
 import { mountLeftSidebar } from "./components/LeftSidebarView";
 
 export const DEFAULT_CANVAS_PAGE_FORMAT = "Canvas/*";
@@ -155,26 +153,28 @@ export default runExtension(async (onloadArgs) => {
     });
   }
 
-  // Register left sidebar flag handler before pull watchers start
-  const handleLeftSidebarFlag = (enabled: boolean) => {
-    const wrapper = document.querySelector<HTMLDivElement>(
-      ".starred-pages-wrapper",
-    );
-    if (!wrapper) return;
-    if (enabled) {
-      wrapper.style.padding = "0";
-      void mountLeftSidebar(wrapper, onloadArgs);
-    } else {
-      const root = wrapper.querySelector("#dg-left-sidebar-root");
-      if (root) {
-        // eslint-disable-next-line react/no-deprecated
-        ReactDOM.unmountComponentAtNode(root);
-        root.remove();
+  const unsubLeftSidebarFlag = onSettingChange(
+    "Enable left sidebar",
+    (newValue) => {
+      const enabled = Boolean(newValue);
+      const wrapper = document.querySelector<HTMLDivElement>(
+        ".starred-pages-wrapper",
+      );
+      if (!wrapper) return;
+      if (enabled) {
+        wrapper.style.padding = "0";
+        void mountLeftSidebar(wrapper, onloadArgs);
+      } else {
+        const root = wrapper.querySelector("#dg-left-sidebar-root");
+        if (root) {
+          // eslint-disable-next-line react/no-deprecated
+          ReactDOM.unmountComponentAtNode(root);
+          root.remove();
+        }
+        wrapper.style.padding = "";
       }
-      wrapper.style.padding = "";
-    }
-  };
-  setLeftSidebarFlagHandler(handleLeftSidebarFlag);
+    },
+  );
 
   const { blockUids } = await initSchema();
   const cleanupPullWatchers = setupPullWatchOnSettingsPage(blockUids);
@@ -189,6 +189,7 @@ export default runExtension(async (onloadArgs) => {
     ],
     observers: observers,
     unload: () => {
+      unsubLeftSidebarFlag();
       cleanupPullWatchers();
       setSyncActivity(false);
       window.roamjs.extension?.smartblocks?.unregisterCommand("QUERYBUILDER");

--- a/apps/roam/src/index.ts
+++ b/apps/roam/src/index.ts
@@ -1,3 +1,4 @@
+import ReactDOM from "react-dom";
 import { addStyle } from "roamjs-components/dom";
 import { render as renderToast } from "roamjs-components/components/Toast";
 import { runExtension } from "roamjs-components/util";
@@ -37,6 +38,11 @@ import {
   getFeatureFlag,
   getPersonalSetting,
 } from "./components/settings/utils/accessors";
+import {
+  setupPullWatchOnSettingsPage,
+  setLeftSidebarFlagHandler,
+} from "./components/settings/utils/pullWatchers";
+import { mountLeftSidebar } from "./components/LeftSidebarView";
 
 export const DEFAULT_CANVAS_PAGE_FORMAT = "Canvas/*";
 
@@ -149,7 +155,29 @@ export default runExtension(async (onloadArgs) => {
     });
   }
 
-  await initSchema();
+  // Register left sidebar flag handler before pull watchers start
+  const handleLeftSidebarFlag = (enabled: boolean) => {
+    const wrapper = document.querySelector<HTMLDivElement>(
+      ".starred-pages-wrapper",
+    );
+    if (!wrapper) return;
+    if (enabled) {
+      wrapper.style.padding = "0";
+      void mountLeftSidebar(wrapper, onloadArgs);
+    } else {
+      const root = wrapper.querySelector("#dg-left-sidebar-root");
+      if (root) {
+        // eslint-disable-next-line react/no-deprecated
+        ReactDOM.unmountComponentAtNode(root);
+        root.remove();
+      }
+      wrapper.style.padding = "";
+    }
+  };
+  setLeftSidebarFlagHandler(handleLeftSidebarFlag);
+
+  const { blockUids } = await initSchema();
+  const cleanupPullWatchers = setupPullWatchOnSettingsPage(blockUids);
 
   return {
     elements: [
@@ -161,6 +189,7 @@ export default runExtension(async (onloadArgs) => {
     ],
     observers: observers,
     unload: () => {
+      cleanupPullWatchers();
       setSyncActivity(false);
       window.roamjs.extension?.smartblocks?.unregisterCommand("QUERYBUILDER");
       // @ts-expect-error - tldraw throws a warning on multiple loads

--- a/apps/roam/src/utils/getLeftSidebarSettings.ts
+++ b/apps/roam/src/utils/getLeftSidebarSettings.ts
@@ -8,6 +8,10 @@ import {
   getUidAndStringSetting,
 } from "./getExportSettings";
 import { getSubTree } from "roamjs-components/util";
+import type {
+  LeftSidebarGlobalSettings,
+  PersonalSection,
+} from "~/components/settings/utils/zodSchema";
 
 type LeftSidebarPersonalSectionSettings = {
   uid: string;
@@ -199,6 +203,58 @@ export const getAllLeftSidebarPersonalSectionConfigs = (
 
   return result;
 };
+
+// TODO(ENG-1471): Remove when migration complete — just use accessor values directly.
+// During dual-read, we need old-system UIDs for block CRUD (fold toggle, reorder, delete)
+// but read setting VALUES from accessors (which route through the feature flag and log
+// mismatches). These helpers merge accessor values onto old-system config objects.
+export const mergeGlobalSectionWithAccessor = (
+  config: LeftSidebarGlobalSectionConfig,
+  globalValues: LeftSidebarGlobalSettings | undefined,
+): LeftSidebarGlobalSectionConfig => {
+  if (!config.settings) return config;
+  return {
+    ...config,
+    settings: {
+      uid: config.settings.uid,
+      collapsable: {
+        uid: config.settings.collapsable.uid,
+        value:
+          globalValues?.Settings.Collapsable ??
+          config.settings.collapsable.value,
+      },
+      folded: {
+        uid: config.settings.folded.uid,
+        value: globalValues?.Settings.Folded ?? config.settings.folded.value,
+      },
+    },
+  };
+};
+
+export const mergePersonalSectionsWithAccessor = (
+  sections: LeftSidebarPersonalSectionConfig[],
+  personalValues: PersonalSection[] | undefined,
+): LeftSidebarPersonalSectionConfig[] => {
+  return sections.map((section, i) => {
+    const newSection = personalValues?.[i];
+    if (!section.settings || !newSection) return section;
+    return {
+      ...section,
+      settings: {
+        ...section.settings,
+        truncateResult: {
+          ...section.settings.truncateResult,
+          value: newSection.Settings["Truncate-result?"],
+        },
+        folded: {
+          ...section.settings.folded,
+          value: newSection.Settings.Folded,
+        },
+      },
+    };
+  });
+};
+
 export const getLeftSidebarSettings = (
   globalTree: RoamBasicNode[],
 ): LeftSidebarConfig => {


### PR DESCRIPTION


https://www.loom.com/share/6258dfb98cd0424a9c1b3ef7794955c3


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/844" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for both global and per-section configuration of left sidebar folding behavior.
  * Enabled dynamic toggling of the left sidebar via feature flag.

* **Improvements**
  * Enhanced settings validation and synchronization across configuration systems to ensure consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->