### PR TITLE
ENG-1503: Replace getFormattedConfigTree consumers with direct helper calls

### DIFF
--- a/apps/roam/src/components/LeftSidebarView.tsx
+++ b/apps/roam/src/components/LeftSidebarView.tsx
@@ -360,10 +360,10 @@ const buildConfig = (): LeftSidebarConfig => {
 
 export const useConfig = () => {
 
-  const [config, setConfig] = useState(() => getCurrentLeftSidebarConfig());
+  const [config, setConfig] = useState(() => buildConfig());
   useEffect(() => {
     const handleUpdate = () => {
-      setConfig(getCurrentLeftSidebarConfig());
+      setConfig(buildConfig());
     };
     const unsubGlobal = onSettingChange(
       settingKeys.globalLeftSidebar,

--- a/apps/roam/src/components/LeftSidebarView.tsx
+++ b/apps/roam/src/components/LeftSidebarView.tsx
@@ -31,9 +31,7 @@ import {
   mergeGlobalSectionWithAccessor,
   mergePersonalSectionsWithAccessor,
 } from "~/utils/getLeftSidebarSettings";
-import discourseConfigRef, {
-  notify,
-} from "~/utils/discourseConfigRef";
+import discourseConfigRef, { notify } from "~/utils/discourseConfigRef";
 import { getLeftSidebarSettings } from "~/utils/getLeftSidebarSettings";
 import {
   getGlobalSetting,
@@ -359,7 +357,6 @@ const buildConfig = (): LeftSidebarConfig => {
 };
 
 export const useConfig = () => {
-
   const [config, setConfig] = useState(() => buildConfig());
   useEffect(() => {
     const handleUpdate = () => {

--- a/apps/roam/src/components/LeftSidebarView.tsx
+++ b/apps/roam/src/components/LeftSidebarView.tsx
@@ -21,7 +21,6 @@ import {
 import getPageUidByPageTitle from "roamjs-components/queries/getPageUidByPageTitle";
 import openBlockInSidebar from "roamjs-components/writes/openBlockInSidebar";
 import extractRef from "roamjs-components/util/extractRef";
-import { getFormattedConfigTree, notify } from "~/utils/discourseConfigRef";
 import {
   onSettingChange,
   settingKeys,
@@ -32,6 +31,10 @@ import {
   mergeGlobalSectionWithAccessor,
   mergePersonalSectionsWithAccessor,
 } from "~/utils/getLeftSidebarSettings";
+import discourseConfigRef, {
+  notify,
+} from "~/utils/discourseConfigRef";
+import { getLeftSidebarSettings } from "~/utils/getLeftSidebarSettings";
 import {
   getGlobalSetting,
   getPersonalSetting,
@@ -61,6 +64,9 @@ import { DISCOURSE_CONFIG_PAGE_TITLE } from "~/utils/renderNodeConfigPage";
 import getPageTitleByPageUid from "roamjs-components/queries/getPageTitleByPageUid";
 import { migrateLeftSidebarSettings } from "~/utils/migrateLeftSidebarSettings";
 import posthog from "posthog-js";
+
+const getCurrentLeftSidebarConfig = (): LeftSidebarConfig =>
+  getLeftSidebarSettings(discourseConfigRef.tree);
 
 const parseReference = (text: string) => {
   const extracted = extractRef(text);
@@ -334,7 +340,7 @@ const buildConfig = (): LeftSidebarConfig => {
   ]);
 
   // Read UIDs from old system (needed for fold CRUD during dual-write)
-  const oldConfig = getFormattedConfigTree().leftSidebar;
+  const oldConfig = getCurrentLeftSidebarConfig();
 
   return {
     uid: oldConfig.uid,
@@ -353,11 +359,11 @@ const buildConfig = (): LeftSidebarConfig => {
 };
 
 export const useConfig = () => {
-  const [config, setConfig] = useState(() => buildConfig());
+
+  const [config, setConfig] = useState(() => getCurrentLeftSidebarConfig());
   useEffect(() => {
     const handleUpdate = () => {
-      refreshConfigTree();
-      setConfig(buildConfig());
+      setConfig(getCurrentLeftSidebarConfig());
     };
     const unsubGlobal = onSettingChange(
       settingKeys.globalLeftSidebar,
@@ -506,7 +512,7 @@ const LeftSidebarView = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
 };
 
 const migrateFavorites = async () => {
-  const config = getFormattedConfigTree().leftSidebar;
+  const config = getCurrentLeftSidebarConfig();
 
   if (config.favoritesMigrated.value) return;
 

--- a/apps/roam/src/components/settings/AdminPanel.tsx
+++ b/apps/roam/src/components/settings/AdminPanel.tsx
@@ -36,13 +36,16 @@ import { countReifiedRelations } from "~/utils/createReifiedBlock";
 import type { DGSupabaseClient } from "@repo/database/lib/client";
 import internalError from "~/utils/internalError";
 import SuggestiveModeSettings from "./SuggestiveModeSettings";
-import { getFormattedConfigTree } from "~/utils/discourseConfigRef";
+import discourseConfigRef from "~/utils/discourseConfigRef";
 import refreshConfigTree from "~/utils/refreshConfigTree";
 import createBlock from "roamjs-components/writes/createBlock";
 import deleteBlock from "roamjs-components/writes/deleteBlock";
 import { USE_REIFIED_RELATIONS } from "~/data/userSettings";
 import posthog from "posthog-js";
 import { FeatureFlagPanel } from "./components/BlockPropSettingPanels";
+import getPageUidByPageTitle from "roamjs-components/queries/getPageUidByPageTitle";
+import { getUidAndBooleanSetting } from "~/utils/getExportSettings";
+import { DISCOURSE_CONFIG_PAGE_TITLE } from "~/data/constants";
 
 const NodeRow = ({ node }: { node: PConceptFull }) => {
   return (
@@ -354,16 +357,22 @@ const FeatureFlagsTab = (): React.ReactElement => {
   const [useReifiedRelations, setUseReifiedRelations] = useState<boolean>(
     getFeatureFlag("Reified relation triples"),
   );
-  const settings = useMemo(() => {
+  const legacySuggestiveModeMeta = useMemo(() => {
     refreshConfigTree();
-    return getFormattedConfigTree();
+    return {
+      settingsUid: getPageUidByPageTitle(DISCOURSE_CONFIG_PAGE_TITLE),
+      suggestiveModeEnabledUid: getUidAndBooleanSetting({
+        tree: discourseConfigRef.tree,
+        text: "(BETA) Suggestive Mode Enabled",
+      }).uid,
+    };
   }, []);
 
   const [suggestiveModeEnabled, setSuggestiveModeEnabled] = useState(
     getFeatureFlag("Suggestive mode enabled"),
   );
   const [suggestiveModeUid, setSuggestiveModeUid] = useState(
-    settings.suggestiveModeEnabled.uid,
+    legacySuggestiveModeMeta.suggestiveModeEnabledUid,
   );
   const [isAlertOpen, setIsAlertOpen] = useState(false);
   const [isInstructionOpen, setIsInstructionOpen] = useState(false);
@@ -400,7 +409,7 @@ const FeatureFlagsTab = (): React.ReactElement => {
         isOpen={isAlertOpen}
         onConfirm={() => {
           void createBlock({
-            parentUid: settings.settingsUid,
+            parentUid: legacySuggestiveModeMeta.settingsUid,
             node: { text: "(BETA) Suggestive Mode Enabled" },
           }).then((uid) => {
             setSuggestiveModeUid(uid);

--- a/apps/roam/src/components/settings/ExportSettings.tsx
+++ b/apps/roam/src/components/settings/ExportSettings.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { getFormattedConfigTree } from "~/utils/discourseConfigRef";
+import { getExportSettingsAndUids } from "~/utils/getExportSettings";
 import {
   GlobalFlagPanel,
   GlobalNumberPanel,
@@ -12,9 +12,8 @@ import {
 } from "~/components/settings/utils/settingKeys";
 
 const DiscourseGraphExport = () => {
-  const settings = getFormattedConfigTree();
-  const exportSettings = settings.export;
-  const parentUid = settings.export.exportUid;
+  const exportSettings = getExportSettingsAndUids();
+  const parentUid = exportSettings.exportUid;
   return (
     <div className="flex flex-col gap-4 p-1">
       {/* TODO: Titles kept as lowercase to match legacy readers in getExportSettings.ts.

--- a/apps/roam/src/components/settings/GeneralSettings.tsx
+++ b/apps/roam/src/components/settings/GeneralSettings.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from "react";
-import { getFormattedConfigTree } from "~/utils/discourseConfigRef";
+import discourseConfigRef from "~/utils/discourseConfigRef";
 import refreshConfigTree from "~/utils/refreshConfigTree";
 import { Alert, Intent } from "@blueprintjs/core";
 import {
@@ -9,11 +9,29 @@ import {
 import { GLOBAL_KEYS } from "~/components/settings/utils/settingKeys";
 import { isNewSettingsStoreEnabled } from "./utils/accessors";
 import posthog from "posthog-js";
+import getPageUidByPageTitle from "roamjs-components/queries/getPageUidByPageTitle";
+import {
+  getUidAndBooleanSetting,
+  getUidAndStringSetting,
+} from "~/utils/getExportSettings";
+import { DISCOURSE_CONFIG_PAGE_TITLE } from "~/data/constants";
 
 const DiscourseGraphHome = () => {
   const settings = useMemo(() => {
     refreshConfigTree();
-    return getFormattedConfigTree();
+    const tree = discourseConfigRef.tree;
+    return {
+      settingsUid: getPageUidByPageTitle(DISCOURSE_CONFIG_PAGE_TITLE),
+      triggerUid: getUidAndStringSetting({ tree, text: "trigger" }).uid,
+      canvasPageFormatUid: getUidAndStringSetting({
+        tree,
+        text: "Canvas Page Format",
+      }).uid,
+      leftSidebarEnabledUid: getUidAndBooleanSetting({
+        tree,
+        text: "(BETA) Left Sidebar",
+      }).uid,
+    };
   }, []);
 
   const [isAlertOpen, setIsAlertOpen] = useState(false);
@@ -26,7 +44,7 @@ const DiscourseGraphHome = () => {
         description="The trigger to create the node menu."
         settingKeys={[GLOBAL_KEYS.trigger]}
         order={0}
-        uid={settings.trigger.uid}
+        uid={settings.triggerUid}
         parentUid={settings.settingsUid}
       />
       <GlobalTextPanel
@@ -34,7 +52,7 @@ const DiscourseGraphHome = () => {
         description="The page format for canvas pages"
         settingKeys={[GLOBAL_KEYS.canvasPageFormat]}
         order={1}
-        uid={settings.canvasPageFormat.uid}
+        uid={settings.canvasPageFormatUid}
         parentUid={settings.settingsUid}
       />
       <FeatureFlagPanel
@@ -42,7 +60,7 @@ const DiscourseGraphHome = () => {
         description="Whether or not to enable the left sidebar."
         featureKey="Enable left sidebar"
         order={2}
-        uid={settings.leftSidebarEnabled.uid}
+        uid={settings.leftSidebarEnabledUid}
         parentUid={settings.settingsUid}
         onAfterChange={(checked: boolean) => {
           if (checked && !isNewSettingsStoreEnabled()) {

--- a/apps/roam/src/components/settings/Settings.tsx
+++ b/apps/roam/src/components/settings/Settings.tsx
@@ -12,7 +12,7 @@ import {
 import renderOverlay from "roamjs-components/util/renderOverlay";
 import DiscourseRelationConfigPanel from "./DiscourseRelationConfigPanel";
 import DEFAULT_RELATION_VALUES from "~/data/defaultDiscourseRelations";
-import { getFormattedConfigTree } from "~/utils/discourseConfigRef";
+import discourseConfigRef from "~/utils/discourseConfigRef";
 import DiscourseGraphHome from "./GeneralSettings";
 import DiscourseGraphExport from "./ExportSettings";
 import QuerySettings from "./QuerySettings";
@@ -73,7 +73,13 @@ export const SettingsDialog = ({
   selectedTabId?: TabId;
 }) => {
   const extensionAPI = onloadArgs.extensionAPI;
-  const settings = getFormattedConfigTree();
+  const grammarNode = discourseConfigRef.tree.find(
+    (node) => node.text === "grammar",
+  );
+  const relationsNode = grammarNode?.children.find(
+    (node) => node.text === "relations",
+  );
+  const nodesNode = grammarNode?.children.find((node) => node.text === "nodes");
   const nodes = getDiscourseNodes().filter(excludeDefaultNodes);
   const [activeTabId, setActiveTabId] = useState<TabId>(
     selectedTabId ?? "discourse-graph-home-personal",
@@ -204,8 +210,8 @@ export const SettingsDialog = ({
               <DiscourseRelationConfigPanel
                 defaultValue={DEFAULT_RELATION_VALUES}
                 title="Relations"
-                parentUid={settings.grammarUid}
-                uid={settings.relationsUid}
+                parentUid={grammarNode?.uid || ""}
+                uid={relationsNode?.uid || ""}
               />
             }
           />
@@ -216,8 +222,8 @@ export const SettingsDialog = ({
             panel={
               <DiscourseNodeConfigPanel
                 title="Nodes"
-                uid={settings.nodesUid}
-                parentUid={settings.grammarUid}
+                uid={nodesNode?.uid || ""}
+                parentUid={grammarNode?.uid || ""}
                 defaultValue={[]}
                 setSelectedTabId={setActiveTabId}
                 isPopup={true}

--- a/apps/roam/src/components/settings/SuggestiveModeSettings.tsx
+++ b/apps/roam/src/components/settings/SuggestiveModeSettings.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import React, { useEffect, useState } from "react";
 import { Button, Intent, Tabs, Tab, TabId } from "@blueprintjs/core";
-import { getFormattedConfigTree } from "~/utils/discourseConfigRef";
+import discourseConfigRef from "~/utils/discourseConfigRef";
 import PageGroupsPanel from "./PageGroupPanel";
 import createBlock from "roamjs-components/writes/createBlock";
 import getPageUidByPageTitle from "roamjs-components/queries/getPageUidByPageTitle";
@@ -15,14 +15,17 @@ import {
   SUGGESTIVE_MODE_KEYS,
 } from "~/components/settings/utils/settingKeys";
 import posthog from "posthog-js";
+import { getSuggestiveModeConfigAndUids } from "~/utils/getSuggestiveModeConfigSettings";
 
 const SuggestiveModeSettings = () => {
-  const settings = getFormattedConfigTree();
+  const suggestiveMode = getSuggestiveModeConfigAndUids(
+    discourseConfigRef.tree,
+  );
 
   const [suggestiveModeUid, setSuggestiveModeUid] = useState(
-    settings.suggestiveMode.parentUid,
+    suggestiveMode.parentUid,
   );
-  const pageGroupsUid = settings.suggestiveMode.pageGroups.uid;
+  const pageGroupsUid = suggestiveMode.pageGroups.uid;
 
   const [includePageRelations, setIncludePageRelations] = useState(
     getGlobalSetting<boolean>([
@@ -43,7 +46,7 @@ const SuggestiveModeSettings = () => {
   }, [suggestiveModeUid]);
 
   const effectiveSuggestiveModeUid =
-    suggestiveModeUid || settings.suggestiveMode.parentUid;
+    suggestiveModeUid || suggestiveMode.parentUid;
 
   const [selectedTabId, setSelectedTabId] = useState<TabId>("page-groups");
 
@@ -67,7 +70,7 @@ const SuggestiveModeSettings = () => {
               <PageGroupsPanel
                 key={pageGroupsUid}
                 uid={pageGroupsUid}
-                initialGroups={settings.suggestiveMode.pageGroups.groups}
+                initialGroups={suggestiveMode.pageGroups.groups}
               />
             </div>
           }
@@ -89,7 +92,7 @@ const SuggestiveModeSettings = () => {
                     SUGGESTIVE_MODE_KEYS.includeCurrentPageRelations,
                   ]}
                   order={0}
-                  uid={settings.suggestiveMode.includePageRelations.uid}
+                  uid={suggestiveMode.includePageRelations.uid}
                   parentUid={effectiveSuggestiveModeUid}
                   onChange={setIncludePageRelations}
                 />
@@ -107,7 +110,7 @@ const SuggestiveModeSettings = () => {
                   ]}
                   value={includePageRelations ? true : undefined}
                   order={1}
-                  uid={settings.suggestiveMode.includeParentAndChildren.uid}
+                  uid={suggestiveMode.includeParentAndChildren.uid}
                   parentUid={effectiveSuggestiveModeUid}
                   disabled={includePageRelations}
                 />

--- a/apps/roam/src/components/settings/utils/accessors.ts
+++ b/apps/roam/src/components/settings/utils/accessors.ts
@@ -10,12 +10,16 @@ import { getSubTree } from "roamjs-components/util";
 import getSettingValueFromTree from "roamjs-components/util/getSettingValueFromTree";
 import internalError from "~/utils/internalError";
 import { getSetting } from "~/utils/extensionSettings";
-import { getFormattedConfigTree } from "~/utils/discourseConfigRef";
+import discourseConfigRef, {
+  getFormattedConfigTree,
+} from "~/utils/discourseConfigRef";
 import { roamNodeToCondition } from "~/utils/parseQuery";
 import type { DiscourseRelation } from "~/utils/getDiscourseRelations";
 import type { DiscourseNode } from "~/utils/getDiscourseNodes";
 import type { Condition } from "~/utils/types";
 import { z } from "zod";
+import { getUidAndBooleanSetting } from "~/utils/getExportSettings";
+import { getLeftSidebarSettings } from "~/utils/getLeftSidebarSettings";
 
 import {
   DG_BLOCK_PROP_SETTINGS_PAGE_TITLE,
@@ -214,10 +218,10 @@ const PERSONAL_SCHEMA_PATH_TO_LEGACY_KEY = new Map<string, string>([
 ]);
 
 const getLegacyPersonalLeftSidebarSetting = (): unknown[] => {
-  const settings = getFormattedConfigTree();
+  const settings = getLeftSidebarSettings(discourseConfigRef.tree);
 
   /* eslint-disable @typescript-eslint/naming-convention */
-  return settings.leftSidebar.personal.sections.map((section) => ({
+  return settings.personal.sections.map((section) => ({
     name: section.text,
     Children: (section.children || []).map((child) => ({
       uid: child.text,
@@ -683,9 +687,15 @@ const FEATURE_FLAG_LEGACY_MAP: Partial<
   Record<keyof FeatureFlags, () => boolean>
 > = {
   "Suggestive mode enabled": () =>
-    getFormattedConfigTree().suggestiveModeEnabled.value,
+    getUidAndBooleanSetting({
+      tree: discourseConfigRef.tree,
+      text: "(BETA) Suggestive Mode Enabled",
+    }).value,
   "Enable left sidebar": () =>
-    getFormattedConfigTree().leftSidebarEnabled.value,
+    getUidAndBooleanSetting({
+      tree: discourseConfigRef.tree,
+      text: "(BETA) Left Sidebar",
+    }).value,
 };
 /* eslint-enable @typescript-eslint/naming-convention */
 

--- a/apps/roam/src/utils/migrateLeftSidebarSettings.ts
+++ b/apps/roam/src/utils/migrateLeftSidebarSettings.ts
@@ -2,7 +2,8 @@ import getPageUidByPageTitle from "roamjs-components/queries/getPageUidByPageTit
 import getPageTitleByPageUid from "roamjs-components/queries/getPageTitleByPageUid";
 import updateBlock from "roamjs-components/writes/updateBlock";
 import createBlock from "roamjs-components/writes/createBlock";
-import { getFormattedConfigTree } from "./discourseConfigRef";
+import discourseConfigRef from "./discourseConfigRef";
+import { getLeftSidebarSettings } from "./getLeftSidebarSettings";
 import { DISCOURSE_CONFIG_PAGE_TITLE } from "./renderNodeConfigPage";
 import refreshConfigTree from "./refreshConfigTree";
 
@@ -37,7 +38,7 @@ const migrateSectionChildren = async (
 };
 
 export const migrateLeftSidebarSettings = async () => {
-  const leftSidebarSettings = getFormattedConfigTree().leftSidebar;
+  const leftSidebarSettings = getLeftSidebarSettings(discourseConfigRef.tree);
 
   if (!leftSidebarSettings.uid) return;
 
@@ -51,12 +52,10 @@ export const migrateLeftSidebarSettings = async () => {
     await migrateSectionChildren(globalChildren);
   }
 
-
   const allPersonalSections = leftSidebarSettings.allPersonalSections;
 
-  for (const [_, userPersonalSection] of Object.entries(
-    allPersonalSections,
-  )) {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/naming-convention
+  for (const [_, userPersonalSection] of Object.entries(allPersonalSections)) {
     for (const section of userPersonalSection.sections) {
       const children = section.children || [];
       if (children.length > 0) {


### PR DESCRIPTION
https://www.loom.com/share/e1bb8573adfe49549013385f6391d21a


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/860" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal settings access patterns across configuration components, transitioning from legacy config tree retrieval to new helper-based utilities for left sidebar, suggestive mode, export, and general settings management. No user-facing changes; improvements to code maintainability and data flow architecture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->