### PR TITLE
ENG-1488 Update posthog.capture to capture proper current url

### DIFF
--- a/apps/roam/src/utils/posthog.ts
+++ b/apps/roam/src/utils/posthog.ts
@@ -18,11 +18,8 @@ const doInitPostHog = (): void => {
     "$geoip_postal_code",
     "$geoip_subdivision_1_name",
     "$raw_user_agent",
-    "$current_url",
     "$referrer",
     "$referring_domain",
-    "$initial_current_url",
-    "$pathname",
   ]);
   posthog.init("phc_SNMmBqwNfcEpNduQ41dBUjtGNEUEKAy6jTn63Fzsrax", {
     /* eslint-disable @typescript-eslint/naming-convention  */


### PR DESCRIPTION
https://linear.app/discourse-graphs/issue/ENG-1488/update-posthogcapture-to-capture-proper-current-url

Basically just removing url from the variables we strip.

https://www.loom.com/share/932d118a8f474b0c81fa98037bc14627


Example event [here](https://us.posthog.com/project/113823/error_tracking/019b234f-3cbf-7293-bd1f-2589c7659e74?timestamp=2026-03-11%2019%3A46%3A58.934000%2B00%3A00)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/881" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
