### PR TITLE
ENG-477 Create new discourse node creation command

### DIFF
--- a/apps/roam/src/utils/registerCommandPaletteCommands.ts
+++ b/apps/roam/src/utils/registerCommandPaletteCommands.ts
@@ -35,38 +35,7 @@ export const registerCommandPaletteCommands = (onloadArgs: OnloadArgs) => {
     pageTitle: string;
     selectionStart: number;
     windowId: string;
-  }): Promise<void> => {
-    const originalText = getTextByBlockUid(blockUid) || "";
-    const pageRef = `[[${pageTitle}]]`;
-    const newText = `${originalText.substring(0, selectionStart)}${pageRef}${originalText.substring(selectionStart)}`;
-    const newCursorPosition = selectionStart + pageRef.length;
-
-    await updateBlock({ uid: blockUid, text: newText });
-
-    if (window.roamAlphaAPI.ui.setBlockFocusAndSelection) {
-      await window.roamAlphaAPI.ui.setBlockFocusAndSelection({
-        location: {
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          "block-uid": blockUid,
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          "window-id": windowId,
-        },
-        selection: { start: newCursorPosition },
-      });
-      return;
-    }
-
-    setTimeout(() => {
-      const textareaElements = document.querySelectorAll("textarea");
-      for (const el of textareaElements) {
-        if (getUids(el).blockUid === blockUid) {
-          el.focus();
-          el.setSelectionRange(newCursorPosition, newCursorPosition);
-          break;
-        }
-      }
-    }, 50);
-  };
+  }): Promise<void> => {};
 
   const createQueryBlock = async () => {
     {
@@ -220,6 +189,7 @@ export const registerCommandPaletteCommands = (onloadArgs: OnloadArgs) => {
     posthog.capture("Discourse Node: Create Command Triggered");
     const focusedBlock = window.roamAlphaAPI.ui.getFocusedBlock();
     const uid = focusedBlock?.["block-uid"];
+    console.log("focusedBlock", focusedBlock);
     const windowId = focusedBlock?.["window-id"] || "main-window";
 
     const selectionStart = uid ? getSelectionStartForBlock(uid) : 0;
@@ -247,12 +217,23 @@ export const registerCommandPaletteCommands = (onloadArgs: OnloadArgs) => {
           });
           return;
         }
-        await insertPageReferenceAtCursor({
-          blockUid: uid,
-          pageTitle: result.text,
-          selectionStart,
-          windowId,
+        const originalText = getTextByBlockUid(uid) || "";
+        const pageRef = `[[${result.text}]]`;
+        const newText = `${originalText.substring(0, selectionStart)}${pageRef}${originalText.substring(selectionStart)}`;
+        const newCursorPosition = selectionStart + pageRef.length;
+
+        await updateBlock({ uid, text: newText });
+
+        await window.roamAlphaAPI.ui.setBlockFocusAndSelection({
+          location: {
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            "block-uid": uid,
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            "window-id": windowId,
+          },
+          selection: { start: newCursorPosition },
         });
+        return;
       },
       onClose: () => {},
     });
@@ -315,14 +296,14 @@ export const registerCommandPaletteCommands = (onloadArgs: OnloadArgs) => {
   };
 
   // Roam organizes commands alphabetically
+  void addCommand(
+    "DG: Create/Insert discourse node",
+    createDiscourseNodeFromCommand,
+  );
   void addCommand("DG: Export - Current page", exportCurrentPage);
   void addCommand("DG: Export - Discourse graph", exportDiscourseGraph);
   void addCommand("DG: Open - Discourse settings", renderSettingsPopup);
   void addCommand("DG: Open - Query drawer", openQueryDrawerWithArgs);
-  void addCommand(
-    "DG: Create/Insert Discourse node",
-    createDiscourseNodeFromCommand,
-  );
   void addCommand(
     "DG: Toggle - Discourse context overlay",
     toggleDiscourseContextOverlay,

--- a/apps/roam/src/utils/registerCommandPaletteCommands.ts
+++ b/apps/roam/src/utils/registerCommandPaletteCommands.ts
@@ -12,6 +12,9 @@ import getDiscourseNodes from "./getDiscourseNodes";
 import fireQuery from "./fireQuery";
 import { excludeDefaultNodes } from "~/utils/getDiscourseNodes";
 import { render as renderSettings } from "~/components/settings/Settings";
+import { renderModifyNodeDialog } from "~/components/ModifyNodeDialog";
+import getTextByBlockUid from "roamjs-components/queries/getTextByBlockUid";
+import getUids from "roamjs-components/dom/getUids";
 import {
   getOverlayHandler,
   onPageRefObserverChange,
@@ -21,6 +24,49 @@ import posthog from "posthog-js";
 
 export const registerCommandPaletteCommands = (onloadArgs: OnloadArgs) => {
   const { extensionAPI } = onloadArgs;
+
+  const insertPageReferenceAtCursor = async ({
+    blockUid,
+    pageTitle,
+    selectionStart,
+    windowId,
+  }: {
+    blockUid: string;
+    pageTitle: string;
+    selectionStart: number;
+    windowId: string;
+  }): Promise<void> => {
+    const originalText = getTextByBlockUid(blockUid) || "";
+    const pageRef = `[[${pageTitle}]]`;
+    const newText = `${originalText.substring(0, selectionStart)}${pageRef}${originalText.substring(selectionStart)}`;
+    const newCursorPosition = selectionStart + pageRef.length;
+
+    await updateBlock({ uid: blockUid, text: newText });
+
+    if (window.roamAlphaAPI.ui.setBlockFocusAndSelection) {
+      await window.roamAlphaAPI.ui.setBlockFocusAndSelection({
+        location: {
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          "block-uid": blockUid,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          "window-id": windowId,
+        },
+        selection: { start: newCursorPosition },
+      });
+      return;
+    }
+
+    setTimeout(() => {
+      const textareaElements = document.querySelectorAll("textarea");
+      for (const el of textareaElements) {
+        if (getUids(el).blockUid === blockUid) {
+          el.focus();
+          el.setSelectionRange(newCursorPosition, newCursorPosition);
+          break;
+        }
+      }
+    }, 50);
+  };
 
   const createQueryBlock = async () => {
     {
@@ -155,6 +201,53 @@ export const registerCommandPaletteCommands = (onloadArgs: OnloadArgs) => {
     renderSettings({ onloadArgs });
   };
 
+  const createDiscourseNodeFromCommand = () => {
+    const focusedBlock = window.roamAlphaAPI.ui.getFocusedBlock();
+    const blockUid = focusedBlock?.["block-uid"];
+    const windowId = focusedBlock?.["window-id"] || "main-window";
+    const activeElement = document.activeElement;
+    const isFocusedTextarea =
+      activeElement instanceof HTMLTextAreaElement &&
+      activeElement.classList.contains("rm-block-input");
+    const selectionStart = isFocusedTextarea
+      ? activeElement.selectionStart
+      : null;
+
+    if (!blockUid || selectionStart === null) {
+      renderToast({
+        id: "create-discourse-node-command-focus",
+        content: "Place your cursor in a block before running this command.",
+      });
+      return;
+    }
+
+    const defaultNodeType =
+      getDiscourseNodes().filter(excludeDefaultNodes)[0]?.type;
+    if (!defaultNodeType) {
+      renderToast({
+        id: "create-discourse-node-command-no-types",
+        content: "No discourse node types found in settings.",
+      });
+      return;
+    }
+
+    renderModifyNodeDialog({
+      mode: "create",
+      nodeType: defaultNodeType,
+      initialValue: { text: "", uid: "" },
+      extensionAPI,
+      onSuccess: async (result) => {
+        await insertPageReferenceAtCursor({
+          blockUid,
+          pageTitle: result.text,
+          selectionStart,
+          windowId,
+        });
+      },
+      onClose: () => {},
+    });
+  };
+
   const toggleDiscourseContextOverlay = async () => {
     const currentValue =
       (extensionAPI.settings.get("discourse-context-overlay") as boolean) ??
@@ -216,6 +309,10 @@ export const registerCommandPaletteCommands = (onloadArgs: OnloadArgs) => {
   void addCommand("DG: Export - Discourse graph", exportDiscourseGraph);
   void addCommand("DG: Open - Discourse settings", renderSettingsPopup);
   void addCommand("DG: Open - Query drawer", openQueryDrawerWithArgs);
+  void addCommand(
+    "DG: Create - Discourse node at cursor",
+    createDiscourseNodeFromCommand,
+  );
   void addCommand(
     "DG: Toggle - Discourse context overlay",
     toggleDiscourseContextOverlay,

--- a/apps/roam/src/utils/registerCommandPaletteCommands.ts
+++ b/apps/roam/src/utils/registerCommandPaletteCommands.ts
@@ -25,18 +25,6 @@ import posthog from "posthog-js";
 export const registerCommandPaletteCommands = (onloadArgs: OnloadArgs) => {
   const { extensionAPI } = onloadArgs;
 
-  const insertPageReferenceAtCursor = async ({
-    blockUid,
-    pageTitle,
-    selectionStart,
-    windowId,
-  }: {
-    blockUid: string;
-    pageTitle: string;
-    selectionStart: number;
-    windowId: string;
-  }): Promise<void> => {};
-
   const createQueryBlock = async () => {
     {
       const uid = window.roamAlphaAPI.ui.getFocusedBlock()?.["block-uid"];
@@ -189,7 +177,6 @@ export const registerCommandPaletteCommands = (onloadArgs: OnloadArgs) => {
     posthog.capture("Discourse Node: Create Command Triggered");
     const focusedBlock = window.roamAlphaAPI.ui.getFocusedBlock();
     const uid = focusedBlock?.["block-uid"];
-    console.log("focusedBlock", focusedBlock);
     const windowId = focusedBlock?.["window-id"] || "main-window";
 
     const selectionStart = uid ? getSelectionStartForBlock(uid) : 0;

--- a/apps/roam/src/utils/registerCommandPaletteCommands.ts
+++ b/apps/roam/src/utils/registerCommandPaletteCommands.ts
@@ -201,25 +201,28 @@ export const registerCommandPaletteCommands = (onloadArgs: OnloadArgs) => {
     renderSettings({ onloadArgs });
   };
 
-  const createDiscourseNodeFromCommand = () => {
-    const focusedBlock = window.roamAlphaAPI.ui.getFocusedBlock();
-    const blockUid = focusedBlock?.["block-uid"];
-    const windowId = focusedBlock?.["window-id"] || "main-window";
+  const getSelectionStartForBlock = (uid: string): number => {
     const activeElement = document.activeElement;
     const isFocusedTextarea =
       activeElement instanceof HTMLTextAreaElement &&
-      activeElement.classList.contains("rm-block-input");
-    const selectionStart = isFocusedTextarea
-      ? activeElement.selectionStart
-      : null;
-
-    if (!blockUid || selectionStart === null) {
-      renderToast({
-        id: "create-discourse-node-command-focus",
-        content: "Place your cursor in a block before running this command.",
-      });
-      return;
+      activeElement.classList.contains("rm-block-input") &&
+      getUids(activeElement).blockUid === uid;
+    if (isFocusedTextarea) return activeElement.selectionStart;
+    const textareas = document.querySelectorAll("textarea.rm-block-input");
+    for (const el of textareas) {
+      const textarea = el as HTMLTextAreaElement;
+      if (getUids(textarea).blockUid === uid) return textarea.selectionStart;
     }
+    return (getTextByBlockUid(uid) || "").length;
+  };
+
+  const createDiscourseNodeFromCommand = () => {
+    posthog.capture("Discourse Node: Create Command Triggered");
+    const focusedBlock = window.roamAlphaAPI.ui.getFocusedBlock();
+    const uid = focusedBlock?.["block-uid"];
+    const windowId = focusedBlock?.["window-id"] || "main-window";
+
+    const selectionStart = uid ? getSelectionStartForBlock(uid) : 0;
 
     const defaultNodeType =
       getDiscourseNodes().filter(excludeDefaultNodes)[0]?.type;
@@ -237,8 +240,15 @@ export const registerCommandPaletteCommands = (onloadArgs: OnloadArgs) => {
       initialValue: { text: "", uid: "" },
       extensionAPI,
       onSuccess: async (result) => {
+        if (!uid) {
+          renderToast({
+            id: "create-discourse-node-command-no-block",
+            content: "No block focused to insert a discourse node.",
+          });
+          return;
+        }
         await insertPageReferenceAtCursor({
-          blockUid,
+          blockUid: uid,
           pageTitle: result.text,
           selectionStart,
           windowId,
@@ -310,7 +320,7 @@ export const registerCommandPaletteCommands = (onloadArgs: OnloadArgs) => {
   void addCommand("DG: Open - Discourse settings", renderSettingsPopup);
   void addCommand("DG: Open - Query drawer", openQueryDrawerWithArgs);
   void addCommand(
-    "DG: Create - Discourse node at cursor",
+    "DG: Create/Insert Discourse node",
     createDiscourseNodeFromCommand,
   );
   void addCommand(


### PR DESCRIPTION
https://www.loom.com/share/949663fd19184f02ae99065948cb363f
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/884" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "Create/Insert Discourse Node" command to the command palette. Users can now create discourse nodes and insert them directly into their blocks at the current cursor position via a dialog interface that handles node type selection and automatic text insertion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->