### PR TITLE
ENG-1490 Fix ZodError in getAllDiscourseNodes for legacy block prop shapes

### DIFF
--- a/apps/roam/src/components/settings/utils/accessors.ts
+++ b/apps/roam/src/components/settings/utils/accessors.ts
@@ -493,6 +493,67 @@ export const setDiscourseNodeSetting = (
   setBlockPropAtPath(pageUid, keys, value);
 };
 
+/**
+ * Migrate known legacy block prop shapes to the current schema.
+ *
+ * - specification: Condition[] → {enabled, query: {conditions, ...}}
+ * - specification: {enabled, query: Condition[]} → {enabled, query: {conditions, ...}}
+ * - suggestiveRules.isFirstChild: {uid, value} → boolean
+ */
+const migrateNodeBlockProps = (
+  props: Record<string, json>,
+): Record<string, json> => {
+  const migrated = { ...props };
+
+  if (Array.isArray(migrated.specification)) {
+    migrated.specification = {
+      enabled: migrated.specification.length > 0,
+      query: {
+        conditions: migrated.specification,
+        selections: [],
+        custom: "",
+        returnNode: "",
+      },
+    };
+  } else if (
+    typeof migrated.specification === "object" &&
+    migrated.specification !== null &&
+    "query" in migrated.specification &&
+    Array.isArray((migrated.specification as Record<string, json>).query)
+  ) {
+    const spec = migrated.specification as Record<string, json>;
+    migrated.specification = {
+      enabled:
+        typeof spec.enabled === "boolean"
+          ? spec.enabled
+          : (spec.query as json[]).length > 0,
+      query: {
+        conditions: spec.query,
+        selections: [],
+        custom: "",
+        returnNode: "",
+      },
+    };
+  }
+
+  if (
+    typeof migrated.suggestiveRules === "object" &&
+    migrated.suggestiveRules !== null &&
+    !Array.isArray(migrated.suggestiveRules)
+  ) {
+    const rules = migrated.suggestiveRules as Record<string, json>;
+    const ifc = rules.isFirstChild;
+    if (typeof ifc === "object" && ifc !== null && !Array.isArray(ifc)) {
+      migrated.suggestiveRules = {
+        ...rules,
+        isFirstChild: (ifc as Record<string, json>).value ?? false,
+      };
+    }
+  }
+
+  return migrated;
+};
+
 export const getAllDiscourseNodes = (): DiscourseNodeSettings[] => {
   const results = window.roamAlphaAPI.data.fast.q(`
     [:find ?uid ?title (pull ?page [:block/props])
@@ -517,20 +578,27 @@ export const getAllDiscourseNodes = (): DiscourseNodeSettings[] => {
     )
       continue;
 
+    const nodeText = title.replace(DISCOURSE_NODE_PAGE_PREFIX, "");
     const result = DiscourseNodeSchema.safeParse(blockProps);
     if (result.success) {
-      nodes.push({
-        ...result.data,
-        type: pageUid,
-        text: title.replace(DISCOURSE_NODE_PAGE_PREFIX, ""),
-      });
+      nodes.push({ ...result.data, type: pageUid, text: nodeText });
     } else {
-      internalError({
-        error: result.error,
-        type: "DG Discourse Node Parse",
-        context: { pageUid, title },
-        sendEmail: false,
-      });
+      // Try migrating legacy field shapes before dropping the node.
+      const migrated = migrateNodeBlockProps(
+        blockProps as Record<string, json>,
+      );
+      const retryResult = DiscourseNodeSchema.safeParse(migrated);
+      if (retryResult.success) {
+        setBlockProps(pageUid, retryResult.data, false);
+        nodes.push({ ...retryResult.data, type: pageUid, text: nodeText });
+      } else {
+        internalError({
+          error: result.error,
+          type: "DG Discourse Node Parse",
+          context: { pageUid, title },
+          sendEmail: false,
+        });
+      }
     }
   }
 

--- a/apps/roam/src/components/settings/utils/accessors.ts
+++ b/apps/roam/src/components/settings/utils/accessors.ts
@@ -512,7 +512,7 @@ const migrateNodeBlockProps = (
         conditions: migrated.specification,
         selections: [],
         custom: "",
-        returnNode: "",
+        returnNode: "node",
       },
     };
   } else if (
@@ -531,7 +531,7 @@ const migrateNodeBlockProps = (
         conditions: spec.query,
         selections: [],
         custom: "",
-        returnNode: "",
+        returnNode: "node",
       },
     };
   }

--- a/apps/roam/src/components/settings/utils/accessors.ts
+++ b/apps/roam/src/components/settings/utils/accessors.ts
@@ -593,7 +593,7 @@ export const getAllDiscourseNodes = (): DiscourseNodeSettings[] => {
         nodes.push({ ...retryResult.data, type: pageUid, text: nodeText });
       } else {
         internalError({
-          error: result.error,
+          error: retryResult.error,
           type: "DG Discourse Node Parse",
           context: { pageUid, title },
           sendEmail: false,


### PR DESCRIPTION
https://www.loom.com/share/7d5857d8340e47fca362f3892c199d8c


Migrate legacy discourse node block props on read instead of dropping nodes that fail schema validation. Handles two known shape changes:
- specification: Condition[] → {enabled, query: {conditions, ...}}
- suggestiveRules.isFirstChild: {uid, value} → boolean

On successful migration, writes the fixed data back so subsequent reads hit the happy path. Nodes that can't be migrated still report to PostHog.

                                                                                                                                                                              
  We're seeing recurring ZodErrors in PostHog from getAllDiscourseNodes. Two schema shape changes from the block props migration left user-created discourse nodes with stale
  data that fails safeParse:                                                                                                                                                
                                                                                                                                                                            
  - specification changed from Condition[] to {enabled, query: {conditions, ...}}
  - suggestiveRules.isFirstChild changed from {uid, value: boolean} to boolean

  Default nodes get re-initialized on schema mismatch (via initSingleDiscourseNode), but user-created nodes were just silently dropped — they'd fail parse and never show up
  in getAllDiscourseNodes.

  Fix: When safeParse fails, we try migrating the known legacy shapes before dropping the node. If migration succeeds, we write the fixed data back to block props (so it's a
  one-time cost) and include the node. If migration can't fix it, we still report to PostHog so we catch genuinely broken data.

  What it doesn't do: No schema changes, no init restructuring. The migration is scoped to the two known shape changes and lives next to the read site where the error is
  detected.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/856" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of existing data structures. When initial data parsing encounters failures, the system now implements an automatic recovery mechanism that attempts to update and reprocess the data. If recovery succeeds, the updated data is properly stored and utilized; if unsuccessful, the original error handling is preserved, ensuring stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->