### PR TITLE
ENG-477 Create new discourse node creation command

### DIFF
--- a/apps/roam/src/utils/registerCommandPaletteCommands.ts
+++ b/apps/roam/src/utils/registerCommandPaletteCommands.ts
@@ -12,12 +12,14 @@ import getDiscourseNodes from "./getDiscourseNodes";
 import fireQuery from "./fireQuery";
 import { excludeDefaultNodes } from "~/utils/getDiscourseNodes";
 import { render as renderSettings } from "~/components/settings/Settings";
+import { renderModifyNodeDialog } from "~/components/ModifyNodeDialog";
 import {
   getOverlayHandler,
   onPageRefObserverChange,
 } from "./pageRefObserverHandlers";
 import { HIDE_METADATA_KEY } from "~/data/userSettings";
 import posthog from "posthog-js";
+import getTextByBlockUid from "roamjs-components/queries/getTextByBlockUid";
 
 export const registerCommandPaletteCommands = (onloadArgs: OnloadArgs) => {
   const { extensionAPI } = onloadArgs;
@@ -204,6 +206,83 @@ export const registerCommandPaletteCommands = (onloadArgs: OnloadArgs) => {
     });
   };
 
+  const createDiscourseNodeFromCommand = () => {
+    const focusedBlock = window.roamAlphaAPI.ui.getFocusedBlock();
+    const blockUid = focusedBlock?.["block-uid"];
+
+    if (!blockUid) {
+      renderToast({
+        id: "discourse-node-create-no-focus",
+        content: "Must be focused on a block to create a discourse node",
+      });
+      return;
+    }
+
+    const userNodeType = getDiscourseNodes().find(
+      (node) => node.backedBy === "user",
+    )?.type;
+
+    if (!userNodeType) {
+      renderToast({
+        id: "discourse-node-create-no-type",
+        content: "No user discourse node type is configured",
+      });
+      return;
+    }
+
+    const activeElement = document.activeElement;
+    const focusedTextarea =
+      activeElement instanceof HTMLTextAreaElement ? activeElement : null;
+    const currentText = getTextByBlockUid(blockUid);
+    const selectionStart = focusedTextarea
+      ? focusedTextarea.selectionStart
+      : currentText.length;
+    const selectionEnd = focusedTextarea
+      ? focusedTextarea.selectionEnd
+      : currentText.length;
+
+    const selectedText = currentText.substring(selectionStart, selectionEnd);
+    posthog.capture("Discourse Node: Create Command Triggered", {
+      hasSelectedText: !!selectedText,
+      nodeType: userNodeType,
+    });
+
+    renderModifyNodeDialog({
+      mode: "create",
+      nodeType: userNodeType,
+      initialValue: { text: selectedText, uid: "" },
+      extensionAPI,
+      onSuccess: async ({ text }) => {
+        const latestBlockText = getTextByBlockUid(blockUid);
+        const pageRef = `[[${text}]]`;
+        const updatedText = `${latestBlockText.substring(
+          0,
+          selectionStart,
+        )}${pageRef}${latestBlockText.substring(selectionEnd)}`;
+
+        await updateBlock({
+          uid: blockUid,
+          text: updatedText,
+        });
+
+        const cursorPosition = selectionStart + pageRef.length;
+        if (window.roamAlphaAPI.ui.setBlockFocusAndSelection) {
+          await window.roamAlphaAPI.ui.setBlockFocusAndSelection({
+            location: {
+              "block-uid": blockUid,
+              "window-id": focusedBlock?.["window-id"] || "main-window",
+            },
+            selection: {
+              start: cursorPosition,
+              end: cursorPosition,
+            },
+          });
+        }
+      },
+      onClose: () => {},
+    });
+  };
+
   const addCommand = (label: string, callback: () => void) => {
     return extensionAPI.ui.commandPalette.addCommand({
       label,
@@ -215,6 +294,10 @@ export const registerCommandPaletteCommands = (onloadArgs: OnloadArgs) => {
   void addCommand("DG: Export - Current page", exportCurrentPage);
   void addCommand("DG: Export - Discourse graph", exportDiscourseGraph);
   void addCommand("DG: Open - Discourse settings", renderSettingsPopup);
+  void addCommand(
+    "DG: Open - Create discourse node",
+    createDiscourseNodeFromCommand,
+  );
   void addCommand("DG: Open - Query drawer", openQueryDrawerWithArgs);
   void addCommand(
     "DG: Toggle - Discourse context overlay",


### PR DESCRIPTION
### Motivation
- Provide a command-palette entry to open the existing node-creation modal so users can create discourse nodes via keyboard palette.
- Reuse the existing `ModifyNodeDialog` flow and keep insertion behavior consistent with other node creation paths.
- Ensure we preserve user selection/cursor behavior and show helpful toasts when preconditions are not met.

### Description
- Added a new command `DG: Open - Create discourse node` in `registerCommandPaletteCommands.ts` that opens `ModifyNodeDialog` in `create` mode and pre-fills it with the currently selected text from the focused block.
- On successful creation the command inserts the created node page reference back into the original block at the captured selection/cursor location and restores focus/selection using `window.roamAlphaAPI.ui.setBlockFocusAndSelection` when available.
- Added guard toasts for missing focused block and for when no user-configured discourse node type exists, and added a `posthog.capture` event for telemetry.
- Imported `renderModifyNodeDialog` and `getTextByBlockUid` and implemented `createDiscourseNodeFromCommand` to orchestrate the flow.

### Testing
- Ran TypeScript checks with `npm run --workspace roam check-types` which completed successfully with no type errors.
- Ran lint for the modified file with `npm run --workspace roam lint -- src/utils/registerCommandPaletteCommands.ts` which completed successfully and produced existing repository warnings but no new errors.
- Confirmed the new command was registered in `registerCommandPaletteCommands.ts` and committed the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b06b4aafe08326ac8e95c32709ee96)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/883" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
