### PR TITLE
[ENG-1125] Add Convert to Node Type button on canvas block shapes

### DIFF
--- a/apps/roam/src/components/canvas/DiscourseNodeUtil.tsx
+++ b/apps/roam/src/components/canvas/DiscourseNodeUtil.tsx
@@ -46,6 +46,8 @@ import DiscourseContextOverlay from "~/components/DiscourseContextOverlay";
 import { getDiscourseNodeColors } from "~/utils/getDiscourseNodeColors";
 import { render as renderToast } from "roamjs-components/components/Toast";
 
+const escapeRegExp = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
 // TODO REPLACE WITH TLDRAW DEFAULTS
 // https://github.com/tldraw/tldraw/pull/1580/files
 const TEXT_PROPS = {
@@ -460,7 +462,7 @@ export class BaseDiscourseNodeUtil extends BaseBoxShapeUtil<DiscourseNodeShape> 
       if (!blockText) return null;
       const nodes = Object.values(discourseContext.nodes);
       for (const node of nodes) {
-        const tag = node.text;
+        const tag = node.tag;
         if (!tag) continue;
         const cleanTag = getCleanTagText(tag);
         const blockTextUpper = blockText.toUpperCase();
@@ -622,20 +624,18 @@ export class BaseDiscourseNodeUtil extends BaseBoxShapeUtil<DiscourseNodeShape> 
               minimal
               small
               icon={
-                <Icon
-                  icon="plus"
-                  color={textColor}
-                  className="opacity-50"
-                />
+                <Icon icon="plus" color={textColor} className="opacity-50" />
               }
               onClick={(e) => {
                 e.stopPropagation();
                 const { node, blockText } = matchedNodeForConversion;
-                const tag = node.text;
+                const tag = node.tag;
+                if (!tag) return;
+                const escapedTag = escapeRegExp(tag);
                 // Strip the tag from block text
                 const cleanedText = blockText
-                  .replace(new RegExp(`#\\[\\[${tag}\\]\\]`, "i"), "")
-                  .replace(new RegExp(`#${tag}`, "i"), "")
+                  .replace(new RegExp(`#\\[\\[${escapedTag}\\]\\]`, "i"), "")
+                  .replace(new RegExp(`#${escapedTag}`, "i"), "")
                   .trim();
                 const { x, y } = shape;
                 renderModifyNodeDialog({

--- a/apps/roam/src/components/canvas/DiscourseNodeUtil.tsx
+++ b/apps/roam/src/components/canvas/DiscourseNodeUtil.tsx
@@ -635,7 +635,10 @@ export class BaseDiscourseNodeUtil extends BaseBoxShapeUtil<DiscourseNodeShape> 
                 const escapedCleanTag = escapeRegExp(cleanTag);
                 // Strip the tag from block text (same pattern as detection above)
                 const cleanedText = blockText
-                  .replace(new RegExp(`#\\[\\[${escapedCleanTag}\\]\\]`, "i"), "")
+                  .replace(
+                    new RegExp(`#\\[\\[${escapedCleanTag}\\]\\]`, "i"),
+                    "",
+                  )
                   .replace(new RegExp(`#${escapedCleanTag}`, "i"), "")
                   .trim();
                 const { x, y } = shape;

--- a/apps/roam/src/components/canvas/DiscourseNodeUtil.tsx
+++ b/apps/roam/src/components/canvas/DiscourseNodeUtil.tsx
@@ -652,8 +652,8 @@ export class BaseDiscourseNodeUtil extends BaseBoxShapeUtil<DiscourseNodeShape> 
                   extensionAPI,
                   includeDefaultNodes: true,
                   onSuccess: async ({ text, uid }) => {
-                    editor.deleteShapes([shape.id]);
                     if (!extensionAPI) return;
+                    editor.deleteShapes([shape.id]);
                     const {
                       h,
                       w,

--- a/apps/roam/src/components/canvas/DiscourseNodeUtil.tsx
+++ b/apps/roam/src/components/canvas/DiscourseNodeUtil.tsx
@@ -461,16 +461,19 @@ export class BaseDiscourseNodeUtil extends BaseBoxShapeUtil<DiscourseNodeShape> 
       const blockText = getTextByBlockUid(shape.props.uid);
       if (!blockText) return null;
       const nodes = Object.values(discourseContext.nodes);
+      const tagPattern = /#(?:\[\[([^\]]*)\]\]|([^\s#[\]]+))/g;
       for (const node of nodes) {
         const tag = node.tag;
         if (!tag) continue;
-        const cleanTag = getCleanTagText(tag);
-        const blockTextUpper = blockText.toUpperCase();
-        if (
-          blockTextUpper.includes(`#${cleanTag}`) ||
-          blockTextUpper.includes(`#[[${cleanTag}]]`)
-        ) {
-          return { node, blockText };
+        const normalizedNodeTag = getCleanTagText(tag);
+        let match;
+        tagPattern.lastIndex = 0;
+        while ((match = tagPattern.exec(blockText)) !== null) {
+          const tagFromBlock = match[1] ?? match[2] ?? "";
+          const normalizedBlockTag = getCleanTagText(tagFromBlock);
+          if (normalizedBlockTag === normalizedNodeTag) {
+            return { node, blockText };
+          }
         }
       }
       return null;

--- a/apps/roam/src/components/canvas/DiscourseNodeUtil.tsx
+++ b/apps/roam/src/components/canvas/DiscourseNodeUtil.tsx
@@ -631,11 +631,12 @@ export class BaseDiscourseNodeUtil extends BaseBoxShapeUtil<DiscourseNodeShape> 
                 const { node, blockText } = matchedNodeForConversion;
                 const tag = node.tag;
                 if (!tag) return;
-                const escapedTag = escapeRegExp(tag);
-                // Strip the tag from block text
+                const cleanTag = getCleanTagText(tag);
+                const escapedCleanTag = escapeRegExp(cleanTag);
+                // Strip the tag from block text (same pattern as detection above)
                 const cleanedText = blockText
-                  .replace(new RegExp(`#\\[\\[${escapedTag}\\]\\]`, "i"), "")
-                  .replace(new RegExp(`#${escapedTag}`, "i"), "")
+                  .replace(new RegExp(`#\\[\\[${escapedCleanTag}\\]\\]`, "i"), "")
+                  .replace(new RegExp(`#${escapedCleanTag}`, "i"), "")
                   .trim();
                 const { x, y } = shape;
                 renderModifyNodeDialog({

--- a/apps/roam/src/components/canvas/DiscourseNodeUtil.tsx
+++ b/apps/roam/src/components/canvas/DiscourseNodeUtil.tsx
@@ -29,6 +29,8 @@ import { Button, Icon } from "@blueprintjs/core";
 import { DiscourseNode } from "~/utils/getDiscourseNodes";
 import { isPageUid } from "./Tldraw";
 import { renderModifyNodeDialog } from "~/components/ModifyNodeDialog";
+import getTextByBlockUid from "roamjs-components/queries/getTextByBlockUid";
+import { getCleanTagText } from "~/components/settings/NodeConfig";
 import { discourseContext } from "./Tldraw";
 import getDiscourseContextResults from "~/utils/getDiscourseContextResults";
 import calcCanvasNodeSizeAndImg from "~/utils/calcCanvasNodeSizeAndImg";
@@ -448,6 +450,30 @@ export class BaseDiscourseNodeUtil extends BaseBoxShapeUtil<DiscourseNodeShape> 
     const [overlayMounted, setOverlayMounted] = useState(false);
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const dialogRenderedRef = useRef(false);
+
+    // Detect discourse node tags in block text for blck-node shapes
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const matchedNodeForConversion = useMemo(() => {
+      if (shape.type !== "blck-node") return null;
+      if (!isLiveBlock(shape.props.uid)) return null;
+      const blockText = getTextByBlockUid(shape.props.uid);
+      if (!blockText) return null;
+      const nodes = Object.values(discourseContext.nodes);
+      for (const node of nodes) {
+        const tag = node.text;
+        if (!tag) continue;
+        const cleanTag = getCleanTagText(tag);
+        const blockTextUpper = blockText.toUpperCase();
+        if (
+          blockTextUpper.includes(`#${cleanTag}`) ||
+          blockTextUpper.includes(`#[[${cleanTag}]]`)
+        ) {
+          return { node, blockText };
+        }
+      }
+      return null;
+    }, [shape.type, shape.props.uid]);
+
     // eslint-disable-next-line react-hooks/rules-of-hooks
     useEffect(() => {
       if (
@@ -588,6 +614,81 @@ export class BaseDiscourseNodeUtil extends BaseBoxShapeUtil<DiscourseNodeShape> 
             onPointerDown={(e) => e.stopPropagation()}
             title="Open in sidebar (Shift+Click)"
           />
+
+          {/* Convert to Node Type Button */}
+          {matchedNodeForConversion && (
+            <Button
+              className="absolute left-7 top-1 z-10"
+              minimal
+              small
+              icon={
+                <Icon
+                  icon="plus"
+                  color={textColor}
+                  className="opacity-50"
+                />
+              }
+              onClick={(e) => {
+                e.stopPropagation();
+                const { node, blockText } = matchedNodeForConversion;
+                const tag = node.text;
+                // Strip the tag from block text
+                const cleanedText = blockText
+                  .replace(new RegExp(`#\\[\\[${tag}\\]\\]`, "i"), "")
+                  .replace(new RegExp(`#${tag}`, "i"), "")
+                  .trim();
+                const { x, y } = shape;
+                renderModifyNodeDialog({
+                  mode: "create",
+                  nodeType: node.type,
+                  initialValue: { text: cleanedText, uid: "" },
+                  extensionAPI,
+                  includeDefaultNodes: true,
+                  onSuccess: async ({ text, uid }) => {
+                    editor.deleteShapes([shape.id]);
+                    if (!extensionAPI) return;
+                    const {
+                      h,
+                      w,
+                      imageUrl: nodeImageUrl,
+                    } = await calcCanvasNodeSizeAndImg({
+                      nodeText: text,
+                      extensionAPI,
+                      nodeType: node.type,
+                      uid,
+                    });
+                    editor.createShapes([
+                      {
+                        type: node.type,
+                        id: createShapeId(),
+                        props: {
+                          uid,
+                          title: text,
+                          h,
+                          w,
+                          imageUrl: nodeImageUrl,
+                          fontFamily: "sans",
+                          size: "s",
+                        },
+                        x,
+                        y,
+                      },
+                    ]);
+                  },
+                  onClose: () => {},
+                });
+              }}
+              onPointerDown={(e) => e.stopPropagation()}
+              title={`Convert to ${matchedNodeForConversion.node.text}`}
+            >
+              <span
+                className="opacity-70"
+                style={{ color: textColor, fontSize: "11px" }}
+              >
+                Convert to {matchedNodeForConversion.node.text}
+              </span>
+            </Button>
+          )}
 
           {shape.props.imageUrl && isKeyImage === "true" ? (
             <div className="mt-2 flex min-h-0 w-full flex-1 items-center justify-center overflow-hidden">

--- a/apps/roam/src/components/canvas/DiscourseNodeUtil.tsx
+++ b/apps/roam/src/components/canvas/DiscourseNodeUtil.tsx
@@ -653,34 +653,44 @@ export class BaseDiscourseNodeUtil extends BaseBoxShapeUtil<DiscourseNodeShape> 
                   includeDefaultNodes: true,
                   onSuccess: async ({ text, uid }) => {
                     if (!extensionAPI) return;
-                    editor.deleteShapes([shape.id]);
-                    const {
-                      h,
-                      w,
-                      imageUrl: nodeImageUrl,
-                    } = await calcCanvasNodeSizeAndImg({
-                      nodeText: text,
-                      extensionAPI,
-                      nodeType: node.type,
-                      uid,
-                    });
-                    editor.createShapes([
-                      {
-                        type: node.type,
-                        id: createShapeId(),
-                        props: {
-                          uid,
-                          title: text,
-                          h,
-                          w,
-                          imageUrl: nodeImageUrl,
-                          fontFamily: "sans",
-                          size: "s",
+                    try {
+                      const {
+                        h,
+                        w,
+                        imageUrl: nodeImageUrl,
+                      } = await calcCanvasNodeSizeAndImg({
+                        nodeText: text,
+                        extensionAPI,
+                        nodeType: node.type,
+                        uid,
+                      });
+                      editor.createShapes([
+                        {
+                          type: node.type,
+                          id: createShapeId(),
+                          props: {
+                            uid,
+                            title: text,
+                            h,
+                            w,
+                            imageUrl: nodeImageUrl,
+                            fontFamily: "sans",
+                            size: "s",
+                          },
+                          x,
+                          y,
                         },
-                        x,
-                        y,
-                      },
-                    ]);
+                      ]);
+                      editor.deleteShapes([shape.id]);
+                    } catch (error) {
+                      renderToast({
+                        id: `discourse-node-convert-error-${Date.now()}`,
+                        intent: "danger",
+                        content: (
+                          <span>Error converting block: {String(error)}</span>
+                        ),
+                      });
+                    }
                   },
                   onClose: () => {},
                 });


### PR DESCRIPTION
https://www.loom.com/share/3a6bed7f17024eb39c73d152a111c81f
## Summary
- When a `blck-node` shape on the canvas contains a discourse node tag (e.g. `#claim`, `#[[claim]]`), a "Convert to {NodeType}" button now appears at the top of the shape
- Clicking the button opens `ModifyNodeDialog` pre-filled with the block text (minus the tag), and on confirmation replaces the block shape with a proper discourse node shape at the same position
- Only appears on `blck-node` shapes with a matching discourse node tag

## Test plan
- [x] Embed a block containing a tag like `#claim` on the canvas
- [x] Verify the "Convert to Claim" button appears at the top of the block shape
- [x] Click the button → ModifyNodeDialog opens pre-filled with the block text (minus the tag)
- [x] Confirm → the blck-node shape is replaced with a claim-node shape at the same position
- [x] Verify the button does NOT appear on blocks without discourse node tags
- [x] Verify the button does NOT appear on non-blck-node shapes
<img width="543" height="276" alt="image" src="https://github.com/user-attachments/assets/b56e9640-3658-41a2-8bd8-908acf90d6d5" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/867" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Convert to Node Type" button to convert blocks to different node types in the canvas. When activated, the button extracts the node information, removes the original block, and creates a new node with the converted content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->