### PR TITLE
[ENG-1517] Command palette sync notice

### DIFF
--- a/apps/obsidian/src/utils/registerCommands.ts
+++ b/apps/obsidian/src/utils/registerCommands.ts
@@ -229,7 +229,9 @@ export const registerCommands = (plugin: DiscourseGraphPlugin) => {
     name: "Sync discourse nodes to Supabase",
     checkCallback: (checking: boolean) => {
       if (!plugin.settings.syncModeEnabled) {
-        new Notice("Sync mode is not enabled", 3000);
+        if (!checking) {
+          new Notice("Sync mode is not enabled", 3000);
+        }
         return false;
       }
       if (!checking) {
@@ -252,7 +254,9 @@ export const registerCommands = (plugin: DiscourseGraphPlugin) => {
     name: "Publish current node to lab space",
     checkCallback: (checking: boolean) => {
       if (!plugin.settings.syncModeEnabled) {
-        new Notice("Sync mode is not enabled", 3000);
+        if (!checking) {
+          new Notice("Sync mode is not enabled", 3000);
+        }
         return false;
       }
       const activeView = plugin.app.workspace.getActiveViewOfType(MarkdownView);


### PR DESCRIPTION
Loom wasn't working so here's my explanation:
- the (!checking) would control when the notification show up, ie only when it's clicked on, not automatically when the command palette open

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Prevents "Sync mode is not enabled" notice from appearing when opening the command palette.

The notice was incorrectly displayed during the `checkCallback`'s initial `checking: true` phase (when the command palette opens), instead of only when a sync command was explicitly executed (`checking: false`). This PR adds `if (!checking)` guards to ensure the notice only appears upon actual command execution.

---
Linear Issue: [ENG-1517](https://linear.app/discourse-graphs/issue/ENG-1517/remove-notice-when-first-open-command-line)

<p><a href="https://cursor.com/agents/bc-9888c389-c8a7-4a1f-a70c-028783b888d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9888c389-c8a7-4a1f-a70c-028783b888d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/864" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
