### PR TITLE
ENG-1531 Remove (1) when duplicating relation types

### DIFF
--- a/apps/roam/src/components/settings/DiscourseRelationConfigPanel.tsx
+++ b/apps/roam/src/components/settings/DiscourseRelationConfigPanel.tsx
@@ -1069,20 +1069,7 @@ const DiscourseRelationConfigPanel: CustomField["options"]["component"] = ({
     setGlobalSetting(["Relations"], remaining);
   };
   const handleDuplicate = (rel: Relation) => {
-    const baseText = rel.text
-      .split(" ")
-      .filter((s) => !/^\(\d+\)$/.test(s))
-      .join(" ");
-    const copy = relations.reduce((p, c) => {
-      if (c.text.startsWith(baseText)) {
-        const copyIndex = Number(/\((\d+)\)$/.exec(c.text)?.[1]);
-        if (copyIndex && copyIndex > p) {
-          return copyIndex;
-        }
-      }
-      return p;
-    }, 0);
-    const text = `${rel.text} (${copy + 1})`;
+    const text = rel.text;
     const copyTree = getBasicTreeByParentUid(rel.uid);
     const stripUid = (n: RoamBasicNode[]): InputTextNode[] =>
       n.map((c) => ({


### PR DESCRIPTION
### Motivation
- Prevent the legacy `(n)` suffix from being appended when duplicating relation types so duplicated relations preserve the original label.

### Description
- Simplified the duplication handler in `apps/roam/src/components/settings/DiscourseRelationConfigPanel.tsx` to keep `rel.text` unchanged instead of computing and appending a numeric suffix.

### Testing
- Ran `pnpm --filter roam lint` which completed successfully with existing repository ESLint warnings and zero errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b068901e9c83269138d69fbe98ccb3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/879" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the duplication functionality in Discourse Relation settings to preserve the original text exactly, without appending automatic numbering suffixes (e.g., " (2)", " (3)") to duplicated items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->