### PR TITLE
ENG-1479: Port suggestive mode settings to dual-read

### DIFF
--- a/apps/roam/src/components/settings/AdminPanel.tsx
+++ b/apps/roam/src/components/settings/AdminPanel.tsx
@@ -424,6 +424,8 @@ const FeatureFlagsTab = (): React.ReactElement => {
         <p>Are you sure you want to proceed?</p>
       </Alert>
 
+      {/* TODO(ENG-1484): Add pull watcher reactivity so toggling suggestive mode
+          starts/stops sync and shows the tab without requiring a reload. */}
       <Alert
         isOpen={isInstructionOpen}
         onConfirm={() => window.location.reload()}

--- a/apps/roam/src/components/settings/AdminPanel.tsx
+++ b/apps/roam/src/components/settings/AdminPanel.tsx
@@ -360,7 +360,7 @@ const FeatureFlagsTab = (): React.ReactElement => {
   }, []);
 
   const [suggestiveModeEnabled, setSuggestiveModeEnabled] = useState(
-    settings.suggestiveModeEnabled.value || false,
+    getFeatureFlag("Suggestive mode enabled"),
   );
   const [suggestiveModeUid, setSuggestiveModeUid] = useState(
     settings.suggestiveModeEnabled.uid,
@@ -498,10 +498,6 @@ const FeatureFlagsTab = (): React.ReactElement => {
 
 const AdminPanel = (): React.ReactElement => {
   const [selectedTabId, setSelectedTabId] = useState<TabId>("admin");
-  const settings = useMemo(() => {
-    refreshConfigTree();
-    return getFormattedConfigTree();
-  }, []);
 
   return (
     <Tabs
@@ -536,7 +532,7 @@ const AdminPanel = (): React.ReactElement => {
           </div>
         }
       />
-      {settings.suggestiveModeEnabled.value && (
+      {getFeatureFlag("Suggestive mode enabled") && (
         <Tab
           id="suggestive-mode-settings"
           title="Suggestive mode"

--- a/apps/roam/src/components/settings/SuggestiveModeSettings.tsx
+++ b/apps/roam/src/components/settings/SuggestiveModeSettings.tsx
@@ -9,6 +9,7 @@ import { DISCOURSE_CONFIG_PAGE_TITLE } from "~/utils/renderNodeConfigPage";
 import { createOrUpdateDiscourseEmbedding } from "~/utils/syncDgNodesToSupabase";
 import { render as renderToast } from "roamjs-components/components/Toast";
 import { GlobalFlagPanel } from "./components/BlockPropSettingPanels";
+import { getGlobalSetting } from "~/components/settings/utils/accessors";
 import posthog from "posthog-js";
 
 const SuggestiveModeSettings = () => {
@@ -20,7 +21,10 @@ const SuggestiveModeSettings = () => {
   const pageGroupsUid = settings.suggestiveMode.pageGroups.uid;
 
   const [includePageRelations, setIncludePageRelations] = useState(
-    settings.suggestiveMode.includePageRelations.value,
+    getGlobalSetting<boolean>([
+      "Suggestive mode",
+      "Include current page relations",
+    ]) ?? false,
   );
 
   useEffect(() => {
@@ -69,8 +73,9 @@ const SuggestiveModeSettings = () => {
           title="Sync config"
           panel={
             <div className="flex flex-col gap-4 p-1">
-              {/* TODO: Titles kept as Title Case to match legacy readers in getSuggestiveModeConfigSettings.ts.
-                  Update titles to Sentence case once read side is migrated to block props. */}
+              {/* TODO(ENG-1469): Titles kept as Title Case because getSuggestiveModeConfigSettings.ts
+                  still reads from the block tree expecting these strings. Update to Sentence case
+                  once the aggregator is refactored to read from block props. */}
               <div className="sync-config-settings">
                 <GlobalFlagPanel
                   title="Include Current Page Relations"
@@ -79,9 +84,6 @@ const SuggestiveModeSettings = () => {
                     "Suggestive mode",
                     "Include current page relations",
                   ]}
-                  initialValue={
-                    settings.suggestiveMode.includePageRelations.value
-                  }
                   order={0}
                   uid={settings.suggestiveMode.includePageRelations.uid}
                   parentUid={effectiveSuggestiveModeUid}
@@ -99,9 +101,6 @@ const SuggestiveModeSettings = () => {
                     "Suggestive mode",
                     "Include parent and child blocks",
                   ]}
-                  initialValue={
-                    settings.suggestiveMode.includeParentAndChildren.value
-                  }
                   value={includePageRelations ? true : undefined}
                   order={1}
                   uid={settings.suggestiveMode.includeParentAndChildren.uid}

--- a/apps/roam/src/components/settings/utils/accessors.ts
+++ b/apps/roam/src/components/settings/utils/accessors.ts
@@ -661,9 +661,38 @@ export const getFeatureFlags = (): FeatureFlags => {
   return FeatureFlagsSchema.parse(blockProps || {});
 };
 
+const FEATURE_FLAG_LEGACY_MAP: Partial<
+  Record<keyof FeatureFlags, () => boolean>
+> = {
+  "Suggestive mode enabled": () =>
+    getFormattedConfigTree().suggestiveModeEnabled.value,
+  "Enable left sidebar": () =>
+    getFormattedConfigTree().leftSidebarEnabled.value,
+};
+
 export const getFeatureFlag = (key: keyof FeatureFlags): boolean => {
+  const legacyReader = FEATURE_FLAG_LEGACY_MAP[key];
+
+  if (!legacyReader) {
+    // Block-props-only flag (no legacy equivalent)
+    const flags = getFeatureFlags();
+    return flags[key];
+  }
+
+  if (!isNewSettingsStoreEnabled()) {
+    return legacyReader();
+  }
+
   const flags = getFeatureFlags();
-  return flags[key];
+  const blockPropsValue = flags[key];
+  const legacyValue = legacyReader();
+  if (blockPropsValue !== legacyValue) {
+    console.warn(`[DG Dual-Read] Mismatch at Feature Flag > ${key}`, {
+      blockProps: blockPropsValue,
+      legacy: legacyValue,
+    });
+  }
+  return blockPropsValue;
 };
 
 export const isNewSettingsStoreEnabled = (): boolean => {

--- a/apps/roam/src/components/settings/utils/accessors.ts
+++ b/apps/roam/src/components/settings/utils/accessors.ts
@@ -661,6 +661,7 @@ export const getFeatureFlags = (): FeatureFlags => {
   return FeatureFlagsSchema.parse(blockProps || {});
 };
 
+/* eslint-disable @typescript-eslint/naming-convention */
 const FEATURE_FLAG_LEGACY_MAP: Partial<
   Record<keyof FeatureFlags, () => boolean>
 > = {
@@ -669,6 +670,7 @@ const FEATURE_FLAG_LEGACY_MAP: Partial<
   "Enable left sidebar": () =>
     getFormattedConfigTree().leftSidebarEnabled.value,
 };
+/* eslint-enable @typescript-eslint/naming-convention */
 
 export const getFeatureFlag = (key: keyof FeatureFlags): boolean => {
   const legacyReader = FEATURE_FLAG_LEGACY_MAP[key];

--- a/apps/roam/src/index.ts
+++ b/apps/roam/src/index.ts
@@ -31,13 +31,12 @@ import {
   setSyncActivity,
 } from "./utils/syncDgNodesToSupabase";
 import { initPluginTimer } from "./utils/pluginTimer";
-import { getUidAndBooleanSetting } from "./utils/getExportSettings";
-import getBasicTreeByParentUid from "roamjs-components/queries/getBasicTreeByParentUid";
-import getPageUidByPageTitle from "roamjs-components/queries/getPageUidByPageTitle";
-import { DISCOURSE_CONFIG_PAGE_TITLE } from "./utils/renderNodeConfigPage";
 import { initPostHog } from "./utils/posthog";
 import { initSchema } from "./components/settings/utils/init";
-import { getPersonalSetting } from "./components/settings/utils/accessors";
+import {
+  getFeatureFlag,
+  getPersonalSetting,
+} from "./components/settings/utils/accessors";
 
 export const DEFAULT_CANVAS_PAGE_FORMAT = "Canvas/*";
 
@@ -112,12 +111,7 @@ export default runExtension(async (onloadArgs) => {
   document.addEventListener("input", discourseNodeSearchTriggerListener);
   document.addEventListener("selectionchange", nodeCreationPopoverListener);
 
-  const isSuggestiveModeEnabled = getUidAndBooleanSetting({
-    tree: getBasicTreeByParentUid(
-      getPageUidByPageTitle(DISCOURSE_CONFIG_PAGE_TITLE),
-    ),
-    text: "(BETA) Suggestive Mode Enabled",
-  }).value;
+  const isSuggestiveModeEnabled = getFeatureFlag("Suggestive mode enabled");
 
   if (isSuggestiveModeEnabled) {
     initializeSupabaseSync();

--- a/apps/roam/src/utils/hyde.ts
+++ b/apps/roam/src/utils/hyde.ts
@@ -419,12 +419,12 @@ export const performHydeSearch = async ({
     getGlobalSetting<boolean>([
       "Suggestive mode",
       "Include current page relations",
-    ]) ?? true;
+    ]) ?? false;
   const shouldGrabParentChildContext =
     getGlobalSetting<boolean>([
       "Suggestive mode",
       "Include parent and child blocks",
-    ]) ?? true;
+    ]) ?? false;
 
   let candidateNodesForHyde: SuggestedNode[] = [];
 

--- a/apps/roam/src/utils/hyde.ts
+++ b/apps/roam/src/utils/hyde.ts
@@ -5,9 +5,9 @@ import { render as renderToast } from "roamjs-components/components/Toast";
 import findDiscourseNode from "./findDiscourseNode";
 import { nextApiRoot } from "@repo/utils/execContext";
 import { DiscourseNode } from "./getDiscourseNodes";
-import getExtensionAPI from "roamjs-components/util/extensionApiContext";
 import { getNodesByType } from "@repo/database/lib/queries";
 import getAllReferencesOnPage from "./getAllReferencesOnPage";
+import { getGlobalSetting } from "~/components/settings/utils/accessors";
 
 type ApiEmbeddingResponse = {
   data: Array<{
@@ -415,15 +415,16 @@ export const performHydeSearch = async ({
     return [];
   }
 
-  const extensionAPI = getExtensionAPI();
   const shouldGrabFromReferencedPages =
-    (extensionAPI.settings.get(
-      "context-grab-from-referenced-pages",
-    ) as boolean) ?? true;
+    getGlobalSetting<boolean>([
+      "Suggestive mode",
+      "Include current page relations",
+    ]) ?? true;
   const shouldGrabParentChildContext =
-    (extensionAPI.settings.get(
-      "context-grab-parent-child-context",
-    ) as boolean) ?? true;
+    getGlobalSetting<boolean>([
+      "Suggestive mode",
+      "Include parent and child blocks",
+    ]) ?? true;
 
   let candidateNodesForHyde: SuggestedNode[] = [];
 


### PR DESCRIPTION
https://www.loom.com/share/6b740485161741e8b5ddd7d58b5f9891



<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/845" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated feature flag access to use a centralized mechanism with diagnostic support for configuration compatibility.
  * Streamlined how settings are retrieved across the admin panel and suggestive mode components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->