### PR TITLE
ENG-1138 Migrate canvas shape node type to discourse-node

### DIFF
--- a/apps/roam/src/components/Export.tsx
+++ b/apps/roam/src/components/Export.tsx
@@ -62,7 +62,8 @@ import {
 } from "@tldraw/editor";
 import calcCanvasNodeSizeAndImg from "~/utils/calcCanvasNodeSizeAndImg";
 import {
-  createNodeShapeUtils,
+  DiscourseNodeUtil,
+  DISCOURSE_NODE_SHAPE_TYPE,
   DiscourseNodeShape,
 } from "~/components/canvas/DiscourseNodeUtil";
 import { discourseContext, MAX_WIDTH } from "~/components/canvas/Tldraw";
@@ -360,7 +361,7 @@ const ExportDialog: ExportDialogComponent = ({
       );
 
       // UTILS
-      const discourseNodeUtils = createNodeShapeUtils(allNodes);
+      const discourseNodeUtils = [DiscourseNodeUtil];
       const discourseRelationUtils =
         createAllRelationShapeUtils(allRelationIds);
       const referencedNodeUtils = createAllReferencedNodeUtils(
@@ -551,12 +552,13 @@ const ExportDialog: ExportDialogComponent = ({
         index: currentIndex,
         rotation: 0,
         isLocked: false,
-        type: nodeType,
+        type: DISCOURSE_NODE_SHAPE_TYPE,
         props: {
           w,
           h,
           uid: r.uid,
           title: String(r[firstColumnKey]),
+          nodeTypeId: nodeType,
           imageUrl,
           size: "s",
           fontFamily: "sans",

--- a/apps/roam/src/components/Export.tsx
+++ b/apps/roam/src/components/Export.tsx
@@ -62,7 +62,8 @@ import {
 } from "@tldraw/editor";
 import calcCanvasNodeSizeAndImg from "~/utils/calcCanvasNodeSizeAndImg";
 import {
-  createNodeShapeUtils,
+  DiscourseNodeUtil,
+  DISCOURSE_NODE_SHAPE_TYPE,
   DiscourseNodeShape,
 } from "~/components/canvas/DiscourseNodeUtil";
 import { discourseContext, MAX_WIDTH } from "~/components/canvas/Tldraw";
@@ -362,7 +363,7 @@ const ExportDialog: ExportDialogComponent = ({
       );
 
       // UTILS
-      const discourseNodeUtils = createNodeShapeUtils(allNodes);
+      const discourseNodeUtils = [DiscourseNodeUtil];
       const discourseRelationUtils =
         createAllRelationShapeUtils(allRelationIds);
       const referencedNodeUtils = createAllReferencedNodeUtils(
@@ -552,12 +553,13 @@ const ExportDialog: ExportDialogComponent = ({
         index: currentIndex,
         rotation: 0,
         isLocked: false,
-        type: nodeType,
+        type: DISCOURSE_NODE_SHAPE_TYPE,
         props: {
           w,
           h,
           uid: r.uid,
           title: String(r[firstColumnKey]),
+          nodeTypeId: nodeType,
           imageUrl,
           size: "s",
           fontFamily: "sans",

--- a/apps/roam/src/components/canvas/CanvasDrawer.tsx
+++ b/apps/roam/src/components/canvas/CanvasDrawer.tsx
@@ -18,7 +18,11 @@ import { Editor, useEditor, TLShapeId } from "tldraw";
 import getPageTitleByPageUid from "roamjs-components/queries/getPageTitleByPageUid";
 import getCurrentPageUid from "roamjs-components/dom/getCurrentPageUid";
 import getDiscourseNodes from "~/utils/getDiscourseNodes";
-import { DiscourseNodeShape } from "./DiscourseNodeUtil";
+import {
+  DISCOURSE_NODE_SHAPE_TYPE,
+  DiscourseNodeShape,
+  getDiscourseNodeTypeId,
+} from "./DiscourseNodeUtil";
 import { formatHexColor } from "~/components/settings/DiscourseNodeCanvasSettings";
 import posthog from "posthog-js";
 
@@ -56,14 +60,15 @@ export const CanvasDrawerContent = ({
     const entries: NodeGroup[] = Object.entries(groupedShapes).map(
       ([uid, shapes]) => {
         const primaryShape = shapes[0];
+        const nodeTypeId = getDiscourseNodeTypeId({ shape: primaryShape });
         const typeLabel =
-          discourseNodes.find((n) => n.type === primaryShape.type)?.text ||
-          primaryShape.type ||
+          discourseNodes.find((n) => n.type === nodeTypeId)?.text ||
+          nodeTypeId ||
           "Unknown";
         return {
           uid,
           title: primaryShape.props.title,
-          type: primaryShape.type,
+          type: nodeTypeId,
           typeLabel,
           shapes,
           isDuplicate: shapes.length > 1,
@@ -402,6 +407,7 @@ export const CanvasDrawerPanel = () => {
       const allRecords = editor.store.allRecords();
       const shapes = allRecords.filter((record) => {
         if (record.typeName !== "shape") return false;
+        if (record.type !== DISCOURSE_NODE_SHAPE_TYPE) return false;
         const shape = record as DiscourseNodeShape;
         return !!shape.props?.uid;
       }) as DiscourseNodeShape[];

--- a/apps/roam/src/components/canvas/CanvasDrawer.tsx
+++ b/apps/roam/src/components/canvas/CanvasDrawer.tsx
@@ -405,11 +405,20 @@ export const CanvasDrawerPanel = () => {
   useEffect(() => {
     const updateGroupedShapes = () => {
       const allRecords = editor.store.allRecords();
+      const nodeTypeSet = new Set(getDiscourseNodes().map((node) => node.type));
       const shapes = allRecords.filter((record) => {
         if (record.typeName !== "shape") return false;
-        if (record.type !== DISCOURSE_NODE_SHAPE_TYPE) return false;
         const shape = record as DiscourseNodeShape;
-        return !!shape.props?.uid;
+        if (
+          record.type !== DISCOURSE_NODE_SHAPE_TYPE &&
+          !nodeTypeSet.has(record.type)
+        ) {
+          return false;
+        }
+        return (
+          !!shape.props?.uid &&
+          nodeTypeSet.has(getDiscourseNodeTypeId({ shape }))
+        );
       }) as DiscourseNodeShape[];
 
       const grouped = shapes.reduce((acc: GroupedShapes, shape) => {

--- a/apps/roam/src/components/canvas/Clipboard.tsx
+++ b/apps/roam/src/components/canvas/Clipboard.tsx
@@ -49,6 +49,7 @@ import getAllReferencesOnPage from "~/utils/getAllReferencesOnPage";
 import {
   DiscourseNodeShape,
   DEFAULT_STYLE_PROPS,
+  DISCOURSE_NODE_SHAPE_TYPE,
   FONT_SIZES,
 } from "./DiscourseNodeUtil";
 import { openBlockInSidebar, createBlock } from "roamjs-components/writes";
@@ -699,7 +700,7 @@ const ClipboardPageSection = ({
       const shapeId = createShapeId();
       const shape = {
         id: shapeId,
-        type: nodeType.type,
+        type: DISCOURSE_NODE_SHAPE_TYPE,
         x: pagePoint.x - w / 2,
         y: pagePoint.y - h / 2,
         props: {
@@ -710,6 +711,7 @@ const ClipboardPageSection = ({
           imageUrl,
           size: "s" as TLDefaultSizeStyle,
           fontFamily: "sans" as TLDefaultFontStyle,
+          nodeTypeId: nodeType.type,
         },
       };
       editor.createShape<DiscourseNodeShape>(shape);

--- a/apps/roam/src/components/canvas/Clipboard.tsx
+++ b/apps/roam/src/components/canvas/Clipboard.tsx
@@ -40,6 +40,7 @@ import {
   TLDefaultSizeStyle,
   TLDefaultFontStyle,
   FONT_FAMILIES,
+  TLShapePartial,
 } from "tldraw";
 import { useAtom } from "@tldraw/state-react";
 import AutocompleteInput from "roamjs-components/components/AutocompleteInput";
@@ -698,7 +699,7 @@ const ClipboardPageSection = ({
       });
 
       const shapeId = createShapeId();
-      const shape = {
+      const shape: TLShapePartial<DiscourseNodeShape> = {
         id: shapeId,
         type: DISCOURSE_NODE_SHAPE_TYPE,
         x: pagePoint.x - w / 2,

--- a/apps/roam/src/components/canvas/Clipboard.tsx
+++ b/apps/roam/src/components/canvas/Clipboard.tsx
@@ -52,6 +52,7 @@ import {
   DEFAULT_STYLE_PROPS,
   DISCOURSE_NODE_SHAPE_TYPE,
   FONT_SIZES,
+  getDiscourseNodeTypeId,
 } from "./DiscourseNodeUtil";
 import { openBlockInSidebar, createBlock } from "roamjs-components/writes";
 import getPageTitleByPageUid from "roamjs-components/queries/getPageTitleByPageUid";
@@ -533,11 +534,18 @@ const ClipboardPageSection = ({
   const shapesByUid = useMemo(() => {
     void storeVersion;
     const groupedShapes = new Map<string, DiscourseNodeShape[]>();
+    const nodeTypeIds = new Set(discourseNodes.map((node) => node.type));
     const allRecords = editor.store.allRecords();
     allRecords.forEach((record) => {
       if (record.typeName !== "shape") return;
-      if (record.type !== DISCOURSE_NODE_SHAPE_TYPE) return;
+      if (
+        record.type !== DISCOURSE_NODE_SHAPE_TYPE &&
+        !nodeTypeIds.has(record.type)
+      ) {
+        return;
+      }
       const shape = record as DiscourseNodeShape;
+      if (!nodeTypeIds.has(getDiscourseNodeTypeId({ shape }))) return;
       const uid = shape.props?.uid;
       if (!uid) return;
       const currentShapes = groupedShapes.get(uid);
@@ -548,7 +556,7 @@ const ClipboardPageSection = ({
       }
     });
     return groupedShapes;
-  }, [editor.store, storeVersion]);
+  }, [discourseNodes, editor.store, storeVersion]);
 
   const groupedNodes = useMemo(() => {
     const groups: NodeGroup[] = discourseNodes.map((node) => {
@@ -673,11 +681,20 @@ const ClipboardPageSection = ({
     async (node: { uid: string; text: string }, pagePoint: Vec) => {
       if (!extensionAPI) return;
       if (!showNodesOnCanvas) {
+        const nodeTypeIds = new Set(discourseNodes.map((node) => node.type));
         const nodeExistsOnCanvas = editor.store.allRecords().some((record) => {
           if (record.typeName !== "shape") return false;
-          if (record.type !== DISCOURSE_NODE_SHAPE_TYPE) return false;
+          if (
+            record.type !== DISCOURSE_NODE_SHAPE_TYPE &&
+            !nodeTypeIds.has(record.type)
+          ) {
+            return false;
+          }
           const shape = record as DiscourseNodeShape;
-          return shape.props?.uid === node.uid;
+          return (
+            nodeTypeIds.has(getDiscourseNodeTypeId({ shape })) &&
+            shape.props?.uid === node.uid
+          );
         });
         if (nodeExistsOnCanvas) return;
       }
@@ -719,7 +736,7 @@ const ClipboardPageSection = ({
       };
       editor.createShape<DiscourseNodeShape>(shape);
     },
-    [editor, extensionAPI, showNodesOnCanvas],
+    [discourseNodes, editor, extensionAPI, showNodesOnCanvas],
   );
 
   // Drag and drop handlers

--- a/apps/roam/src/components/canvas/Clipboard.tsx
+++ b/apps/roam/src/components/canvas/Clipboard.tsx
@@ -536,6 +536,7 @@ const ClipboardPageSection = ({
     const allRecords = editor.store.allRecords();
     allRecords.forEach((record) => {
       if (record.typeName !== "shape") return;
+      if (record.type !== DISCOURSE_NODE_SHAPE_TYPE) return;
       const shape = record as DiscourseNodeShape;
       const uid = shape.props?.uid;
       if (!uid) return;
@@ -674,6 +675,7 @@ const ClipboardPageSection = ({
       if (!showNodesOnCanvas) {
         const nodeExistsOnCanvas = editor.store.allRecords().some((record) => {
           if (record.typeName !== "shape") return false;
+          if (record.type !== DISCOURSE_NODE_SHAPE_TYPE) return false;
           const shape = record as DiscourseNodeShape;
           return shape.props?.uid === node.uid;
         });

--- a/apps/roam/src/components/canvas/Clipboard.tsx
+++ b/apps/roam/src/components/canvas/Clipboard.tsx
@@ -49,6 +49,7 @@ import getAllReferencesOnPage from "~/utils/getAllReferencesOnPage";
 import {
   DiscourseNodeShape,
   DEFAULT_STYLE_PROPS,
+  DISCOURSE_NODE_SHAPE_TYPE,
   FONT_SIZES,
 } from "./DiscourseNodeUtil";
 import { openBlockInSidebar, createBlock } from "roamjs-components/writes";
@@ -702,7 +703,7 @@ const ClipboardPageSection = ({
       const shapeId = createShapeId();
       const shape = {
         id: shapeId,
-        type: nodeType.type,
+        type: DISCOURSE_NODE_SHAPE_TYPE,
         x: pagePoint.x - w / 2,
         y: pagePoint.y - h / 2,
         props: {
@@ -713,6 +714,7 @@ const ClipboardPageSection = ({
           imageUrl,
           size: "s" as TLDefaultSizeStyle,
           fontFamily: "sans" as TLDefaultFontStyle,
+          nodeTypeId: nodeType.type,
         },
       };
       editor.createShape<DiscourseNodeShape>(shape);

--- a/apps/roam/src/components/canvas/Clipboard.tsx
+++ b/apps/roam/src/components/canvas/Clipboard.tsx
@@ -394,8 +394,16 @@ type NodeGroup = {
   uid: string;
   text: string;
   type: string;
+  typeId: string;
   shapes: DiscourseNodeShape[];
   isDuplicate: boolean;
+};
+
+type ClipboardDiscourseNode = {
+  uid: string;
+  text: string;
+  type: string;
+  typeId: string;
 };
 
 type DragState =
@@ -440,7 +448,7 @@ const ClipboardPageSection = ({
 }) => {
   const [isOpen, setIsOpen] = useState(true);
   const [discourseNodes, setDiscourseNodes] = useState<
-    Array<{ uid: string; text: string; type: string }>
+    ClipboardDiscourseNode[]
   >([]);
   const [isLoading, setIsLoading] = useState(false);
   const [openSections, setOpenSections] = useState<Record<string, boolean>>({});
@@ -472,6 +480,7 @@ const ClipboardPageSection = ({
               uid: refPage.uid,
               text: refPage.text,
               type: discourseNode.text,
+              typeId: discourseNode.type,
             },
           ];
         });
@@ -534,7 +543,7 @@ const ClipboardPageSection = ({
   const shapesByUid = useMemo(() => {
     void storeVersion;
     const groupedShapes = new Map<string, DiscourseNodeShape[]>();
-    const nodeTypeIds = new Set(discourseNodes.map((node) => node.type));
+    const nodeTypeIds = new Set(discourseNodes.map((node) => node.typeId));
     const allRecords = editor.store.allRecords();
     allRecords.forEach((record) => {
       if (record.typeName !== "shape") return;
@@ -565,6 +574,7 @@ const ClipboardPageSection = ({
         uid: node.uid,
         text: node.text,
         type: node.type,
+        typeId: node.typeId,
         shapes,
         isDuplicate: shapes.length > 1,
       };
@@ -681,7 +691,7 @@ const ClipboardPageSection = ({
     async (node: { uid: string; text: string }, pagePoint: Vec) => {
       if (!extensionAPI) return;
       if (!showNodesOnCanvas) {
-        const nodeTypeIds = new Set(discourseNodes.map((node) => node.type));
+        const nodeTypeIds = new Set(discourseNodes.map((node) => node.typeId));
         const nodeExistsOnCanvas = editor.store.allRecords().some((record) => {
           if (record.typeName !== "shape") return false;
           if (

--- a/apps/roam/src/components/canvas/DiscourseNodeUtil.tsx
+++ b/apps/roam/src/components/canvas/DiscourseNodeUtil.tsx
@@ -4,7 +4,6 @@ import {
   TLBaseShape,
   useEditor,
   DefaultColorStyle,
-  Editor,
   createShapeId,
   TLDefaultHorizontalAlignStyle,
   TLDefaultVerticalAlignStyle,
@@ -16,6 +15,7 @@ import {
   DefaultSizeStyle,
   T,
   FONT_FAMILIES,
+  TLShape,
   TLDefaultFontStyle,
   DefaultFontStyle,
   toDomPrecision,
@@ -92,6 +92,8 @@ export const COLOR_PALETTE: Record<string, string> = {
   yellow: "#ffc078",
 };
 
+export const DISCOURSE_NODE_SHAPE_TYPE = "discourse-node";
+
 const getRelationIds = () =>
   new Set(
     Object.values(discourseContext.relations).flatMap((rs) =>
@@ -107,7 +109,7 @@ export const createNodeShapeTools = (
       static id = n.type;
       static initial = "idle";
       static isLockable = true;
-      shapeType = n.type;
+      nodeTypeId = n.type;
 
       override onEnter = () => {
         this.editor.setCursor({
@@ -121,10 +123,14 @@ export const createNodeShapeTools = (
         const shapeId = createShapeId();
         this.editor.createShape({
           id: shapeId,
-          type: this.shapeType,
+          type: DISCOURSE_NODE_SHAPE_TYPE,
           x: currentPagePoint.x,
           y: currentPagePoint.y,
-          props: { fontFamily: "sans", size: "s" },
+          props: {
+            fontFamily: "sans",
+            size: "s",
+            nodeTypeId: this.nodeTypeId,
+          },
         });
         this.editor.setEditingShape(shapeId);
       };
@@ -132,45 +138,42 @@ export const createNodeShapeTools = (
   });
 };
 
-export const createNodeShapeUtils = (nodes: DiscourseNode[]) => {
-  return nodes.map((node) => {
-    class DiscourseNodeUtil extends BaseDiscourseNodeUtil {
-      constructor(editor: Editor) {
-        super(editor, node.type);
-      }
-      static override type = node.type; // removing this gives undefined error
-      // getDefaultProps(): DiscourseNodeShape["props"] {
-      //   const baseProps = super.getDefaultProps();
-      //   return {
-      //     ...baseProps,
-      //     color: node.color,
-      //   };
-      // }
-    }
-    return DiscourseNodeUtil;
-  });
+type ShapeWithOptionalNodeTypeId = TLShape & {
+  props?: {
+    nodeTypeId?: string;
+  };
+};
+
+export const getDiscourseNodeTypeId = ({
+  shape,
+}: {
+  shape: ShapeWithOptionalNodeTypeId;
+}): string => {
+  return shape.props?.nodeTypeId || shape.type;
+};
+
+export const isDiscourseNodeShape = (
+  shape: TLShape,
+): shape is DiscourseNodeShape => {
+  return shape.type === DISCOURSE_NODE_SHAPE_TYPE;
 };
 
 export type DiscourseNodeShape = TLBaseShape<
-  string,
+  typeof DISCOURSE_NODE_SHAPE_TYPE,
   {
     w: number;
     h: number;
     // opacity: TLOpacityType;
     uid: string;
     title: string;
+    nodeTypeId: string;
     imageUrl?: string;
     size: TLDefaultSizeStyle;
     fontFamily: TLDefaultFontStyle;
   }
 >;
-export class BaseDiscourseNodeUtil extends BaseBoxShapeUtil<DiscourseNodeShape> {
-  type: string;
-
-  constructor(editor: Editor, type: string) {
-    super(editor);
-    this.type = type;
-  }
+export class DiscourseNodeUtil extends BaseBoxShapeUtil<DiscourseNodeShape> {
+  static override type = DISCOURSE_NODE_SHAPE_TYPE;
 
   static override props = {
     w: T.number,
@@ -178,6 +181,7 @@ export class BaseDiscourseNodeUtil extends BaseBoxShapeUtil<DiscourseNodeShape> 
     // opacity: T.number,
     uid: T.string,
     title: T.string,
+    nodeTypeId: T.string,
     imageUrl: T.optional(T.string),
     size: DefaultSizeStyle,
     fontFamily: DefaultFontStyle,
@@ -194,6 +198,7 @@ export class BaseDiscourseNodeUtil extends BaseBoxShapeUtil<DiscourseNodeShape> 
       h: 64,
       uid: window.roamAlphaAPI.util.generateUID(),
       title: "",
+      nodeTypeId: "",
       size: "s",
       fontFamily: "sans",
     };
@@ -239,7 +244,11 @@ export class BaseDiscourseNodeUtil extends BaseBoxShapeUtil<DiscourseNodeShape> 
     const nodesInCanvas = Object.fromEntries(
       allRecords
         .filter((r): r is DiscourseNodeShape => {
-          return r.typeName === "shape" && nodeIds.has(r.type);
+          if (r.typeName !== "shape") return false;
+          const nodeTypeId = getDiscourseNodeTypeId({ shape: r });
+          return (
+            r.typeName === "shape" && !!nodeTypeId && nodeIds.has(nodeTypeId)
+          );
         })
         .map((r) => [r.props.uid, r] as const),
     );
@@ -330,12 +339,14 @@ export class BaseDiscourseNodeUtil extends BaseBoxShapeUtil<DiscourseNodeShape> 
     editor.createShapes(shapesToCreate).createBindings(bindingsToCreate);
   }
 
-  getColors() {
-    return getDiscourseNodeColors({ nodeType: this.type });
+  getColors(shape: DiscourseNodeShape) {
+    return getDiscourseNodeColors({
+      nodeType: getDiscourseNodeTypeId({ shape }),
+    });
   }
 
   async toSvg(shape: DiscourseNodeShape): Promise<JSX.Element> {
-    const { backgroundColor, textColor } = this.getColors();
+    const { backgroundColor, textColor } = this.getColors(shape);
     const padding = Number(DEFAULT_STYLE_PROPS.padding.replace("px", ""));
     const props = shape.props;
     const bounds = new Box(0, 0, props.w, props.h);
@@ -432,7 +443,7 @@ export class BaseDiscourseNodeUtil extends BaseBoxShapeUtil<DiscourseNodeShape> 
     const extensionAPI = useExtensionAPI();
     const {
       canvasSettings: { alias = "", "key-image": isKeyImage = "" } = {},
-    } = discourseContext.nodes[shape.type] || {};
+    } = discourseContext.nodes[getDiscourseNodeTypeId({ shape })] || {};
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const isOverlayEnabled = useMemo(
       () => getPersonalSetting<boolean>([PERSONAL_KEYS.overlayInCanvas]),
@@ -448,7 +459,7 @@ export class BaseDiscourseNodeUtil extends BaseBoxShapeUtil<DiscourseNodeShape> 
     // Detect discourse node tags in block text for blck-node shapes
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const matchedNodeForConversion = useMemo(() => {
-      if (shape.type !== "blck-node") return null;
+      if (getDiscourseNodeTypeId({ shape }) !== "blck-node") return null;
       if (!isLiveBlock(shape.props.uid)) return null;
       const blockText = getTextByBlockUid(shape.props.uid);
       if (!blockText) return null;
@@ -469,9 +480,9 @@ export class BaseDiscourseNodeUtil extends BaseBoxShapeUtil<DiscourseNodeShape> 
         }
       }
       return null;
-    }, [shape.type, shape.props.uid]);
+    }, [shape]);
 
-    const { backgroundColor, textColor } = this.getColors();
+    const { backgroundColor, textColor } = this.getColors(shape);
     const showEmbeddedRoamBlock =
       !isPageUid(shape.props.uid) && isLiveBlock(shape.props.uid);
 
@@ -490,7 +501,7 @@ export class BaseDiscourseNodeUtil extends BaseBoxShapeUtil<DiscourseNodeShape> 
           const { h, w, imageUrl } = await calcCanvasNodeSizeAndImg({
             nodeText: text,
             uid,
-            nodeType: this.type,
+            nodeType: getDiscourseNodeTypeId({ shape }),
             extensionAPI,
           });
           this.updateProps(shape.id, shape.type, { h, w, imageUrl });
@@ -501,7 +512,7 @@ export class BaseDiscourseNodeUtil extends BaseBoxShapeUtil<DiscourseNodeShape> 
         const restoreToolState = () => {
           if (wasToolLocked) {
             this.editor.updateInstanceState({ isToolLocked: true });
-            this.editor.setCurrentTool(shape.type);
+            this.editor.setCurrentTool(getDiscourseNodeTypeId({ shape }));
           } else {
             this.editor.setCurrentTool("select");
           }
@@ -511,7 +522,7 @@ export class BaseDiscourseNodeUtil extends BaseBoxShapeUtil<DiscourseNodeShape> 
 
         renderModifyNodeDialog({
           mode: isCreating ? "create" : "edit",
-          nodeType: shape.type,
+          nodeType: getDiscourseNodeTypeId({ shape }),
           initialValue: { text: shape.props.title, uid: shape.props.uid },
           // Only pass it when editing an existing node that has a valid Roam block UID
           sourceBlockUid:
@@ -536,6 +547,7 @@ export class BaseDiscourseNodeUtil extends BaseBoxShapeUtil<DiscourseNodeShape> 
             this.updateProps(shape.id, shape.type, {
               title: text,
               uid,
+              nodeTypeId: getDiscourseNodeTypeId({ shape }),
             });
 
             const autoCanvasRelations = getPersonalSetting<boolean>([
@@ -658,7 +670,7 @@ export class BaseDiscourseNodeUtil extends BaseBoxShapeUtil<DiscourseNodeShape> 
                       });
                       editor.createShapes([
                         {
-                          type: node.type,
+                          type: DISCOURSE_NODE_SHAPE_TYPE,
                           id: createShapeId(),
                           props: {
                             uid,
@@ -668,6 +680,7 @@ export class BaseDiscourseNodeUtil extends BaseBoxShapeUtil<DiscourseNodeShape> 
                             imageUrl: nodeImageUrl,
                             fontFamily: "sans",
                             size: "s",
+                            nodeTypeId: node.type,
                           },
                           x,
                           y,

--- a/apps/roam/src/components/canvas/DiscourseNodeUtil.tsx
+++ b/apps/roam/src/components/canvas/DiscourseNodeUtil.tsx
@@ -4,7 +4,6 @@ import {
   TLBaseShape,
   useEditor,
   DefaultColorStyle,
-  Editor,
   createShapeId,
   TLDefaultHorizontalAlignStyle,
   TLDefaultVerticalAlignStyle,
@@ -16,6 +15,7 @@ import {
   DefaultSizeStyle,
   T,
   FONT_FAMILIES,
+  TLShape,
   TLDefaultFontStyle,
   DefaultFontStyle,
   toDomPrecision,
@@ -94,6 +94,8 @@ export const COLOR_PALETTE: Record<string, string> = {
 };
 /* eslint-disable @typescript-eslint/naming-convention */
 
+export const DISCOURSE_NODE_SHAPE_TYPE = "discourse-node";
+
 const getRelationIds = () =>
   new Set(
     Object.values(discourseContext.relations).flatMap((rs) =>
@@ -109,7 +111,7 @@ export const createNodeShapeTools = (
       static id = n.type;
       static initial = "idle";
       static isLockable = true;
-      shapeType = n.type;
+      nodeTypeId = n.type;
 
       override onEnter = () => {
         this.editor.setCursor({
@@ -123,10 +125,14 @@ export const createNodeShapeTools = (
         const shapeId = createShapeId();
         this.editor.createShape({
           id: shapeId,
-          type: this.shapeType,
+          type: DISCOURSE_NODE_SHAPE_TYPE,
           x: currentPagePoint.x,
           y: currentPagePoint.y,
-          props: { fontFamily: "sans", size: "s" },
+          props: {
+            fontFamily: "sans",
+            size: "s",
+            nodeTypeId: this.nodeTypeId,
+          },
         });
         this.editor.setEditingShape(shapeId);
       };
@@ -134,23 +140,24 @@ export const createNodeShapeTools = (
   });
 };
 
-export const createNodeShapeUtils = (nodes: DiscourseNode[]) => {
-  return nodes.map((node) => {
-    class DiscourseNodeUtil extends BaseDiscourseNodeUtil {
-      constructor(editor: Editor) {
-        super(editor, node.type);
-      }
-      static override type = node.type; // removing this gives undefined error
-      // getDefaultProps(): DiscourseNodeShape["props"] {
-      //   const baseProps = super.getDefaultProps();
-      //   return {
-      //     ...baseProps,
-      //     color: node.color,
-      //   };
-      // }
-    }
-    return DiscourseNodeUtil;
-  });
+type ShapeWithOptionalNodeTypeId = TLShape & {
+  props?: {
+    nodeTypeId?: string;
+  };
+};
+
+export const getDiscourseNodeTypeId = ({
+  shape,
+}: {
+  shape: ShapeWithOptionalNodeTypeId;
+}): string => {
+  return shape.props?.nodeTypeId || shape.type;
+};
+
+export const isDiscourseNodeShape = (
+  shape: TLShape,
+): shape is DiscourseNodeShape => {
+  return shape.type === DISCOURSE_NODE_SHAPE_TYPE;
 };
 
 export type DiscourseNodeShape = TLBaseShape<
@@ -161,18 +168,14 @@ export type DiscourseNodeShape = TLBaseShape<
     // opacity: TLOpacityType;
     uid: string;
     title: string;
+    nodeTypeId: string;
     imageUrl?: string;
     size: TLDefaultSizeStyle;
     fontFamily: TLDefaultFontStyle;
   }
 >;
-export class BaseDiscourseNodeUtil extends BaseBoxShapeUtil<DiscourseNodeShape> {
-  type: string;
-
-  constructor(editor: Editor, type: string) {
-    super(editor);
-    this.type = type;
-  }
+export class DiscourseNodeUtil extends BaseBoxShapeUtil<DiscourseNodeShape> {
+  static override type = DISCOURSE_NODE_SHAPE_TYPE;
 
   static override props = {
     w: T.number,
@@ -180,6 +183,7 @@ export class BaseDiscourseNodeUtil extends BaseBoxShapeUtil<DiscourseNodeShape> 
     // opacity: T.number,
     uid: T.string,
     title: T.string,
+    nodeTypeId: T.string,
     imageUrl: T.optional(T.string),
     size: DefaultSizeStyle,
     fontFamily: DefaultFontStyle,
@@ -196,6 +200,7 @@ export class BaseDiscourseNodeUtil extends BaseBoxShapeUtil<DiscourseNodeShape> 
       h: 64,
       uid: window.roamAlphaAPI.util.generateUID(),
       title: "",
+      nodeTypeId: "",
       size: "s",
       fontFamily: "sans",
     };
@@ -241,7 +246,11 @@ export class BaseDiscourseNodeUtil extends BaseBoxShapeUtil<DiscourseNodeShape> 
     const nodesInCanvas = Object.fromEntries(
       allRecords
         .filter((r): r is DiscourseNodeShape => {
-          return r.typeName === "shape" && nodeIds.has(r.type);
+          if (r.typeName !== "shape") return false;
+          const nodeTypeId = getDiscourseNodeTypeId({ shape: r });
+          return (
+            r.typeName === "shape" && !!nodeTypeId && nodeIds.has(nodeTypeId)
+          );
         })
         .map((r) => [r.props.uid, r] as const),
     );
@@ -332,12 +341,14 @@ export class BaseDiscourseNodeUtil extends BaseBoxShapeUtil<DiscourseNodeShape> 
     editor.createShapes(shapesToCreate).createBindings(bindingsToCreate);
   }
 
-  getColors() {
-    return getDiscourseNodeColors({ nodeType: this.type });
+  getColors(shape: DiscourseNodeShape) {
+    return getDiscourseNodeColors({
+      nodeType: getDiscourseNodeTypeId({ shape }),
+    });
   }
 
   async toSvg(shape: DiscourseNodeShape): Promise<JSX.Element> {
-    const { backgroundColor, textColor } = this.getColors();
+    const { backgroundColor, textColor } = this.getColors(shape);
     const padding = Number(DEFAULT_STYLE_PROPS.padding.replace("px", ""));
     const props = shape.props;
     const bounds = new Box(0, 0, props.w, props.h);
@@ -434,7 +445,7 @@ export class BaseDiscourseNodeUtil extends BaseBoxShapeUtil<DiscourseNodeShape> 
     const extensionAPI = useExtensionAPI();
     const {
       canvasSettings: { alias = "", "key-image": isKeyImage = "" } = {},
-    } = discourseContext.nodes[shape.type] || {};
+    } = discourseContext.nodes[getDiscourseNodeTypeId({ shape })] || {};
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const isOverlayEnabled = useMemo(
       () => getPersonalSetting<boolean>([PERSONAL_KEYS.overlayInCanvas]),
@@ -450,7 +461,7 @@ export class BaseDiscourseNodeUtil extends BaseBoxShapeUtil<DiscourseNodeShape> 
     // Detect discourse node tags in block text for blck-node shapes
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const matchedNodeForConversion = useMemo(() => {
-      if (shape.type !== "blck-node") return null;
+      if (getDiscourseNodeTypeId({ shape }) !== "blck-node") return null;
       if (!isLiveBlock(shape.props.uid)) return null;
       const blockText = getTextByBlockUid(shape.props.uid);
       if (!blockText) return null;
@@ -471,9 +482,9 @@ export class BaseDiscourseNodeUtil extends BaseBoxShapeUtil<DiscourseNodeShape> 
         }
       }
       return null;
-    }, [shape.type, shape.props.uid]);
+    }, [shape]);
 
-    const { backgroundColor, textColor } = this.getColors();
+    const { backgroundColor, textColor } = this.getColors(shape);
     const showEmbeddedRoamBlock =
       !isPageUid(shape.props.uid) && isLiveBlock(shape.props.uid);
 
@@ -492,7 +503,7 @@ export class BaseDiscourseNodeUtil extends BaseBoxShapeUtil<DiscourseNodeShape> 
           const { h, w, imageUrl } = await calcCanvasNodeSizeAndImg({
             nodeText: text,
             uid,
-            nodeType: this.type,
+            nodeType: getDiscourseNodeTypeId({ shape }),
             extensionAPI,
           });
           this.updateProps(shape.id, shape.type, { h, w, imageUrl });
@@ -513,7 +524,7 @@ export class BaseDiscourseNodeUtil extends BaseBoxShapeUtil<DiscourseNodeShape> 
 
         renderModifyNodeDialog({
           mode: isCreating ? "create" : "edit",
-          nodeType: shape.type,
+          nodeType: getDiscourseNodeTypeId({ shape }),
           initialValue: { text: shape.props.title, uid: shape.props.uid },
           // Only pass it when editing an existing node that has a valid Roam block UID
           sourceBlockUid:
@@ -538,6 +549,7 @@ export class BaseDiscourseNodeUtil extends BaseBoxShapeUtil<DiscourseNodeShape> 
             this.updateProps(shape.id, shape.type, {
               title: text,
               uid,
+              nodeTypeId: getDiscourseNodeTypeId({ shape }),
             });
 
             const autoCanvasRelations = getPersonalSetting<boolean>([
@@ -660,7 +672,7 @@ export class BaseDiscourseNodeUtil extends BaseBoxShapeUtil<DiscourseNodeShape> 
                       });
                       editor.createShapes([
                         {
-                          type: node.type,
+                          type: DISCOURSE_NODE_SHAPE_TYPE,
                           id: createShapeId(),
                           props: {
                             uid,
@@ -670,6 +682,7 @@ export class BaseDiscourseNodeUtil extends BaseBoxShapeUtil<DiscourseNodeShape> 
                             imageUrl: nodeImageUrl,
                             fontFamily: "sans",
                             size: "s",
+                            nodeTypeId: node.type,
                           },
                           x,
                           y,

--- a/apps/roam/src/components/canvas/DiscourseNodeUtil.tsx
+++ b/apps/roam/src/components/canvas/DiscourseNodeUtil.tsx
@@ -19,6 +19,7 @@ import {
   TLDefaultFontStyle,
   DefaultFontStyle,
   toDomPrecision,
+  TLAnyShapeUtilConstructor,
 } from "tldraw";
 import React, { useState, useEffect, useRef, useMemo } from "react";
 import { useExtensionAPI } from "roamjs-components/components/ExtensionApiContext";
@@ -155,18 +156,21 @@ export const getDiscourseNodeTypeId = ({
 export const isDiscourseNodeShape = (
   shape: TLShape,
 ): shape is DiscourseNodeShape => {
-  return shape.type === DISCOURSE_NODE_SHAPE_TYPE;
+  return (
+    shape.type === DISCOURSE_NODE_SHAPE_TYPE ||
+    !!discourseContext.nodes[shape.type]
+  );
 };
 
 export type DiscourseNodeShape = TLBaseShape<
-  typeof DISCOURSE_NODE_SHAPE_TYPE,
+  string,
   {
     w: number;
     h: number;
     // opacity: TLOpacityType;
     uid: string;
     title: string;
-    nodeTypeId: string;
+    nodeTypeId?: string;
     imageUrl?: string;
     size: TLDefaultSizeStyle;
     fontFamily: TLDefaultFontStyle;
@@ -769,3 +773,28 @@ export class DiscourseNodeUtil extends BaseBoxShapeUtil<DiscourseNodeShape> {
     );
   }
 }
+
+export const createLegacyDiscourseNodeShapeUtils = (
+  nodes: DiscourseNode[],
+): TLAnyShapeUtilConstructor[] => {
+  return nodes
+    .filter((node) => node.type !== DISCOURSE_NODE_SHAPE_TYPE)
+    .map((node) => {
+      class LegacyDiscourseNodeUtil extends DiscourseNodeUtil {
+        static override type = node.type;
+        static override props = {
+          ...DiscourseNodeUtil.props,
+          nodeTypeId: T.optional(T.string),
+        } as typeof DiscourseNodeUtil.props;
+
+        override getDefaultProps(): DiscourseNodeShape["props"] {
+          return {
+            ...super.getDefaultProps(),
+            nodeTypeId: node.type,
+          };
+        }
+      }
+
+      return LegacyDiscourseNodeUtil as TLAnyShapeUtilConstructor;
+    });
+};

--- a/apps/roam/src/components/canvas/DiscourseRelationShape/DiscourseRelationTool.tsx
+++ b/apps/roam/src/components/canvas/DiscourseRelationShape/DiscourseRelationTool.tsx
@@ -11,6 +11,7 @@ import {
 } from "./DiscourseRelationUtil";
 import { discourseContext } from "~/components/canvas/Tldraw";
 import { dispatchToastEvent } from "~/components/canvas/ToastListener";
+import { getDiscourseNodeTypeId } from "~/components/canvas/DiscourseNodeUtil";
 
 export type AddReferencedNodeType = Record<string, ReferenceFormatType[]>;
 type ReferenceFormatType = {
@@ -78,7 +79,10 @@ export const createAllReferencedNodeTools = (
 
           const sourceType = allAddReferencedNodeByAction[action][0].sourceType;
           const sourceName = allAddReferencedNodeByAction[action][0].sourceName;
-          if (target?.type === sourceType) {
+          if (
+            target &&
+            getDiscourseNodeTypeId({ shape: target }) === sourceType
+          ) {
             this.shapeType = `${action}`;
           } else {
             this.cancelAndWarn(`Starting node must be one of ${sourceName}`);
@@ -360,8 +364,13 @@ export const createAllRelationShapeTools = (
             // }
           );
 
+          const targetNodeTypeId = target
+            ? getDiscourseNodeTypeId({ shape: target })
+            : undefined;
           const relation = discourseContext.relations[name].find(
-            (r) => r.source === target?.type || r.destination === target?.type,
+            (r) =>
+              r.source === targetNodeTypeId ||
+              r.destination === targetNodeTypeId,
           );
           if (relation) {
             this.shapeType = relation.id;

--- a/apps/roam/src/components/canvas/DiscourseRelationShape/DiscourseRelationTool.tsx
+++ b/apps/roam/src/components/canvas/DiscourseRelationShape/DiscourseRelationTool.tsx
@@ -11,7 +11,10 @@ import {
 import { discourseContext } from "~/components/canvas/Tldraw";
 import { dispatchToastEvent } from "~/components/canvas/ToastListener";
 import { isRelationComplete } from "~/utils/isRelationComplete";
-import { getDiscourseNodeTypeId } from "~/components/canvas/DiscourseNodeUtil";
+import {
+  getDiscourseNodeTypeId,
+  isDiscourseNodeShape,
+} from "~/components/canvas/DiscourseNodeUtil";
 
 export type AddReferencedNodeType = Record<string, ReferenceFormatType[]>;
 type ReferenceFormatType = {
@@ -81,6 +84,7 @@ export const createAllReferencedNodeTools = (
           const sourceName = allAddReferencedNodeByAction[action][0].sourceName;
           if (
             target &&
+            isDiscourseNodeShape(target) &&
             getDiscourseNodeTypeId({ shape: target }) === sourceType
           ) {
             this.shapeType = `${action}`;
@@ -376,9 +380,10 @@ export const createAllRelationShapeTools = (
             // }
           );
 
-          const targetNodeTypeId = target
-            ? getDiscourseNodeTypeId({ shape: target })
-            : undefined;
+          const targetNodeTypeId =
+            target && isDiscourseNodeShape(target)
+              ? getDiscourseNodeTypeId({ shape: target })
+              : undefined;
           const relation = discourseContext.relations[name].find(
             (r) =>
               r.source === targetNodeTypeId ||

--- a/apps/roam/src/components/canvas/DiscourseRelationShape/DiscourseRelationTool.tsx
+++ b/apps/roam/src/components/canvas/DiscourseRelationShape/DiscourseRelationTool.tsx
@@ -11,6 +11,7 @@ import {
 import { discourseContext } from "~/components/canvas/Tldraw";
 import { dispatchToastEvent } from "~/components/canvas/ToastListener";
 import { isRelationComplete } from "~/utils/isRelationComplete";
+import { getDiscourseNodeTypeId } from "~/components/canvas/DiscourseNodeUtil";
 
 export type AddReferencedNodeType = Record<string, ReferenceFormatType[]>;
 type ReferenceFormatType = {
@@ -78,7 +79,10 @@ export const createAllReferencedNodeTools = (
 
           const sourceType = allAddReferencedNodeByAction[action][0].sourceType;
           const sourceName = allAddReferencedNodeByAction[action][0].sourceName;
-          if (target?.type === sourceType) {
+          if (
+            target &&
+            getDiscourseNodeTypeId({ shape: target }) === sourceType
+          ) {
             this.shapeType = `${action}`;
           } else {
             this.cancelAndWarn(`Starting node must be one of ${sourceName}`);
@@ -372,8 +376,13 @@ export const createAllRelationShapeTools = (
             // }
           );
 
+          const targetNodeTypeId = target
+            ? getDiscourseNodeTypeId({ shape: target })
+            : undefined;
           const relation = discourseContext.relations[name].find(
-            (r) => r.source === target?.type || r.destination === target?.type,
+            (r) =>
+              r.source === targetNodeTypeId ||
+              r.destination === targetNodeTypeId,
           );
           if (relation) {
             this.shapeType = relation.id;

--- a/apps/roam/src/components/canvas/DiscourseRelationShape/DiscourseRelationUtil.tsx
+++ b/apps/roam/src/components/canvas/DiscourseRelationShape/DiscourseRelationUtil.tsx
@@ -119,6 +119,15 @@ const COLOR_ARRAY = Array.from(DefaultColorStyle.values)
   .filter((c) => !["red", "green", "grey"].includes(c))
   .reverse() as TLDefaultColorStyle[];
 
+const isRelationShapeType = (shapeType: string): boolean =>
+  Object.values(discourseContext.relations).some((relations) =>
+    relations.some((relation) => relation.id === shapeType),
+  );
+
+const isBindableDiscourseNodeShapeType = (shapeType: string): boolean =>
+  shapeType === DISCOURSE_NODE_SHAPE_TYPE ||
+  (!!discourseContext.nodes[shapeType] && !isRelationShapeType(shapeType));
+
 export const getRelationColor = (
   relationName: string,
   index?: number,
@@ -1230,7 +1239,7 @@ export class BaseDiscourseRelationUtil extends ShapeUtil<DiscourseRelationShape>
     toShapeType,
   }: TLShapeUtilCanBindOpts<DiscourseRelationShape>): boolean {
     // bindings can go from arrows to shapes, but not from shapes to arrows
-    return toShapeType === DISCOURSE_NODE_SHAPE_TYPE;
+    return isBindableDiscourseNodeShapeType(toShapeType);
   }
 
   override canBeLaidOut: TLShapeUtilFlag<DiscourseRelationShape> = () => {

--- a/apps/roam/src/components/canvas/DiscourseRelationShape/DiscourseRelationUtil.tsx
+++ b/apps/roam/src/components/canvas/DiscourseRelationShape/DiscourseRelationUtil.tsx
@@ -103,8 +103,10 @@ import createPage from "roamjs-components/writes/createPage";
 import openBlockInSidebar from "roamjs-components/writes/openBlockInSidebar";
 import triplesToBlocks from "~/utils/triplesToBlocks";
 import {
-  BaseDiscourseNodeUtil,
+  DiscourseNodeUtil,
   DiscourseNodeShape,
+  getDiscourseNodeTypeId,
+  isDiscourseNodeShape as isDiscourseNodeShapeTypeGuard,
 } from "~/components/canvas/DiscourseNodeUtil";
 import { checkConnectionType } from "~/components/canvas/canvasUtils";
 import getPageTitleByPageUid from "roamjs-components/queries/getPageTitleByPageUid";
@@ -147,8 +149,7 @@ export const createAllReferencedNodeUtils = (
       static override type = action;
 
       isDiscourseNodeShape(shape: TLShape): shape is DiscourseNodeShape {
-        const shapeUtil = this.editor.getShapeUtil(shape.type);
-        return shapeUtil instanceof BaseDiscourseNodeUtil;
+        return isDiscourseNodeShapeTypeGuard(shape);
       }
 
       handleCreateRelationsInRoam = async ({
@@ -178,7 +179,11 @@ export const createAllReferencedNodeUtils = (
         const possibleTargets = allAddReferencedNodeByAction[arrow.type].map(
           (action) => action.destinationType,
         );
-        if (!possibleTargets.includes(target.type)) {
+        if (
+          !possibleTargets.includes(
+            getDiscourseNodeTypeId({ shape: target }) || "",
+          )
+        ) {
           return deleteAndWarn(
             `Target node must be of type ${possibleTargets
               .map((t) => discourseContext.nodes[t].text)
@@ -588,7 +593,7 @@ const asDiscourseNodeShape = (
   editor: Editor,
 ): DiscourseNodeShape | null => {
   const shapeUtil = editor.getShapeUtil(shape.type);
-  return shapeUtil instanceof BaseDiscourseNodeUtil
+  return shapeUtil instanceof DiscourseNodeUtil
     ? (shape as DiscourseNodeShape)
     : null;
 };
@@ -626,8 +631,8 @@ export const createAllRelationShapeUtils = (
         const relation = relations.find((r) => r.id === arrow.type);
         if (!relation) return;
 
-        const sourceNodeType = source.type;
-        const targetNodeType = target.type;
+        const sourceNodeType = getDiscourseNodeTypeId({ shape: source });
+        const targetNodeType = getDiscourseNodeTypeId({ shape: target });
 
         // Check all relations with the same label for a match
         const {
@@ -884,15 +889,18 @@ export const createAllRelationShapeUtils = (
 
         // Validate target node type compatibility before creating binding
         if (
-          target.type !== "arrow" &&
+          isDiscourseNodeShapeTypeGuard(target) &&
           otherBinding &&
           target.id !== otherBinding.toId &&
           (!currentBinding || target.id !== currentBinding.toId)
         ) {
           const sourceNodeId = otherBinding.toId;
           const sourceNode = this.editor.getShape(sourceNodeId);
-          const targetNodeType = target.type;
-          const sourceNodeType = sourceNode?.type;
+          if (!sourceNode || !isDiscourseNodeShapeTypeGuard(sourceNode)) {
+            return update;
+          }
+          const targetNodeType = getDiscourseNodeTypeId({ shape: target });
+          const sourceNodeType = getDiscourseNodeTypeId({ shape: sourceNode });
 
           if (sourceNodeType && targetNodeType && shape.type) {
             const isValidConnection = this.isValidNodeConnection(
@@ -996,8 +1004,10 @@ export const createAllRelationShapeUtils = (
             const endNode = this.editor.getShape(newBindings.end.toId);
 
             if (startNode && endNode) {
-              const startNodeType = startNode.type;
-              const endNodeType = endNode.type;
+              const startNodeType = getDiscourseNodeTypeId({
+                shape: startNode,
+              });
+              const endNodeType = getDiscourseNodeTypeId({ shape: endNode });
 
               const { isReverse, matchingRelation } =
                 this.checkConnectionTypeAcrossLabel(

--- a/apps/roam/src/components/canvas/DiscourseRelationShape/DiscourseRelationUtil.tsx
+++ b/apps/roam/src/components/canvas/DiscourseRelationShape/DiscourseRelationUtil.tsx
@@ -104,8 +104,10 @@ import createPage from "roamjs-components/writes/createPage";
 import openBlockInSidebar from "roamjs-components/writes/openBlockInSidebar";
 import triplesToBlocks from "~/utils/triplesToBlocks";
 import {
-  BaseDiscourseNodeUtil,
+  DiscourseNodeUtil,
   DiscourseNodeShape,
+  getDiscourseNodeTypeId,
+  isDiscourseNodeShape as isDiscourseNodeShapeTypeGuard,
 } from "~/components/canvas/DiscourseNodeUtil";
 import { checkConnectionType } from "~/components/canvas/canvasUtils";
 import getPageTitleByPageUid from "roamjs-components/queries/getPageTitleByPageUid";
@@ -148,8 +150,7 @@ export const createAllReferencedNodeUtils = (
       static override type = action;
 
       isDiscourseNodeShape(shape: TLShape): shape is DiscourseNodeShape {
-        const shapeUtil = this.editor.getShapeUtil(shape.type);
-        return shapeUtil instanceof BaseDiscourseNodeUtil;
+        return isDiscourseNodeShapeTypeGuard(shape);
       }
 
       handleCreateRelationsInRoam = async ({
@@ -179,7 +180,11 @@ export const createAllReferencedNodeUtils = (
         const possibleTargets = allAddReferencedNodeByAction[arrow.type].map(
           (action) => action.destinationType,
         );
-        if (!possibleTargets.includes(target.type)) {
+        if (
+          !possibleTargets.includes(
+            getDiscourseNodeTypeId({ shape: target }) || "",
+          )
+        ) {
           return deleteAndWarn(
             `Target node must be of type ${possibleTargets
               .map((t) => discourseContext.nodes[t].text)
@@ -589,7 +594,7 @@ const asDiscourseNodeShape = (
   editor: Editor,
 ): DiscourseNodeShape | null => {
   const shapeUtil = editor.getShapeUtil(shape.type);
-  return shapeUtil instanceof BaseDiscourseNodeUtil
+  return shapeUtil instanceof DiscourseNodeUtil
     ? (shape as DiscourseNodeShape)
     : null;
 };
@@ -627,8 +632,8 @@ export const createAllRelationShapeUtils = (
         const relation = relations.find((r) => r.id === arrow.type);
         if (!relation) return;
 
-        const sourceNodeType = source.type;
-        const targetNodeType = target.type;
+        const sourceNodeType = getDiscourseNodeTypeId({ shape: source });
+        const targetNodeType = getDiscourseNodeTypeId({ shape: target });
 
         // Check all relations with the same label for a match
         const {
@@ -892,8 +897,10 @@ export const createAllRelationShapeUtils = (
         ) {
           const sourceNodeId = otherBinding.toId;
           const sourceNode = this.editor.getShape(sourceNodeId);
-          const targetNodeType = target.type;
-          const sourceNodeType = sourceNode?.type;
+          const targetNodeType = getDiscourseNodeTypeId({ shape: target });
+          const sourceNodeType = sourceNode
+            ? getDiscourseNodeTypeId({ shape: sourceNode })
+            : undefined;
 
           if (sourceNodeType && targetNodeType && shape.type) {
             const isValidConnection = this.isValidNodeConnection(
@@ -997,8 +1004,10 @@ export const createAllRelationShapeUtils = (
             const endNode = this.editor.getShape(newBindings.end.toId);
 
             if (startNode && endNode) {
-              const startNodeType = startNode.type;
-              const endNodeType = endNode.type;
+              const startNodeType = getDiscourseNodeTypeId({
+                shape: startNode,
+              });
+              const endNodeType = getDiscourseNodeTypeId({ shape: endNode });
 
               const { isReverse, matchingRelation } =
                 this.checkConnectionTypeAcrossLabel(

--- a/apps/roam/src/components/canvas/DiscourseRelationShape/DiscourseRelationUtil.tsx
+++ b/apps/roam/src/components/canvas/DiscourseRelationShape/DiscourseRelationUtil.tsx
@@ -103,6 +103,7 @@ import createPage from "roamjs-components/writes/createPage";
 import openBlockInSidebar from "roamjs-components/writes/openBlockInSidebar";
 import triplesToBlocks from "~/utils/triplesToBlocks";
 import {
+  DISCOURSE_NODE_SHAPE_TYPE,
   DiscourseNodeUtil,
   DiscourseNodeShape,
   getDiscourseNodeTypeId,
@@ -175,6 +176,14 @@ export const createAllReferencedNodeUtils = (
         if (!sourceId) return;
         const source = editor.getShape(sourceId);
         if (!target || !source) return;
+        if (
+          !isDiscourseNodeShapeTypeGuard(target) ||
+          !isDiscourseNodeShapeTypeGuard(source)
+        ) {
+          return deleteAndWarn(
+            "Invalid shape type. Expected a DiscourseNodeShape.",
+          );
+        }
 
         const possibleTargets = allAddReferencedNodeByAction[arrow.type].map(
           (action) => action.destinationType,
@@ -188,16 +197,6 @@ export const createAllReferencedNodeUtils = (
             `Target node must be of type ${possibleTargets
               .map((t) => discourseContext.nodes[t].text)
               .join(", ")}`,
-          );
-        }
-
-        // type check
-        if (
-          !this.isDiscourseNodeShape(target) ||
-          !this.isDiscourseNodeShape(source)
-        ) {
-          return deleteAndWarn(
-            "Invalid shape type. Expected a DiscourseNodeShape.",
           );
         }
 
@@ -627,6 +626,14 @@ export const createAllRelationShapeUtils = (
         if (!sourceId) return;
         const source = editor.getShape(sourceId);
         if (!target || !source) return;
+        if (
+          !isDiscourseNodeShapeTypeGuard(target) ||
+          !isDiscourseNodeShapeTypeGuard(source)
+        ) {
+          return deleteAndWarn(
+            "Invalid shape type. Expected a DiscourseNodeShape.",
+          );
+        }
         const relations = Object.values(discourseContext.relations).flat();
         const relation = relations.find((r) => r.id === arrow.type);
         if (!relation) return;
@@ -1003,7 +1010,12 @@ export const createAllRelationShapeUtils = (
             const startNode = this.editor.getShape(newBindings.start.toId);
             const endNode = this.editor.getShape(newBindings.end.toId);
 
-            if (startNode && endNode) {
+            if (
+              startNode &&
+              endNode &&
+              isDiscourseNodeShapeTypeGuard(startNode) &&
+              isDiscourseNodeShapeTypeGuard(endNode)
+            ) {
               const startNodeType = getDiscourseNodeTypeId({
                 shape: startNode,
               });
@@ -1218,7 +1230,7 @@ export class BaseDiscourseRelationUtil extends ShapeUtil<DiscourseRelationShape>
     toShapeType,
   }: TLShapeUtilCanBindOpts<DiscourseRelationShape>): boolean {
     // bindings can go from arrows to shapes, but not from shapes to arrows
-    return toShapeType !== "arrow";
+    return toShapeType === DISCOURSE_NODE_SHAPE_TYPE;
   }
 
   override canBeLaidOut: TLShapeUtilFlag<DiscourseRelationShape> = () => {

--- a/apps/roam/src/components/canvas/DiscourseRelationShape/discourseRelationMigrations.ts
+++ b/apps/roam/src/components/canvas/DiscourseRelationShape/discourseRelationMigrations.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
@@ -14,6 +15,7 @@ import {
 import { createMigrationIds } from "tldraw";
 import { RelationBinding } from "./DiscourseRelationBindings";
 import { getRelationColor } from "./DiscourseRelationUtil";
+import { DISCOURSE_NODE_SHAPE_TYPE } from "~/components/canvas/DiscourseNodeUtil";
 
 const SEQUENCE_ID_BASE = "com.roam-research.discourse-graphs";
 
@@ -35,6 +37,7 @@ export const createMigrations = ({
     "2.3.0": 2,
     AddSizeAndFontFamily: 3,
     RemoveNullAssetFileSize: 4,
+    MigrateNodeTypeToDiscourseNode: 5,
   });
   return createMigrationSequence({
     sequenceId: `${SEQUENCE_ID_BASE}`,
@@ -154,6 +157,16 @@ export const createMigrations = ({
           r.props?.fileSize === null,
         up: (asset: any) => {
           delete asset.props.fileSize;
+        },
+      },
+      {
+        id: versions["MigrateNodeTypeToDiscourseNode"],
+        scope: "record",
+        filter: (r: any) =>
+          r.typeName === "shape" && allNodeTypes.includes(r.type),
+        up: (shape: any) => {
+          shape.props.nodeTypeId = shape.type;
+          shape.type = DISCOURSE_NODE_SHAPE_TYPE;
         },
       },
     ],

--- a/apps/roam/src/components/canvas/DiscourseRelationShape/discourseRelationMigrations.ts
+++ b/apps/roam/src/components/canvas/DiscourseRelationShape/discourseRelationMigrations.ts
@@ -189,8 +189,7 @@ export const createMigrations = ({
       {
         id: versions["MigrateNodeTypeToDiscourseNode"],
         scope: "record",
-        // Assumes node type ids and relation ids are distinct. Legacy
-        // /anchor/-backed relation nodes are not supported by this migration.
+        // Assumes node type ids and relation ids are distin
         filter: (r: any) => {
           const recordType = getRecordType(r);
           return (

--- a/apps/roam/src/components/canvas/DiscourseRelationShape/discourseRelationMigrations.ts
+++ b/apps/roam/src/components/canvas/DiscourseRelationShape/discourseRelationMigrations.ts
@@ -4,6 +4,9 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
+
+// TODO rename/move this file to discourseMigrations.ts
+// as it is used for both relation and node shapes
 import {
   createMigrationSequence,
   createBindingId,
@@ -186,6 +189,8 @@ export const createMigrations = ({
       {
         id: versions["MigrateNodeTypeToDiscourseNode"],
         scope: "record",
+        // Assumes node type ids and relation ids are distinct. Legacy
+        // /anchor/-backed relation nodes are not supported by this migration.
         filter: (r: any) => {
           const recordType = getRecordType(r);
           return (

--- a/apps/roam/src/components/canvas/DiscourseRelationShape/discourseRelationMigrations.ts
+++ b/apps/roam/src/components/canvas/DiscourseRelationShape/discourseRelationMigrations.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
@@ -13,8 +14,21 @@ import {
 import { createMigrationIds } from "tldraw";
 import { RelationBinding } from "./DiscourseRelationBindings";
 import { getRelationColor } from "./DiscourseRelationUtil";
+import { DISCOURSE_NODE_SHAPE_TYPE } from "~/components/canvas/DiscourseNodeUtil";
 
 const SEQUENCE_ID_BASE = "com.roam-research.discourse-graphs";
+
+const getRecordType = (record: unknown): string | undefined => {
+  if (typeof record !== "object" || record === null) return undefined;
+  const candidate = (record as { type?: unknown }).type;
+  return typeof candidate === "string" ? candidate : undefined;
+};
+
+const getRecordTypeName = (record: unknown): string | undefined => {
+  if (typeof record !== "object" || record === null) return undefined;
+  const candidate = (record as { typeName?: unknown }).typeName;
+  return typeof candidate === "string" ? candidate : undefined;
+};
 
 export const createMigrations = ({
   allRelationIds,
@@ -34,6 +48,7 @@ export const createMigrations = ({
     "2.3.0": 2,
     AddSizeAndFontFamily: 3,
     RemoveNullAssetFileSize: 4,
+    MigrateNodeTypeToDiscourseNode: 5,
   });
   return createMigrationSequence({
     sequenceId: `${SEQUENCE_ID_BASE}`,
@@ -59,12 +74,14 @@ export const createMigrations = ({
             { start: OldArrowTerminal; end: OldArrowTerminal }
           >;
 
-          const arrows = Object.values(oldStore).filter(
-            (r: any): r is OldArrow =>
-              r.typeName === "shape" &&
-              "type" in r &&
-              allRelationShapeIds.includes(r.type),
-          );
+          const arrows = Object.values(oldStore).filter((r): r is OldArrow => {
+            const recordType = getRecordType(r);
+            return (
+              getRecordTypeName(r) === "shape" &&
+              !!recordType &&
+              allRelationShapeIds.includes(recordType)
+            );
+          });
 
           for (const a of arrows) {
             const arrow = a as unknown as OldArrow;
@@ -121,7 +138,12 @@ export const createMigrations = ({
         id: versions["2.3.0"],
         scope: "record",
         filter: (r: any) => {
-          return r.typeName === "shape" && allRelationShapeIds.includes(r.type);
+          const recordType = getRecordType(r);
+          return (
+            getRecordTypeName(r) === "shape" &&
+            !!recordType &&
+            allRelationShapeIds.includes(recordType)
+          );
         },
         up: (arrow: any) => {
           arrow.props.start = { x: 0, y: 0 };
@@ -137,8 +159,14 @@ export const createMigrations = ({
       {
         id: versions["AddSizeAndFontFamily"],
         scope: "record",
-        filter: (r: any) =>
-          r.typeName === "shape" && allNodeTypes.includes(r.type),
+        filter: (r: any) => {
+          const recordType = getRecordType(r);
+          return (
+            getRecordTypeName(r) === "shape" &&
+            !!recordType &&
+            allNodeTypes.includes(recordType)
+          );
+        },
         up: (shape: any) => {
           if (!shape.props.size) shape.props.size = "m";
           if (!shape.props.fontFamily) shape.props.fontFamily = "draw";
@@ -153,6 +181,22 @@ export const createMigrations = ({
           r.props?.fileSize === null,
         up: (asset: any) => {
           delete asset.props.fileSize;
+        },
+      },
+      {
+        id: versions["MigrateNodeTypeToDiscourseNode"],
+        scope: "record",
+        filter: (r: any) => {
+          const recordType = getRecordType(r);
+          return (
+            getRecordTypeName(r) === "shape" &&
+            !!recordType &&
+            allNodeTypes.includes(recordType)
+          );
+        },
+        up: (shape: any) => {
+          shape.props.nodeTypeId = shape.type;
+          shape.type = DISCOURSE_NODE_SHAPE_TYPE;
         },
       },
     ],

--- a/apps/roam/src/components/canvas/DiscourseToolPanel.tsx
+++ b/apps/roam/src/components/canvas/DiscourseToolPanel.tsx
@@ -15,7 +15,11 @@ import { useAtom } from "@tldraw/state-react";
 import { TOOL_ARROW_ICON_SVG, NODE_COLOR_ICON_SVG } from "~/icons";
 import { getDiscourseNodeColors } from "~/utils/getDiscourseNodeColors";
 import { DEFAULT_WIDTH, DEFAULT_HEIGHT } from "./Tldraw";
-import { DEFAULT_STYLE_PROPS, FONT_SIZES } from "./DiscourseNodeUtil";
+import {
+  DEFAULT_STYLE_PROPS,
+  DISCOURSE_NODE_SHAPE_TYPE,
+  FONT_SIZES,
+} from "./DiscourseNodeUtil";
 
 export type DiscourseGraphPanelProps = {
   nodes: DiscourseNode[];
@@ -184,10 +188,14 @@ const DiscourseGraphPanel = ({
             const shapeId = createShapeId();
             editor.createShape({
               id: shapeId,
-              type: current.item.id,
+              type: DISCOURSE_NODE_SHAPE_TYPE,
               x: pagePoint.x - offsetX,
               y: pagePoint.y - offsetY,
-              props: { fontFamily: "sans", size: "s" },
+              props: {
+                fontFamily: "sans",
+                size: "s",
+                nodeTypeId: current.item.id,
+              },
             });
             editor.setEditingShape(shapeId);
           } else {

--- a/apps/roam/src/components/canvas/Tldraw.tsx
+++ b/apps/roam/src/components/canvas/Tldraw.tsx
@@ -65,9 +65,10 @@ import {
   createUiOverrides,
 } from "./uiOverrides";
 import {
-  BaseDiscourseNodeUtil,
+  DiscourseNodeUtil,
   DiscourseNodeShape,
   createNodeShapeTools,
+  DISCOURSE_NODE_SHAPE_TYPE,
 } from "./DiscourseNodeUtil";
 import { useRoamStore } from "./useRoamStore";
 import {
@@ -845,13 +846,14 @@ const TldrawCanvasShared = ({
       if (nodeType) {
         app.createShapes([
           {
-            type: nodeType.type,
+            type: DISCOURSE_NODE_SHAPE_TYPE,
             id: createShapeId(),
             props: {
               uid: e.detail.uid,
               title: e.detail.val,
               size: "s",
               fontFamily: "sans",
+              nodeTypeId: nodeType.type,
             },
             ...position,
           },
@@ -1208,7 +1210,7 @@ const InsideEditorAndUiContext = ({
       editor.createShapes([
         {
           id: createShapeId(),
-          type: nodeType,
+          type: DISCOURSE_NODE_SHAPE_TYPE,
           x: position.x - w / 2,
           y: position.y - h / 2,
           props: {
@@ -1219,6 +1221,7 @@ const InsideEditorAndUiContext = ({
             ...(imageUrl && { imageUrl }),
             size: "s",
             fontFamily: "sans",
+            nodeTypeId: nodeType,
           },
         },
       ]);
@@ -1486,7 +1489,7 @@ const InsideEditorAndUiContext = ({
       const removeAfterCreateHandler =
         editor.sideEffects.registerAfterCreateHandler("shape", (shape) => {
           const util = editor.getShapeUtil(shape);
-          if (util instanceof BaseDiscourseNodeUtil) {
+          if (util instanceof DiscourseNodeUtil) {
             const autoCanvasRelations = getPersonalSetting<boolean>([
               PERSONAL_KEYS.autoCanvasRelations,
             ]);

--- a/apps/roam/src/components/canvas/Tldraw.tsx
+++ b/apps/roam/src/components/canvas/Tldraw.tsx
@@ -1083,10 +1083,8 @@ const TldrawCanvasShared = ({
                 // navigate / open in sidebar
                 const validModifier = e.shiftKey || e.ctrlKey; // || e.metaKey;
                 if (!(e.name === "pointer_up" && validModifier)) return;
-                const shape = app.getShapeAtPoint(
-                  app.inputs.currentPagePoint,
-                ) as DiscourseNodeShape;
-                if (!shape) return;
+                const shape = app.getShapeAtPoint(app.inputs.currentPagePoint);
+                if (!shape || !isDiscourseNodeShape(app, shape)) return;
                 const shapeUid = shape.props.uid;
 
                 if (!isLiveBlock(shapeUid)) {

--- a/apps/roam/src/components/canvas/Tldraw.tsx
+++ b/apps/roam/src/components/canvas/Tldraw.tsx
@@ -38,7 +38,6 @@ import {
   TLAssetId,
   getHashForString,
   TLShapeId,
-  TLShape,
   TLStore,
   TLStoreWithStatus,
   useToasts,
@@ -67,9 +66,10 @@ import {
   createUiOverrides,
 } from "./uiOverrides";
 import {
-  BaseDiscourseNodeUtil,
+  DiscourseNodeUtil,
   DiscourseNodeShape,
   createNodeShapeTools,
+  DISCOURSE_NODE_SHAPE_TYPE,
 } from "./DiscourseNodeUtil";
 import { useRoamStore } from "./useRoamStore";
 import {
@@ -847,13 +847,14 @@ const TldrawCanvasShared = ({
       if (nodeType) {
         app.createShapes([
           {
-            type: nodeType.type,
+            type: DISCOURSE_NODE_SHAPE_TYPE,
             id: createShapeId(),
             props: {
               uid: e.detail.uid,
               title: e.detail.val,
               size: "s",
               fontFamily: "sans",
+              nodeTypeId: nodeType.type,
             },
             ...position,
           },
@@ -1210,7 +1211,7 @@ const InsideEditorAndUiContext = ({
       editor.createShapes([
         {
           id: createShapeId(),
-          type: nodeType,
+          type: DISCOURSE_NODE_SHAPE_TYPE,
           x: position.x - w / 2,
           y: position.y - h / 2,
           props: {
@@ -1221,6 +1222,7 @@ const InsideEditorAndUiContext = ({
             ...(imageUrl && { imageUrl }),
             size: "s",
             fontFamily: "sans",
+            nodeTypeId: nodeType,
           },
         },
       ]);
@@ -1488,7 +1490,7 @@ const InsideEditorAndUiContext = ({
       const removeAfterCreateHandler =
         editor.sideEffects.registerAfterCreateHandler("shape", (shape) => {
           const util = editor.getShapeUtil(shape);
-          if (util instanceof BaseDiscourseNodeUtil) {
+          if (util instanceof DiscourseNodeUtil) {
             const autoCanvasRelations = getPersonalSetting<boolean>([
               PERSONAL_KEYS.autoCanvasRelations,
             ]);

--- a/apps/roam/src/components/canvas/canvasUtils.ts
+++ b/apps/roam/src/components/canvas/canvasUtils.ts
@@ -1,6 +1,6 @@
 import { Editor, TLShape } from "tldraw";
 import {
-  BaseDiscourseNodeUtil,
+  DiscourseNodeUtil,
   DiscourseNodeShape,
 } from "~/components/canvas/DiscourseNodeUtil";
 import { discourseContext } from "~/components/canvas/Tldraw";
@@ -10,7 +10,7 @@ export const isDiscourseNodeShape = (
   shape: TLShape,
 ): shape is DiscourseNodeShape => {
   try {
-    return editor.getShapeUtil(shape) instanceof BaseDiscourseNodeUtil;
+    return editor.getShapeUtil(shape) instanceof DiscourseNodeUtil;
   } catch {
     return false;
   }

--- a/apps/roam/src/components/canvas/overlays/DragHandleOverlay.tsx
+++ b/apps/roam/src/components/canvas/overlays/DragHandleOverlay.tsx
@@ -1,6 +1,9 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { TLShapeId, createShapeId, useEditor, useValue } from "tldraw";
-import { DiscourseNodeShape } from "~/components/canvas/DiscourseNodeUtil";
+import {
+  DiscourseNodeShape,
+  getDiscourseNodeTypeId,
+} from "~/components/canvas/DiscourseNodeUtil";
 import {
   BaseDiscourseRelationUtil,
   DiscourseRelationShape,
@@ -211,7 +214,11 @@ export const DragHandleOverlay = () => {
         }
 
         // Validate that relation types exist between these node types
-        if (!hasValidRelationTypes(selectedNode.type, target.type)) {
+        const selectedNodeTypeId = getDiscourseNodeTypeId({
+          shape: selectedNode,
+        });
+        const targetNodeTypeId = getDiscourseNodeTypeId({ shape: target });
+        if (!hasValidRelationTypes(selectedNodeTypeId, targetNodeTypeId)) {
           dispatchToastEvent({
             id: "tldraw-no-valid-relation",
             title: "No relation types are defined between these node types",
@@ -271,10 +278,22 @@ export const DragHandleOverlay = () => {
       // the arrow is in reverse and should display the complement label.
       const sourceNode = editor.getShape(pending.sourceId);
       const targetNode = editor.getShape(pending.targetId);
+      if (
+        !sourceNode ||
+        !targetNode ||
+        !isDiscourseNodeShape(editor, sourceNode) ||
+        !isDiscourseNodeShape(editor, targetNode)
+      ) {
+        setPending(null);
+        sourceNodeRef.current = null;
+        return;
+      }
+      const sourceNodeTypeId = getDiscourseNodeTypeId({ shape: sourceNode });
+      const targetNodeTypeId = getDiscourseNodeTypeId({ shape: targetNode });
       const { isReverse } = checkConnectionType(
         selectedRelation,
-        sourceNode?.type ?? "",
-        targetNode?.type ?? "",
+        sourceNodeTypeId,
+        targetNodeTypeId,
       );
       const label =
         isReverse && selectedRelation.complement

--- a/apps/roam/src/components/canvas/overlays/RelationTypeDropdown.tsx
+++ b/apps/roam/src/components/canvas/overlays/RelationTypeDropdown.tsx
@@ -7,6 +7,7 @@ import {
   isDiscourseNodeShape,
 } from "~/components/canvas/canvasUtils";
 import { isRelationComplete } from "~/utils/isRelationComplete";
+import { getDiscourseNodeTypeId } from "~/components/canvas/DiscourseNodeUtil";
 
 type RelationTypeDropdownProps = {
   sourceId: TLShapeId;
@@ -32,15 +33,15 @@ export const RelationTypeDropdown = ({
     const endNode = editor.getShape(targetId);
     if (!startNode || !endNode) return [];
 
-    const startNodeType = startNode.type;
-    const endNodeType = endNode.type;
-
     // Verify both are discourse nodes
     if (
       !isDiscourseNodeShape(editor, startNode) ||
       !isDiscourseNodeShape(editor, endNode)
     )
       return [];
+
+    const startNodeType = getDiscourseNodeTypeId({ shape: startNode });
+    const endNodeType = getDiscourseNodeTypeId({ shape: endNode });
 
     const colorPalette = DefaultColorThemePalette.lightMode;
     const validTypes: { id: string; label: string; color: string }[] = [];

--- a/apps/roam/src/components/canvas/uiOverrides.tsx
+++ b/apps/roam/src/components/canvas/uiOverrides.tsx
@@ -46,8 +46,10 @@ import type { OnloadArgs } from "roamjs-components/types";
 import { DiscourseContextType } from "./Tldraw";
 import { formatHexColor } from "~/components/settings/DiscourseNodeCanvasSettings";
 import {
-  BaseDiscourseNodeUtil,
   COLOR_ARRAY,
+  DISCOURSE_NODE_SHAPE_TYPE,
+  getDiscourseNodeTypeId,
+  isDiscourseNodeShape,
   type DiscourseNodeShape,
 } from "./DiscourseNodeUtil";
 import calcCanvasNodeSizeAndImg from "~/utils/calcCanvasNodeSizeAndImg";
@@ -188,7 +190,7 @@ export const getOnSelectForShape = ({
         });
         editor.createShapes([
           {
-            type: nodeType,
+            type: DISCOURSE_NODE_SHAPE_TYPE,
             id: createShapeId(),
             props: {
               uid,
@@ -198,6 +200,7 @@ export const getOnSelectForShape = ({
               imageUrl: nodeImageUrl,
               fontFamily: "sans",
               size: "s",
+              nodeTypeId: nodeType,
             },
             x,
             y,
@@ -236,15 +239,8 @@ export const getOnSelectForShape = ({
 type ShareableCanvasResult = Result & { type: string };
 
 const isCanvasDiscourseNodeShape = (
-  editor: Editor,
   shape: TLShape,
-): shape is DiscourseNodeShape => {
-  try {
-    return editor.getShapeUtil(shape) instanceof BaseDiscourseNodeUtil;
-  } catch {
-    return false;
-  }
-};
+): shape is DiscourseNodeShape => isDiscourseNodeShape(shape);
 
 const getCanvasNodeText = (shape: DiscourseNodeShape): string =>
   getPageTitleByPageUid(shape.props.uid) ||
@@ -252,16 +248,14 @@ const getCanvasNodeText = (shape: DiscourseNodeShape): string =>
   shape.props.title;
 
 export const getShareableCanvasSelectionResults = ({
-  editor,
   shapes,
 }: {
-  editor: Editor;
   shapes: TLShape[];
 }): ShareableCanvasResult[] => {
   const seenUids = new Set<string>();
 
   return shapes.reduce<ShareableCanvasResult[]>((results, shape) => {
-    if (!isCanvasDiscourseNodeShape(editor, shape)) return results;
+    if (!isCanvasDiscourseNodeShape(shape)) return results;
 
     const { uid } = shape.props;
     if (!uid || !isLiveBlock(uid) || seenUids.has(uid)) return results;
@@ -270,7 +264,7 @@ export const getShareableCanvasSelectionResults = ({
     if (!text) return results;
 
     seenUids.add(uid);
-    results.push({ text, uid, type: shape.type });
+    results.push({ text, uid, type: getDiscourseNodeTypeId({ shape }) });
     return results;
   }, []);
 };
@@ -294,7 +288,6 @@ export const CustomContextMenu = ({
     [editor],
   );
   const shareableResults = getShareableCanvasSelectionResults({
-    editor,
     shapes: selectedShapes,
   });
   const isTextSelected = selectedShape?.type === "text";
@@ -312,7 +305,6 @@ export const CustomContextMenu = ({
             onSelect={() => {
               const currentSelectedShapes = editor.getSelectedShapes();
               const currentResults = getShareableCanvasSelectionResults({
-                editor,
                 shapes: currentSelectedShapes,
               });
               if (!currentResults.length) return;

--- a/apps/roam/src/components/canvas/uiOverrides.tsx
+++ b/apps/roam/src/components/canvas/uiOverrides.tsx
@@ -60,6 +60,7 @@ import { CanvasSyncMode } from "./canvasSyncMode";
 import { getPersonalSetting } from "~/components/settings/utils/accessors";
 import { PERSONAL_KEYS } from "~/components/settings/utils/settingKeys";
 import posthog from "posthog-js";
+import { DISCOURSE_NODE_SHAPE_TYPE } from "./DiscourseNodeUtil";
 
 const SyncModeMenuSwitchItem = ({
   checked,
@@ -182,7 +183,7 @@ export const getOnSelectForShape = ({
         });
         editor.createShapes([
           {
-            type: nodeType,
+            type: DISCOURSE_NODE_SHAPE_TYPE,
             id: createShapeId(),
             props: {
               uid,
@@ -192,6 +193,7 @@ export const getOnSelectForShape = ({
               imageUrl: nodeImageUrl,
               fontFamily: "sans",
               size: "s",
+              nodeTypeId: nodeType,
             },
             x,
             y,

--- a/apps/roam/src/components/canvas/useCanvasStoreAdapterArgs.ts
+++ b/apps/roam/src/components/canvas/useCanvasStoreAdapterArgs.ts
@@ -5,7 +5,7 @@ import {
   TLAnyShapeUtilConstructor,
 } from "tldraw";
 import { DiscourseNode } from "~/utils/getDiscourseNodes";
-import { createNodeShapeUtils } from "./DiscourseNodeUtil";
+import { DiscourseNodeUtil } from "./DiscourseNodeUtil";
 import {
   createAllReferencedNodeUtils,
   createAllRelationShapeUtils,
@@ -56,7 +56,6 @@ const getUtilTypes = <T extends { type: string }>({
 };
 
 const createShapeUtils = ({
-  allNodes,
   allRelationIds,
   allAddReferencedNodeByAction,
 }: {
@@ -65,7 +64,7 @@ const createShapeUtils = ({
   allAddReferencedNodeByAction: AddReferencedNodeType;
 }): TLAnyShapeUtilConstructor[] => {
   return [
-    ...createNodeShapeUtils(allNodes),
+    DiscourseNodeUtil,
     ...createAllRelationShapeUtils(allRelationIds),
     ...createAllReferencedNodeUtils(allAddReferencedNodeByAction),
   ];

--- a/apps/roam/src/components/canvas/useCanvasStoreAdapterArgs.ts
+++ b/apps/roam/src/components/canvas/useCanvasStoreAdapterArgs.ts
@@ -5,7 +5,10 @@ import {
   TLAnyShapeUtilConstructor,
 } from "tldraw";
 import { DiscourseNode } from "~/utils/getDiscourseNodes";
-import { DiscourseNodeUtil } from "./DiscourseNodeUtil";
+import {
+  createLegacyDiscourseNodeShapeUtils,
+  DiscourseNodeUtil,
+} from "./DiscourseNodeUtil";
 import {
   createAllReferencedNodeUtils,
   createAllRelationShapeUtils,
@@ -55,28 +58,22 @@ const getUtilTypes = <T extends { type: string }>({
   return utils.map((u) => u.type);
 };
 
-const getCustomShapeTypes = ({
-  allNodes,
-  utils,
-}: {
-  allNodes: DiscourseNode[];
-  utils: readonly TLAnyShapeUtilConstructor[];
-}): string[] => {
-  return [
-    ...new Set([...getUtilTypes({ utils }), ...allNodes.map((n) => n.type)]),
-  ];
-};
-
 const createShapeUtils = ({
+  allNodes,
   allRelationIds,
   allAddReferencedNodeByAction,
+  includeLegacyNodeTypes = false,
 }: {
   allNodes: DiscourseNode[];
   allRelationIds: string[];
   allAddReferencedNodeByAction: AddReferencedNodeType;
+  includeLegacyNodeTypes?: boolean;
 }): TLAnyShapeUtilConstructor[] => {
   return [
     DiscourseNodeUtil,
+    ...(includeLegacyNodeTypes
+      ? createLegacyDiscourseNodeShapeUtils(allNodes)
+      : []),
     ...createAllRelationShapeUtils(allRelationIds),
     ...createAllReferencedNodeUtils(allAddReferencedNodeByAction),
   ];
@@ -117,8 +114,7 @@ export const useCanvasStoreAdapterArgs = ({
     allRelationIds,
     allAddReferencedNodeByAction,
   });
-  const customShapeTypes = getCustomShapeTypes({
-    allNodes,
+  const customShapeTypes = getUtilTypes({
     utils: customShapeUtils,
   });
   const customBindingTypes = getUtilTypes({
@@ -142,6 +138,8 @@ export const useCanvasStoreAdapterArgs = ({
         allNodes,
         allRelationIds,
         allAddReferencedNodeByAction,
+        // Cloudflare rooms may still stream pre-migration node-id shape records.
+        includeLegacyNodeTypes: true,
       }),
     }),
     [pageUid, allNodes, allRelationIds, allAddReferencedNodeByAction],
@@ -159,12 +157,11 @@ export const useCanvasStoreAdapterArgs = ({
   const stableCustomShapeTypes = useMemo(
     () => ({
       pageUid,
-      value: getCustomShapeTypes({
-        allNodes,
+      value: getUtilTypes({
         utils: stableCustomShapeUtils,
       }),
     }),
-    [pageUid, allNodes, stableCustomShapeUtils],
+    [pageUid, stableCustomShapeUtils],
   ).value;
   const stableCustomBindingTypes = useMemo(
     () => ({

--- a/apps/roam/src/components/canvas/useCanvasStoreAdapterArgs.ts
+++ b/apps/roam/src/components/canvas/useCanvasStoreAdapterArgs.ts
@@ -5,7 +5,7 @@ import {
   TLAnyShapeUtilConstructor,
 } from "tldraw";
 import { DiscourseNode } from "~/utils/getDiscourseNodes";
-import { createNodeShapeUtils } from "./DiscourseNodeUtil";
+import { DiscourseNodeUtil } from "./DiscourseNodeUtil";
 import {
   createAllReferencedNodeUtils,
   createAllRelationShapeUtils,
@@ -55,8 +55,19 @@ const getUtilTypes = <T extends { type: string }>({
   return utils.map((u) => u.type);
 };
 
-const createShapeUtils = ({
+const getCustomShapeTypes = ({
   allNodes,
+  utils,
+}: {
+  allNodes: DiscourseNode[];
+  utils: readonly TLAnyShapeUtilConstructor[];
+}): string[] => {
+  return [
+    ...new Set([...getUtilTypes({ utils }), ...allNodes.map((n) => n.type)]),
+  ];
+};
+
+const createShapeUtils = ({
   allRelationIds,
   allAddReferencedNodeByAction,
 }: {
@@ -65,7 +76,7 @@ const createShapeUtils = ({
   allAddReferencedNodeByAction: AddReferencedNodeType;
 }): TLAnyShapeUtilConstructor[] => {
   return [
-    ...createNodeShapeUtils(allNodes),
+    DiscourseNodeUtil,
     ...createAllRelationShapeUtils(allRelationIds),
     ...createAllReferencedNodeUtils(allAddReferencedNodeByAction),
   ];
@@ -106,7 +117,8 @@ export const useCanvasStoreAdapterArgs = ({
     allRelationIds,
     allAddReferencedNodeByAction,
   });
-  const customShapeTypes = getUtilTypes({
+  const customShapeTypes = getCustomShapeTypes({
+    allNodes,
     utils: customShapeUtils,
   });
   const customBindingTypes = getUtilTypes({
@@ -147,11 +159,12 @@ export const useCanvasStoreAdapterArgs = ({
   const stableCustomShapeTypes = useMemo(
     () => ({
       pageUid,
-      value: getUtilTypes({
+      value: getCustomShapeTypes({
+        allNodes,
         utils: stableCustomShapeUtils,
       }),
     }),
-    [pageUid, stableCustomShapeUtils],
+    [pageUid, allNodes, stableCustomShapeUtils],
   ).value;
   const stableCustomBindingTypes = useMemo(
     () => ({

--- a/apps/roam/src/utils/syncCanvasNodeTitlesOnLoad.ts
+++ b/apps/roam/src/utils/syncCanvasNodeTitlesOnLoad.ts
@@ -1,5 +1,8 @@
 import type { Editor } from "tldraw";
-import type { DiscourseNodeShape } from "~/components/canvas/DiscourseNodeUtil";
+import {
+  DISCOURSE_NODE_SHAPE_TYPE,
+  type DiscourseNodeShape,
+} from "~/components/canvas/DiscourseNodeUtil";
 
 /**
  * Query Roam for current :node/title or :block/string for each uid.
@@ -64,12 +67,13 @@ export const syncCanvasNodeTitlesOnLoad = async (
   const nodeTypeSet = new Set(nodeTypeIds);
   const relationIds = new Set(relationShapeTypeIds);
   const allRecords = editor.store.allRecords();
-  const discourseNodeShapes = allRecords.filter(
-    (r) =>
-      r.typeName === "shape" &&
-      nodeTypeSet.has((r as DiscourseNodeShape).type) &&
-      typeof (r as DiscourseNodeShape).props?.uid === "string",
-  ) as DiscourseNodeShape[];
+  const discourseNodeShapes = allRecords.filter((r) => {
+    if (r.typeName !== "shape") return false;
+    if (r.type !== DISCOURSE_NODE_SHAPE_TYPE) return false;
+    const shape = r as DiscourseNodeShape;
+    if (!nodeTypeSet.has(shape.props.nodeTypeId)) return false;
+    return typeof shape.props?.uid === "string";
+  }) as DiscourseNodeShape[];
 
   const uids = [...new Set(discourseNodeShapes.map((s) => s.props.uid))];
   if (uids.length === 0) return;

--- a/apps/roam/src/utils/syncCanvasNodeTitlesOnLoad.ts
+++ b/apps/roam/src/utils/syncCanvasNodeTitlesOnLoad.ts
@@ -1,5 +1,8 @@
 import type { Editor } from "tldraw";
-import type { DiscourseNodeShape } from "~/components/canvas/DiscourseNodeUtil";
+import {
+  DISCOURSE_NODE_SHAPE_TYPE,
+  type DiscourseNodeShape,
+} from "~/components/canvas/DiscourseNodeUtil";
 
 /**
  * Query Roam for current :node/title or :block/string for each uid.
@@ -63,12 +66,13 @@ export const syncCanvasNodeTitlesOnLoad = async (
   const nodeTypeSet = new Set(nodeTypeIds);
   const relationIds = new Set(relationShapeTypeIds);
   const allRecords = editor.store.allRecords();
-  const discourseNodeShapes = allRecords.filter(
-    (r) =>
-      r.typeName === "shape" &&
-      nodeTypeSet.has((r as DiscourseNodeShape).type) &&
-      typeof (r as DiscourseNodeShape).props?.uid === "string",
-  ) as DiscourseNodeShape[];
+  const discourseNodeShapes = allRecords.filter((r) => {
+    if (r.typeName !== "shape") return false;
+    if (r.type !== DISCOURSE_NODE_SHAPE_TYPE) return false;
+    const shape = r as DiscourseNodeShape;
+    if (!nodeTypeSet.has(shape.props.nodeTypeId)) return false;
+    return typeof shape.props?.uid === "string";
+  }) as DiscourseNodeShape[];
 
   const uids = [...new Set(discourseNodeShapes.map((s) => s.props.uid))];
   if (uids.length === 0) return;

--- a/apps/roam/src/utils/syncCanvasNodeTitlesOnLoad.ts
+++ b/apps/roam/src/utils/syncCanvasNodeTitlesOnLoad.ts
@@ -1,6 +1,7 @@
 import type { Editor } from "tldraw";
 import {
   DISCOURSE_NODE_SHAPE_TYPE,
+  getDiscourseNodeTypeId,
   type DiscourseNodeShape,
 } from "~/components/canvas/DiscourseNodeUtil";
 
@@ -68,9 +69,11 @@ export const syncCanvasNodeTitlesOnLoad = async (
   const allRecords = editor.store.allRecords();
   const discourseNodeShapes = allRecords.filter((r) => {
     if (r.typeName !== "shape") return false;
-    if (r.type !== DISCOURSE_NODE_SHAPE_TYPE) return false;
     const shape = r as DiscourseNodeShape;
-    if (!nodeTypeSet.has(shape.props.nodeTypeId)) return false;
+    if (r.type !== DISCOURSE_NODE_SHAPE_TYPE && !nodeTypeSet.has(r.type)) {
+      return false;
+    }
+    if (!nodeTypeSet.has(getDiscourseNodeTypeId({ shape }))) return false;
     return typeof shape.props?.uid === "string";
   }) as DiscourseNodeShape[];
 


### PR DESCRIPTION
- [x] Open an existing Roam canvas created before this change that already contains discourse nodes.
- [x] Confirm the canvas loads without migration errors or unknown-shape errors.
- [x] Confirm old discourse nodes still render with the right title, color, and image behavior.
- [x] Edit an existing migrated discourse node and save it successfully.
- [x] Create a brand new discourse node from the canvas toolbar for at least two different node types.
- [x] Confirm both new nodes behave correctly even though they now share the same TL shape type.
- [x] Create a relation between valid node types and confirm the arrow renders and binds correctly.
- [x] Attempt an invalid relation connection and confirm the warning/validation still works.
- [x] Paste `[[Page]]` into the canvas and confirm it creates a discourse node correctly.
- [x] Paste `((block-uid))` into the canvas and confirm it creates a discourse node correctly.
- [x] Use the query builder canvas insertion flow and confirm inserted nodes appear correctly.
- [x] Drag a node from the Clipboard panel onto the canvas and confirm it creates correctly.
- [x] Use Convert To from a text shape and confirm the created discourse node works correctly.
- [x] Reload a canvas containing newly created discourse nodes and confirm they persist and reload correctly.
- [x] Load a canvas where a node title changed in Roam and confirm the canvas title sync still works.
- [x] Load a canvas where a referenced node was deleted and confirm the stale node and attached relations are cleaned up.
- [x] With auto canvas relations enabled, create or edit a node that should auto-create relations and confirm no duplicate-loop or update-cascade behavior appears.
- [x] If cloud sync is used, open a synced canvas with older discourse nodes and confirm the canvas still loads.
- [x] If cloud sync is used, create or edit a discourse node on one client and confirm another client/session sees the update.
- [x] Test a canvas from the beta version
- [x] Delete a node type and load a canvas with said node type
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/894" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized node shape management throughout the canvas system by introducing a unified shape type constant and explicit node type identifier storage in shape properties, improving consistency and maintainability of shape operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->