### PR TITLE
[ENG-1527] Handle image embeds in editor right-click convert to node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ local/*
 .cursor/debug.log
 apps/tldraw-sync-worker/tsconfig.tsbuildinfo
 apps/tldraw-sync-worker/.wrangler/*
+.claude/*

--- a/apps/obsidian/src/index.ts
+++ b/apps/obsidian/src/index.ts
@@ -152,14 +152,14 @@ export default class DiscourseGraphPlugin extends Plugin {
     );
 
     this.registerEvent(
-      // @ts-ignore - file-menu event exists but is not in the type definitions
+      // @ts-expect-error - file-menu event exists but is not in the type definitions
       this.app.workspace.on("file-menu", (menu: Menu, file: TFile) => {
         if (isImageFile(file)) {
-          addConvertSubmenu(
+          addConvertSubmenu({
             menu,
-            "Convert into",
-            this.settings.nodeTypes,
-            (nodeType) => {
+            label: "Convert into",
+            nodeTypes: this.settings.nodeTypes,
+            onClick: (nodeType) => {
               new ModifyNodeModal(this.app, {
                 nodeTypes: this.settings.nodeTypes,
                 plugin: this,
@@ -192,7 +192,7 @@ export default class DiscourseGraphPlugin extends Plugin {
                 },
               }).open();
             },
-          );
+          });
           return;
         }
 
@@ -205,11 +205,11 @@ export default class DiscourseGraphPlugin extends Plugin {
             (nodeType) => nodeType.id === fileNodeType,
           )
         ) {
-          addConvertSubmenu(
+          addConvertSubmenu({
             menu,
-            "Convert into",
-            this.settings.nodeTypes,
-            (nodeType) => {
+            label: "Convert into",
+            nodeTypes: this.settings.nodeTypes,
+            onClick: (nodeType) => {
               new ModifyNodeModal(this.app, {
                 nodeTypes: this.settings.nodeTypes,
                 plugin: this,
@@ -225,7 +225,7 @@ export default class DiscourseGraphPlugin extends Plugin {
                 },
               }).open();
             },
-          );
+          });
         }
       }),
     );
@@ -237,11 +237,11 @@ export default class DiscourseGraphPlugin extends Plugin {
         const selection = editor.getSelection().trim();
         const imageEmbed = isImageEmbed(selection);
 
-        addConvertSubmenu(
+        addConvertSubmenu({
           menu,
-          "Turn into discourse node",
-          this.settings.nodeTypes,
-          async (nodeType) => {
+          label: "Turn into discourse node",
+          nodeTypes: this.settings.nodeTypes,
+          onClick: async (nodeType) => {
             if (imageEmbed) {
               new ModifyNodeModal(this.app, {
                 nodeTypes: this.settings.nodeTypes,
@@ -278,7 +278,7 @@ export default class DiscourseGraphPlugin extends Plugin {
               });
             }
           },
-        );
+        });
       }),
     );
 

--- a/apps/obsidian/src/index.ts
+++ b/apps/obsidian/src/index.ts
@@ -196,11 +196,13 @@ export default class DiscourseGraphPlugin extends Plugin {
       this.app.workspace.on("editor-menu", (menu: Menu, editor: Editor) => {
         if (!editor.getSelection()) return;
 
+        const selection = editor.getSelection().trim();
+        const imageFile = this.resolveImageEmbedToFile(selection);
+
         menu.addItem((menuItem) => {
           menuItem.setTitle("Turn into discourse node");
           menuItem.setIcon("file-type");
 
-          // Create submenu using the unofficial API pattern
           // @ts-ignore - setSubmenu is not officially in the API but works
           const submenu = menuItem.setSubmenu();
 
@@ -210,12 +212,43 @@ export default class DiscourseGraphPlugin extends Plugin {
                 .setTitle(nodeType.name)
                 .setIcon("file-type")
                 .onClick(async () => {
-                  await createDiscourseNode({
-                    plugin: this,
-                    editor,
-                    nodeType,
-                    text: editor.getSelection().trim() || "",
-                  });
+                  if (imageFile) {
+                    new ModifyNodeModal(this.app, {
+                      nodeTypes: this.settings.nodeTypes,
+                      plugin: this,
+                      initialTitle: "",
+                      initialNodeType: nodeType,
+                      onSubmit: async ({ nodeType: selectedType, title }) => {
+                        const newFile = await createDiscourseNode({
+                          plugin: this,
+                          nodeType: selectedType,
+                          text: title,
+                        });
+
+                        if (newFile) {
+                          const imageLink =
+                            this.app.metadataCache.fileToLinktext(
+                              imageFile,
+                              newFile.path,
+                            );
+                          await this.app.vault.process(
+                            newFile,
+                            (data: string) => {
+                              return `${data}\n![[${imageLink}]]\n`;
+                            },
+                          );
+                          editor.replaceSelection(`[[${newFile.basename}]]`);
+                        }
+                      },
+                    }).open();
+                  } else {
+                    await createDiscourseNode({
+                      plugin: this,
+                      editor,
+                      nodeType,
+                      text: selection,
+                    });
+                  }
                 });
             });
           });
@@ -225,6 +258,66 @@ export default class DiscourseGraphPlugin extends Plugin {
 
     // Register editor keydown listener for node tag hotkey
     this.setupNodeTagHotkey();
+  }
+
+  private readonly IMAGE_EXTENSIONS =
+    /^(png|jpe?g|gif|svg|bmp|webp|avif|tiff?)$/i;
+
+  /**
+   * If `selection` is a single image embed (wikilink, markdown, or HTML img),
+   * resolve it to the vault TFile. Returns null when the selection is not an
+   * image embed or the file cannot be found.
+   */
+  private resolveImageEmbedToFile(selection: string): TFile | null {
+    const activeFile = this.app.workspace.getActiveFile();
+    if (!activeFile) return null;
+
+    let rawPath: string | null = null;
+
+    // Wikilink embed: ![[path/image.png|optional alias or size]]
+    const wikiMatch = selection.match(/^!\[\[([^\]]+)\]\]$/);
+    if (wikiMatch?.[1]) {
+      rawPath = wikiMatch[1].split("|")[0]?.split("#")[0]?.trim() ?? null;
+    }
+
+    // Markdown image: ![alt](path "optional title")
+    if (!rawPath) {
+      const mdMatch = selection.match(/^!\[([^\]]*)\]\(([^)]+)\)$/);
+      if (mdMatch?.[2]) {
+        let target = mdMatch[2].trim();
+        // Strip optional title: ![alt](path "title")
+        target = target.replace(/\s+"[^"]*"\s*$/, "");
+        // Unwrap angle brackets: ![alt](<path with spaces>)
+        target = target.replace(/^<(.+)>$/, "$1");
+        // Skip external URLs
+        if (/^https?:\/\//i.test(target)) return null;
+        rawPath = target;
+      }
+    }
+
+    // HTML img tag: <img src="path" ...>
+    if (!rawPath) {
+      const htmlMatch = selection.match(
+        /^<img\s[^>]*src=["']([^"']+)["'][^>]*\/?>$/i,
+      );
+      if (htmlMatch?.[1]) {
+        const target = htmlMatch[1].trim();
+        if (/^https?:\/\//i.test(target)) return null;
+        rawPath = target;
+      }
+    }
+
+    if (!rawPath) return null;
+
+    const resolved = this.app.metadataCache.getFirstLinkpathDest(
+      rawPath,
+      activeFile.path,
+    );
+    if (!resolved) return null;
+
+    if (!this.IMAGE_EXTENSIONS.test(resolved.extension)) return null;
+
+    return resolved;
   }
 
   private setupNodeTagHotkey() {

--- a/apps/obsidian/src/index.ts
+++ b/apps/obsidian/src/index.ts
@@ -11,6 +11,12 @@ import {
 import { EditorView } from "@codemirror/view";
 import { SettingsTab } from "~/components/Settings";
 import { Settings, VIEW_TYPE_DISCOURSE_CONTEXT } from "~/types";
+import {
+  addConvertSubmenu,
+  isImageEmbed,
+  isImageFile,
+  replaceImageEmbedInEditor,
+} from "~/utils/editorMenuUtils";
 import { registerCommands } from "~/utils/registerCommands";
 import { DiscourseContextView } from "~/components/DiscourseContextView";
 import { VIEW_TYPE_TLDRAW_DG_PREVIEW, FRONTMATTER_KEY } from "~/constants";
@@ -148,6 +154,48 @@ export default class DiscourseGraphPlugin extends Plugin {
     this.registerEvent(
       // @ts-ignore - file-menu event exists but is not in the type definitions
       this.app.workspace.on("file-menu", (menu: Menu, file: TFile) => {
+        if (isImageFile(file)) {
+          addConvertSubmenu(
+            menu,
+            "Convert into",
+            this.settings.nodeTypes,
+            (nodeType) => {
+              new ModifyNodeModal(this.app, {
+                nodeTypes: this.settings.nodeTypes,
+                plugin: this,
+                initialTitle: "",
+                initialNodeType: nodeType,
+                onSubmit: async ({
+                  nodeType: selectedType,
+                  title,
+                  selectedExistingNode,
+                }) => {
+                  const targetFile =
+                    selectedExistingNode ??
+                    (await createDiscourseNode({
+                      plugin: this,
+                      nodeType: selectedType,
+                      text: title,
+                    }));
+
+                  if (!targetFile) return;
+
+                  const imageLink = this.app.metadataCache.fileToLinktext(
+                    file,
+                    targetFile.path,
+                  );
+                  await this.app.vault.append(
+                    targetFile,
+                    `\n![[${imageLink}]]\n`,
+                  );
+                  replaceImageEmbedInEditor(this.app, file, targetFile);
+                },
+              }).open();
+            },
+          );
+          return;
+        }
+
         const fileCache = this.app.metadataCache.getFileCache(file);
         const fileNodeType = fileCache?.frontmatter?.nodeTypeId;
 
@@ -157,37 +205,27 @@ export default class DiscourseGraphPlugin extends Plugin {
             (nodeType) => nodeType.id === fileNodeType,
           )
         ) {
-          menu.addItem((menuItem) => {
-            menuItem.setTitle("Convert into");
-            menuItem.setIcon("file-type");
-
-            // @ts-ignore - setSubmenu is not officially in the API but works
-            const submenu = menuItem.setSubmenu();
-
-            this.settings.nodeTypes.forEach((nodeType) => {
-              submenu.addItem((item: any) => {
-                item
-                  .setTitle(nodeType.name)
-                  .setIcon("file-type")
-                  .onClick(() => {
-                    new ModifyNodeModal(this.app, {
-                      nodeTypes: this.settings.nodeTypes,
-                      plugin: this,
-                      initialTitle: file.basename,
-                      initialNodeType: nodeType,
-                      onSubmit: async ({ nodeType, title }) => {
-                        await convertPageToDiscourseNode({
-                          plugin: this,
-                          file,
-                          nodeType,
-                          title,
-                        });
-                      },
-                    }).open();
+          addConvertSubmenu(
+            menu,
+            "Convert into",
+            this.settings.nodeTypes,
+            (nodeType) => {
+              new ModifyNodeModal(this.app, {
+                nodeTypes: this.settings.nodeTypes,
+                plugin: this,
+                initialTitle: file.basename,
+                initialNodeType: nodeType,
+                onSubmit: async ({ nodeType, title }) => {
+                  await convertPageToDiscourseNode({
+                    plugin: this,
+                    file,
+                    nodeType,
+                    title,
                   });
-              });
-            });
-          });
+                },
+              }).open();
+            },
+          );
         }
       }),
     );
@@ -197,127 +235,55 @@ export default class DiscourseGraphPlugin extends Plugin {
         if (!editor.getSelection()) return;
 
         const selection = editor.getSelection().trim();
-        const imageFile = this.resolveImageEmbedToFile(selection);
+        const imageEmbed = isImageEmbed(selection);
 
-        menu.addItem((menuItem) => {
-          menuItem.setTitle("Turn into discourse node");
-          menuItem.setIcon("file-type");
-
-          // @ts-ignore - setSubmenu is not officially in the API but works
-          const submenu = menuItem.setSubmenu();
-
-          this.settings.nodeTypes.forEach((nodeType) => {
-            submenu.addItem((item: any) => {
-              item
-                .setTitle(nodeType.name)
-                .setIcon("file-type")
-                .onClick(async () => {
-                  if (imageFile) {
-                    new ModifyNodeModal(this.app, {
-                      nodeTypes: this.settings.nodeTypes,
+        addConvertSubmenu(
+          menu,
+          "Turn into discourse node",
+          this.settings.nodeTypes,
+          async (nodeType) => {
+            if (imageEmbed) {
+              new ModifyNodeModal(this.app, {
+                nodeTypes: this.settings.nodeTypes,
+                plugin: this,
+                initialTitle: "",
+                initialNodeType: nodeType,
+                onSubmit: async ({
+                  nodeType: selectedType,
+                  title,
+                  selectedExistingNode,
+                }) => {
+                  const targetFile =
+                    selectedExistingNode ??
+                    (await createDiscourseNode({
                       plugin: this,
-                      initialTitle: "",
-                      initialNodeType: nodeType,
-                      onSubmit: async ({ nodeType: selectedType, title }) => {
-                        const newFile = await createDiscourseNode({
-                          plugin: this,
-                          nodeType: selectedType,
-                          text: title,
-                        });
+                      nodeType: selectedType,
+                      text: title,
+                    }));
 
-                        if (newFile) {
-                          const imageLink =
-                            this.app.metadataCache.fileToLinktext(
-                              imageFile,
-                              newFile.path,
-                            );
-                          await this.app.vault.process(
-                            newFile,
-                            (data: string) => {
-                              return `${data}\n![[${imageLink}]]\n`;
-                            },
-                          );
-                          editor.replaceSelection(`[[${newFile.basename}]]`);
-                        }
-                      },
-                    }).open();
-                  } else {
-                    await createDiscourseNode({
-                      plugin: this,
-                      editor,
-                      nodeType,
-                      text: selection,
-                    });
+                  if (!targetFile) return;
+
+                  if (!selectedExistingNode) {
+                    await this.app.vault.append(targetFile, `\n${selection}\n`);
                   }
-                });
-            });
-          });
-        });
+                  editor.replaceSelection(`[[${targetFile.basename}]]`);
+                },
+              }).open();
+            } else {
+              await createDiscourseNode({
+                plugin: this,
+                editor,
+                nodeType,
+                text: selection,
+              });
+            }
+          },
+        );
       }),
     );
 
     // Register editor keydown listener for node tag hotkey
     this.setupNodeTagHotkey();
-  }
-
-  private readonly IMAGE_EXTENSIONS =
-    /^(png|jpe?g|gif|svg|bmp|webp|avif|tiff?)$/i;
-
-  /**
-   * If `selection` is a single image embed (wikilink, markdown, or HTML img),
-   * resolve it to the vault TFile. Returns null when the selection is not an
-   * image embed or the file cannot be found.
-   */
-  private resolveImageEmbedToFile(selection: string): TFile | null {
-    const activeFile = this.app.workspace.getActiveFile();
-    if (!activeFile) return null;
-
-    let rawPath: string | null = null;
-
-    // Wikilink embed: ![[path/image.png|optional alias or size]]
-    const wikiMatch = selection.match(/^!\[\[([^\]]+)\]\]$/);
-    if (wikiMatch?.[1]) {
-      rawPath = wikiMatch[1].split("|")[0]?.split("#")[0]?.trim() ?? null;
-    }
-
-    // Markdown image: ![alt](path "optional title")
-    if (!rawPath) {
-      const mdMatch = selection.match(/^!\[([^\]]*)\]\(([^)]+)\)$/);
-      if (mdMatch?.[2]) {
-        let target = mdMatch[2].trim();
-        // Strip optional title: ![alt](path "title")
-        target = target.replace(/\s+"[^"]*"\s*$/, "");
-        // Unwrap angle brackets: ![alt](<path with spaces>)
-        target = target.replace(/^<(.+)>$/, "$1");
-        // Skip external URLs
-        if (/^https?:\/\//i.test(target)) return null;
-        rawPath = target;
-      }
-    }
-
-    // HTML img tag: <img src="path" ...>
-    if (!rawPath) {
-      const htmlMatch = selection.match(
-        /^<img\s[^>]*src=["']([^"']+)["'][^>]*\/?>$/i,
-      );
-      if (htmlMatch?.[1]) {
-        const target = htmlMatch[1].trim();
-        if (/^https?:\/\//i.test(target)) return null;
-        rawPath = target;
-      }
-    }
-
-    if (!rawPath) return null;
-
-    const resolved = this.app.metadataCache.getFirstLinkpathDest(
-      rawPath,
-      activeFile.path,
-    );
-    if (!resolved) return null;
-
-    if (!this.IMAGE_EXTENSIONS.test(resolved.extension)) return null;
-
-    return resolved;
   }
 
   private setupNodeTagHotkey() {

--- a/apps/obsidian/src/index.ts
+++ b/apps/obsidian/src/index.ts
@@ -151,7 +151,6 @@ export default class DiscourseGraphPlugin extends Plugin {
     );
 
     this.registerEvent(
-      // @ts-expect-error - file-menu event exists but is not in the type definitions
       this.app.workspace.on("file-menu", (menu: Menu, file: TFile) => {
         if (isImageFile(file)) {
           addConvertSubmenu({

--- a/apps/obsidian/src/index.ts
+++ b/apps/obsidian/src/index.ts
@@ -13,7 +13,6 @@ import { SettingsTab } from "~/components/Settings";
 import { Settings, VIEW_TYPE_DISCOURSE_CONTEXT } from "~/types";
 import {
   addConvertSubmenu,
-  isImageEmbed,
   isImageFile,
   replaceImageEmbedInEditor,
 } from "~/utils/editorMenuUtils";
@@ -188,7 +187,11 @@ export default class DiscourseGraphPlugin extends Plugin {
                     targetFile,
                     `\n![[${imageLink}]]\n`,
                   );
-                  replaceImageEmbedInEditor(this.app, file, targetFile);
+                  replaceImageEmbedInEditor({
+                    app: this.app,
+                    imageFile: file,
+                    targetFile,
+                  });
                 },
               }).open();
             },
@@ -235,46 +238,17 @@ export default class DiscourseGraphPlugin extends Plugin {
         if (!editor.getSelection()) return;
 
         const selection = editor.getSelection().trim();
-        const imageEmbed = isImageEmbed(selection);
-
         addConvertSubmenu({
           menu,
           label: "Turn into discourse node",
           nodeTypes: this.settings.nodeTypes,
           onClick: async (nodeType) => {
-            if (imageEmbed) {
-              new ModifyNodeModal(this.app, {
-                nodeTypes: this.settings.nodeTypes,
-                plugin: this,
-                initialTitle: "",
-                initialNodeType: nodeType,
-                onSubmit: async ({
-                  nodeType: selectedType,
-                  title,
-                  selectedExistingNode,
-                }) => {
-                  const targetFile =
-                    selectedExistingNode ??
-                    (await createDiscourseNode({
-                      plugin: this,
-                      nodeType: selectedType,
-                      text: title,
-                    }));
-
-                  if (!targetFile) return;
-
-                  await this.app.vault.append(targetFile, `\n${selection}\n`);
-                  editor.replaceSelection(`[[${targetFile.basename}]]`);
-                },
-              }).open();
-            } else {
-              await createDiscourseNode({
-                plugin: this,
-                editor,
-                nodeType,
-                text: selection,
-              });
-            }
+            await createDiscourseNode({
+              plugin: this,
+              editor,
+              nodeType,
+              text: selection,
+            });
           },
         });
       }),

--- a/apps/obsidian/src/index.ts
+++ b/apps/obsidian/src/index.ts
@@ -263,9 +263,7 @@ export default class DiscourseGraphPlugin extends Plugin {
 
                   if (!targetFile) return;
 
-                  if (!selectedExistingNode) {
-                    await this.app.vault.append(targetFile, `\n${selection}\n`);
-                  }
+                  await this.app.vault.append(targetFile, `\n${selection}\n`);
                   editor.replaceSelection(`[[${targetFile.basename}]]`);
                 },
               }).open();

--- a/apps/obsidian/src/types/obsidian-unofficial.d.ts
+++ b/apps/obsidian/src/types/obsidian-unofficial.d.ts
@@ -1,0 +1,17 @@
+// Unofficial Obsidian APIs — may break on Obsidian updates.
+// Only declare what we actually use.
+import "obsidian";
+
+declare module "obsidian" {
+  // module has to be declared using interface instead of type to merge with the official types
+  interface Workspace {
+    on(
+      name: "file-menu",
+      callback: (menu: Menu, file: TFile) => void,
+    ): EventRef;
+  }
+
+  interface MenuItem {
+    setSubmenu(): Menu;
+  }
+}

--- a/apps/obsidian/src/types/obsidian-unofficial.d.ts
+++ b/apps/obsidian/src/types/obsidian-unofficial.d.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/consistent-type-definitions */
 // Unofficial Obsidian APIs — may break on Obsidian updates.
 // Only declare what we actually use.
 import "obsidian";

--- a/apps/obsidian/src/utils/editorMenuUtils.ts
+++ b/apps/obsidian/src/utils/editorMenuUtils.ts
@@ -33,7 +33,7 @@ export const addConvertSubmenu = ({
           .setIcon("file-type")
           .onClick(() => void onClick(nodeType));
       });
-      /* eslint-disable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access */
+      /* eslint-enable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access */
     });
   });
 };
@@ -41,11 +41,15 @@ export const addConvertSubmenu = ({
 /**
  * Replace the first embed of `imageFile` in the active editor with a link to `targetFile`.
  */
-export const replaceImageEmbedInEditor = (
-  app: App,
-  imageFile: TFile,
-  targetFile: TFile,
-) => {
+export const replaceImageEmbedInEditor = ({
+  app,
+  imageFile,
+  targetFile,
+}: {
+  app: App;
+  imageFile: TFile;
+  targetFile: TFile;
+}) => {
   const activeView = app.workspace.getActiveViewOfType(MarkdownView);
   if (!activeView?.file) return;
 
@@ -68,17 +72,3 @@ const IMAGE_EXTENSIONS = /^(png|jpe?g|gif|svg|bmp|webp|avif|tiff?)$/i;
 
 export const isImageFile = (file: TFile): boolean =>
   IMAGE_EXTENSIONS.test(file.extension);
-
-/**
- * Returns true when `selection` looks like a single image embed
- * (wikilink, markdown, or HTML img tag).
- */
-export const isImageEmbed = (selection: string): boolean => {
-  // Wikilink embed: ![[image.png]] or ![[image.png|500]]
-  if (/^!\[\[[^\]]+\]\]$/.test(selection)) return true;
-  // Markdown image: ![alt](path) or ![alt](path "title")
-  if (/^!\[[^\]]*\]\([^)]+\)$/.test(selection)) return true;
-  // HTML img tag: <img src="path" ...>
-  if (/^<img\s[^>]*src=["'][^"']+["'][^>]*\/?>$/i.test(selection)) return true;
-  return false;
-};

--- a/apps/obsidian/src/utils/editorMenuUtils.ts
+++ b/apps/obsidian/src/utils/editorMenuUtils.ts
@@ -1,0 +1,76 @@
+import { App, MarkdownView, Menu, TFile } from "obsidian";
+import { DiscourseNode } from "~/types";
+
+/**
+ * Add a "Convert into" / "Turn into discourse node" submenu to a context menu,
+ * with one item per node type.
+ */
+export const addConvertSubmenu = (
+  menu: Menu,
+  label: string,
+  nodeTypes: DiscourseNode[],
+  onClick: (nodeType: DiscourseNode) => void | Promise<void>,
+) => {
+  menu.addItem((menuItem) => {
+    menuItem.setTitle(label);
+    menuItem.setIcon("file-type");
+
+    // @ts-ignore - setSubmenu is not officially in the API but works
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
+    const submenu = menuItem.setSubmenu();
+
+    nodeTypes.forEach((nodeType) => {
+      submenu.addItem((item: any) => {
+        item
+          .setTitle(nodeType.name)
+          .setIcon("file-type")
+          .onClick(() => void onClick(nodeType));
+      });
+    });
+  });
+};
+
+/**
+ * Replace the first embed of `imageFile` in the active editor with a link to `targetFile`.
+ */
+export const replaceImageEmbedInEditor = (
+  app: App,
+  imageFile: TFile,
+  targetFile: TFile,
+) => {
+  const activeView = app.workspace.getActiveViewOfType(MarkdownView);
+  if (!activeView?.file) return;
+
+  const cache = app.metadataCache.getFileCache(activeView.file);
+  const embed = cache?.embeds?.find((e) => {
+    const resolved = app.metadataCache.getFirstLinkpathDest(
+      e.link,
+      activeView.file!.path,
+    );
+    return resolved?.path === imageFile.path;
+  });
+  if (!embed) return;
+
+  const from = activeView.editor.offsetToPos(embed.position.start.offset);
+  const to = activeView.editor.offsetToPos(embed.position.end.offset);
+  activeView.editor.replaceRange(`[[${targetFile.basename}]]`, from, to);
+};
+
+const IMAGE_EXTENSIONS = /^(png|jpe?g|gif|svg|bmp|webp|avif|tiff?)$/i;
+
+export const isImageFile = (file: TFile): boolean =>
+  IMAGE_EXTENSIONS.test(file.extension);
+
+/**
+ * Returns true when `selection` looks like a single image embed
+ * (wikilink, markdown, or HTML img tag).
+ */
+export const isImageEmbed = (selection: string): boolean => {
+  // Wikilink embed: ![[image.png]] or ![[image.png|500]]
+  if (/^!\[\[[^\]]+\]\]$/.test(selection)) return true;
+  // Markdown image: ![alt](path) or ![alt](path "title")
+  if (/^!\[[^\]]*\]\([^)]+\)$/.test(selection)) return true;
+  // HTML img tag: <img src="path" ...>
+  if (/^<img\s[^>]*src=["'][^"']+["'][^>]*\/?>$/i.test(selection)) return true;
+  return false;
+};

--- a/apps/obsidian/src/utils/editorMenuUtils.ts
+++ b/apps/obsidian/src/utils/editorMenuUtils.ts
@@ -20,20 +20,15 @@ export const addConvertSubmenu = ({
     menuItem.setTitle(label);
     menuItem.setIcon("file-type");
 
-    /* eslint-disable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment*/
-    // @ts-expect-error - setSubmenu is not officially in the API but works
     const submenu = menuItem.setSubmenu();
 
     nodeTypes.forEach((nodeType) => {
-      // setSubmenu is not officially in the API but works
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      submenu.addItem((item: any) => {
+      submenu.addItem((item) => {
         item
           .setTitle(nodeType.name)
           .setIcon("file-type")
           .onClick(() => void onClick(nodeType));
       });
-      /* eslint-enable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment */
     });
   });
 };
@@ -65,7 +60,11 @@ export const replaceImageEmbedInEditor = ({
 
   const from = activeView.editor.offsetToPos(embed.position.start.offset);
   const to = activeView.editor.offsetToPos(embed.position.end.offset);
-  activeView.editor.replaceRange(`[[${targetFile.basename}]]`, from, to);
+  const linkText = app.metadataCache.fileToLinktext(
+    targetFile,
+    activeView.file.path,
+  );
+  activeView.editor.replaceRange(`[[${linkText}]]`, from, to);
 };
 
 const IMAGE_EXTENSIONS = /^(png|jpe?g|gif|svg|bmp|webp|avif|tiff?)$/i;

--- a/apps/obsidian/src/utils/editorMenuUtils.ts
+++ b/apps/obsidian/src/utils/editorMenuUtils.ts
@@ -5,18 +5,23 @@ import { DiscourseNode } from "~/types";
  * Add a "Convert into" / "Turn into discourse node" submenu to a context menu,
  * with one item per node type.
  */
-export const addConvertSubmenu = (
-  menu: Menu,
-  label: string,
-  nodeTypes: DiscourseNode[],
-  onClick: (nodeType: DiscourseNode) => void | Promise<void>,
-) => {
+export const addConvertSubmenu = ({
+  menu,
+  label,
+  nodeTypes,
+  onClick,
+}: {
+  menu: Menu;
+  label: string;
+  nodeTypes: DiscourseNode[];
+  onClick: (nodeType: DiscourseNode) => void | Promise<void>;
+}) => {
   menu.addItem((menuItem) => {
     menuItem.setTitle(label);
     menuItem.setIcon("file-type");
 
-    // @ts-ignore - setSubmenu is not officially in the API but works
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
+    /* eslint-disable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access */
+    // @ts-expect-error - setSubmenu is not officially in the API but works
     const submenu = menuItem.setSubmenu();
 
     nodeTypes.forEach((nodeType) => {
@@ -26,6 +31,7 @@ export const addConvertSubmenu = (
           .setIcon("file-type")
           .onClick(() => void onClick(nodeType));
       });
+      /* eslint-disable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access */
     });
   });
 };

--- a/apps/obsidian/src/utils/editorMenuUtils.ts
+++ b/apps/obsidian/src/utils/editorMenuUtils.ts
@@ -49,7 +49,7 @@ export const replaceImageEmbedInEditor = ({
   app: App;
   imageFile: TFile;
   targetFile: TFile;
-}) => {
+}): void => {
   const activeView = app.workspace.getActiveViewOfType(MarkdownView);
   if (!activeView?.file) return;
 

--- a/apps/obsidian/src/utils/editorMenuUtils.ts
+++ b/apps/obsidian/src/utils/editorMenuUtils.ts
@@ -33,7 +33,7 @@ export const addConvertSubmenu = ({
           .setIcon("file-type")
           .onClick(() => void onClick(nodeType));
       });
-      /* eslint-enable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access */
+      /* eslint-enable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment */
     });
   });
 };

--- a/apps/obsidian/src/utils/editorMenuUtils.ts
+++ b/apps/obsidian/src/utils/editorMenuUtils.ts
@@ -15,7 +15,7 @@ export const addConvertSubmenu = ({
   label: string;
   nodeTypes: DiscourseNode[];
   onClick: (nodeType: DiscourseNode) => void | Promise<void>;
-}) => {
+}): void => {
   menu.addItem((menuItem) => {
     menuItem.setTitle(label);
     menuItem.setIcon("file-type");

--- a/apps/obsidian/src/utils/editorMenuUtils.ts
+++ b/apps/obsidian/src/utils/editorMenuUtils.ts
@@ -20,11 +20,13 @@ export const addConvertSubmenu = ({
     menuItem.setTitle(label);
     menuItem.setIcon("file-type");
 
-    /* eslint-disable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access */
+    /* eslint-disable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment*/
     // @ts-expect-error - setSubmenu is not officially in the API but works
     const submenu = menuItem.setSubmenu();
 
     nodeTypes.forEach((nodeType) => {
+      // setSubmenu is not officially in the API but works
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       submenu.addItem((item: any) => {
         item
           .setTitle(nodeType.name)


### PR DESCRIPTION
https://www.loom.com/share/e4cff9d723bd495e9a3c7e01ce6032f8

## Summary
- When the user selects an image embed in the markdown editor and right-clicks "Turn into discourse node", the selection is now detected as an image and handled with the `ModifyNodeModal` flow (like file-menu) instead of treating the embed syntax as literal text
- Creates a new discourse node, embeds the image in it, and replaces the selection with a wikilink to the new node

Closes ENG-1527

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/885" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
