### PR TITLE
ENG-1508: Open canvas as TldrawView immediately after creation

### DIFF
--- a/apps/obsidian/src/components/canvas/utils/tldraw.ts
+++ b/apps/obsidian/src/components/canvas/utils/tldraw.ts
@@ -14,6 +14,7 @@ import {
   TLDATA_DELIMITER_END,
   TLDATA_DELIMITER_START,
   TLDRAW_VERSION,
+  VIEW_TYPE_TLDRAW_DG_PREVIEW,
 } from "~/constants";
 import DiscourseGraphPlugin from "~/index";
 import { checkAndCreateFolder, getNewUniqueFilepath } from "~/utils/file";
@@ -178,8 +179,7 @@ export const createCanvas = async (plugin: DiscourseGraphPlugin) => {
   try {
     const filename = `Canvas-${format(new Date(), "yyyy-MM-dd-HHmm")}`;
     const folderpath = plugin.settings.canvasFolderPath;
-    const attachmentsFolder =
-      plugin.settings.canvasAttachmentsFolderPath;
+    const attachmentsFolder = plugin.settings.canvasAttachmentsFolderPath;
 
     await checkAndCreateFolder(folderpath, plugin.app.vault);
     await checkAndCreateFolder(attachmentsFolder, plugin.app.vault);
@@ -193,6 +193,10 @@ export const createCanvas = async (plugin: DiscourseGraphPlugin) => {
     const file = await plugin.app.vault.create(fname, content);
     const leaf = plugin.app.workspace.getLeaf(false);
     await leaf.openFile(file);
+    await leaf.setViewState({
+      type: VIEW_TYPE_TLDRAW_DG_PREVIEW,
+      state: { file: file.path },
+    });
 
     return file;
   } catch (e) {


### PR DESCRIPTION
https://www.loom.com/share/f7344e99624f40fa9edf321f5ae8f10c


## Summary
- Fixes bug where newly created canvas files show raw JSON markdown instead of the Tldraw canvas view
- Root cause: `metadataCache.getFileCache()` returns `null` for newly created files (cache not yet indexed), so the file path never gets added to `pendingCanvasSwitches` and the view never switches
- Fix: directly call `leaf.setViewState({ type: VIEW_TYPE_TLDRAW_DG_PREVIEW })` in `createCanvas()` after `openFile()`, bypassing the event-based switching for the creation case

## Test plan
- [x] Run "Create new Discourse Graph canvas" command
- [x] Verify the canvas opens directly in Tldraw canvas view (not markdown/JSON view)
- [x] Verify re-opening an existing canvas file still auto-switches to canvas view
- [x] Verify switching between markdown and canvas views still works via the action buttons

Closes [ENG-1508](https://linear.app/discourse-graphs/issue/ENG-1508)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/892" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
