### PR TITLE
[ENG-1335] Node create modal results limit

### DIFF
--- a/apps/roam/src/components/FuzzySelectInput.tsx
+++ b/apps/roam/src/components/FuzzySelectInput.tsx
@@ -57,10 +57,6 @@ const FuzzySelectInput = <T extends Result = Result>({
     return filteredItems.slice(0, RESULTS_LIMIT);
   }, [filteredItems]);
 
-  const isResultsTruncated = useMemo(() => {
-    return filteredItems.length > RESULTS_LIMIT;
-  }, [filteredItems.length]);
-
   const handleSelect = useCallback(
     (item: T) => {
       setQuery(item.text);
@@ -209,28 +205,20 @@ const FuzzySelectInput = <T extends Result = Result>({
       autoFocus={false}
       enforceFocus={false}
       content={
-        <div>
-          <Menu className="max-h-64 max-w-md overflow-auto" ulRef={menuRef}>
-            {displayedItems.map((item, index) => (
-              <MenuItem
-                key={item.uid || index}
-                text={item.text}
-                active={activeIndex === index}
-                onMouseDown={(e) => {
-                  e.preventDefault();
-                  handleSelect(item);
-                }}
-                multiline
-              />
-            ))}
-          </Menu>
-          {isResultsTruncated && (
-            <div className="border-t border-gray-300 bg-gray-50 px-3 py-2 text-xs text-gray-600 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-400">
-              Showing first {RESULTS_LIMIT} results — refine your search to see
-              more.
-            </div>
-          )}
-        </div>
+        <Menu className="max-h-64 max-w-md overflow-auto" ulRef={menuRef}>
+          {displayedItems.map((item, index) => (
+            <MenuItem
+              key={item.uid || index}
+              text={item.text}
+              active={activeIndex === index}
+              onMouseDown={(e) => {
+                e.preventDefault();
+                handleSelect(item);
+              }}
+              multiline
+            />
+          ))}
+        </Menu>
       }
       target={
         <InputGroup

--- a/apps/roam/src/components/FuzzySelectInput.tsx
+++ b/apps/roam/src/components/FuzzySelectInput.tsx
@@ -17,6 +17,8 @@ import {
 import fuzzy from "fuzzy";
 import { Result } from "~/utils/types";
 
+const RESULTS_LIMIT = 50;
+
 type FuzzySelectInputProps<T extends Result = Result> = {
   value?: T;
   setValue: (q: T) => void;
@@ -51,6 +53,14 @@ const FuzzySelectInput = <T extends Result = Result>({
       .map((result) => result.original);
   }, [query, options]);
 
+  const displayedItems = useMemo(() => {
+    return filteredItems.slice(0, RESULTS_LIMIT);
+  }, [filteredItems]);
+
+  const isResultsTruncated = useMemo(() => {
+    return filteredItems.length > RESULTS_LIMIT;
+  }, [filteredItems.length]);
+
   const handleSelect = useCallback(
     (item: T) => {
       setQuery(item.text);
@@ -84,7 +94,7 @@ const FuzzySelectInput = <T extends Result = Result>({
       if (e.key === "ArrowDown") {
         e.preventDefault();
         setActiveIndex((prev) =>
-          prev < filteredItems.length - 1 ? prev + 1 : prev,
+          prev < displayedItems.length - 1 ? prev + 1 : prev,
         );
       } else if (e.key === "ArrowUp") {
         e.preventDefault();
@@ -92,7 +102,7 @@ const FuzzySelectInput = <T extends Result = Result>({
       } else if (e.key === "Enter") {
         e.preventDefault();
         e.stopPropagation();
-        if (isOpen && filteredItems[activeIndex]) {
+        if (isOpen && displayedItems[activeIndex]) {
           const keyUpHandler = (keyUpEvent: KeyboardEvent) => {
             if (keyUpEvent.key === "Enter" || keyUpEvent.key === " ") {
               keyUpEvent.preventDefault();
@@ -104,14 +114,14 @@ const FuzzySelectInput = <T extends Result = Result>({
           setTimeout(() => {
             document.removeEventListener("keyup", keyUpHandler, true);
           }, 150);
-          handleSelect(filteredItems[activeIndex]);
+          handleSelect(displayedItems[activeIndex]);
         }
       } else if (e.key === "Escape") {
         e.preventDefault();
         setIsOpen(false);
       }
     },
-    [filteredItems, activeIndex, isOpen, handleSelect],
+    [displayedItems, activeIndex, isOpen, handleSelect],
   );
 
   useEffect(() => {
@@ -129,7 +139,7 @@ const FuzzySelectInput = <T extends Result = Result>({
 
   useEffect(() => {
     setActiveIndex(0);
-  }, [filteredItems]);
+  }, [displayedItems]);
 
   useEffect(() => {
     if (menuRef.current && isOpen) {
@@ -199,20 +209,28 @@ const FuzzySelectInput = <T extends Result = Result>({
       autoFocus={false}
       enforceFocus={false}
       content={
-        <Menu className="max-h-64 max-w-md overflow-auto" ulRef={menuRef}>
-          {filteredItems.map((item, index) => (
-            <MenuItem
-              key={item.uid || index}
-              text={item.text}
-              active={activeIndex === index}
-              onMouseDown={(e) => {
-                e.preventDefault();
-                handleSelect(item);
-              }}
-              multiline
-            />
-          ))}
-        </Menu>
+        <div>
+          <Menu className="max-h-64 max-w-md overflow-auto" ulRef={menuRef}>
+            {displayedItems.map((item, index) => (
+              <MenuItem
+                key={item.uid || index}
+                text={item.text}
+                active={activeIndex === index}
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  handleSelect(item);
+                }}
+                multiline
+              />
+            ))}
+          </Menu>
+          {isResultsTruncated && (
+            <div className="border-t border-gray-300 bg-gray-50 px-3 py-2 text-xs text-gray-600 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-400">
+              Showing first {RESULTS_LIMIT} results — refine your search to see
+              more.
+            </div>
+          )}
+        </div>
       }
       target={
         <InputGroup

--- a/apps/roam/src/components/FuzzySelectInput.tsx
+++ b/apps/roam/src/components/FuzzySelectInput.tsx
@@ -17,7 +17,7 @@ import {
 import fuzzy from "fuzzy";
 import { Result } from "~/utils/types";
 
-const RESULTS_LIMIT = 50;
+const RESULTS_LIMIT = 20;
 
 type FuzzySelectInputProps<T extends Result = Result> = {
   value?: T;

--- a/apps/roam/src/components/FuzzySelectInput.tsx
+++ b/apps/roam/src/components/FuzzySelectInput.tsx
@@ -17,7 +17,7 @@ import {
 import fuzzy from "fuzzy";
 import { Result } from "~/utils/types";
 
-const RESULTS_LIMIT = 20;
+const RESULTS_LIMIT = 50;
 
 type FuzzySelectInputProps<T extends Result = Result> = {
   value?: T;
@@ -218,6 +218,12 @@ const FuzzySelectInput = <T extends Result = Result>({
               multiline
             />
           ))}
+          {filteredItems.length > RESULTS_LIMIT && (
+            <li className="px-3 py-2 text-center text-xs italic text-gray-500">
+              Showing first {RESULTS_LIMIT} results — refine your search to see
+              more.
+            </li>
+          )}
         </Menu>
       }
       target={


### PR DESCRIPTION
https://www.loom.com/share/e67a2e2a37384fd5b8b1ad6ed5ae2a28

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Limits the number of displayed results in the Node Create modal to prevent UI freezes on large graphs.

This prevents UI freezes and lag when typing queries that return a large number of matches, and includes a UI hint when results are truncated.

---
Linear Issue: [ENG-1335](https://linear.app/discourse-graphs/issue/ENG-1335/add-limit-to-results-in-node-create-modal)

<p><a href="https://cursor.com/agents/bc-9f5fa953-5f13-415a-9c13-76326c1439a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9f5fa953-5f13-415a-9c13-76326c1439a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/854" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
