### PR TITLE
ENG-1536 Support multiple vault paths in Obsidian build script

### DIFF
--- a/apps/obsidian/.env.example
+++ b/apps/obsidian/.env.example
@@ -1,1 +1,3 @@
-# OBSIDIAN_PLUGIN_PATH="path/to/your/obsidian/plugins/folder"
+# OBSIDIAN_PLUGIN_PATH="path/to/your/obsidian/vault/.obsidian/plugins/discourse-graph"
+# For multiple vaults, separate paths with commas:
+# OBSIDIAN_PLUGIN_PATH="path/to/vault1/.obsidian/plugins/discourse-graph,path/to/vault2/.obsidian/plugins/discourse-graph"

--- a/apps/obsidian/.env.example
+++ b/apps/obsidian/.env.example
@@ -1,3 +1,4 @@
 # OBSIDIAN_PLUGIN_PATH="path/to/your/obsidian/vault/.obsidian/plugins/discourse-graph"
 # For multiple vaults, separate paths with commas:
-# OBSIDIAN_PLUGIN_PATH="path/to/vault1/.obsidian/plugins/discourse-graph,path/to/vault2/.obsidian/plugins/discourse-graph"
+# OBSIDIAN_PLUGIN_PATH='["/vault one/plugins/discourse-graph","/vault two/plugins/discourse-graph"]'
+# OBSIDIAN_PLUGIN_REPO_TOKEN=your-github-pat-here

--- a/apps/obsidian/.env.example
+++ b/apps/obsidian/.env.example
@@ -1,4 +1,4 @@
 # OBSIDIAN_PLUGIN_PATH="path/to/your/obsidian/vault/.obsidian/plugins/discourse-graph"
-# For multiple vaults, separate paths with commas:
+# For multiple vaults, use a JSON array:
 # OBSIDIAN_PLUGIN_PATH='["/vault one/plugins/discourse-graph","/vault two/plugins/discourse-graph"]'
 # OBSIDIAN_PLUGIN_REPO_TOKEN=your-github-pat-here

--- a/apps/obsidian/scripts/compile.ts
+++ b/apps/obsidian/scripts/compile.ts
@@ -197,25 +197,34 @@ export const compile = ({
             build.onEnd(async () => {
               if (!mirror) return;
 
-              const normalizedMirrorPath = path.normalize(mirror);
-              const resolvedMirrorPath = path.resolve(
-                root,
-                normalizedMirrorPath,
-              );
+              const mirrorPaths = mirror
+                .split(",")
+                .map((p) => p.trim())
+                .filter(Boolean);
 
-              if (!fs.existsSync(resolvedMirrorPath)) {
-                fs.mkdirSync(resolvedMirrorPath, { recursive: true });
+              for (const mirrorPath of mirrorPaths) {
+                const normalizedMirrorPath = path.normalize(mirrorPath);
+                const resolvedMirrorPath = path.resolve(
+                  root,
+                  normalizedMirrorPath,
+                );
+
+                if (!fs.existsSync(resolvedMirrorPath)) {
+                  fs.mkdirSync(resolvedMirrorPath, { recursive: true });
+                }
+
+                readDir(outdir)
+                  .filter((file) => fs.existsSync(appPath(file)))
+                  .forEach((file) => {
+                    const destinationPath = path.join(
+                      resolvedMirrorPath,
+                      path.relative(outdir, file),
+                    );
+                    fs.cpSync(appPath(file), destinationPath);
+                  });
+
+                console.log(`mirrored to ${resolvedMirrorPath}`);
               }
-
-              readDir(outdir)
-                .filter((file) => fs.existsSync(appPath(file)))
-                .forEach((file) => {
-                  const destinationPath = path.join(
-                    resolvedMirrorPath,
-                    path.relative(outdir, file),
-                  );
-                  fs.cpSync(appPath(file), destinationPath);
-                });
             });
           },
         },

--- a/apps/obsidian/scripts/compile.ts
+++ b/apps/obsidian/scripts/compile.ts
@@ -200,7 +200,7 @@ export const compile = ({
               let mirrorPaths: string[];
               try {
                 const parsed = JSON.parse(mirror);
-                mirrorPaths = Array.isArray(parsed) ? parsed : [mirror];
+                mirrorPaths = Array.isArray(parsed) ? parsed : [parsed];
               } catch {
                 mirrorPaths = [mirror];
               }

--- a/apps/obsidian/scripts/compile.ts
+++ b/apps/obsidian/scripts/compile.ts
@@ -139,7 +139,7 @@ export const compile = ({
         },
         {
           name: "combineStyles",
-          setup(build) {
+          setup: (build): void => {
             build.onEnd(async () => {
               const rootStylesPath = path.join(root, "styles.css");
               if (fs.existsSync(rootStylesPath)) {
@@ -181,7 +181,7 @@ export const compile = ({
         },
         {
           name: "copyDefaultFiles",
-          setup(build) {
+          setup: (build): void => {
             build.onEnd(async () => {
               DEFAULT_FILES_INCLUDED.map((f) => path.join(root, f))
                 .filter((f) => fs.existsSync(f))
@@ -194,12 +194,12 @@ export const compile = ({
         {
           name: "mirrorFiles",
           setup: (build) => {
-            build.onEnd(async () => {
+            build.onEnd(() => {
               if (!mirror) return;
 
               let mirrorPaths: string[];
               try {
-                const parsed = JSON.parse(mirror);
+                const parsed: unknown = JSON.parse(mirror);
                 mirrorPaths = Array.isArray(parsed) ? parsed : [parsed];
               } catch {
                 mirrorPaths = [mirror];

--- a/apps/obsidian/scripts/compile.ts
+++ b/apps/obsidian/scripts/compile.ts
@@ -193,14 +193,18 @@ export const compile = ({
         },
         {
           name: "mirrorFiles",
-          setup(build) {
+          setup: (build) => {
             build.onEnd(async () => {
               if (!mirror) return;
 
-              const mirrorPaths = mirror
-                .split(",")
-                .map((p) => p.trim())
-                .filter(Boolean);
+              let mirrorPaths: string[];
+              try {
+                const parsed = JSON.parse(mirror);
+                mirrorPaths = Array.isArray(parsed) ? parsed : [mirror];
+              } catch {
+                mirrorPaths = [mirror];
+              }
+              mirrorPaths = mirrorPaths.map((p) => p.trim()).filter(Boolean);
 
               for (const mirrorPath of mirrorPaths) {
                 const normalizedMirrorPath = path.normalize(mirrorPath);

--- a/apps/obsidian/scripts/compile.ts
+++ b/apps/obsidian/scripts/compile.ts
@@ -194,7 +194,7 @@ export const compile = ({
         },
         {
           name: "mirrorFiles",
-          setup: (build) => {
+          setup: (build): void => {
             build.onEnd(() => {
               if (!mirror) return;
 

--- a/apps/obsidian/scripts/compile.ts
+++ b/apps/obsidian/scripts/compile.ts
@@ -12,9 +12,10 @@ import autoprefixer from "autoprefixer";
 dotenv.config();
 
 // For local dev: Set SUPABASE_USE_DB=local and run `pnpm run genenv` in packages/database
-let envContents: (() => Record<string, string>) | null = null;
+let envContents: () => Partial<Record<string, string>>;
 try {
   const dbDotEnv = require("@repo/database/dbDotEnv");
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   envContents = dbDotEnv.envContents;
 } catch (error) {
   if ((error as Error).message.includes("Cannot find module")) {
@@ -182,7 +183,7 @@ export const compile = ({
         {
           name: "copyDefaultFiles",
           setup: (build): void => {
-            build.onEnd(async () => {
+            build.onEnd(() => {
               DEFAULT_FILES_INCLUDED.map((f) => path.join(root, f))
                 .filter((f) => fs.existsSync(f))
                 .forEach((f) => {
@@ -200,7 +201,9 @@ export const compile = ({
               let mirrorPaths: string[];
               try {
                 const parsed: unknown = JSON.parse(mirror);
-                mirrorPaths = Array.isArray(parsed) ? parsed : [parsed];
+                mirrorPaths = Array.isArray(parsed)
+                  ? (parsed as string[])
+                  : [parsed as string];
               } catch {
                 mirrorPaths = [mirror];
               }
@@ -247,4 +250,4 @@ const main = async () => {
     process.exit(1);
   }
 };
-if (require.main === module) main();
+if (require.main === module) void main();


### PR DESCRIPTION
https://www.loom.com/share/79291c06196e43bcae5544a7d2a3dd7c

## Summary
- Updates `OBSIDIAN_PLUGIN_PATH` to accept a comma-separated list of vault paths
- Build output is now mirrored to all specified vaults on each rebuild
- Updates `.env.example` with documentation on the multi-vault syntax

## Test plan
- [x] Set `OBSIDIAN_PLUGIN_PATH="vault1/path,vault2/path"` in `.env`
- [x] Run `turbo dev`
- [x] Verify built files are copied to both vault paths
- [x] Verify single-path config still works as before
<img width="1860" height="862" alt="image" src="https://github.com/user-attachments/assets/74d3503f-f252-40d3-a840-bde5d4342b46" />
here's how the "General" looks differently if i set the path to be single again

Closes [ENG-1536](https://linear.app/discourse-graphs/issue/ENG-1536)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/891" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
