### PR TITLE
ENG-134 Query Builder - quotations in titles break {current} and {this page}

### DIFF
--- a/apps/roam/src/utils/conditionToDatalog.ts
+++ b/apps/roam/src/utils/conditionToDatalog.ts
@@ -82,7 +82,7 @@ export const getTitleDatalog = ({
           { type: "constant", value: ":node/title" },
           {
             type: "constant",
-            value: `"${getPageTitleByPageUid(mainWindowUid)}"`,
+            value: `"${normalizePageTitle(getPageTitleByPageUid(mainWindowUid))}"`,
           },
         ],
       },
@@ -98,7 +98,7 @@ export const getTitleDatalog = ({
           { type: "constant", value: ":node/title" },
           {
             type: "constant",
-            value: `"${getPageTitleByBlockUid(uid)}"`,
+            value: `"${normalizePageTitle(getPageTitleByBlockUid(uid))}"`,
           },
         ],
       },
@@ -112,7 +112,10 @@ export const getTitleDatalog = ({
         arguments: [
           { type: "variable", value: source },
           { type: "constant", value: ":node/title" },
-          { type: "constant", value: `"${getCurrentUserDisplayName()}"` },
+          {
+            type: "constant",
+            value: `"${normalizePageTitle(getCurrentUserDisplayName())}"`,
+          },
         ],
       },
     ];
@@ -159,7 +162,10 @@ export const getTitleDatalog = ({
         arguments: [
           { type: "variable", value: source },
           { type: "constant", value: ":node/title" },
-          { type: "variable", value: target.replace(INPUT_REGEX, "") },
+          {
+            type: "variable",
+            value: normalizePageTitle(target.replace(INPUT_REGEX, "")),
+          },
         ],
       },
     ];
@@ -308,7 +314,7 @@ const translator: Record<string, Translator> = {
               { type: "variable", value: `${source}-Title` },
               {
                 type: "constant",
-                value: `"${getPageTitleByPageUid(uid)}"`,
+                value: `"${normalizePageTitle(getPageTitleByPageUid(uid))}"`,
               },
             ],
           },
@@ -337,7 +343,7 @@ const translator: Record<string, Translator> = {
         arguments: [
           { type: "variable", value: `${target}-Attribute` },
           { type: "constant", value: ":node/title" },
-          { type: "constant", value: `"${target}"` },
+          { type: "constant", value: `"normalizePageTitle(${target})"` },
         ],
       },
       {
@@ -448,7 +454,10 @@ const translator: Record<string, Translator> = {
             pred: "clojure.string/includes?",
             arguments: [
               { type: "variable", value: `${source}-String` },
-              { type: "constant", value: `"${getCurrentUserDisplayName()}"` },
+              {
+                type: "constant",
+                value: `"${normalizePageTitle(getCurrentUserDisplayName())}"`,
+              },
             ],
           },
         ];

--- a/apps/roam/src/utils/conditionToDatalog.ts
+++ b/apps/roam/src/utils/conditionToDatalog.ts
@@ -164,7 +164,7 @@ export const getTitleDatalog = ({
           { type: "constant", value: ":node/title" },
           {
             type: "variable",
-            value: normalizePageTitle(target.replace(INPUT_REGEX, "")),
+            value: target.replace(INPUT_REGEX, ""),
           },
         ],
       },
@@ -343,7 +343,7 @@ const translator: Record<string, Translator> = {
         arguments: [
           { type: "variable", value: `${target}-Attribute` },
           { type: "constant", value: ":node/title" },
-          { type: "constant", value: `"normalizePageTitle(${target})"` },
+          { type: "constant", value: `"${normalizePageTitle(target)}"` },
         ],
       },
       {


### PR DESCRIPTION
https://linear.app/discourse-graphs/issue/ENG-134/query-builder-quotations-in-titles-break-current-and-this-page

https://www.loom.com/share/a7ff0a5385464a3faa127ee5189993d6

Applied normalizePageTitle to more cases; including, in one case, username.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/858" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
