### PR TITLE
[ENG-1515] Separate imported types (In settings) from local types

### DIFF
--- a/apps/obsidian/src/components/ImportNodesModal.tsx
+++ b/apps/obsidian/src/components/ImportNodesModal.tsx
@@ -8,6 +8,7 @@ import {
   getPublishedNodesForGroups,
   getLocalNodeInstanceIds,
   getSpaceNameFromIds,
+  getSpaceUris,
   importSelectedNodes,
 } from "~/utils/importNodes";
 import { getLoggedInClient, getSupabaseContext } from "~/utils/supabaseContext";
@@ -68,7 +69,25 @@ const ImportNodesContent = ({ plugin, onClose }: ImportNodesModalProps) => {
       const uniqueSpaceIds = [
         ...new Set(importableNodes.map((n) => n.space_id)),
       ];
-      const spaceNames = await getSpaceNameFromIds(client, uniqueSpaceIds);
+      const [spaceNames, spaceUris] = await Promise.all([
+        getSpaceNameFromIds(client, uniqueSpaceIds),
+        getSpaceUris(client, uniqueSpaceIds),
+      ]);
+
+      // Populate plugin settings with current space names so they stay up to date
+      if (uniqueSpaceIds.length > 0) {
+        if (!plugin.settings.spaceNames) plugin.settings.spaceNames = {};
+
+        for (const spaceId of uniqueSpaceIds) {
+          const spaceUri = spaceUris.get(spaceId);
+          const spaceName = spaceNames.get(spaceId);
+          if (spaceUri && spaceName) {
+            plugin.settings.spaceNames[spaceUri] = spaceName;
+          }
+        }
+        await plugin.saveSettings();
+      }
+
       const grouped: Map<string, GroupWithNodes> = new Map();
 
       for (const node of importableNodes) {

--- a/apps/obsidian/src/components/NodeTypeSettings.tsx
+++ b/apps/obsidian/src/components/NodeTypeSettings.tsx
@@ -6,6 +6,7 @@ import generateUid from "~/utils/generateUid";
 import { DiscourseNode } from "~/types";
 import { ConfirmationModal } from "./ConfirmationModal";
 import { getTemplateFiles, getTemplatePluginInfo } from "~/utils/templates";
+import { getImportInfo, formatImportSource } from "~/utils/typeUtils";
 
 const generateTagPlaceholder = (format: string, nodeName?: string): string => {
   if (!format) return "Enter tag (e.g., clm-candidate)";
@@ -508,26 +509,40 @@ const NodeTypeSettings = () => {
     );
   };
 
-  const renderNodeList = () => (
-    <div className="node-type-list">
-      <button onClick={handleAddNodeType} className="mod-cta">
-        Add Node Type
-      </button>
-      {nodeTypes.map((nodeType, index) => (
+  const renderNodeList = () => {
+    const localNodeTypes = nodeTypes.filter(
+      (nodeType) => !nodeType.importedFromRid,
+    );
+    const importedNodeTypes = nodeTypes.filter(
+      (nodeType) => nodeType.importedFromRid,
+    );
+
+    const renderNodeTypeItem = (nodeType: DiscourseNode, index: number) => {
+      const importInfo = getImportInfo(nodeType.importedFromRid);
+      const isImported = importInfo.isImported;
+
+      return (
         <div
           key={nodeType.id}
           className="node-type-item hover:bg-secondary-lt flex cursor-pointer flex-col gap-1 p-2"
           onClick={() => startEditing(index)}
         >
           <div className="flex items-center justify-between">
-            <div className="flex items-center gap-2">
-              {nodeType.color && (
-                <div
-                  className="h-4 w-4 rounded-full"
-                  style={{ backgroundColor: nodeType.color }}
-                />
+            <div className="flex flex-col gap-1">
+              <div className="flex items-center gap-2">
+                {nodeType.color && (
+                  <div
+                    className="h-4 w-4 rounded-full"
+                    style={{ backgroundColor: nodeType.color }}
+                  />
+                )}
+                <span>{nodeType.name}</span>
+              </div>
+              {isImported && importInfo.spaceUri && (
+                <span className="text-muted text-xs pl-6">
+                  Imported from: {formatImportSource(importInfo.spaceUri)}
+                </span>
               )}
-              <span>{nodeType.name}</span>
             </div>
             <div className="flex gap-2">
               <button
@@ -562,9 +577,37 @@ const NodeTypeSettings = () => {
             <span className="text-muted text-sm">{nodeType.description}</span>
           )}
         </div>
-      ))}
-    </div>
-  );
+      );
+    };
+
+    return (
+      <div className="node-type-list">
+        <button onClick={handleAddNodeType} className="mod-cta">
+          Add Node Type
+        </button>
+
+        {localNodeTypes.length > 0 && (
+          <div className="mt-4">
+            <h4 className="mb-2 font-semibold">Local Node Types</h4>
+            {localNodeTypes.map((nodeType) => {
+              const index = nodeTypes.indexOf(nodeType);
+              return renderNodeTypeItem(nodeType, index);
+            })}
+          </div>
+        )}
+
+        {importedNodeTypes.length > 0 && (
+          <div className="mt-4">
+            <h4 className="mb-2 font-semibold">Imported Node Types</h4>
+            {importedNodeTypes.map((nodeType) => {
+              const index = nodeTypes.indexOf(nodeType);
+              return renderNodeTypeItem(nodeType, index);
+            })}
+          </div>
+        )}
+      </div>
+    );
+  };
 
   const renderEditForm = () => {
     if (!editingNodeType) return null;

--- a/apps/obsidian/src/components/NodeTypeSettings.tsx
+++ b/apps/obsidian/src/components/NodeTypeSettings.tsx
@@ -479,8 +479,9 @@ const NodeTypeSettings = () => {
     return isValid;
   };
 
-  const isEditingImported =
-    getImportInfo(editingNodeType?.importedFromRid).isImported;
+  const isEditingImported = getImportInfo(
+    editingNodeType?.importedFromRid,
+  ).isImported;
 
   const renderField = (fieldConfig: BaseFieldConfig) => {
     if (!editingNodeType) return null;

--- a/apps/obsidian/src/components/NodeTypeSettings.tsx
+++ b/apps/obsidian/src/components/NodeTypeSettings.tsx
@@ -539,8 +539,12 @@ const NodeTypeSettings = () => {
                 <span>{nodeType.name}</span>
               </div>
               {isImported && importInfo.spaceUri && (
-                <span className="text-muted text-xs pl-6">
-                  Imported from: {formatImportSource(importInfo.spaceUri)}
+                <span className="text-muted pl-6 text-xs">
+                  from{" "}
+                  {formatImportSource(
+                    importInfo.spaceUri,
+                    plugin.settings.spaceNames,
+                  )}
                 </span>
               )}
             </div>
@@ -588,21 +592,29 @@ const NodeTypeSettings = () => {
 
         {localNodeTypes.length > 0 && (
           <div className="mt-4">
-            <h4 className="mb-2 font-semibold">Local Node Types</h4>
-            {localNodeTypes.map((nodeType) => {
-              const index = nodeTypes.indexOf(nodeType);
-              return renderNodeTypeItem(nodeType, index);
-            })}
+            <h4 className="text-muted mb-2 text-sm font-semibold uppercase tracking-wide">
+              Local
+            </h4>
+            <div className="flex flex-col gap-0.5">
+              {localNodeTypes.map((nodeType) => {
+                const index = nodeTypes.indexOf(nodeType);
+                return renderNodeTypeItem(nodeType, index);
+              })}
+            </div>
           </div>
         )}
 
         {importedNodeTypes.length > 0 && (
-          <div className="mt-4">
-            <h4 className="mb-2 font-semibold">Imported Node Types</h4>
-            {importedNodeTypes.map((nodeType) => {
-              const index = nodeTypes.indexOf(nodeType);
-              return renderNodeTypeItem(nodeType, index);
-            })}
+          <div className="border-modifier-border mt-6 border-t pt-4">
+            <h4 className="text-muted mb-2 text-sm font-semibold uppercase tracking-wide">
+              Imported
+            </h4>
+            <div className="border-modifier-border flex flex-col gap-0.5 rounded border bg-secondary p-2">
+              {importedNodeTypes.map((nodeType) => {
+                const index = nodeTypes.indexOf(nodeType);
+                return renderNodeTypeItem(nodeType, index);
+              })}
+            </div>
           </div>
         )}
       </div>

--- a/apps/obsidian/src/components/NodeTypeSettings.tsx
+++ b/apps/obsidian/src/components/NodeTypeSettings.tsx
@@ -135,14 +135,17 @@ const FIELD_CONFIG_ARRAY = Object.values(FIELD_CONFIGS);
 const BooleanField = ({
   value,
   onChange,
+  disabled,
 }: {
   value: boolean;
   onChange: (value: boolean) => void;
+  disabled?: boolean;
 }) => (
   <input
     type="checkbox"
     checked={!!value}
     onChange={(e) => onChange((e.target as HTMLInputElement).checked)}
+    disabled={disabled}
   />
 );
 
@@ -152,12 +155,14 @@ const TextField = ({
   error,
   onChange,
   nodeType,
+  disabled,
 }: {
   fieldConfig: BaseFieldConfig;
   value: string;
   error?: string;
   onChange: (value: string) => void;
   nodeType?: DiscourseNode;
+  disabled?: boolean;
 }) => {
   // Generate dynamic placeholder for tag field based on node format and name
   const getPlaceholder = (): string => {
@@ -174,6 +179,7 @@ const TextField = ({
       onChange={(e) => onChange(e.target.value)}
       placeholder={getPlaceholder()}
       className={`w-full ${error ? "input-error" : ""}`}
+      disabled={disabled}
     />
   );
 };
@@ -182,16 +188,19 @@ const ColorField = ({
   value,
   error,
   onChange,
+  disabled,
 }: {
   value: string;
   error?: string;
   onChange: (value: string) => void;
+  disabled?: boolean;
 }) => (
   <input
     type="color"
     value={value || "#000000"}
     onChange={(e) => onChange(e.target.value)}
     className={`h-8 w-20 ${error ? "input-error" : ""}`}
+    disabled={disabled}
   />
 );
 
@@ -201,18 +210,22 @@ const TemplateField = ({
   onChange,
   templateConfig,
   templateFiles,
+  disabled,
 }: {
   value: string;
   error?: string;
   onChange: (value: string) => void;
   templateConfig: { isEnabled: boolean; folderPath: string };
   templateFiles: string[];
+  disabled?: boolean;
 }) => (
   <select
     value={value || ""}
     onChange={(e) => onChange(e.target.value)}
     className={`w-full ${error ? "input-error" : ""}`}
-    disabled={!templateConfig.isEnabled || !templateConfig.folderPath}
+    disabled={
+      disabled || !templateConfig.isEnabled || !templateConfig.folderPath
+    }
   >
     <option value="">
       {!templateConfig.isEnabled || !templateConfig.folderPath
@@ -466,6 +479,9 @@ const NodeTypeSettings = () => {
     return isValid;
   };
 
+  const isEditingImported =
+    getImportInfo(editingNodeType?.importedFromRid).isImported;
+
   const renderField = (fieldConfig: BaseFieldConfig) => {
     if (!editingNodeType) return null;
 
@@ -487,15 +503,21 @@ const NodeTypeSettings = () => {
             onChange={handleChange}
             templateConfig={templateConfig}
             templateFiles={templateFiles}
+            disabled={isEditingImported}
           />
         ) : fieldConfig.type === "color" ? (
           <ColorField
             value={value as string}
             error={error}
             onChange={handleChange}
+            disabled={isEditingImported}
           />
         ) : fieldConfig.type === "boolean" ? (
-          <BooleanField value={value as boolean} onChange={handleChange} />
+          <BooleanField
+            value={value as boolean}
+            onChange={handleChange}
+            disabled={isEditingImported}
+          />
         ) : (
           <TextField
             fieldConfig={fieldConfig}
@@ -503,6 +525,7 @@ const NodeTypeSettings = () => {
             error={error}
             onChange={handleChange}
             nodeType={editingNodeType}
+            disabled={isEditingImported}
           />
         )}
       </FieldWrapper>
@@ -548,34 +571,36 @@ const NodeTypeSettings = () => {
                 </span>
               )}
             </div>
-            <div className="flex gap-2">
-              <button
-                className="icon-button"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  startEditing(index);
-                }}
-                aria-label="Edit node type"
-              >
-                <div
-                  className="icon"
-                  ref={(el) => (el && setIcon(el, "pencil")) || undefined}
-                />
-              </button>
-              <button
-                className="icon-button mod-warning"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  confirmDeleteNodeType(index);
-                }}
-                aria-label="Delete node type"
-              >
-                <div
-                  className="icon"
-                  ref={(el) => (el && setIcon(el, "trash")) || undefined}
-                />
-              </button>
-            </div>
+            {!isImported && (
+              <div className="flex gap-2">
+                <button
+                  className="icon-button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    startEditing(index);
+                  }}
+                  aria-label="Edit node type"
+                >
+                  <div
+                    className="icon"
+                    ref={(el) => (el && setIcon(el, "pencil")) || undefined}
+                  />
+                </button>
+                <button
+                  className="icon-button mod-warning"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    confirmDeleteNodeType(index);
+                  }}
+                  aria-label="Delete node type"
+                >
+                  <div
+                    className="icon"
+                    ref={(el) => (el && setIcon(el, "trash")) || undefined}
+                  />
+                </button>
+              </div>
+            )}
           </div>
           {nodeType.description && (
             <span className="text-muted text-sm">{nodeType.description}</span>
@@ -637,10 +662,12 @@ const NodeTypeSettings = () => {
               ref={(el) => (el && setIcon(el, "arrow-left")) || undefined}
             />
           </button>
-          <h3 className="dg-h3">Edit Node Type</h3>
+          <h3 className="dg-h3">
+            {isEditingImported ? "Node Type (read-only)" : "Edit Node Type"}
+          </h3>
         </div>
         {FIELD_CONFIG_ARRAY.map(renderField)}
-        {hasUnsavedChanges && (
+        {hasUnsavedChanges && !isEditingImported && (
           <div className="mt-4 flex justify-end gap-2">
             <button onClick={handleCancel} className="mod-muted">
               Cancel

--- a/apps/obsidian/src/components/NodeTypeSettings.tsx
+++ b/apps/obsidian/src/components/NodeTypeSettings.tsx
@@ -6,7 +6,11 @@ import generateUid from "~/utils/generateUid";
 import { DiscourseNode } from "~/types";
 import { ConfirmationModal } from "./ConfirmationModal";
 import { getTemplateFiles, getTemplatePluginInfo } from "~/utils/templates";
-import { getImportInfo, formatImportSource } from "~/utils/typeUtils";
+import {
+  getImportInfo,
+  formatImportSource,
+  getAndFormatImportSource,
+} from "~/utils/typeUtils";
 
 const generateTagPlaceholder = (format: string, nodeName?: string): string => {
   if (!format) return "Enter tag (e.g., clm-candidate)";
@@ -566,7 +570,7 @@ const NodeTypeSettings = () => {
                 <span className="text-muted pl-6 text-xs">
                   from{" "}
                   {formatImportSource(
-                    importInfo.spaceUri,
+                    importInfo.spaceUri || "",
                     plugin.settings.spaceNames,
                   )}
                 </span>
@@ -618,9 +622,11 @@ const NodeTypeSettings = () => {
 
         {localNodeTypes.length > 0 && (
           <div className="mt-4">
-            <h4 className="text-muted mb-2 text-sm font-semibold uppercase tracking-wide">
-              Local
-            </h4>
+            {importedNodeTypes.length > 0 && (
+              <h4 className="text-muted mb-2 text-sm font-semibold uppercase tracking-wide">
+                Local
+              </h4>
+            )}
             <div className="flex flex-col gap-0.5">
               {localNodeTypes.map((nodeType) => {
                 const index = nodeTypes.indexOf(nodeType);
@@ -664,7 +670,9 @@ const NodeTypeSettings = () => {
             />
           </button>
           <h3 className="dg-h3">
-            {isEditingImported ? "Node Type (read-only)" : "Edit Node Type"}
+            {isEditingImported
+              ? `[Read only] Imported from ${getAndFormatImportSource(editingNodeType.importedFromRid || "", plugin.settings.spaceNames)}`
+              : "Edit Node Type"}
           </h3>
         </div>
         {FIELD_CONFIG_ARRAY.map(renderField)}

--- a/apps/obsidian/src/components/RelationshipSettings.tsx
+++ b/apps/obsidian/src/components/RelationshipSettings.tsx
@@ -155,7 +155,7 @@ const RelationshipSettings = () => {
             <select
               value={relation.sourceId}
               onChange={(e) =>
-                handleRelationChange(index, "sourceId", e.target.value)
+                void handleRelationChange(index, "sourceId", e.target.value)
               }
               className="flex-1 pl-2"
               disabled={isImported}
@@ -171,7 +171,7 @@ const RelationshipSettings = () => {
             <select
               value={relation.relationshipTypeId}
               onChange={(e) =>
-                handleRelationChange(
+                void handleRelationChange(
                   index,
                   "relationshipTypeId",
                   e.target.value,
@@ -191,7 +191,11 @@ const RelationshipSettings = () => {
             <select
               value={relation.destinationId}
               onChange={(e) =>
-                handleRelationChange(index, "destinationId", e.target.value)
+                void handleRelationChange(
+                  index,
+                  "destinationId",
+                  e.target.value,
+                )
               }
               className="flex-1 pl-2"
               disabled={isImported}

--- a/apps/obsidian/src/components/RelationshipSettings.tsx
+++ b/apps/obsidian/src/components/RelationshipSettings.tsx
@@ -3,7 +3,11 @@ import { DiscourseRelation, DiscourseRelationType } from "~/types";
 import { Notice } from "obsidian";
 import { usePlugin } from "./PluginContext";
 import { ConfirmationModal } from "./ConfirmationModal";
-import { getNodeTypeById } from "~/utils/typeUtils";
+import {
+  getNodeTypeById,
+  getImportInfo,
+  formatImportSource,
+} from "~/utils/typeUtils";
 import generateUid from "~/utils/generateUid";
 
 const RelationshipSettings = () => {
@@ -133,6 +137,87 @@ const RelationshipSettings = () => {
     setHasUnsavedChanges(false);
   };
 
+  const localRelations = discourseRelations.filter(
+    (relation) => !relation.importedFromRid,
+  );
+  const importedRelations = discourseRelations.filter(
+    (relation) => relation.importedFromRid,
+  );
+
+  const renderRelationItem = (relation: DiscourseRelation, index: number) => {
+    const importInfo = getImportInfo(relation.importedFromRid);
+    const isImported = importInfo.isImported;
+
+    return (
+      <div key={index} className="setting-item">
+        <div className="flex w-full flex-col gap-1">
+          <div className="flex gap-2">
+            <select
+              value={relation.sourceId}
+              onChange={(e) =>
+                handleRelationChange(index, "sourceId", e.target.value)
+              }
+              className="flex-1 pl-2"
+            >
+              <option value="">Source Node Type</option>
+              {plugin.settings.nodeTypes.map((nodeType) => (
+                <option key={nodeType.id} value={nodeType.id}>
+                  {nodeType.name}
+                </option>
+              ))}
+            </select>
+
+            <select
+              value={relation.relationshipTypeId}
+              onChange={(e) =>
+                handleRelationChange(
+                  index,
+                  "relationshipTypeId",
+                  e.target.value,
+                )
+              }
+              className="flex-1 pl-2"
+            >
+              <option value="">Relation Type</option>
+              {plugin.settings.relationTypes.map((relType) => (
+                <option key={relType.id} value={relType.id}>
+                  {relType.label} / {relType.complement}
+                </option>
+              ))}
+            </select>
+
+            <select
+              value={relation.destinationId}
+              onChange={(e) =>
+                handleRelationChange(index, "destinationId", e.target.value)
+              }
+              className="flex-1 pl-2"
+            >
+              <option value="">Target Node Type</option>
+              {plugin.settings.nodeTypes.map((nodeType) => (
+                <option key={nodeType.id} value={nodeType.id}>
+                  {nodeType.name}
+                </option>
+              ))}
+            </select>
+
+            <button
+              onClick={() => confirmDeleteRelation(index)}
+              className="mod-warning p-2"
+            >
+              Delete
+            </button>
+          </div>
+          {isImported && importInfo.spaceUri && (
+            <span className="text-muted text-xs">
+              Imported from: {formatImportSource(importInfo.spaceUri)}
+            </span>
+          )}
+        </div>
+      </div>
+    );
+  };
+
   return (
     <div className="discourse-relations">
       {plugin.settings.nodeTypes.length === 0 ? (
@@ -141,74 +226,29 @@ const RelationshipSettings = () => {
         <div>You need to create some relation types first.</div>
       ) : (
         <>
-          {discourseRelations.map((relation, index) => (
-            <div key={index} className="setting-item">
-              <div className="flex w-full flex-col">
-                <div className="flex gap-2">
-                  <select
-                    value={relation.sourceId}
-                    onChange={(e) =>
-                      handleRelationChange(index, "sourceId", e.target.value)
-                    }
-                    className="flex-1 pl-2"
-                  >
-                    <option value="">Source Node Type</option>
-                    {plugin.settings.nodeTypes.map((nodeType) => (
-                      <option key={nodeType.id} value={nodeType.id}>
-                        {nodeType.name}
-                      </option>
-                    ))}
-                  </select>
-
-                  <select
-                    value={relation.relationshipTypeId}
-                    onChange={(e) =>
-                      handleRelationChange(
-                        index,
-                        "relationshipTypeId",
-                        e.target.value,
-                      )
-                    }
-                    className="flex-1 pl-2"
-                  >
-                    <option value="">Relation Type</option>
-                    {plugin.settings.relationTypes.map((relType) => (
-                      <option key={relType.id} value={relType.id}>
-                        {relType.label} / {relType.complement}
-                      </option>
-                    ))}
-                  </select>
-
-                  <select
-                    value={relation.destinationId}
-                    onChange={(e) =>
-                      handleRelationChange(
-                        index,
-                        "destinationId",
-                        e.target.value,
-                      )
-                    }
-                    className="flex-1 pl-2"
-                  >
-                    <option value="">Target Node Type</option>
-                    {plugin.settings.nodeTypes.map((nodeType) => (
-                      <option key={nodeType.id} value={nodeType.id}>
-                        {nodeType.name}
-                      </option>
-                    ))}
-                  </select>
-
-                  <button
-                    onClick={() => confirmDeleteRelation(index)}
-                    className="mod-warning p-2"
-                  >
-                    Delete
-                  </button>
-                </div>
-              </div>
+          {localRelations.length > 0 && (
+            <div>
+              <h4 className="mb-2 font-semibold">Local Discourse Relations</h4>
+              {localRelations.map((relation) => {
+                const index = discourseRelations.indexOf(relation);
+                return renderRelationItem(relation, index);
+              })}
             </div>
-          ))}
-          <div className="setting-item">
+          )}
+
+          {importedRelations.length > 0 && (
+            <div className="mt-4">
+              <h4 className="mb-2 font-semibold">
+                Imported Discourse Relations
+              </h4>
+              {importedRelations.map((relation) => {
+                const index = discourseRelations.indexOf(relation);
+                return renderRelationItem(relation, index);
+              })}
+            </div>
+          )}
+
+          <div className="setting-item mt-4">
             <div className="flex gap-2">
               <button onClick={handleAddRelation} className="p-2">
                 Add Relation

--- a/apps/obsidian/src/components/RelationshipSettings.tsx
+++ b/apps/obsidian/src/components/RelationshipSettings.tsx
@@ -208,10 +208,12 @@ const RelationshipSettings = () => {
               Delete
             </button>
           </div>
-          {isImported && importInfo.spaceUri && (
-            <span className="text-muted text-xs">
-              Imported from: {formatImportSource(importInfo.spaceUri)}
-            </span>
+          {isImported && (
+            <div className="flex items-center gap-2 text-xs text-muted">
+              {importInfo.spaceUri && (
+                <span>from {formatImportSource(importInfo.spaceUri, plugin.settings.spaceNames)}</span>
+              )}
+            </div>
           )}
         </div>
       </div>
@@ -228,7 +230,9 @@ const RelationshipSettings = () => {
         <>
           {localRelations.length > 0 && (
             <div>
-              <h4 className="mb-2 font-semibold">Local Discourse Relations</h4>
+              <h4 className="mb-2 text-sm font-semibold uppercase tracking-wide text-muted">
+                Local
+              </h4>
               {localRelations.map((relation) => {
                 const index = discourseRelations.indexOf(relation);
                 return renderRelationItem(relation, index);
@@ -237,14 +241,16 @@ const RelationshipSettings = () => {
           )}
 
           {importedRelations.length > 0 && (
-            <div className="mt-4">
-              <h4 className="mb-2 font-semibold">
-                Imported Discourse Relations
+            <div className="mt-6 border-t border-modifier-border pt-4">
+              <h4 className="mb-2 text-sm font-semibold uppercase tracking-wide text-muted">
+                Imported
               </h4>
-              {importedRelations.map((relation) => {
-                const index = discourseRelations.indexOf(relation);
-                return renderRelationItem(relation, index);
-              })}
+              <div className="rounded border border-modifier-border bg-secondary p-2">
+                {importedRelations.map((relation) => {
+                  const index = discourseRelations.indexOf(relation);
+                  return renderRelationItem(relation, index);
+                })}
+              </div>
             </div>
           )}
 

--- a/apps/obsidian/src/components/RelationshipSettings.tsx
+++ b/apps/obsidian/src/components/RelationshipSettings.tsx
@@ -158,6 +158,7 @@ const RelationshipSettings = () => {
                 handleRelationChange(index, "sourceId", e.target.value)
               }
               className="flex-1 pl-2"
+              disabled={isImported}
             >
               <option value="">Source Node Type</option>
               {plugin.settings.nodeTypes.map((nodeType) => (
@@ -177,6 +178,7 @@ const RelationshipSettings = () => {
                 )
               }
               className="flex-1 pl-2"
+              disabled={isImported}
             >
               <option value="">Relation Type</option>
               {plugin.settings.relationTypes.map((relType) => (
@@ -192,6 +194,7 @@ const RelationshipSettings = () => {
                 handleRelationChange(index, "destinationId", e.target.value)
               }
               className="flex-1 pl-2"
+              disabled={isImported}
             >
               <option value="">Target Node Type</option>
               {plugin.settings.nodeTypes.map((nodeType) => (
@@ -201,12 +204,14 @@ const RelationshipSettings = () => {
               ))}
             </select>
 
-            <button
-              onClick={() => confirmDeleteRelation(index)}
-              className="mod-warning p-2"
-            >
-              Delete
-            </button>
+            {!isImported && (
+              <button
+                onClick={() => confirmDeleteRelation(index)}
+                className="mod-warning p-2"
+              >
+                Delete
+              </button>
+            )}
           </div>
           {isImported && (
             <div className="text-muted flex items-center gap-2 text-xs">

--- a/apps/obsidian/src/components/RelationshipSettings.tsx
+++ b/apps/obsidian/src/components/RelationshipSettings.tsx
@@ -209,9 +209,15 @@ const RelationshipSettings = () => {
             </button>
           </div>
           {isImported && (
-            <div className="flex items-center gap-2 text-xs text-muted">
+            <div className="text-muted flex items-center gap-2 text-xs">
               {importInfo.spaceUri && (
-                <span>from {formatImportSource(importInfo.spaceUri, plugin.settings.spaceNames)}</span>
+                <span>
+                  from{" "}
+                  {formatImportSource(
+                    importInfo.spaceUri,
+                    plugin.settings.spaceNames,
+                  )}
+                </span>
               )}
             </div>
           )}
@@ -230,7 +236,7 @@ const RelationshipSettings = () => {
         <>
           {localRelations.length > 0 && (
             <div>
-              <h4 className="mb-2 text-sm font-semibold uppercase tracking-wide text-muted">
+              <h4 className="text-muted mb-2 text-sm font-semibold uppercase tracking-wide">
                 Local
               </h4>
               {localRelations.map((relation) => {
@@ -241,11 +247,11 @@ const RelationshipSettings = () => {
           )}
 
           {importedRelations.length > 0 && (
-            <div className="mt-6 border-t border-modifier-border pt-4">
-              <h4 className="mb-2 text-sm font-semibold uppercase tracking-wide text-muted">
+            <div className="border-modifier-border mt-6 border-t pt-4">
+              <h4 className="text-muted mb-2 text-sm font-semibold uppercase tracking-wide">
                 Imported
               </h4>
-              <div className="rounded border border-modifier-border bg-secondary p-2">
+              <div className="border-modifier-border rounded border bg-secondary p-2">
                 {importedRelations.map((relation) => {
                   const index = discourseRelations.indexOf(relation);
                   return renderRelationItem(relation, index);

--- a/apps/obsidian/src/components/RelationshipTypeSettings.tsx
+++ b/apps/obsidian/src/components/RelationshipTypeSettings.tsx
@@ -17,9 +17,10 @@ import { getImportInfo, formatImportSource } from "~/utils/typeUtils";
 type ColorPickerProps = {
   value: string;
   onChange: (color: TldrawColorName) => void;
+  disabled?: boolean;
 };
 
-const ColorPicker = ({ value, onChange }: ColorPickerProps) => {
+const ColorPicker = ({ value, onChange, disabled }: ColorPickerProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
@@ -49,9 +50,10 @@ const ColorPicker = ({ value, onChange }: ColorPickerProps) => {
     <div ref={dropdownRef} className="relative min-w-32">
       <button
         type="button"
-        onClick={() => setIsOpen(!isOpen)}
+        onClick={() => !disabled && setIsOpen(!isOpen)}
         className="flex w-full items-center justify-between rounded border px-3 py-2 text-left"
         style={{ backgroundColor: bgColor, color: textColor }}
+        disabled={disabled}
       >
         <span className="flex items-center gap-2">
           <span
@@ -237,6 +239,7 @@ const RelationshipTypeSettings = () => {
                 handleRelationTypeChange(index, "label", e.target.value)
               }
               className="flex-2"
+              disabled={isImported}
             />
             <input
               type="text"
@@ -246,19 +249,23 @@ const RelationshipTypeSettings = () => {
                 handleRelationTypeChange(index, "complement", e.target.value)
               }
               className="flex-1"
+              disabled={isImported}
             />
             <ColorPicker
               value={relationType.color}
               onChange={(color) =>
                 handleRelationTypeChange(index, "color", color)
               }
+              disabled={isImported}
             />
-            <button
-              onClick={() => confirmDeleteRelationType(index)}
-              className="mod-warning p-2"
-            >
-              Delete
-            </button>
+            {!isImported && (
+              <button
+                onClick={() => confirmDeleteRelationType(index)}
+                className="mod-warning p-2"
+              >
+                Delete
+              </button>
+            )}
           </div>
           {isImported && (
             <div className="text-muted flex items-center gap-2 text-xs">

--- a/apps/obsidian/src/components/RelationshipTypeSettings.tsx
+++ b/apps/obsidian/src/components/RelationshipTypeSettings.tsx
@@ -258,10 +258,18 @@ const RelationshipTypeSettings = () => {
               Delete
             </button>
           </div>
-          {isImported && importInfo.spaceUri && (
-            <span className="text-muted text-xs">
-              Imported from: {formatImportSource(importInfo.spaceUri)}
-            </span>
+          {isImported && (
+            <div className="text-muted flex items-center gap-2 text-xs">
+              {importInfo.spaceUri && (
+                <span>
+                  from{" "}
+                  {formatImportSource(
+                    importInfo.spaceUri,
+                    plugin.settings.spaceNames,
+                  )}
+                </span>
+              )}
+            </div>
           )}
         </div>
       </div>
@@ -272,7 +280,9 @@ const RelationshipTypeSettings = () => {
     <div className="discourse-relation-types">
       {localRelationTypes.length > 0 && (
         <div>
-          <h4 className="mb-2 font-semibold">Local Relation Types</h4>
+          <h4 className="text-muted mb-2 text-sm font-semibold uppercase tracking-wide">
+            Local
+          </h4>
           {localRelationTypes.map((relationType) => {
             const index = relationTypes.indexOf(relationType);
             return renderRelationTypeItem(relationType, index);
@@ -281,12 +291,16 @@ const RelationshipTypeSettings = () => {
       )}
 
       {importedRelationTypes.length > 0 && (
-        <div className="mt-4">
-          <h4 className="mb-2 font-semibold">Imported Relation Types</h4>
-          {importedRelationTypes.map((relationType) => {
-            const index = relationTypes.indexOf(relationType);
-            return renderRelationTypeItem(relationType, index);
-          })}
+        <div className="border-modifier-border mt-6 border-t pt-4">
+          <h4 className="text-muted mb-2 text-sm font-semibold uppercase tracking-wide">
+            Imported
+          </h4>
+          <div className="border-modifier-border rounded border bg-secondary p-2">
+            {importedRelationTypes.map((relationType) => {
+              const index = relationTypes.indexOf(relationType);
+              return renderRelationTypeItem(relationType, index);
+            })}
+          </div>
         </div>
       )}
 

--- a/apps/obsidian/src/components/RelationshipTypeSettings.tsx
+++ b/apps/obsidian/src/components/RelationshipTypeSettings.tsx
@@ -159,7 +159,9 @@ const RelationshipTypeSettings = () => {
     const modal = new ConfirmationModal(plugin.app, {
       title: "Delete Relation Type",
       message: `Are you sure you want to delete the relation type "${relationType.label}"?`,
-      onConfirm: () => handleDeleteRelationType(index),
+      onConfirm: () => {
+        void handleDeleteRelationType(index);
+      },
     });
     modal.open();
   };
@@ -310,7 +312,7 @@ const RelationshipTypeSettings = () => {
             Add Relation Type
           </button>
           <button
-            onClick={handleSave}
+            onClick={() => void handleSave()}
             className={`p-2 ${hasUnsavedChanges ? "mod-cta" : ""}`}
             disabled={!hasUnsavedChanges}
           >

--- a/apps/obsidian/src/components/RelationshipTypeSettings.tsx
+++ b/apps/obsidian/src/components/RelationshipTypeSettings.tsx
@@ -12,6 +12,7 @@ import {
   type TldrawColorName,
 } from "~/utils/tldrawColors";
 import { getContrastColor } from "~/utils/colorUtils";
+import { getImportInfo, formatImportSource } from "~/utils/typeUtils";
 
 type ColorPickerProps = {
   value: string;
@@ -208,47 +209,88 @@ const RelationshipTypeSettings = () => {
     new Notice("Relation types saved.");
   };
 
+  const localRelationTypes = relationTypes.filter(
+    (relationType) => !relationType.importedFromRid,
+  );
+  const importedRelationTypes = relationTypes.filter(
+    (relationType) => relationType.importedFromRid,
+  );
+
+  const renderRelationTypeItem = (
+    relationType: DiscourseRelationType,
+    index: number,
+  ) => {
+    const importInfo = getImportInfo(relationType.importedFromRid);
+    const isImported = importInfo.isImported;
+
+    return (
+      <div key={index} className="setting-item">
+        <div className="flex w-full flex-col gap-1">
+          <div className="flex gap-2">
+            <input
+              type="text"
+              placeholder="Label (e.g., supports)"
+              value={relationType.label}
+              onChange={(e) =>
+                handleRelationTypeChange(index, "label", e.target.value)
+              }
+              className="flex-2"
+            />
+            <input
+              type="text"
+              placeholder="Complement (e.g., is supported by)"
+              value={relationType.complement}
+              onChange={(e) =>
+                handleRelationTypeChange(index, "complement", e.target.value)
+              }
+              className="flex-1"
+            />
+            <ColorPicker
+              value={relationType.color}
+              onChange={(color) =>
+                handleRelationTypeChange(index, "color", color)
+              }
+            />
+            <button
+              onClick={() => confirmDeleteRelationType(index)}
+              className="mod-warning p-2"
+            >
+              Delete
+            </button>
+          </div>
+          {isImported && importInfo.spaceUri && (
+            <span className="text-muted text-xs">
+              Imported from: {formatImportSource(importInfo.spaceUri)}
+            </span>
+          )}
+        </div>
+      </div>
+    );
+  };
+
   return (
     <div className="discourse-relation-types">
-      {relationTypes.map((relationType, index) => (
-        <div key={index} className="setting-item">
-          <div className="flex w-full flex-col">
-            <div className="flex gap-2">
-              <input
-                type="text"
-                placeholder="Label (e.g., supports)"
-                value={relationType.label}
-                onChange={(e) =>
-                  handleRelationTypeChange(index, "label", e.target.value)
-                }
-                className="flex-2"
-              />
-              <input
-                type="text"
-                placeholder="Complement (e.g., is supported by)"
-                value={relationType.complement}
-                onChange={(e) =>
-                  handleRelationTypeChange(index, "complement", e.target.value)
-                }
-                className="flex-1"
-              />
-              <ColorPicker
-                value={relationType.color}
-                onChange={(color) =>
-                  handleRelationTypeChange(index, "color", color)
-                }
-              />
-              <button
-                onClick={() => confirmDeleteRelationType(index)}
-                className="mod-warning p-2"
-              >
-                Delete
-              </button>
-            </div>
-          </div>
+      {localRelationTypes.length > 0 && (
+        <div>
+          <h4 className="mb-2 font-semibold">Local Relation Types</h4>
+          {localRelationTypes.map((relationType) => {
+            const index = relationTypes.indexOf(relationType);
+            return renderRelationTypeItem(relationType, index);
+          })}
         </div>
-      ))}
-      <div className="setting-item">
+      )}
+
+      {importedRelationTypes.length > 0 && (
+        <div className="mt-4">
+          <h4 className="mb-2 font-semibold">Imported Relation Types</h4>
+          {importedRelationTypes.map((relationType) => {
+            const index = relationTypes.indexOf(relationType);
+            return renderRelationTypeItem(relationType, index);
+          })}
+        </div>
+      )}
+
+      <div className="setting-item mt-4">
         <div className="flex gap-2">
           <button onClick={handleAddRelationType} className="p-2">
             Add Relation Type

--- a/apps/obsidian/src/constants.ts
+++ b/apps/obsidian/src/constants.ts
@@ -121,6 +121,7 @@ export const DEFAULT_SETTINGS: Settings = {
   spacePassword: undefined,
   accountLocalId: undefined,
   syncModeEnabled: false,
+  spaceNames: {},
 };
 
 export const FEATURE_FLAGS = {

--- a/apps/obsidian/src/types.ts
+++ b/apps/obsidian/src/types.ts
@@ -60,6 +60,8 @@ export type Settings = {
   spacePassword?: string;
   accountLocalId?: string;
   syncModeEnabled?: boolean;
+  /** Maps spaceUri (e.g. "obsidian:abc123") to human-readable name (e.g. "My Vault") */
+  spaceNames?: Record<string, string>;
 };
 
 export type BulkImportCandidate = {

--- a/apps/obsidian/src/utils/importNodes.ts
+++ b/apps/obsidian/src/utils/importNodes.ts
@@ -1182,6 +1182,12 @@ export const importSelectedNodes = async ({
       continue;
     }
 
+    if (!plugin.settings.spaceNames) plugin.settings.spaceNames = {};
+    if (!plugin.settings.spaceNames[spaceUri]) {
+      plugin.settings.spaceNames[spaceUri] = spaceName;
+      await plugin.saveSettings();
+    }
+
     // Ensure the import folder exists
     const folderExists =
       await plugin.app.vault.adapter.exists(importFolderPath);

--- a/apps/obsidian/src/utils/importNodes.ts
+++ b/apps/obsidian/src/utils/importNodes.ts
@@ -1182,12 +1182,6 @@ export const importSelectedNodes = async ({
       continue;
     }
 
-    if (!plugin.settings.spaceNames) plugin.settings.spaceNames = {};
-    if (!plugin.settings.spaceNames[spaceUri]) {
-      plugin.settings.spaceNames[spaceUri] = spaceName;
-      await plugin.saveSettings();
-    }
-
     // Ensure the import folder exists
     const folderExists =
       await plugin.app.vault.adapter.exists(importFolderPath);

--- a/apps/obsidian/src/utils/typeUtils.ts
+++ b/apps/obsidian/src/utils/typeUtils.ts
@@ -70,3 +70,11 @@ export const formatImportSource = (
 
   return spaceUri;
 };
+
+export const getAndFormatImportSource = (
+  importedFromRid: string | undefined,
+  spaceNames?: Record<string, string>,
+): string => {
+  const importInfo = getImportInfo(importedFromRid);
+  return formatImportSource(importInfo.spaceUri || "", spaceNames);
+};

--- a/apps/obsidian/src/utils/typeUtils.ts
+++ b/apps/obsidian/src/utils/typeUtils.ts
@@ -1,5 +1,6 @@
 import type DiscourseGraphPlugin from "~/index";
 import { DiscourseNode, DiscourseRelationType } from "~/types";
+import { ridToSpaceUriAndLocalId } from "./rid";
 
 export const getNodeTypeById = (
   plugin: DiscourseGraphPlugin,
@@ -15,4 +16,48 @@ export const getRelationTypeById = (
   return plugin.settings.relationTypes.find(
     (relation) => relation.id === relationTypeId,
   );
+};
+
+export type ImportInfo = {
+  isImported: boolean;
+  spaceUri?: string;
+  sourceLocalId?: string;
+};
+
+export const getImportInfo = (
+  importedFromRid: string | undefined,
+): ImportInfo => {
+  if (!importedFromRid) {
+    return { isImported: false };
+  }
+
+  try {
+    const { spaceUri, sourceLocalId } = ridToSpaceUriAndLocalId(importedFromRid);
+    return {
+      isImported: true,
+      spaceUri,
+      sourceLocalId,
+    };
+  } catch (error) {
+    console.error("Error parsing importedFromRid:", error);
+    return { isImported: false };
+  }
+};
+
+export const formatImportSource = (spaceUri: string): string => {
+  if (spaceUri.startsWith("obsidian:")) {
+    const vaultId = spaceUri.replace("obsidian:", "");
+    return `Vault ID: ${vaultId}`;
+  }
+  
+  if (spaceUri.startsWith("http")) {
+    return spaceUri;
+  }
+  
+  const parts = spaceUri.split(":");
+  if (parts.length === 2) {
+    return `${parts[0]}: ${parts[1]}`;
+  }
+  
+  return spaceUri;
 };

--- a/apps/obsidian/src/utils/typeUtils.ts
+++ b/apps/obsidian/src/utils/typeUtils.ts
@@ -32,7 +32,8 @@ export const getImportInfo = (
   }
 
   try {
-    const { spaceUri, sourceLocalId } = ridToSpaceUriAndLocalId(importedFromRid);
+    const { spaceUri, sourceLocalId } =
+      ridToSpaceUriAndLocalId(importedFromRid);
     return {
       isImported: true,
       spaceUri,
@@ -44,20 +45,28 @@ export const getImportInfo = (
   }
 };
 
-export const formatImportSource = (spaceUri: string): string => {
+export const formatImportSource = (
+  spaceUri: string,
+  spaceNames?: Record<string, string>,
+): string => {
+  const knownName = spaceNames?.[spaceUri];
+  if (knownName) {
+    return knownName;
+  }
+
   if (spaceUri.startsWith("obsidian:")) {
     const vaultId = spaceUri.replace("obsidian:", "");
-    return `Vault ID: ${vaultId}`;
+    return `Vault ${vaultId.slice(0, 8)}...`;
   }
-  
+
   if (spaceUri.startsWith("http")) {
     return spaceUri;
   }
-  
+
   const parts = spaceUri.split(":");
   if (parts.length === 2) {
     return `${parts[0]}: ${parts[1]}`;
   }
-  
+
   return spaceUri;
 };


### PR DESCRIPTION

<img width="1177" height="930" alt="image" src="https://github.com/user-attachments/assets/54cdc7bd-68fa-450f-b26a-65ed7e43381d" />

<img width="801" height="689" alt="Screenshot 2026-03-04 at 20 17 51" src="https://github.com/user-attachments/assets/faf5371b-ea3d-48bf-893c-0f5e88de4a5c" />
<img width="824" height="794" alt="Screenshot 2026-03-04 at 20 17 58" src="https://github.com/user-attachments/assets/9edd739a-3497-4e28-9cc3-1ab7323e654c" />

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Separate imported types from local types in the Obsidian settings to clearly distinguish their origin.

---
Linear Issue: [ENG-1515](https://linear.app/discourse-graphs/issue/ENG-1515/separate-imported-types-in-settings-from-local-types)

<p><a href="https://cursor.com/agents/bc-ce01226e-247f-4a20-bdc0-d9ea9b564ef2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ce01226e-247f-4a20-bdc0-d9ea9b564ef2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/857" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
