### PR TITLE
ENG-1371 Add ability to choose custom hotkey for node tag menu

### DIFF
--- a/apps/obsidian/src/components/GeneralSettings.tsx
+++ b/apps/obsidian/src/components/GeneralSettings.tsx
@@ -306,7 +306,6 @@ const GeneralSettings = () => {
             }}
             placeholder="\\"
             maxLength={1}
-            className="setting-item-control"
           />
         </div>
       </div>


### PR DESCRIPTION
https://linear.app/discourse-graphs/issue/ENG-1371/add-ability-to-choose-custom-hotkey-for-node-tag-menu

The ability was there, but the input field was hidden because of an inappropriate css class.
Removing this enables using the preference.

https://www.loom.com/share/956670c2417d4f7a89961ed9714ef365

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/855" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
