### PR TITLE
[ENG-988] Fix color circle not showing for new node types

### DIFF
--- a/apps/obsidian/src/components/NodeTypeSettings.tsx
+++ b/apps/obsidian/src/components/NodeTypeSettings.tsx
@@ -365,6 +365,7 @@ const NodeTypeSettings = () => {
       format: "",
       template: "",
       tag: "",
+      color: "#808080",
       created: now,
       modified: now,
     };


### PR DESCRIPTION
## Summary
- Add default grey color (`#808080`) to new node types created via "Add Node Type" in settings, so the color circle renders immediately

## Test plan
- [x] Open plugin settings, go to Node Types tab
- [x] Click "Add Node Type" and verify a grey color circle appears
<img width="704" height="806" alt="image" src="https://github.com/user-attachments/assets/966c81bb-472b-4ef6-92fd-98646d557ea9" />

- [x] Even without changing the color, now the node has a default node color
<img width="514" height="65" alt="image" src="https://github.com/user-attachments/assets/62977869-d6d2-4910-85d9-5466870cd8af" />
- [x] when picking a node color from creation step, it is saved
<img width="670" height="793" alt="image" src="https://github.com/user-attachments/assets/bbcfd14a-9b89-452c-b313-c7e7df5852e1" />
<img width="502" height="60" alt="Screenshot 2026-03-12 at 18 51 31" src="https://github.com/user-attachments/assets/e55c789d-aa6c-4b8e-9488-2857623b31fd" />

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/887" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
