### PR TITLE
ENG-1398 Bug: is in canvas query builder condition only supports legacy canvas schema

### DIFF
--- a/apps/roam/src/utils/conditionToDatalog.ts
+++ b/apps/roam/src/utils/conditionToDatalog.ts
@@ -13,14 +13,28 @@ import { Condition } from "./types";
 import gatherDatalogVariablesFromClause from "./gatherDatalogVariablesFromClause";
 import getCurrentPageUid from "roamjs-components/dom/getCurrentPageUid";
 import getPageTitleByPageUid from "roamjs-components/queries/getPageTitleByPageUid";
-import getPageTitlesStartingWithPrefix from "roamjs-components/queries/getPageTitlesStartingWithPrefix";
 import extractRef from "roamjs-components/util/extractRef";
 import getCurrentUserDisplayName from "roamjs-components/queries/getCurrentUserDisplayName";
 import getPageTitleByBlockUid from "roamjs-components/queries/getPageTitleByBlockUid";
+import { getFormattedConfigTree } from "./discourseConfigRef";
+import { getCanvasMembershipShapeClauses } from "./isInCanvasDatalog";
 
 type ConditionToDatalog = (condition: Condition) => DatalogClause[];
 
 const INPUT_REGEX = /^:in /;
+const DEFAULT_CANVAS_PAGE_FORMAT = "Canvas/*";
+
+const getCanvasPageTargets = (): string[] => {
+  const { canvasPageFormat } = getFormattedConfigTree();
+  const canvasFormat = canvasPageFormat.value || DEFAULT_CANVAS_PAGE_FORMAT;
+  const formatRegex = new RegExp(
+    `^${canvasFormat
+      .replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+      .replace(/\\\*/g, ".+")}$`,
+  );
+  return getAllPageNames().filter((title) => formatRegex.test(title));
+};
+
 
 const isRegex = (str: string) => /^\/.+\/(i)?$/.test(str);
 const regexRePatternValue = (str: string) => {
@@ -917,49 +931,10 @@ const translator: Record<string, Translator> = {
           variable: { type: "variable", value: `${target}-Canvas-RQB` },
         },
       },
-      {
-        type: "fn-expr",
-        fn: "get",
-        arguments: [
-          { type: "variable", value: `${target}-Canvas-RQB` },
-          { type: "constant", value: ":tldraw" },
-        ],
-        binding: {
-          type: "bind-rel",
-          args: [
-            { type: "variable", value: `${target}-TLDraw-Key` },
-            { type: "variable", value: `${target}-TLDraw-Value` },
-          ],
-        },
-      },
-      {
-        type: "fn-expr",
-        fn: "get",
-        arguments: [
-          { type: "variable", value: `${target}-TLDraw-Value` },
-          { type: "constant", value: ":props" },
-        ],
-        binding: {
-          type: "bind-scalar",
-          variable: { type: "variable", value: `${target}-Shape-Props` },
-        },
-      },
-      {
-        type: "fn-expr",
-        fn: "get",
-        arguments: [
-          { type: "variable", value: `${target}-Shape-Props` },
-          { type: "constant", value: ":uid" },
-        ],
-        binding: {
-          type: "bind-scalar",
-          variable: { type: "variable", value: `${source}-uid` },
-        },
-      },
+      ...getCanvasMembershipShapeClauses({ source, target }),
     ],
     targetOptions: () =>
-      // TODO - use roam depot setting
-      getPageTitlesStartingWithPrefix("Canvas/").concat(["{current}"]),
+      getCanvasPageTargets().concat(["{current}"]),
     placeholder: "Enter a page name",
   },
   "has block reference": {
@@ -1035,7 +1010,7 @@ const conditionToDatalog: ConditionToDatalog = (con) => {
         type: "or-join-clause",
         clauses,
         variables: Object.entries(variableSet)
-          .filter(([_, v]) => v === clauses.length)
+          .filter(([, v]) => v === clauses.length)
           .map(([value]) => ({
             type: "variable",
             value,

--- a/apps/roam/src/utils/conditionToDatalog.ts
+++ b/apps/roam/src/utils/conditionToDatalog.ts
@@ -35,7 +35,6 @@ const getCanvasPageTargets = (): string[] => {
   return getAllPageNames().filter((title) => formatRegex.test(title));
 };
 
-
 const isRegex = (str: string) => /^\/.+\/(i)?$/.test(str);
 const regexRePatternValue = (str: string) => {
   const isCaseInsensitive = str.endsWith("/i");
@@ -933,8 +932,7 @@ const translator: Record<string, Translator> = {
       },
       ...getCanvasMembershipShapeClauses({ source, target }),
     ],
-    targetOptions: () =>
-      getCanvasPageTargets().concat(["{current}"]),
+    targetOptions: () => getCanvasPageTargets().concat(["{current}"]),
     placeholder: "Enter a page name",
   },
   "has block reference": {

--- a/apps/roam/src/utils/isInCanvasDatalog.ts
+++ b/apps/roam/src/utils/isInCanvasDatalog.ts
@@ -1,0 +1,117 @@
+import type { DatalogAndClause, DatalogClause } from "roamjs-components/types";
+
+const getLegacyCanvasLookupClauses = ({
+  target,
+}: {
+  target: string;
+}): DatalogClause[] =>
+  [
+    {
+      type: "fn-expr",
+      fn: "get",
+      arguments: [
+        { type: "variable", value: `${target}-Canvas-RQB` },
+        { type: "constant", value: ":tldraw" },
+      ],
+      binding: {
+        type: "bind-rel",
+        args: [
+          { type: "variable", value: `${target}-TLDraw-Key` },
+          { type: "variable", value: `${target}-TLDraw-Value` },
+        ],
+      },
+    },
+  ] as DatalogClause[];
+
+// tldraw 2.x schema
+const getCanvas2LookupClauses = ({
+  target,
+}: {
+  target: string;
+}): DatalogClause[] =>
+  [
+    {
+      type: "fn-expr",
+      fn: "get",
+      arguments: [
+        { type: "variable", value: `${target}-Canvas-RQB` },
+        { type: "constant", value: ":tldraw" },
+      ],
+      binding: {
+        type: "bind-scalar",
+        variable: { type: "variable", value: `${target}-TLDraw` },
+      },
+    },
+    {
+      type: "fn-expr",
+      fn: "get",
+      arguments: [
+        { type: "variable", value: `${target}-TLDraw` },
+        { type: "constant", value: ":store" },
+      ],
+      binding: {
+        type: "bind-rel",
+        args: [
+          { type: "variable", value: `${target}-TLDraw-Key` },
+          { type: "variable", value: `${target}-TLDraw-Value` },
+        ],
+      },
+    },
+  ] as DatalogClause[];
+
+export const getCanvasMembershipShapeClauses = ({
+  source,
+  target,
+}: {
+  source: string;
+  target: string;
+}): DatalogClause[] => {
+  const sourceUidVar = `${source}-uid`;
+  const canvasRqbVar = `${target}-Canvas-RQB`;
+  const tldrawValueVar = `${target}-TLDraw-Value`;
+  const shapePropsVar = `${target}-Shape-Props`;
+
+  return [
+    {
+      type: "or-join-clause",
+      variables: [
+        { type: "variable", value: canvasRqbVar },
+        { type: "variable", value: tldrawValueVar },
+      ],
+      clauses: [
+        {
+          type: "and-clause",
+          clauses: getLegacyCanvasLookupClauses({ target }),
+        } as DatalogAndClause,
+        {
+          type: "and-clause",
+          clauses: getCanvas2LookupClauses({ target }),
+        } as DatalogAndClause,
+      ],
+    } as DatalogClause,
+    {
+      type: "fn-expr",
+      fn: "get",
+      arguments: [
+        { type: "variable", value: tldrawValueVar },
+        { type: "constant", value: ":props" },
+      ],
+      binding: {
+        type: "bind-scalar",
+        variable: { type: "variable", value: shapePropsVar },
+      },
+    } as DatalogClause,
+    {
+      type: "fn-expr",
+      fn: "get",
+      arguments: [
+        { type: "variable", value: shapePropsVar },
+        { type: "constant", value: ":uid" },
+      ],
+      binding: {
+        type: "bind-scalar",
+        variable: { type: "variable", value: sourceUidVar },
+      },
+    } as DatalogClause,
+  ];
+};


### PR DESCRIPTION
- Introduced getCanvasPageTargets function to dynamically fetch canvas page names based on configuration.
- Replaced hardcoded canvas page title retrieval with the new function in targetOptions.
- Simplified shape clause handling by utilizing getCanvasMembershipShapeClauses.

This update improves flexibility and maintainability of the query builder's canvas integration.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/870" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable Canvas page targeting, allowing users to customize which pages are recognized as Canvas pages.

* **Improvements**
  * Enhanced Canvas and TLDraw integration with optimized data query handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->