### PR TITLE
ENG-1470: Fix dual-read gaps found during flag-ON validation

### DIFF
--- a/apps/roam/src/components/DiscourseFloatingMenu.tsx
+++ b/apps/roam/src/components/DiscourseFloatingMenu.tsx
@@ -13,7 +13,7 @@ import {
 import { FeedbackWidget } from "./BirdEatsBugs";
 import { render as renderSettings } from "~/components/settings/Settings";
 import posthog from "posthog-js";
-import { getPersonalSetting } from "./settings/utils/accessors";
+import { type SettingsSnapshot } from "./settings/utils/accessors";
 import { PERSONAL_KEYS } from "./settings/utils/settingKeys";
 
 type DiscourseFloatingMenuProps = {
@@ -118,11 +118,7 @@ export const showDiscourseFloatingMenu = () => {
 
 export const installDiscourseFloatingMenu = (
   onLoadArgs: OnloadArgs,
-  props: DiscourseFloatingMenuProps = {
-    position: "bottom-right",
-    theme: "bp3-light",
-    buttonTheme: "bp3-light",
-  },
+  snapshot: SettingsSnapshot,
 ) => {
   let floatingMenuAnchor = document.getElementById(ANCHOR_ID);
   if (!floatingMenuAnchor) {
@@ -130,14 +126,15 @@ export const installDiscourseFloatingMenu = (
     floatingMenuAnchor.id = ANCHOR_ID;
     document.getElementById("app")?.appendChild(floatingMenuAnchor);
   }
-  if (getPersonalSetting<boolean>([PERSONAL_KEYS.hideFeedbackButton])) {
+  if (snapshot.personalSettings[PERSONAL_KEYS.hideFeedbackButton]) {
     floatingMenuAnchor.classList.add("hidden");
   }
+  // eslint-disable-next-line react/no-deprecated
   ReactDOM.render(
     <DiscourseFloatingMenu
-      position={props.position}
-      theme={props.theme}
-      buttonTheme={props.buttonTheme}
+      position="bottom-right"
+      theme="bp3-light"
+      buttonTheme="bp3-light"
       onloadArgs={onLoadArgs}
     />,
     floatingMenuAnchor,
@@ -148,6 +145,7 @@ export const removeDiscourseFloatingMenu = () => {
   const anchor = document.getElementById(ANCHOR_ID);
   if (anchor) {
     try {
+      // eslint-disable-next-line react/no-deprecated
       ReactDOM.unmountComponentAtNode(anchor);
     } catch (e) {
       // no-op: unmount best-effort

--- a/apps/roam/src/components/DiscourseNodeMenu.tsx
+++ b/apps/roam/src/components/DiscourseNodeMenu.tsx
@@ -27,11 +27,9 @@ import { getNewDiscourseNodeText } from "~/utils/formatUtils";
 import { OnloadArgs } from "roamjs-components/types";
 import { formatHexColor } from "./settings/DiscourseNodeCanvasSettings";
 import posthog from "posthog-js";
-import {
-  getPersonalSetting,
-  setPersonalSetting,
-} from "~/components/settings/utils/accessors";
+import { setPersonalSetting } from "~/components/settings/utils/accessors";
 import { PERSONAL_KEYS } from "~/components/settings/utils/settingKeys";
+import type { PersonalSettings } from "~/components/settings/utils/zodSchema";
 
 type Props = {
   textarea?: HTMLTextAreaElement;
@@ -420,19 +418,15 @@ export const comboToString = (combo: IKeyCombo): string => {
 
 export const NodeMenuTriggerComponent = ({
   extensionAPI,
+  initialValue,
 }: {
   extensionAPI: OnloadArgs["extensionAPI"];
+  initialValue: PersonalSettings["Personal node menu trigger"];
 }) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const [isActive, setIsActive] = useState(false);
-  const [comboKey, setComboKey] = useState<IKeyCombo>(
-    () =>
-      getPersonalSetting<IKeyCombo>([
-        PERSONAL_KEYS.personalNodeMenuTrigger,
-      ]) || {
-        modifiers: 0,
-        key: "",
-      },
+  const [comboKey, setComboKey] = useState<IKeyCombo>(() =>
+    typeof initialValue === "object" ? initialValue : { modifiers: 0, key: "" },
   );
 
   const handleKeyDown = useCallback(

--- a/apps/roam/src/components/DiscourseNodeSearchMenu.tsx
+++ b/apps/roam/src/components/DiscourseNodeSearchMenu.tsx
@@ -25,10 +25,7 @@ import getDiscourseNodes, { DiscourseNode } from "~/utils/getDiscourseNodes";
 import getDiscourseNodeFormatExpression from "~/utils/getDiscourseNodeFormatExpression";
 import { Result } from "~/utils/types";
 import MiniSearch from "minisearch";
-import {
-  getPersonalSetting,
-  setPersonalSetting,
-} from "~/components/settings/utils/accessors";
+import { setPersonalSetting } from "~/components/settings/utils/accessors";
 import { PERSONAL_KEYS } from "~/components/settings/utils/settingKeys";
 
 type Props = {
@@ -709,12 +706,14 @@ export const renderDiscourseNodeSearchMenu = (props: Props) => {
 
 export const NodeSearchMenuTriggerSetting = ({
   onloadArgs,
+  initialValue,
 }: {
   onloadArgs: OnloadArgs;
+  initialValue: string;
 }) => {
   const extensionAPI = onloadArgs.extensionAPI;
   const [nodeSearchTrigger, setNodeSearchTrigger] = useState<string>(
-    getPersonalSetting<string>([PERSONAL_KEYS.nodeSearchMenuTrigger]) ?? "@",
+    () => initialValue,
   );
 
   const handleNodeSearchTriggerChange = (

--- a/apps/roam/src/components/LeftSidebarView.tsx
+++ b/apps/roam/src/components/LeftSidebarView.tsx
@@ -36,6 +36,7 @@ import { getLeftSidebarSettings } from "~/utils/getLeftSidebarSettings";
 import {
   getGlobalSetting,
   getPersonalSetting,
+  getPersonalSettings,
   setGlobalSetting,
   setPersonalSetting,
 } from "~/components/settings/utils/accessors";
@@ -45,10 +46,7 @@ import {
   LEFT_SIDEBAR_KEYS,
   LEFT_SIDEBAR_SETTINGS_KEYS,
 } from "~/components/settings/utils/settingKeys";
-import type {
-  LeftSidebarGlobalSettings,
-  PersonalSection,
-} from "~/components/settings/utils/zodSchema";
+import type { LeftSidebarGlobalSettings } from "~/components/settings/utils/zodSchema";
 import { createBlock } from "roamjs-components/writes";
 import deleteBlock from "roamjs-components/writes/deleteBlock";
 import getTextByBlockUid from "roamjs-components/queries/getTextByBlockUid";
@@ -112,7 +110,7 @@ const openTarget = async (e: React.MouseEvent, targetUid: string) => {
   }
 };
 
-const toggleFoldedState = ({
+const toggleFoldedState = async ({
   isOpen,
   setIsOpen,
   folded,
@@ -130,22 +128,25 @@ const toggleFoldedState = ({
   const newFolded = !isOpen;
 
   if (isOpen) {
-    setIsOpen(false);
-    if (folded.uid) {
-      void deleteBlock(folded.uid);
-      folded.uid = undefined;
-      folded.value = false;
-    }
+    const children = getBasicTreeByParentUid(parentUid);
+    await Promise.all(
+      children
+        .filter((c) => c.text === "Folded")
+        .map((c) => deleteBlock(c.uid)),
+    );
+    folded.uid = undefined;
+    folded.value = false;
   } else {
-    setIsOpen(true);
     const newUid = window.roamAlphaAPI.util.generateUID();
-    void createBlock({
+    await createBlock({
       parentUid,
       node: { text: "Folded", uid: newUid },
     });
     folded.uid = newUid;
     folded.value = true;
   }
+
+  refreshConfigTree();
 
   if (isGlobal) {
     setGlobalSetting(
@@ -157,13 +158,20 @@ const toggleFoldedState = ({
       newFolded,
     );
   } else if (sectionIndex !== undefined) {
-    const sections =
-      getPersonalSetting<PersonalSection[]>([PERSONAL_KEYS.leftSidebar]) || [];
+    const sections = [...getPersonalSettings()[PERSONAL_KEYS.leftSidebar]];
     if (sections[sectionIndex]) {
-      sections[sectionIndex].Settings.Folded = newFolded;
+      sections[sectionIndex] = {
+        ...sections[sectionIndex],
+        Settings: {
+          ...sections[sectionIndex].Settings,
+          Folded: newFolded,
+        },
+      };
       setPersonalSetting([PERSONAL_KEYS.leftSidebar], sections);
     }
   }
+
+  setIsOpen(newFolded);
 };
 
 const SectionChildren = ({
@@ -225,7 +233,7 @@ const PersonalSectionItem = ({
   const handleChevronClick = () => {
     if (!section.settings) return;
 
-    toggleFoldedState({
+    void toggleFoldedState({
       isOpen,
       setIsOpen,
       folded: section.settings.folded,
@@ -297,7 +305,7 @@ const GlobalSection = ({ config }: { config: LeftSidebarConfig["global"] }) => {
         className="sidebar-title-button flex w-full items-center border-none bg-transparent py-1 pl-6 pr-2.5 font-semibold outline-none"
         onClick={() => {
           if (!isCollapsable || !config.settings) return;
-          toggleFoldedState({
+          void toggleFoldedState({
             isOpen,
             setIsOpen,
             folded: config.settings.folded,
@@ -333,9 +341,9 @@ const buildConfig = (): LeftSidebarConfig => {
   const globalValues = getGlobalSetting<LeftSidebarGlobalSettings>([
     GLOBAL_KEYS.leftSidebar,
   ]);
-  const personalValues = getPersonalSetting<PersonalSection[]>([
-    PERSONAL_KEYS.leftSidebar,
-  ]);
+  const personalValues = getPersonalSetting<
+    ReturnType<typeof getPersonalSettings>[typeof PERSONAL_KEYS.leftSidebar]
+  >([PERSONAL_KEYS.leftSidebar]);
 
   // Read UIDs from old system (needed for fold CRUD during dual-write)
   const oldConfig = getCurrentLeftSidebarConfig();

--- a/apps/roam/src/components/LeftSidebarView.tsx
+++ b/apps/roam/src/components/LeftSidebarView.tsx
@@ -39,6 +39,7 @@ import {
   getPersonalSettings,
   setGlobalSetting,
   setPersonalSetting,
+  type SettingsSnapshot,
 } from "~/components/settings/utils/accessors";
 import {
   PERSONAL_KEYS,
@@ -336,14 +337,16 @@ const GlobalSection = ({ config }: { config: LeftSidebarConfig["global"] }) => {
 
 // TODO(ENG-1471): Remove old-system merge when migration complete — just use accessor values directly.
 // See mergeGlobalSectionWithAccessor/mergePersonalSectionsWithAccessor for why the merge exists.
-const buildConfig = (): LeftSidebarConfig => {
+const buildConfig = (snapshot?: SettingsSnapshot): LeftSidebarConfig => {
   // Read VALUES from accessor (handles flag routing + mismatch detection)
-  const globalValues = getGlobalSetting<LeftSidebarGlobalSettings>([
-    GLOBAL_KEYS.leftSidebar,
-  ]);
-  const personalValues = getPersonalSetting<
-    ReturnType<typeof getPersonalSettings>[typeof PERSONAL_KEYS.leftSidebar]
-  >([PERSONAL_KEYS.leftSidebar]);
+  const globalValues = snapshot
+    ? snapshot.globalSettings[GLOBAL_KEYS.leftSidebar]
+    : getGlobalSetting<LeftSidebarGlobalSettings>([GLOBAL_KEYS.leftSidebar]);
+  const personalValues = snapshot
+    ? snapshot.personalSettings[PERSONAL_KEYS.leftSidebar]
+    : getPersonalSetting<
+        ReturnType<typeof getPersonalSettings>[typeof PERSONAL_KEYS.leftSidebar]
+      >([PERSONAL_KEYS.leftSidebar]);
 
   // Read UIDs from old system (needed for fold CRUD during dual-write)
   const oldConfig = getCurrentLeftSidebarConfig();
@@ -364,8 +367,8 @@ const buildConfig = (): LeftSidebarConfig => {
   };
 };
 
-export const useConfig = () => {
-  const [config, setConfig] = useState(() => buildConfig());
+export const useConfig = (initialSnapshot?: SettingsSnapshot) => {
+  const [config, setConfig] = useState(() => buildConfig(initialSnapshot));
   useEffect(() => {
     const handleUpdate = () => {
       setConfig(buildConfig());
@@ -504,8 +507,14 @@ const FavoritesPopover = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
   );
 };
 
-const LeftSidebarView = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
-  const { config } = useConfig();
+const LeftSidebarView = ({
+  onloadArgs,
+  initialSnapshot,
+}: {
+  onloadArgs: OnloadArgs;
+  initialSnapshot?: SettingsSnapshot;
+}) => {
+  const { config } = useConfig(initialSnapshot);
 
   return (
     <>
@@ -610,10 +619,15 @@ const migrateFavorites = async () => {
   refreshConfigTree();
 };
 
-export const mountLeftSidebar = async (
-  wrapper: HTMLElement,
-  onloadArgs: OnloadArgs,
-): Promise<void> => {
+export const mountLeftSidebar = async ({
+  wrapper,
+  onloadArgs,
+  initialSnapshot,
+}: {
+  wrapper: HTMLElement;
+  onloadArgs: OnloadArgs;
+  initialSnapshot?: SettingsSnapshot;
+}): Promise<void> => {
   if (!wrapper) return;
 
   const id = "dg-left-sidebar-root";
@@ -630,7 +644,14 @@ export const mountLeftSidebar = async (
   } else {
     root.className = "starred-pages";
   }
-  ReactDOM.render(<LeftSidebarView onloadArgs={onloadArgs} />, root);
+  // eslint-disable-next-line react/no-deprecated
+  ReactDOM.render(
+    <LeftSidebarView
+      onloadArgs={onloadArgs}
+      initialSnapshot={initialSnapshot}
+    />,
+    root,
+  );
 };
 
 export default LeftSidebarView;

--- a/apps/roam/src/components/settings/AdminPanel.tsx
+++ b/apps/roam/src/components/settings/AdminPanel.tsx
@@ -277,7 +277,7 @@ const FeatureFlagsTab = (): React.ReactElement => {
   }, []);
 
   const [suggestiveModeEnabled, setSuggestiveModeEnabled] = useState(
-    getFeatureFlag("Suggestive mode enabled"),
+    () => getFeatureFlag("Suggestive mode enabled"),
   );
   const [suggestiveModeUid, setSuggestiveModeUid] = useState(
     legacySuggestiveModeMeta.suggestiveModeEnabledUid,

--- a/apps/roam/src/components/settings/AdminPanel.tsx
+++ b/apps/roam/src/components/settings/AdminPanel.tsx
@@ -15,8 +15,8 @@ import {
 import Description from "roamjs-components/components/Description";
 import { Select } from "@blueprintjs/select";
 import {
-  getFeatureFlag,
   setFeatureFlag,
+  type SettingsSnapshot,
 } from "~/components/settings/utils/accessors";
 import {
   onSettingChange,
@@ -264,7 +264,11 @@ const NodeListTab = (): React.ReactElement => {
   );
 };
 
-const FeatureFlagsTab = (): React.ReactElement => {
+const FeatureFlagsTab = ({
+  featureFlags,
+}: {
+  featureFlags: SettingsSnapshot["featureFlags"];
+}): React.ReactElement => {
   const legacySuggestiveModeMeta = useMemo(() => {
     refreshConfigTree();
     return {
@@ -276,8 +280,8 @@ const FeatureFlagsTab = (): React.ReactElement => {
     };
   }, []);
 
-  const [suggestiveModeEnabled, setSuggestiveModeEnabled] = useState(() =>
-    getFeatureFlag("Suggestive mode enabled"),
+  const [suggestiveModeEnabled, setSuggestiveModeEnabled] = useState(
+    featureFlags["Suggestive mode enabled"],
   );
   const [suggestiveModeUid, setSuggestiveModeUid] = useState(
     legacySuggestiveModeMeta.suggestiveModeEnabledUid,
@@ -365,6 +369,7 @@ const FeatureFlagsTab = (): React.ReactElement => {
         title="Use new settings store"
         description="When enabled, accessor getters read from block props instead of the old system. Surfaces dual-write gaps during development."
         featureKey="Use new settings store"
+        initialValue={featureFlags["Use new settings store"]}
       />
 
       <Button
@@ -386,10 +391,16 @@ const FeatureFlagsTab = (): React.ReactElement => {
   );
 };
 
-const AdminPanel = (): React.ReactElement => {
+const AdminPanel = ({
+  featureFlags,
+  globalSettings,
+}: {
+  featureFlags: SettingsSnapshot["featureFlags"];
+  globalSettings: SettingsSnapshot["globalSettings"];
+}): React.ReactElement => {
   const [selectedTabId, setSelectedTabId] = useState<TabId>("admin");
   const [showSuggestiveTab, setShowSuggestiveTab] = useState(
-    getFeatureFlag("Suggestive mode enabled"),
+    featureFlags["Suggestive mode enabled"],
   );
 
   useEffect(() => {
@@ -409,7 +420,7 @@ const AdminPanel = (): React.ReactElement => {
         title="Admin"
         panel={
           <div className="flex flex-col gap-4 p-1">
-            <FeatureFlagsTab />
+            <FeatureFlagsTab featureFlags={featureFlags} />
           </div>
         }
       />
@@ -427,7 +438,7 @@ const AdminPanel = (): React.ReactElement => {
           id="suggestive-mode-settings"
           title="Suggestive mode"
           className="overflow-y-auto"
-          panel={<SuggestiveModeSettings />}
+          panel={<SuggestiveModeSettings globalSettings={globalSettings} />}
         />
       )}
     </Tabs>

--- a/apps/roam/src/components/settings/AdminPanel.tsx
+++ b/apps/roam/src/components/settings/AdminPanel.tsx
@@ -294,12 +294,15 @@ const FeatureFlagsTab = (): React.ReactElement => {
           if (checked) {
             setIsAlertOpen(true);
           } else {
-            if (suggestiveModeUid) {
-              void deleteBlock(suggestiveModeUid);
-              setSuggestiveModeUid(undefined);
-            }
-            setSuggestiveModeEnabled(false);
-            setFeatureFlag("Suggestive mode enabled", false);
+            void (async () => {
+              if (suggestiveModeUid) {
+                await deleteBlock(suggestiveModeUid);
+                setSuggestiveModeUid(undefined);
+              }
+              refreshConfigTree();
+              setSuggestiveModeEnabled(false);
+              setFeatureFlag("Suggestive mode enabled", false);
+            })();
           }
         }}
         labelElement={
@@ -321,6 +324,7 @@ const FeatureFlagsTab = (): React.ReactElement => {
             node: { text: "(BETA) Suggestive Mode Enabled" },
           }).then((uid) => {
             setSuggestiveModeUid(uid);
+            refreshConfigTree();
             setSuggestiveModeEnabled(true);
             setFeatureFlag("Suggestive mode enabled", true);
             setIsAlertOpen(false);

--- a/apps/roam/src/components/settings/AdminPanel.tsx
+++ b/apps/roam/src/components/settings/AdminPanel.tsx
@@ -276,8 +276,8 @@ const FeatureFlagsTab = (): React.ReactElement => {
     };
   }, []);
 
-  const [suggestiveModeEnabled, setSuggestiveModeEnabled] = useState(
-    () => getFeatureFlag("Suggestive mode enabled"),
+  const [suggestiveModeEnabled, setSuggestiveModeEnabled] = useState(() =>
+    getFeatureFlag("Suggestive mode enabled"),
   );
   const [suggestiveModeUid, setSuggestiveModeUid] = useState(
     legacySuggestiveModeMeta.suggestiveModeEnabledUid,

--- a/apps/roam/src/components/settings/DefaultFilters.tsx
+++ b/apps/roam/src/components/settings/DefaultFilters.tsx
@@ -1,12 +1,9 @@
 import { Button, Intent, InputGroup } from "@blueprintjs/core";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import type { OnloadArgs } from "roamjs-components/types";
 import type { Filters } from "roamjs-components/components/Filter";
 import posthog from "posthog-js";
-import {
-  getPersonalSetting,
-  setPersonalSetting,
-} from "~/components/settings/utils/accessors";
+import { setPersonalSetting } from "~/components/settings/utils/accessors";
 import {
   PERSONAL_KEYS,
   QUERY_KEYS,
@@ -106,18 +103,15 @@ const Filter = ({
 
 const DefaultFilters = ({
   extensionAPI,
+  defaultFilters,
 }: {
   extensionAPI: OnloadArgs["extensionAPI"];
+  defaultFilters: Record<string, StoredFilters>;
 }) => {
   const [newColumn, setNewColumn] = useState("");
   const [filters, setFilters] = useState(() =>
     Object.fromEntries(
-      Object.entries(
-        getPersonalSetting<Record<string, StoredFilters>>([
-          PERSONAL_KEYS.query,
-          QUERY_KEYS.defaultFilters,
-        ]) ?? {},
-      ).map(([k, v]) => [
+      Object.entries(defaultFilters).map(([k, v]) => [
         k,
         {
           includes: Object.fromEntries(
@@ -131,7 +125,12 @@ const DefaultFilters = ({
     ),
   );
 
+  const isInitialMount = useRef(true);
   useEffect(() => {
+    if (isInitialMount.current) {
+      isInitialMount.current = false;
+      return;
+    }
     const serialized = Object.fromEntries(
       Object.entries(filters).map(([k, v]) => [
         k,
@@ -156,7 +155,7 @@ const DefaultFilters = ({
       [PERSONAL_KEYS.query, QUERY_KEYS.defaultFilters],
       serialized,
     );
-  }, [filters]);
+  }, [filters, extensionAPI.settings]);
   return (
     <div
       style={{

--- a/apps/roam/src/components/settings/DiscourseNodeCanvasSettings.tsx
+++ b/apps/roam/src/components/settings/DiscourseNodeCanvasSettings.tsx
@@ -142,13 +142,13 @@ const DiscourseNodeCanvasSettings = ({
         settingKeys={[DISCOURSE_NODE_KEYS.canvasSettings, CANVAS_KEYS.keyImage]}
         initialValue={isKeyImage}
         onChange={(checked) => {
-          setIsKeyImage(checked);
           if (checked && !keyImageOption) setKeyImageOption("first-image");
           void setInputSetting({
             blockUid: uid,
             key: "key-image",
             value: checked ? "true" : "false",
           });
+          setTimeout(() => setIsKeyImage(checked), 100);
         }}
       />
       <RadioGroup

--- a/apps/roam/src/components/settings/DiscourseRelationConfigPanel.tsx
+++ b/apps/roam/src/components/settings/DiscourseRelationConfigPanel.tsx
@@ -43,7 +43,6 @@ import { render as renderToast } from "roamjs-components/components/Toast";
 import getPageTitleByPageUid from "roamjs-components/queries/getPageTitleByPageUid";
 import updateBlock from "roamjs-components/writes/updateBlock";
 import getTextByBlockUid from "roamjs-components/queries/getTextByBlockUid";
-import { CustomField } from "roamjs-components/components/ConfigPanels/types";
 import getDiscourseNodes from "~/utils/getDiscourseNodes";
 import { getConditionLabels } from "~/utils/conditionToDatalog";
 import { formatHexColor } from "./DiscourseNodeCanvasSettings";
@@ -51,9 +50,9 @@ import posthog from "posthog-js";
 import { getSetting, setSetting } from "~/utils/extensionSettings";
 import { getStoredRelationsEnabled } from "~/utils/storedRelations";
 import {
-  getGlobalSetting,
   setGlobalSetting,
   getGlobalSettings,
+  type SettingsSnapshot,
 } from "~/components/settings/utils/accessors";
 import { GLOBAL_KEYS } from "~/components/settings/utils/settingKeys";
 import { RenderRoamBlock } from "~/utils/roamReactComponents";
@@ -78,12 +77,14 @@ export const RelationEditPanel = ({
   back,
   translatorKeys,
   previewUid,
+  globalSettings,
 }: {
   editingRelationInfo: TreeNode;
   back: () => void;
   nodes: Record<string, { label: string; format: string; color: string }>;
   translatorKeys: string[];
   previewUid: string;
+  globalSettings: SettingsSnapshot["globalSettings"];
 }) => {
   const nodeFormatsByLabel = useMemo(
     () =>
@@ -124,42 +125,21 @@ export const RelationEditPanel = ({
     DEFAULT_SELECTED_RELATION,
   );
   const [tab, setTab] = useState(0);
-  const initialSourceUid = useMemo(
-    () =>
-      getGlobalSetting<string>([
-        GLOBAL_KEYS.relations,
-        editingRelationInfo.uid,
-        "source",
-      ]) ?? "",
-    [],
-  );
+  const relation = globalSettings.Relations[editingRelationInfo.uid];
+  const initialSourceUid = relation?.source ?? "";
   const initialSource = useMemo(
     () => edgeDisplayByUid(initialSourceUid),
     [initialSourceUid],
   );
   const [source, setSource] = useState(initialSourceUid);
-  const initialDestinationUid = useMemo(
-    () =>
-      getGlobalSetting<string>([
-        GLOBAL_KEYS.relations,
-        editingRelationInfo.uid,
-        "destination",
-      ]) ?? "",
-    [],
-  );
+  const initialDestinationUid = relation?.destination ?? "";
   const initialDestination = useMemo(
     () => edgeDisplayByUid(initialDestinationUid),
     [initialDestinationUid],
   );
   const [destination, setDestination] = useState(initialDestinationUid);
   const [label, setLabel] = useState(editingRelationInfo.text);
-  const [complement, setComplement] = useState(
-    getGlobalSetting<string>([
-      GLOBAL_KEYS.relations,
-      editingRelationInfo.uid,
-      "complement",
-    ]) ?? "",
-  );
+  const [complement, setComplement] = useState(relation?.complement ?? "");
 
   const edgeCallback = useCallback(
     (edge: cytoscape.EdgeSingular) => {
@@ -980,9 +960,16 @@ type Relation = {
   source: string | undefined;
   destination: string | undefined;
 };
-const DiscourseRelationConfigPanel: CustomField["options"]["component"] = ({
+const DiscourseRelationConfigPanel = ({
   uid,
   parentUid,
+  globalSettings,
+}: {
+  uid: string;
+  parentUid: string;
+  defaultValue: unknown;
+  title: string;
+  globalSettings: SettingsSnapshot["globalSettings"];
 }) => {
   const refreshRelations = useCallback(
     () =>
@@ -1122,6 +1109,7 @@ const DiscourseRelationConfigPanel: CustomField["options"]["component"] = ({
           back={handleBack}
           translatorKeys={translatorKeys}
           previewUid={previewUid}
+          globalSettings={globalSettings}
         />
       </div>
     );

--- a/apps/roam/src/components/settings/ExportSettings.tsx
+++ b/apps/roam/src/components/settings/ExportSettings.tsx
@@ -10,8 +10,14 @@ import {
   GLOBAL_KEYS,
   EXPORT_KEYS,
 } from "~/components/settings/utils/settingKeys";
+import { type SettingsSnapshot } from "./utils/accessors";
 
-const DiscourseGraphExport = () => {
+const DiscourseGraphExport = ({
+  globalSettings,
+}: {
+  globalSettings: SettingsSnapshot["globalSettings"];
+}) => {
+  const exportBlockProps = globalSettings.Export;
   const exportSettings = getExportSettingsAndUids();
   const parentUid = exportSettings.exportUid;
   return (
@@ -26,6 +32,7 @@ const DiscourseGraphExport = () => {
             GLOBAL_KEYS.export,
             EXPORT_KEYS.removeSpecialCharacters,
           ]}
+          initialValue={exportBlockProps[EXPORT_KEYS.removeSpecialCharacters]}
           order={1}
           uid={exportSettings.removeSpecialCharacters.uid}
           parentUid={parentUid}
@@ -35,6 +42,7 @@ const DiscourseGraphExport = () => {
           title="resolve block references"
           description="Replaces block references in the markdown content with the block's content"
           settingKeys={[GLOBAL_KEYS.export, EXPORT_KEYS.resolveBlockReferences]}
+          initialValue={exportBlockProps[EXPORT_KEYS.resolveBlockReferences]}
           order={3}
           uid={exportSettings.optsRefs.uid}
           parentUid={parentUid}
@@ -43,6 +51,7 @@ const DiscourseGraphExport = () => {
           title="resolve block embeds"
           description="Replaces block embeds in the markdown content with the block's content tree"
           settingKeys={[GLOBAL_KEYS.export, EXPORT_KEYS.resolveBlockEmbeds]}
+          initialValue={exportBlockProps[EXPORT_KEYS.resolveBlockEmbeds]}
           order={4}
           uid={exportSettings.optsEmbeds.uid}
           parentUid={parentUid}
@@ -52,6 +61,7 @@ const DiscourseGraphExport = () => {
           title="append referenced node"
           description="If a referenced node is defined in a node's format, it will be appended to the discourse context"
           settingKeys={[GLOBAL_KEYS.export, EXPORT_KEYS.appendReferencedNode]}
+          initialValue={exportBlockProps[EXPORT_KEYS.appendReferencedNode]}
           order={6}
           uid={exportSettings.appendRefNodeContext.uid}
           parentUid={parentUid}
@@ -62,6 +72,7 @@ const DiscourseGraphExport = () => {
           title="link type"
           description="How to format links that appear in your export."
           settingKeys={[GLOBAL_KEYS.export, EXPORT_KEYS.linkType]}
+          initialValue={exportBlockProps[EXPORT_KEYS.linkType]}
           order={5}
           options={["alias", "wikilinks", "roam url"]}
           uid={exportSettings.linkType.uid}
@@ -72,6 +83,7 @@ const DiscourseGraphExport = () => {
         title="max filename length"
         description="Set the maximum name length for markdown file exports"
         settingKeys={[GLOBAL_KEYS.export, EXPORT_KEYS.maxFilenameLength]}
+        initialValue={exportBlockProps[EXPORT_KEYS.maxFilenameLength]}
         order={0}
         uid={exportSettings.maxFilenameLength.uid}
         parentUid={parentUid}
@@ -80,6 +92,7 @@ const DiscourseGraphExport = () => {
         title="frontmatter"
         description="Specify all the lines that should go to the Frontmatter of the markdown file"
         settingKeys={[GLOBAL_KEYS.export, EXPORT_KEYS.frontmatter]}
+        initialValue={exportBlockProps[EXPORT_KEYS.frontmatter]}
         order={2}
         uid={exportSettings.frontmatter.uid}
         parentUid={parentUid}

--- a/apps/roam/src/components/settings/GeneralSettings.tsx
+++ b/apps/roam/src/components/settings/GeneralSettings.tsx
@@ -7,7 +7,7 @@ import {
   FeatureFlagPanel,
 } from "./components/BlockPropSettingPanels";
 import { GLOBAL_KEYS } from "~/components/settings/utils/settingKeys";
-import { isNewSettingsStoreEnabled } from "./utils/accessors";
+import { type SettingsSnapshot } from "./utils/accessors";
 import posthog from "posthog-js";
 import getPageUidByPageTitle from "roamjs-components/queries/getPageUidByPageTitle";
 import {
@@ -16,7 +16,13 @@ import {
 } from "~/utils/getExportSettings";
 import { DISCOURSE_CONFIG_PAGE_TITLE } from "~/data/constants";
 
-const DiscourseGraphHome = () => {
+const DiscourseGraphHome = ({
+  globalSettings,
+  featureFlags,
+}: {
+  globalSettings: SettingsSnapshot["globalSettings"];
+  featureFlags: SettingsSnapshot["featureFlags"];
+}) => {
   const settings = useMemo(() => {
     refreshConfigTree();
     const tree = discourseConfigRef.tree;
@@ -43,6 +49,7 @@ const DiscourseGraphHome = () => {
         title="trigger"
         description="The trigger to create the node menu."
         settingKeys={[GLOBAL_KEYS.trigger]}
+        initialValue={globalSettings[GLOBAL_KEYS.trigger]}
         order={0}
         uid={settings.triggerUid}
         parentUid={settings.settingsUid}
@@ -51,6 +58,7 @@ const DiscourseGraphHome = () => {
         title="Canvas Page Format"
         description="The page format for canvas pages"
         settingKeys={[GLOBAL_KEYS.canvasPageFormat]}
+        initialValue={globalSettings[GLOBAL_KEYS.canvasPageFormat]}
         order={1}
         uid={settings.canvasPageFormatUid}
         parentUid={settings.settingsUid}
@@ -59,11 +67,12 @@ const DiscourseGraphHome = () => {
         title="(BETA) Left Sidebar"
         description="Whether or not to enable the left sidebar."
         featureKey="Enable left sidebar"
+        initialValue={featureFlags["Enable left sidebar"]}
         order={2}
         uid={settings.leftSidebarEnabledUid}
         parentUid={settings.settingsUid}
         onAfterChange={(checked: boolean) => {
-          if (checked && !isNewSettingsStoreEnabled()) {
+          if (checked && !featureFlags["Use new settings store"]) {
             setIsAlertOpen(true);
           }
           posthog.capture("General Settings: Left Sidebar Toggled", {

--- a/apps/roam/src/components/settings/HomePersonalSettings.tsx
+++ b/apps/roam/src/components/settings/HomePersonalSettings.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import React, { useState } from "react";
 import { OnloadArgs } from "roamjs-components/types";
 import { render as renderToast } from "roamjs-components/components/Toast";
 import { Label, Dialog, Button, Intent, Classes } from "@blueprintjs/core";
@@ -28,14 +28,13 @@ import { setSetting } from "~/utils/extensionSettings";
 import { enablePostHog, disablePostHog } from "~/utils/posthog";
 import KeyboardShortcutInput from "./KeyboardShortcutInput";
 import streamlineStyling from "~/styles/streamlineStyling";
-import { getFeatureFlag } from "~/components/settings/utils/accessors";
 import { PersonalFlagPanel } from "./components/BlockPropSettingPanels";
 import { PERSONAL_KEYS } from "./utils/settingKeys";
 import migrateRelations from "~/utils/migrateRelations";
 import { countReifiedRelations } from "~/utils/createReifiedBlock";
 import posthog from "posthog-js";
 import internalError from "~/utils/internalError";
-import { setPersonalSetting } from "./utils/accessors";
+import { setPersonalSetting, type SettingsSnapshot } from "./utils/accessors";
 import { getStoredRelationsEnabled } from "~/utils/storedRelations";
 
 const enum RelationMigrationDialog {
@@ -45,7 +44,15 @@ const enum RelationMigrationDialog {
   "reactivate",
 }
 
-const HomePersonalSettings = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
+const HomePersonalSettings = ({
+  onloadArgs,
+  personalSettings,
+  featureFlags,
+}: {
+  onloadArgs: OnloadArgs;
+  personalSettings: SettingsSnapshot["personalSettings"];
+  featureFlags: SettingsSnapshot["featureFlags"];
+}) => {
   const extensionAPI = onloadArgs.extensionAPI;
   const overlayHandler = getOverlayHandler(onloadArgs);
   const [activeRelationMigration, setActiveRelationMigration] =
@@ -116,12 +123,18 @@ const HomePersonalSettings = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
       <Label>
         Personal node menu trigger
         <Description description="Override the global trigger for the discourse node menu." />
-        <NodeMenuTriggerComponent extensionAPI={extensionAPI} />
+        <NodeMenuTriggerComponent
+          extensionAPI={extensionAPI}
+          initialValue={personalSettings[PERSONAL_KEYS.personalNodeMenuTrigger]}
+        />
       </Label>
       <Label>
         Node search menu trigger
         <Description description="Set the trigger character for the node search menu." />
-        <NodeSearchMenuTriggerSetting onloadArgs={onloadArgs} />
+        <NodeSearchMenuTriggerSetting
+          onloadArgs={onloadArgs}
+          initialValue={personalSettings[PERSONAL_KEYS.nodeSearchMenuTrigger]}
+        />
       </Label>
       <KeyboardShortcutInput
         onloadArgs={onloadArgs}
@@ -130,11 +143,13 @@ const HomePersonalSettings = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
         label="Discourse tool keyboard shortcut"
         description="Set a single key to activate the discourse tool in tldraw. Only single keys (no modifiers) are supported. Leave empty for no shortcut."
         placeholder="Click to set single key"
+        initialValue={personalSettings[PERSONAL_KEYS.discourseToolShortcut]}
       />
       <PersonalFlagPanel
         title="Overlay"
         description="Whether or not to overlay discourse context information over discourse node references."
         settingKeys={[PERSONAL_KEYS.discourseContextOverlay]}
+        initialValue={personalSettings[PERSONAL_KEYS.discourseContextOverlay]}
         onChange={(checked) => {
           void setSetting("discourse-context-overlay", checked);
           onPageRefObserverChange(overlayHandler)(checked);
@@ -143,11 +158,12 @@ const HomePersonalSettings = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
           });
         }}
       />
-      {getFeatureFlag("Suggestive mode enabled") && (
+      {featureFlags["Suggestive mode enabled"] && (
         <PersonalFlagPanel
           title="Suggestive mode overlay"
           description="Whether or not to overlay suggestive mode button over discourse node references."
           settingKeys={[PERSONAL_KEYS.suggestiveModeOverlay]}
+          initialValue={personalSettings[PERSONAL_KEYS.suggestiveModeOverlay]}
           onChange={(checked) => {
             void setSetting("suggestive-mode-overlay", checked);
             onPageRefObserverChange(getSuggestiveOverlayHandler(onloadArgs))(
@@ -161,6 +177,7 @@ const HomePersonalSettings = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
         title="Enable stored relations"
         description="Use stored relations instead of legacy pattern-based relations"
         settingKeys={["Reified relation triples"]}
+        initialValue={personalSettings["Reified relation triples"]}
         value={storedRelations}
         onBeforeChange={async (checked) => {
           if (checked) {
@@ -182,6 +199,7 @@ const HomePersonalSettings = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
         title="Text selection popup"
         description="Whether or not to show the discourse node menu when selecting text."
         settingKeys={[PERSONAL_KEYS.textSelectionPopup]}
+        initialValue={personalSettings[PERSONAL_KEYS.textSelectionPopup]}
         onChange={(checked) => {
           void setSetting("text-selection-popup", checked);
         }}
@@ -190,6 +208,7 @@ const HomePersonalSettings = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
         title="Disable sidebar open"
         description="Disable opening new nodes in the sidebar when created"
         settingKeys={[PERSONAL_KEYS.disableSidebarOpen]}
+        initialValue={personalSettings[PERSONAL_KEYS.disableSidebarOpen]}
         onChange={(checked) => {
           void setSetting("disable-sidebar-open", checked);
         }}
@@ -198,6 +217,7 @@ const HomePersonalSettings = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
         title="Page preview"
         description="Whether or not to display page previews when hovering over page refs"
         settingKeys={[PERSONAL_KEYS.pagePreview]}
+        initialValue={personalSettings[PERSONAL_KEYS.pagePreview]}
         onChange={(checked) => {
           void setSetting("page-preview", checked);
           onPageRefObserverChange(previewPageRefHandler)(checked);
@@ -207,6 +227,7 @@ const HomePersonalSettings = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
         title="Hide feedback button"
         description="Hide the 'Send feedback' button at the bottom right of the screen."
         settingKeys={[PERSONAL_KEYS.hideFeedbackButton]}
+        initialValue={personalSettings[PERSONAL_KEYS.hideFeedbackButton]}
         onChange={(checked) => {
           void setSetting("hide-feedback-button", checked);
           if (checked) {
@@ -220,6 +241,7 @@ const HomePersonalSettings = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
         title="Auto canvas relations"
         description="Automatically add discourse relations to canvas when a node is added"
         settingKeys={[PERSONAL_KEYS.autoCanvasRelations]}
+        initialValue={personalSettings[PERSONAL_KEYS.autoCanvasRelations]}
         onChange={(checked) => {
           void setSetting(AUTO_CANVAS_RELATIONS_KEY, checked);
         }}
@@ -229,6 +251,7 @@ const HomePersonalSettings = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
         title="(BETA) Overlay in canvas"
         description="Whether or not to overlay discourse context information over canvas nodes."
         settingKeys={[PERSONAL_KEYS.overlayInCanvas]}
+        initialValue={personalSettings[PERSONAL_KEYS.overlayInCanvas]}
         onChange={(checked) => {
           void setSetting(DISCOURSE_CONTEXT_OVERLAY_IN_CANVAS_KEY, checked);
         }}
@@ -237,6 +260,7 @@ const HomePersonalSettings = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
         title="Streamline styling"
         description="Apply streamlined styling to your personal graph for a cleaner appearance."
         settingKeys={[PERSONAL_KEYS.streamlineStyling]}
+        initialValue={personalSettings[PERSONAL_KEYS.streamlineStyling]}
         onChange={(checked) => {
           void setSetting(STREAMLINE_STYLING_KEY, checked);
           const existingStyleElement =
@@ -254,6 +278,7 @@ const HomePersonalSettings = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
         title="Disable product diagnostics"
         description="Disable sending usage signals and error reports that help us improve the product."
         settingKeys={[PERSONAL_KEYS.disableProductDiagnostics]}
+        initialValue={personalSettings[PERSONAL_KEYS.disableProductDiagnostics]}
         onChange={(checked) => {
           void setSetting(DISALLOW_DIAGNOSTICS, checked);
           if (checked) {

--- a/apps/roam/src/components/settings/KeyboardShortcutInput.tsx
+++ b/apps/roam/src/components/settings/KeyboardShortcutInput.tsx
@@ -9,10 +9,7 @@ import {
 } from "@blueprintjs/core";
 import Description from "roamjs-components/components/Description";
 import { DISCOURSE_TOOL_SHORTCUT_KEY } from "~/data/userSettings";
-import {
-  getPersonalSetting,
-  setPersonalSetting,
-} from "~/components/settings/utils/accessors";
+import { setPersonalSetting } from "~/components/settings/utils/accessors";
 import { comboToString } from "~/components/DiscourseNodeMenu";
 import type { PersonalSettings } from "~/components/settings/utils/zodSchema";
 
@@ -22,6 +19,7 @@ type KeyboardShortcutInputProps = {
   blockPropKey: keyof PersonalSettings;
   label: string;
   description: string;
+  initialValue: IKeyCombo;
   placeholder?: string;
 };
 
@@ -31,18 +29,13 @@ const KeyboardShortcutInput = ({
   blockPropKey,
   label,
   description,
+  initialValue,
   placeholder = "Click to set shortcut",
 }: KeyboardShortcutInputProps) => {
   const extensionAPI = onloadArgs.extensionAPI;
   const inputRef = useRef<HTMLInputElement>(null);
   const [isActive, setIsActive] = useState(false);
-  const [comboKey, setComboKey] = useState<IKeyCombo>(
-    () =>
-      getPersonalSetting<IKeyCombo>([blockPropKey]) || {
-        modifiers: 0,
-        key: "",
-      },
-  );
+  const [comboKey, setComboKey] = useState<IKeyCombo>(() => initialValue);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {

--- a/apps/roam/src/components/settings/LeftSidebarGlobalSettings.tsx
+++ b/apps/roam/src/components/settings/LeftSidebarGlobalSettings.tsx
@@ -3,14 +3,13 @@ import { Button, ButtonGroup, Collapse } from "@blueprintjs/core";
 import { GlobalFlagPanel } from "~/components/settings/components/BlockPropSettingPanels";
 import {
   setGlobalSetting,
-  getGlobalSetting,
+  type SettingsSnapshot,
 } from "~/components/settings/utils/accessors";
 import {
   GLOBAL_KEYS,
   LEFT_SIDEBAR_KEYS,
   LEFT_SIDEBAR_SETTINGS_KEYS,
 } from "~/components/settings/utils/settingKeys";
-import type { LeftSidebarGlobalSettings } from "~/components/settings/utils/zodSchema";
 import AutocompleteInput from "roamjs-components/components/AutocompleteInput";
 import getAllPageNames from "roamjs-components/queries/getAllPageNames";
 import createBlock from "roamjs-components/writes/createBlock";
@@ -92,8 +91,10 @@ PageItem.displayName = "PageItem";
 
 const LeftSidebarGlobalSectionsContent = ({
   leftSidebar,
+  globalSettings,
 }: {
   leftSidebar: RoamBasicNode;
+  globalSettings: SettingsSnapshot["globalSettings"];
 }) => {
   const [globalSection, setGlobalSection] =
     useState<LeftSidebarGlobalSectionConfig | null>(null);
@@ -110,9 +111,7 @@ const LeftSidebarGlobalSectionsContent = ({
     const initialize = async () => {
       setIsInitializing(true);
       const globalSectionText = "Global-Section";
-      const globalValues = getGlobalSetting<LeftSidebarGlobalSettings>([
-        GLOBAL_KEYS.leftSidebar,
-      ]);
+      const globalValues = globalSettings[GLOBAL_KEYS.leftSidebar];
       const config = getLeftSidebarGlobalSectionConfig(leftSidebar.children);
 
       const existingGlobalSection = leftSidebar.children.find(
@@ -166,7 +165,7 @@ const LeftSidebarGlobalSectionsContent = ({
     };
 
     void initialize();
-  }, [leftSidebar]);
+  }, [leftSidebar, globalSettings]);
 
   const movePage = useCallback(
     (index: number, direction: "up" | "down") => {
@@ -402,7 +401,11 @@ const LeftSidebarGlobalSectionsContent = ({
   );
 };
 
-export const LeftSidebarGlobalSections = () => {
+export const LeftSidebarGlobalSections = ({
+  globalSettings,
+}: {
+  globalSettings: SettingsSnapshot["globalSettings"];
+}) => {
   const [leftSidebar, setLeftSidebar] = useState<RoamBasicNode | null>(null);
 
   useEffect(() => {
@@ -430,5 +433,10 @@ export const LeftSidebarGlobalSections = () => {
     return null;
   }
 
-  return <LeftSidebarGlobalSectionsContent leftSidebar={leftSidebar} />;
+  return (
+    <LeftSidebarGlobalSectionsContent
+      leftSidebar={leftSidebar}
+      globalSettings={globalSettings}
+    />
+  );
 };

--- a/apps/roam/src/components/settings/LeftSidebarPersonalSettings.tsx
+++ b/apps/roam/src/components/settings/LeftSidebarPersonalSettings.tsx
@@ -125,14 +125,9 @@ const SectionItem = memo(
             order: 0,
             node: { text: "Settings" },
           });
-          const foldedUid = await createBlock({
-            parentUid: settingsUid,
-            order: 0,
-            node: { text: "Folded" },
-          });
           const truncateSettingUid = await createBlock({
             parentUid: settingsUid,
-            order: 1,
+            order: 0,
             node: { text: "Truncate-result?", children: [{ text: "75" }] },
           });
 
@@ -149,7 +144,7 @@ const SectionItem = memo(
                   ...s,
                   settings: {
                     uid: settingsUid,
-                    folded: { uid: foldedUid, value: false },
+                    folded: { uid: undefined, value: false },
                     truncateResult: { uid: truncateSettingUid, value: 75 },
                   },
                   childrenUid,
@@ -167,7 +162,7 @@ const SectionItem = memo(
                     ...s,
                     settings: {
                       uid: settingsUid,
-                      folded: { uid: foldedUid, value: false },
+                      folded: { uid: undefined, value: false },
                       truncateResult: { uid: truncateSettingUid, value: 75 },
                     },
                     children: [],

--- a/apps/roam/src/components/settings/LeftSidebarPersonalSettings.tsx
+++ b/apps/roam/src/components/settings/LeftSidebarPersonalSettings.tsx
@@ -21,10 +21,9 @@ import updateBlock from "roamjs-components/writes/updateBlock";
 import type { RoamBasicNode } from "roamjs-components/types";
 import {
   setPersonalSetting,
-  getPersonalSetting,
+  type SettingsSnapshot,
 } from "~/components/settings/utils/accessors";
 import { PERSONAL_KEYS } from "~/components/settings/utils/settingKeys";
-import type { PersonalSection } from "~/components/settings/utils/zodSchema";
 import {
   PersonalNumberPanel,
   PersonalTextPanel,
@@ -565,8 +564,10 @@ SectionItem.displayName = "SectionItem";
 
 const LeftSidebarPersonalSectionsContent = ({
   leftSidebar,
+  personalSettings,
 }: {
   leftSidebar: RoamBasicNode;
+  personalSettings: SettingsSnapshot["personalSettings"];
 }) => {
   const [sections, setSections] = useState<LeftSidebarPersonalSectionConfig[]>(
     [],
@@ -604,9 +605,7 @@ const LeftSidebarPersonalSectionsContent = ({
       } else {
         setPersonalSectionUid(personalSection.uid);
 
-        const personalValues = getPersonalSetting<PersonalSection[]>([
-          PERSONAL_KEYS.leftSidebar,
-        ]);
+        const personalValues = personalSettings[PERSONAL_KEYS.leftSidebar];
         const loadedSections = getLeftSidebarPersonalSectionConfig(
           leftSidebar.children,
         ).sections;
@@ -617,7 +616,7 @@ const LeftSidebarPersonalSectionsContent = ({
     };
 
     void initialize();
-  }, [leftSidebar]);
+  }, [leftSidebar, personalSettings]);
 
   const addSection = useCallback(
     async (sectionName: string) => {
@@ -832,7 +831,11 @@ const LeftSidebarPersonalSectionsContent = ({
   );
 };
 
-export const LeftSidebarPersonalSections = () => {
+export const LeftSidebarPersonalSections = ({
+  personalSettings,
+}: {
+  personalSettings: SettingsSnapshot["personalSettings"];
+}) => {
   const [leftSidebar, setLeftSidebar] = useState<RoamBasicNode | null>(null);
 
   useEffect(() => {
@@ -860,5 +863,10 @@ export const LeftSidebarPersonalSections = () => {
     return null;
   }
 
-  return <LeftSidebarPersonalSectionsContent leftSidebar={leftSidebar} />;
+  return (
+    <LeftSidebarPersonalSectionsContent
+      leftSidebar={leftSidebar}
+      personalSettings={personalSettings}
+    />
+  );
 };

--- a/apps/roam/src/components/settings/NodeConfig.tsx
+++ b/apps/roam/src/components/settings/NodeConfig.tsx
@@ -9,14 +9,16 @@ import DiscourseNodeAttributes from "./DiscourseNodeAttributes";
 import DiscourseNodeCanvasSettings from "./DiscourseNodeCanvasSettings";
 import DiscourseNodeIndex from "./DiscourseNodeIndex";
 import { OnloadArgs } from "roamjs-components/types";
-import { getDiscourseNodeSetting } from "~/components/settings/utils/accessors";
+import {
+  getDiscourseNodeSetting,
+  type SettingsSnapshot,
+} from "~/components/settings/utils/accessors";
 import {
   DISCOURSE_NODE_KEYS,
   SPECIFICATION_KEYS,
   TEMPLATE_SETTING_KEYS,
 } from "~/components/settings/utils/settingKeys";
 import DiscourseNodeSuggestiveRules from "./DiscourseNodeSuggestiveRules";
-import { getFeatureFlag } from "~/components/settings/utils/accessors";
 import {
   DiscourseNodeTextPanel,
   DiscourseNodeFlagPanel,
@@ -43,9 +45,11 @@ const generateTagPlaceholder = (node: DiscourseNode): string => {
 const NodeConfig = ({
   node,
   onloadArgs,
+  featureFlags,
 }: {
   node: DiscourseNode;
   onloadArgs: OnloadArgs;
+  featureFlags: SettingsSnapshot["featureFlags"];
 }) => {
   const getUid = (key: string) =>
     getSubTree({
@@ -299,7 +303,7 @@ const NodeConfig = ({
             </div>
           }
         />
-        {getFeatureFlag("Suggestive mode enabled") && (
+        {featureFlags["Suggestive mode enabled"] && (
           <Tab
             id="suggestive-mode"
             title="Suggestive mode"

--- a/apps/roam/src/components/settings/QueryPagesPanel.tsx
+++ b/apps/roam/src/components/settings/QueryPagesPanel.tsx
@@ -5,6 +5,7 @@ import type { OnloadArgs } from "roamjs-components/types";
 import {
   getPersonalSetting,
   setPersonalSetting,
+  type SettingsSnapshot,
 } from "~/components/settings/utils/accessors";
 import {
   PERSONAL_KEYS,
@@ -13,11 +14,13 @@ import {
 
 // Legacy extensionAPI stored query-pages as string | string[] | Record<string, string>.
 // Coerce to string[] for backward compatibility with old stored formats.
-export const getQueryPages = (): string[] => {
-  const value = getPersonalSetting<string[] | string | Record<string, string>>([
-    PERSONAL_KEYS.query,
-    QUERY_KEYS.queryPages,
-  ]);
+export const getQueryPages = (snapshot?: SettingsSnapshot): string[] => {
+  const value: string[] | string | Record<string, string> | undefined = snapshot
+    ? snapshot.personalSettings[PERSONAL_KEYS.query][QUERY_KEYS.queryPages]
+    : getPersonalSetting<string[] | string | Record<string, string>>([
+        PERSONAL_KEYS.query,
+        QUERY_KEYS.queryPages,
+      ]);
   return typeof value === "string"
     ? [value]
     : Array.isArray(value)

--- a/apps/roam/src/components/settings/QuerySettings.tsx
+++ b/apps/roam/src/components/settings/QuerySettings.tsx
@@ -13,19 +13,24 @@ import {
   PERSONAL_KEYS,
   QUERY_KEYS,
 } from "~/components/settings/utils/settingKeys";
+import { type SettingsSnapshot } from "./utils/accessors";
 import posthog from "posthog-js";
 
 const QuerySettings = ({
   extensionAPI,
+  personalSettings,
 }: {
   extensionAPI: OnloadArgs["extensionAPI"];
+  personalSettings: SettingsSnapshot["personalSettings"];
 }) => {
+  const querySettings = personalSettings.Query;
   return (
     <div className="flex flex-col gap-4 p-1">
       <PersonalFlagPanel
         title="Hide query metadata"
         description="Hide the Roam blocks that are used to power each query"
         settingKeys={[PERSONAL_KEYS.query, QUERY_KEYS.hideQueryMetadata]}
+        initialValue={querySettings[QUERY_KEYS.hideQueryMetadata]}
         onChange={(checked) => {
           void extensionAPI.settings.set(HIDE_METADATA_KEY, checked);
           posthog.capture("Query Settings: Hide Metadata Toggled", {
@@ -37,6 +42,7 @@ const QuerySettings = ({
         title="Default page size"
         description="The default page size used for query results"
         settingKeys={[PERSONAL_KEYS.query, QUERY_KEYS.defaultPageSize]}
+        initialValue={querySettings[QUERY_KEYS.defaultPageSize]}
         onChange={(value) => {
           void extensionAPI.settings.set(DEFAULT_PAGE_SIZE_KEY, value);
           posthog.capture("Query Settings: Default Page Size Changed", {
@@ -48,6 +54,7 @@ const QuerySettings = ({
         title="Query pages"
         description="The title formats of pages that you would like to serve as pages that generate queries"
         settingKeys={[PERSONAL_KEYS.query, QUERY_KEYS.queryPages]}
+        initialValue={querySettings[QUERY_KEYS.queryPages]}
         onChange={(values) => {
           void extensionAPI.settings.set("query-pages", values);
         }}
@@ -59,7 +66,10 @@ const QuerySettings = ({
             "Any filters that should be applied to your results by default"
           }
         />
-        <DefaultFilters extensionAPI={extensionAPI} />
+        <DefaultFilters
+          extensionAPI={extensionAPI}
+          defaultFilters={querySettings[QUERY_KEYS.defaultFilters]}
+        />
       </Label>
     </div>
   );

--- a/apps/roam/src/components/settings/Settings.tsx
+++ b/apps/roam/src/components/settings/Settings.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { OnloadArgs } from "roamjs-components/types";
 import {
   Classes,
@@ -29,6 +29,7 @@ import { getVersionWithDate } from "~/utils/getVersion";
 import { LeftSidebarPersonalSections } from "./LeftSidebarPersonalSettings";
 import { LeftSidebarGlobalSections } from "./LeftSidebarGlobalSettings";
 import posthog from "posthog-js";
+import { bulkReadSettings } from "./utils/accessors";
 
 type SectionHeaderProps = {
   children: React.ReactNode;
@@ -84,6 +85,8 @@ export const SettingsDialog = ({
   const [activeTabId, setActiveTabId] = useState<TabId>(
     selectedTabId ?? "discourse-graph-home-personal",
   );
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const settings = useMemo(() => bulkReadSettings(), [activeTabId]);
   const [showAdminPanel, setShowAdminPanel] = useState(
     window.roamAlphaAPI.graph.name === "discourse-graphs" || false,
   );
@@ -166,19 +169,34 @@ export const SettingsDialog = ({
             id="discourse-graph-home-personal"
             title="Home"
             className="overflow-y-auto"
-            panel={<HomePersonalSettings onloadArgs={onloadArgs} />}
+            panel={
+              <HomePersonalSettings
+                onloadArgs={onloadArgs}
+                personalSettings={settings.personalSettings}
+                featureFlags={settings.featureFlags}
+              />
+            }
           />
           <Tab
             id="query-settings"
             title="Queries"
             className="overflow-y-auto"
-            panel={<QuerySettings extensionAPI={extensionAPI} />}
+            panel={
+              <QuerySettings
+                extensionAPI={extensionAPI}
+                personalSettings={settings.personalSettings}
+              />
+            }
           />
           <Tab
             id="left-sidebar-personal-settings"
             title="Left sidebar"
             className="overflow-y-auto"
-            panel={<LeftSidebarPersonalSections />}
+            panel={
+              <LeftSidebarPersonalSections
+                personalSettings={settings.personalSettings}
+              />
+            }
           />
           <SectionHeader className="text-lg font-semibold text-neutral-dark">
             Global Settings
@@ -187,19 +205,30 @@ export const SettingsDialog = ({
             id="discourse-graph-home"
             title="Home"
             className="overflow-y-auto"
-            panel={<DiscourseGraphHome />}
+            panel={
+              <DiscourseGraphHome
+                globalSettings={settings.globalSettings}
+                featureFlags={settings.featureFlags}
+              />
+            }
           />
           <Tab
             id="discourse-graph-export"
             title="Export"
             className="overflow-y-auto"
-            panel={<DiscourseGraphExport />}
+            panel={
+              <DiscourseGraphExport globalSettings={settings.globalSettings} />
+            }
           />
           <Tab
             id="left-sidebar-global-settings"
             title="Left sidebar"
             className="overflow-y-auto"
-            panel={<LeftSidebarGlobalSections />}
+            panel={
+              <LeftSidebarGlobalSections
+                globalSettings={settings.globalSettings}
+              />
+            }
           />
           <SectionHeader>Grammar</SectionHeader>
           <Tab
@@ -212,6 +241,7 @@ export const SettingsDialog = ({
                 title="Relations"
                 parentUid={grammarNode?.uid || ""}
                 uid={relationsNode?.uid || ""}
+                globalSettings={settings.globalSettings}
               />
             }
           />
@@ -236,7 +266,13 @@ export const SettingsDialog = ({
               id={n.type}
               title={n.text}
               className="overflow-y-auto"
-              panel={<NodeConfig node={n} onloadArgs={onloadArgs} />}
+              panel={
+                <NodeConfig
+                  node={n}
+                  onloadArgs={onloadArgs}
+                  featureFlags={settings.featureFlags}
+                />
+              }
             />
           ))}
           <Tabs.Expander />
@@ -246,7 +282,12 @@ export const SettingsDialog = ({
             id="secret-admin-panel"
             title="Admin"
             className="overflow-y-auto"
-            panel={<AdminPanel />}
+            panel={
+              <AdminPanel
+                featureFlags={settings.featureFlags}
+                globalSettings={settings.globalSettings}
+              />
+            }
           />
         </Tabs>
       </div>

--- a/apps/roam/src/components/settings/SuggestiveModeSettings.tsx
+++ b/apps/roam/src/components/settings/SuggestiveModeSettings.tsx
@@ -9,7 +9,7 @@ import { DISCOURSE_CONFIG_PAGE_TITLE } from "~/data/constants";
 import { createOrUpdateDiscourseEmbedding } from "~/utils/syncDgNodesToSupabase";
 import { render as renderToast } from "roamjs-components/components/Toast";
 import { GlobalFlagPanel } from "./components/BlockPropSettingPanels";
-import { getGlobalSetting } from "~/components/settings/utils/accessors";
+import { type SettingsSnapshot } from "~/components/settings/utils/accessors";
 import {
   GLOBAL_KEYS,
   SUGGESTIVE_MODE_KEYS,
@@ -17,7 +17,11 @@ import {
 import posthog from "posthog-js";
 import { getSuggestiveModeConfigAndUids } from "~/utils/getSuggestiveModeConfigSettings";
 
-const SuggestiveModeSettings = () => {
+const SuggestiveModeSettings = ({
+  globalSettings,
+}: {
+  globalSettings: SettingsSnapshot["globalSettings"];
+}) => {
   const suggestiveMode = getSuggestiveModeConfigAndUids(
     discourseConfigRef.tree,
   );
@@ -27,11 +31,10 @@ const SuggestiveModeSettings = () => {
   );
   const pageGroupsUid = suggestiveMode.pageGroups.uid;
 
+  const suggestiveModeSettings = globalSettings[GLOBAL_KEYS.suggestiveMode];
+
   const [includePageRelations, setIncludePageRelations] = useState(
-    getGlobalSetting<boolean>([
-      GLOBAL_KEYS.suggestiveMode,
-      SUGGESTIVE_MODE_KEYS.includeCurrentPageRelations,
-    ]) ?? false,
+    suggestiveModeSettings[SUGGESTIVE_MODE_KEYS.includeCurrentPageRelations],
   );
 
   useEffect(() => {
@@ -91,6 +94,11 @@ const SuggestiveModeSettings = () => {
                     GLOBAL_KEYS.suggestiveMode,
                     SUGGESTIVE_MODE_KEYS.includeCurrentPageRelations,
                   ]}
+                  initialValue={
+                    suggestiveModeSettings[
+                      SUGGESTIVE_MODE_KEYS.includeCurrentPageRelations
+                    ]
+                  }
                   order={0}
                   uid={suggestiveMode.includePageRelations.uid}
                   parentUid={effectiveSuggestiveModeUid}
@@ -108,6 +116,11 @@ const SuggestiveModeSettings = () => {
                     GLOBAL_KEYS.suggestiveMode,
                     SUGGESTIVE_MODE_KEYS.includeParentAndChildBlocks,
                   ]}
+                  initialValue={
+                    suggestiveModeSettings[
+                      SUGGESTIVE_MODE_KEYS.includeParentAndChildBlocks
+                    ]
+                  }
                   value={includePageRelations ? true : undefined}
                   order={1}
                   uid={suggestiveMode.includeParentAndChildren.uid}

--- a/apps/roam/src/components/settings/components/BlockPropSettingPanels.tsx
+++ b/apps/roam/src/components/settings/components/BlockPropSettingPanels.tsx
@@ -20,8 +20,6 @@ import useSingleChildValue from "roamjs-components/components/ConfigPanels/useSi
 import getShallowTreeByParentUid from "roamjs-components/queries/getShallowTreeByParentUid";
 import refreshConfigTree from "~/utils/refreshConfigTree";
 import {
-  getGlobalSetting,
-  getPersonalSetting,
   getFeatureFlag,
   getDiscourseNodeSetting,
   setGlobalSetting,
@@ -50,7 +48,7 @@ type BaseTextPanelProps = {
   description: string;
   settingKeys: string[];
   setter: TextSetter;
-  initialValue?: string;
+  initialValue: string;
   placeholder?: string;
   multiline?: boolean;
   error?: string;
@@ -62,7 +60,7 @@ type BaseFlagPanelProps = {
   description: string;
   settingKeys: string[];
   setter: FlagSetter;
-  initialValue?: boolean;
+  initialValue: boolean;
   value?: boolean;
   disabled?: boolean;
   onBeforeChange?: (checked: boolean) => Promise<boolean>;
@@ -74,7 +72,7 @@ type BaseNumberPanelProps = {
   description: string;
   settingKeys: string[];
   setter: NumberSetter;
-  initialValue?: number;
+  initialValue: number;
   min?: number;
   max?: number;
   onChange?: (value: number) => void;
@@ -86,7 +84,7 @@ type BaseSelectPanelProps = {
   settingKeys: string[];
   setter: TextSetter;
   options: string[];
-  initialValue?: string;
+  initialValue: string;
 } & RoamBlockSyncProps;
 
 type BaseMultiTextPanelProps = {
@@ -94,7 +92,7 @@ type BaseMultiTextPanelProps = {
   description: string;
   settingKeys: string[];
   setter: MultiTextSetter;
-  initialValue?: string[];
+  initialValue: string[];
   onChange?: (values: string[]) => void;
 } & RoamBlockSyncProps;
 
@@ -513,6 +511,7 @@ export const FeatureFlagPanel = ({
   title,
   description,
   featureKey,
+  initialValue,
   onBeforeEnable,
   onAfterChange,
   parentUid,
@@ -522,6 +521,7 @@ export const FeatureFlagPanel = ({
   title: string;
   description: string;
   featureKey: keyof FeatureFlags;
+  initialValue?: boolean;
   onBeforeEnable?: () => Promise<boolean>;
   onAfterChange?: (checked: boolean) => void;
 } & RoamBlockSyncProps) => {
@@ -542,7 +542,7 @@ export const FeatureFlagPanel = ({
       description={description}
       settingKeys={[featureKey as string]}
       setter={featureFlagSetter}
-      initialValue={getFeatureFlag(featureKey)}
+      initialValue={initialValue ?? getFeatureFlag(featureKey)}
       onBeforeChange={handleBeforeChange}
       onChange={onAfterChange}
       parentUid={parentUid}
@@ -553,73 +553,31 @@ export const FeatureFlagPanel = ({
 };
 
 export const GlobalTextPanel = (props: TextWrapperProps) => (
-  <BaseTextPanel
-    {...props}
-    initialValue={
-      getGlobalSetting<string>(props.settingKeys) ?? props.initialValue
-    }
-    {...globalAccessors.text}
-  />
+  <BaseTextPanel {...props} {...globalAccessors.text} />
 );
 
 export const GlobalFlagPanel = (props: FlagWrapperProps) => (
-  <BaseFlagPanel
-    {...props}
-    initialValue={
-      getGlobalSetting<boolean>(props.settingKeys) ?? props.initialValue
-    }
-    {...globalAccessors.flag}
-  />
+  <BaseFlagPanel {...props} {...globalAccessors.flag} />
 );
 
 export const GlobalNumberPanel = (props: NumberWrapperProps) => (
-  <BaseNumberPanel
-    {...props}
-    initialValue={
-      getGlobalSetting<number>(props.settingKeys) ?? props.initialValue
-    }
-    {...globalAccessors.number}
-  />
+  <BaseNumberPanel {...props} {...globalAccessors.number} />
 );
 
 export const GlobalSelectPanel = (props: SelectWrapperProps) => (
-  <BaseSelectPanel
-    {...props}
-    initialValue={
-      getGlobalSetting<string>(props.settingKeys) ?? props.initialValue
-    }
-    {...globalAccessors.text}
-  />
+  <BaseSelectPanel {...props} {...globalAccessors.text} />
 );
 
 export const GlobalMultiTextPanel = (props: MultiTextWrapperProps) => (
-  <BaseMultiTextPanel
-    {...props}
-    initialValue={
-      getGlobalSetting<string[]>(props.settingKeys) ?? props.initialValue
-    }
-    {...globalAccessors.multiText}
-  />
+  <BaseMultiTextPanel {...props} {...globalAccessors.multiText} />
 );
 
 export const PersonalTextPanel = ({ setter, ...props }: TextWrapperProps) => (
-  <BaseTextPanel
-    {...props}
-    initialValue={
-      getPersonalSetting<string>(props.settingKeys) ?? props.initialValue
-    }
-    setter={setter ?? personalAccessors.text.setter}
-  />
+  <BaseTextPanel {...props} setter={setter ?? personalAccessors.text.setter} />
 );
 
 export const PersonalFlagPanel = (props: FlagWrapperProps) => (
-  <BaseFlagPanel
-    {...props}
-    initialValue={
-      getPersonalSetting<boolean>(props.settingKeys) ?? props.initialValue
-    }
-    {...personalAccessors.flag}
-  />
+  <BaseFlagPanel {...props} {...personalAccessors.flag} />
 );
 
 export const PersonalNumberPanel = ({
@@ -628,31 +586,16 @@ export const PersonalNumberPanel = ({
 }: NumberWrapperProps) => (
   <BaseNumberPanel
     {...props}
-    initialValue={
-      getPersonalSetting<number>(props.settingKeys) ?? props.initialValue
-    }
     setter={setter ?? personalAccessors.number.setter}
   />
 );
 
 export const PersonalSelectPanel = (props: SelectWrapperProps) => (
-  <BaseSelectPanel
-    {...props}
-    initialValue={
-      getPersonalSetting<string>(props.settingKeys) ?? props.initialValue
-    }
-    {...personalAccessors.text}
-  />
+  <BaseSelectPanel {...props} {...personalAccessors.text} />
 );
 
 export const PersonalMultiTextPanel = (props: MultiTextWrapperProps) => (
-  <BaseMultiTextPanel
-    {...props}
-    initialValue={
-      getPersonalSetting<string[]>(props.settingKeys) ?? props.initialValue
-    }
-    {...personalAccessors.multiText}
-  />
+  <BaseMultiTextPanel {...props} {...personalAccessors.multiText} />
 );
 
 const createDiscourseNodeSetter =
@@ -682,7 +625,8 @@ export const DiscourseNodeTextPanel = ({
     {...props}
     initialValue={
       getDiscourseNodeSetting<string>(nodeType, props.settingKeys) ??
-      props.initialValue
+      props.initialValue ??
+      ""
     }
     setter={createDiscourseNodeSetter(nodeType)}
   />
@@ -702,7 +646,8 @@ export const DiscourseNodeFlagPanel = ({
     {...props}
     initialValue={
       getDiscourseNodeSetting<boolean>(nodeType, props.settingKeys) ??
-      props.initialValue
+      props.initialValue ??
+      false
     }
     setter={createDiscourseNodeSetter(nodeType)}
   />
@@ -717,7 +662,9 @@ export const DiscourseNodeSelectPanel = ({
     {...props}
     initialValue={
       getDiscourseNodeSetting<string>(nodeType, props.settingKeys) ??
-      props.initialValue
+      props.initialValue ??
+      props.options[0] ??
+      ""
     }
     setter={createDiscourseNodeSetter(nodeType)}
   />
@@ -736,7 +683,8 @@ export const DiscourseNodeNumberPanel = ({
     {...props}
     initialValue={
       getDiscourseNodeSetting<number>(nodeType, props.settingKeys) ??
-      props.initialValue
+      props.initialValue ??
+      0
     }
     setter={createDiscourseNodeSetter(nodeType)}
   />

--- a/apps/roam/src/components/settings/components/BlockPropSettingPanels.tsx
+++ b/apps/roam/src/components/settings/components/BlockPropSettingPanels.tsx
@@ -18,6 +18,7 @@ import {
 import Description from "roamjs-components/components/Description";
 import useSingleChildValue from "roamjs-components/components/ConfigPanels/useSingleChildValue";
 import getShallowTreeByParentUid from "roamjs-components/queries/getShallowTreeByParentUid";
+import refreshConfigTree from "~/utils/refreshConfigTree";
 import {
   getGlobalSetting,
   getPersonalSetting,
@@ -143,8 +144,9 @@ const BaseTextPanel = ({
     window.clearTimeout(debounceRef.current);
     debounceRef.current = window.setTimeout(() => {
       if (errorRef.current) return;
-      setter(settingKeys, newValue);
       syncToBlock?.(newValue);
+      refreshConfigTree();
+      setter(settingKeys, newValue);
     }, DEBOUNCE_MS);
   };
 
@@ -227,8 +229,9 @@ const BaseFlagPanel = ({
     }
 
     setInternalValue(checked);
-    setter(settingKeys, checked);
     await syncFlagToBlock(checked);
+    refreshConfigTree();
+    setter(settingKeys, checked);
     onChange?.(checked);
   };
 
@@ -276,8 +279,9 @@ const BaseNumberPanel = ({
   const handleChange = (valueAsNumber: number) => {
     if (Number.isNaN(valueAsNumber)) return;
     setValue(valueAsNumber);
-    setter(settingKeys, valueAsNumber);
     syncToBlock?.(valueAsNumber);
+    refreshConfigTree();
+    setter(settingKeys, valueAsNumber);
     onChange?.(valueAsNumber);
   };
 
@@ -323,8 +327,9 @@ const BaseSelectPanel = ({
   const handleChange = (e: ChangeEvent<HTMLSelectElement>) => {
     const newValue = e.target.value;
     setValue(newValue);
-    setter(settingKeys, newValue);
     syncToBlock?.(newValue);
+    refreshConfigTree();
+    setter(settingKeys, newValue);
   };
 
   return (
@@ -400,6 +405,7 @@ const BaseMultiTextPanel = ({
           },
         });
         childUidsRef.current = [...childUidsRef.current, valueUid];
+        refreshConfigTree();
       }
     }
   };
@@ -408,7 +414,6 @@ const BaseMultiTextPanel = ({
     // eslint-disable-next-line @typescript-eslint/naming-convention
     const newValues = values.filter((_, i) => i !== index);
     setValues(newValues);
-    setter(settingKeys, newValues);
     onChange?.(newValues);
 
     if (hasBlockSync) {
@@ -420,7 +425,9 @@ const BaseMultiTextPanel = ({
         // eslint-disable-next-line @typescript-eslint/naming-convention
         (_, i) => i !== index,
       );
+      refreshConfigTree();
     }
+    setter(settingKeys, newValues);
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {

--- a/apps/roam/src/components/settings/components/BlockPropSettingPanels.tsx
+++ b/apps/roam/src/components/settings/components/BlockPropSettingPanels.tsx
@@ -145,8 +145,10 @@ const BaseTextPanel = ({
     debounceRef.current = window.setTimeout(() => {
       if (errorRef.current) return;
       syncToBlock?.(newValue);
-      refreshConfigTree();
-      setter(settingKeys, newValue);
+      setTimeout(() => {
+        refreshConfigTree();
+        setter(settingKeys, newValue);
+      }, 100);
     }, DEBOUNCE_MS);
   };
 
@@ -232,9 +234,6 @@ const BaseFlagPanel = ({
     await syncFlagToBlock(checked);
     refreshConfigTree();
     setter(settingKeys, checked);
-    // Delay onChange to let the async Roam block.update flush before
-    // the re-render reads block props via dual-read comparison.
-    // TODO(ENG-1471): remove with dual-read cleanup
     setTimeout(() => onChange?.(checked), 100);
   };
 

--- a/apps/roam/src/components/settings/components/BlockPropSettingPanels.tsx
+++ b/apps/roam/src/components/settings/components/BlockPropSettingPanels.tsx
@@ -232,7 +232,10 @@ const BaseFlagPanel = ({
     await syncFlagToBlock(checked);
     refreshConfigTree();
     setter(settingKeys, checked);
-    onChange?.(checked);
+    // Delay onChange to let the async Roam block.update flush before
+    // the re-render reads block props via dual-read comparison.
+    // TODO(ENG-1471): remove with dual-read cleanup
+    setTimeout(() => onChange?.(checked), 100);
   };
 
   return (

--- a/apps/roam/src/components/settings/utils/accessors.ts
+++ b/apps/roam/src/components/settings/utils/accessors.ts
@@ -568,7 +568,7 @@ const getLegacyDiscourseNodeSetting = (
       enabled: specificationUid
         ? getBasicTreeByParentUid(specificationUid).some(
             (c) => c.text === "enabled",
-          ) || specificationQuery.conditions.length > 0
+          )
         : false,
       query: specificationQuery,
     },
@@ -936,11 +936,13 @@ export const setPersonalSetting = (keys: string[], value: json): void => {
   });
 };
 
-const getRawDiscourseNodeBlockProps = (nodeType: string): json | undefined => {
+const getRawDiscourseNodeBlockProps = (
+  nodeType: string,
+): Record<string, json> | undefined => {
   let pageUid = nodeType;
   let blockProps = getBlockPropsByUid(pageUid, []);
 
-  if (!blockProps || Object.keys(blockProps).length === 0) {
+  if (!isRecord(blockProps) || Object.keys(blockProps).length === 0) {
     const lookedUpUid = getPageUidByPageTitle(
       `${DISCOURSE_NODE_PAGE_PREFIX}${nodeType}`,
     );
@@ -950,7 +952,9 @@ const getRawDiscourseNodeBlockProps = (nodeType: string): json | undefined => {
     }
   }
 
-  return blockProps;
+  return isRecord(blockProps) && Object.keys(blockProps).length > 0
+    ? (blockProps as Record<string, json>)
+    : undefined;
 };
 
 export const getDiscourseNodeSettings = (

--- a/apps/roam/src/components/settings/utils/accessors.ts
+++ b/apps/roam/src/components/settings/utils/accessors.ts
@@ -47,7 +47,8 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
 
 const deepEqual = (a: unknown, b: unknown): boolean => {
   if (a === b) return true;
-  const isEmpty = (v: unknown) => v === undefined || v === "" || v === false;
+  const isEmpty = (v: unknown) =>
+    v === undefined || v === null || v === "" || v === false;
   if (isEmpty(a) && isEmpty(b)) return true;
   if (a == null || b == null) return a === b;
   if (Array.isArray(a) && Array.isArray(b)) {

--- a/apps/roam/src/components/settings/utils/accessors.ts
+++ b/apps/roam/src/components/settings/utils/accessors.ts
@@ -45,6 +45,24 @@ import { PERSONAL_KEYS, QUERY_KEYS, GLOBAL_KEYS } from "./settingKeys";
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
+const deepEqual = (a: unknown, b: unknown): boolean => {
+  if (a === b) return true;
+  const isEmpty = (v: unknown) => v === undefined || v === "" || v === false;
+  if (isEmpty(a) && isEmpty(b)) return true;
+  if (a == null || b == null) return a === b;
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false;
+    return a.every((v, i) => deepEqual(v, b[i]));
+  }
+  if (isRecord(a) && isRecord(b)) {
+    const keysA = Object.keys(a);
+    const keysB = Object.keys(b);
+    if (keysA.length !== keysB.length) return false;
+    return keysA.every((k) => k in b && deepEqual(a[k], b[k]));
+  }
+  return false;
+};
+
 const unwrapSchema = (schema: z.ZodTypeAny): z.ZodTypeAny => {
   let current = schema;
   let didUnwrap = true;
@@ -444,7 +462,10 @@ const getLegacyGlobalSetting = (keys: string[]): unknown => {
 };
 
 const getLegacyQuerySettingByParentUid = (parentUid: string) => {
-  const scratchNode = getSubTree({ parentUid, key: "scratch" });
+  const scratchNode = getSubTree({
+    tree: getBasicTreeByParentUid(parentUid),
+    key: "scratch",
+  });
   const conditionsNode = getSubTree({
     tree: scratchNode.children,
     key: "conditions",
@@ -514,6 +535,9 @@ const getLegacyDiscourseNodeSetting = (
   }).children;
   const indexUid = getSubTree({ tree, key: "Index" }).uid;
   const specificationUid = getSubTree({ tree, key: "Specification" }).uid;
+  const specificationQuery = specificationUid
+    ? getLegacyQuerySettingByParentUid(specificationUid)
+    : DEFAULT_LEGACY_QUERY;
 
   const legacySettings = {
     type: nodeUid,
@@ -542,11 +566,11 @@ const getLegacyDiscourseNodeSetting = (
       : DEFAULT_LEGACY_QUERY,
     specification: {
       enabled: specificationUid
-        ? !!getSubTree({ parentUid: specificationUid, key: "enabled" }).uid
+        ? getBasicTreeByParentUid(specificationUid).some(
+            (c) => c.text === "enabled",
+          ) || specificationQuery.conditions.length > 0
         : false,
-      query: specificationUid
-        ? getLegacyQuerySettingByParentUid(specificationUid)
-        : DEFAULT_LEGACY_QUERY,
+      query: specificationQuery,
     },
   };
 
@@ -803,7 +827,7 @@ export const getGlobalSetting = <T = unknown>(
   const settings = getGlobalSettings();
   const blockPropsValue = readPathValue(settings, keys);
   const legacyValue = getLegacyGlobalSetting(keys);
-  if (JSON.stringify(blockPropsValue) !== JSON.stringify(legacyValue)) {
+  if (!deepEqual(blockPropsValue, legacyValue)) {
     console.warn(
       `[DG Dual-Read] Mismatch at Global > ${formatSettingPath(keys)}`,
       { blockProps: blockPropsValue, legacy: legacyValue },
@@ -875,7 +899,7 @@ export const getPersonalSetting = <T = unknown>(
   const settings = getPersonalSettings();
   const blockPropsValue = readPathValue(settings, keys);
   const legacyValue = getLegacyPersonalSetting(keys);
-  if (JSON.stringify(blockPropsValue) !== JSON.stringify(legacyValue)) {
+  if (!deepEqual(blockPropsValue, legacyValue)) {
     console.warn(
       `[DG Dual-Read] Mismatch at Personal > ${formatSettingPath(keys)}`,
       { blockProps: blockPropsValue, legacy: legacyValue },
@@ -959,7 +983,7 @@ export const getDiscourseNodeSetting = <T = unknown>(
   const settings = getDiscourseNodeSettings(nodeType);
   const blockPropsValue = settings ? readPathValue(settings, keys) : undefined;
   const legacyValue = getLegacyDiscourseNodeSetting(nodeType, keys);
-  if (JSON.stringify(blockPropsValue) !== JSON.stringify(legacyValue)) {
+  if (!deepEqual(blockPropsValue, legacyValue)) {
     console.warn(
       `[DG Dual-Read] Mismatch at Discourse Node (${nodeType}) > ${formatSettingPath(keys)}`,
       { blockProps: blockPropsValue, legacy: legacyValue },

--- a/apps/roam/src/components/settings/utils/accessors.ts
+++ b/apps/roam/src/components/settings/utils/accessors.ts
@@ -863,8 +863,10 @@ export const setGlobalSetting = (keys: string[], value: json): void => {
   });
 };
 
-export const getAllRelations = (): DiscourseRelation[] => {
-  const settings = getGlobalSettings();
+export const getAllRelations = (
+  snapshot?: SettingsSnapshot,
+): DiscourseRelation[] => {
+  const settings = snapshot ? snapshot.globalSettings : getGlobalSettings();
 
   return Object.entries(settings.Relations).flatMap(([id, relation]) =>
     relation.ifConditions.map((ifCondition) => ({
@@ -907,6 +909,61 @@ export const getPersonalSetting = <T = unknown>(
     );
   }
   return blockPropsValue as T | undefined;
+};
+
+export type SettingsSnapshot = {
+  featureFlags: FeatureFlags;
+  globalSettings: GlobalSettings;
+  personalSettings: PersonalSettings;
+};
+
+export const bulkReadSettings = (): SettingsSnapshot => {
+  const pageResult = window.roamAlphaAPI.pull(
+    "[{:block/children [:block/string :block/props]}]",
+    [":node/title", DG_BLOCK_PROP_SETTINGS_PAGE_TITLE],
+  ) as Record<string, json> | null;
+
+  const children = (pageResult?.[":block/children"] ?? []) as Record<
+    string,
+    json
+  >[];
+  const personalKey = getPersonalSettingsKey();
+  let featureFlagsProps: json = {};
+  let globalProps: json = {};
+  let personalProps: json = {};
+
+  for (const child of children) {
+    const text = child[":block/string"];
+    if (typeof text !== "string") continue;
+    const rawBlockProps = child[":block/props"];
+    const blockProps =
+      rawBlockProps && typeof rawBlockProps === "object"
+        ? normalizeProps(rawBlockProps)
+        : {};
+    if (text === TOP_LEVEL_BLOCK_PROP_KEYS.featureFlags) {
+      featureFlagsProps = blockProps;
+    } else if (text === TOP_LEVEL_BLOCK_PROP_KEYS.global) {
+      globalProps = blockProps;
+    } else if (text === personalKey) {
+      personalProps = blockProps;
+    }
+  }
+
+  const featureFlags = FeatureFlagsSchema.parse(featureFlagsProps || {});
+
+  if (!featureFlags["Use new settings store"]) {
+    return {
+      featureFlags,
+      globalSettings: readAllLegacyGlobalSettings() as GlobalSettings,
+      personalSettings: readAllLegacyPersonalSettings() as PersonalSettings,
+    };
+  }
+
+  return {
+    featureFlags,
+    globalSettings: GlobalSettingsSchema.parse(globalProps || {}),
+    personalSettings: PersonalSettingsSchema.parse(personalProps || {}),
+  };
 };
 
 export const setPersonalSetting = (keys: string[], value: json): void => {

--- a/apps/roam/src/components/settings/utils/accessors.ts
+++ b/apps/roam/src/components/settings/utils/accessors.ts
@@ -650,33 +650,6 @@ const setBlockPropAtPath = (
   setBlockProps(blockUid, updatedProps, false);
 };
 
-const getBlockPropBasedSettings = ({
-  keys,
-}: {
-  keys: string[];
-}): { blockProps: json | undefined; blockUid: string } => {
-  if (keys.length === 0) {
-    internalError({
-      error: "getBlockPropBasedSettings called with no keys",
-      type: "DG Accessor",
-    });
-    return { blockProps: undefined, blockUid: "" };
-  }
-
-  const blockUid = getBlockUidByTextOnPage({
-    text: keys[0],
-    title: DG_BLOCK_PROP_SETTINGS_PAGE_TITLE,
-  });
-
-  if (!blockUid) {
-    return { blockProps: undefined, blockUid: "" };
-  }
-
-  const blockProps = getBlockPropsByUid(blockUid, keys.slice(1));
-
-  return { blockProps, blockUid };
-};
-
 const setBlockPropBasedSettings = ({
   keys,
   value,
@@ -709,11 +682,7 @@ const setBlockPropBasedSettings = ({
 };
 
 export const getFeatureFlags = (): FeatureFlags => {
-  const { blockProps } = getBlockPropBasedSettings({
-    keys: [TOP_LEVEL_BLOCK_PROP_KEYS.featureFlags],
-  });
-
-  return FeatureFlagsSchema.parse(blockProps || {});
+  return bulkReadSettings().featureFlags;
 };
 
 /* eslint-disable @typescript-eslint/naming-convention */
@@ -734,28 +703,7 @@ const FEATURE_FLAG_LEGACY_MAP: Partial<
 /* eslint-enable @typescript-eslint/naming-convention */
 
 export const getFeatureFlag = (key: keyof FeatureFlags): boolean => {
-  const legacyReader = FEATURE_FLAG_LEGACY_MAP[key];
-
-  if (!legacyReader) {
-    // Block-props-only flag (no legacy equivalent)
-    const flags = getFeatureFlags();
-    return flags[key];
-  }
-
-  if (!isNewSettingsStoreEnabled()) {
-    return legacyReader();
-  }
-
-  const flags = getFeatureFlags();
-  const blockPropsValue = flags[key];
-  const legacyValue = legacyReader();
-  if (blockPropsValue !== legacyValue) {
-    console.warn(`[DG Dual-Read] Mismatch at Feature Flag > ${key}`, {
-      blockProps: blockPropsValue,
-      legacy: legacyValue,
-    });
-  }
-  return blockPropsValue;
+  return bulkReadSettings().featureFlags[key];
 };
 
 export const isNewSettingsStoreEnabled = (): boolean => {
@@ -809,32 +757,16 @@ export const setFeatureFlag = (
 };
 
 export const getGlobalSettings = (): GlobalSettings => {
-  const { blockProps } = getBlockPropBasedSettings({
-    keys: [TOP_LEVEL_BLOCK_PROP_KEYS.global],
-  });
-
-  return GlobalSettingsSchema.parse(blockProps || {});
+  return bulkReadSettings().globalSettings;
 };
 
 export const getGlobalSetting = <T = unknown>(
   keys: string[],
 ): T | undefined => {
   if (keys.length === 0) return undefined;
-
-  if (!isNewSettingsStoreEnabled()) {
-    return getLegacyGlobalSetting(keys) as T | undefined;
-  }
-
-  const settings = getGlobalSettings();
-  const blockPropsValue = readPathValue(settings, keys);
-  const legacyValue = getLegacyGlobalSetting(keys);
-  if (!deepEqual(blockPropsValue, legacyValue)) {
-    console.warn(
-      `[DG Dual-Read] Mismatch at Global > ${formatSettingPath(keys)}`,
-      { blockProps: blockPropsValue, legacy: legacyValue },
-    );
-  }
-  return blockPropsValue as T | undefined;
+  return readPathValue(bulkReadSettings().globalSettings, keys) as
+    | T
+    | undefined;
 };
 
 export const setGlobalSetting = (keys: string[], value: json): void => {
@@ -864,11 +796,13 @@ export const setGlobalSetting = (keys: string[], value: json): void => {
 };
 
 export const getAllRelations = (
-  snapshot?: SettingsSnapshot,
+  settings?: SettingsSnapshot,
 ): DiscourseRelation[] => {
-  const settings = snapshot ? snapshot.globalSettings : getGlobalSettings();
+  const globalSettings = settings
+    ? settings.globalSettings
+    : getGlobalSettings();
 
-  return Object.entries(settings.Relations).flatMap(([id, relation]) =>
+  return Object.entries(globalSettings.Relations).flatMap(([id, relation]) =>
     relation.ifConditions.map((ifCondition) => ({
       id,
       label: relation.label,
@@ -881,34 +815,16 @@ export const getAllRelations = (
 };
 
 export const getPersonalSettings = (): PersonalSettings => {
-  const personalKey = getPersonalSettingsKey();
-
-  const { blockProps } = getBlockPropBasedSettings({
-    keys: [personalKey],
-  });
-
-  return PersonalSettingsSchema.parse(blockProps || {});
+  return bulkReadSettings().personalSettings;
 };
 
 export const getPersonalSetting = <T = unknown>(
   keys: string[],
 ): T | undefined => {
   if (keys.length === 0) return undefined;
-
-  if (!isNewSettingsStoreEnabled()) {
-    return getLegacyPersonalSetting(keys) as T | undefined;
-  }
-
-  const settings = getPersonalSettings();
-  const blockPropsValue = readPathValue(settings, keys);
-  const legacyValue = getLegacyPersonalSetting(keys);
-  if (!deepEqual(blockPropsValue, legacyValue)) {
-    console.warn(
-      `[DG Dual-Read] Mismatch at Personal > ${formatSettingPath(keys)}`,
-      { blockProps: blockPropsValue, legacy: legacyValue },
-    );
-  }
-  return blockPropsValue as T | undefined;
+  return readPathValue(bulkReadSettings().personalSettings, keys) as
+    | T
+    | undefined;
 };
 
 export type SettingsSnapshot = {
@@ -1038,20 +954,14 @@ export const getDiscourseNodeSetting = <T = unknown>(
   nodeType: string,
   keys: string[],
 ): T | undefined => {
-  if (!isNewSettingsStoreEnabled()) {
+  if (!bulkReadSettings().featureFlags["Use new settings store"]) {
     return getLegacyDiscourseNodeSetting(nodeType, keys) as T | undefined;
   }
 
   const settings = getDiscourseNodeSettings(nodeType);
-  const blockPropsValue = settings ? readPathValue(settings, keys) : undefined;
-  const legacyValue = getLegacyDiscourseNodeSetting(nodeType, keys);
-  if (!deepEqual(blockPropsValue, legacyValue)) {
-    console.warn(
-      `[DG Dual-Read] Mismatch at Discourse Node (${nodeType}) > ${formatSettingPath(keys)}`,
-      { blockProps: blockPropsValue, legacy: legacyValue },
-    );
-  }
-  return blockPropsValue as T | undefined;
+  return (settings ? readPathValue(settings, keys) : undefined) as
+    | T
+    | undefined;
 };
 
 export const setDiscourseNodeSetting = (

--- a/apps/roam/src/components/settings/utils/accessors.ts
+++ b/apps/roam/src/components/settings/utils/accessors.ts
@@ -45,7 +45,7 @@ import { PERSONAL_KEYS, QUERY_KEYS, GLOBAL_KEYS } from "./settingKeys";
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
-const deepEqual = (a: unknown, b: unknown): boolean => {
+export const deepEqual = (a: unknown, b: unknown): boolean => {
   if (a === b) return true;
   const isEmpty = (v: unknown) =>
     v === undefined || v === null || v === "" || v === false;

--- a/apps/roam/src/components/settings/utils/init.ts
+++ b/apps/roam/src/components/settings/utils/init.ts
@@ -5,6 +5,7 @@ import setBlockProps from "~/utils/setBlockProps";
 import getBlockProps from "~/utils/getBlockProps";
 import type { json } from "~/utils/getBlockProps";
 import INITIAL_NODE_VALUES from "~/data/defaultDiscourseNodes";
+import DEFAULT_RELATION_VALUES from "~/data/defaultDiscourseRelations";
 import DEFAULT_RELATIONS_BLOCK_PROPS from "~/components/settings/data/defaultRelationsBlockProps";
 import { getAllDiscourseNodes } from "./accessors";
 import {
@@ -72,6 +73,70 @@ const buildBlockMap = (pageUid: string): Record<string, string> => {
   return blockMap;
 };
 
+const ensureLegacyConfigBlocks = async (pageUid: string): Promise<void> => {
+  const pageBlockMap = buildBlockMap(pageUid);
+
+  await ensureBlocksExist(
+    pageUid,
+    ["trigger", "grammar", "export", "Suggestive Mode", "Left Sidebar"],
+    pageBlockMap,
+  );
+
+  const triggerMap = buildBlockMap(pageBlockMap["trigger"]);
+  if (Object.keys(triggerMap).length === 0) {
+    await createBlock({
+      parentUid: pageBlockMap["trigger"],
+      node: { text: "\\" },
+    });
+  }
+
+  const grammarMap = buildBlockMap(pageBlockMap["grammar"]);
+  await ensureBlocksExist(pageBlockMap["grammar"], ["relations"], grammarMap);
+  const relationsChildren = getShallowTreeByParentUid(grammarMap["relations"]);
+  if (relationsChildren.length === 0) {
+    for (const relation of DEFAULT_RELATION_VALUES) {
+      await createBlock({
+        parentUid: grammarMap["relations"],
+        node: relation,
+      });
+    }
+  }
+
+  const suggestiveMap = buildBlockMap(pageBlockMap["Suggestive Mode"]);
+  await ensureBlocksExist(
+    pageBlockMap["Suggestive Mode"],
+    ["Page Groups"],
+    suggestiveMap,
+  );
+
+  const leftSidebarMap = buildBlockMap(pageBlockMap["Left Sidebar"]);
+  await ensureBlocksExist(
+    pageBlockMap["Left Sidebar"],
+    ["Global-Section"],
+    leftSidebarMap,
+  );
+  const globalSectionMap = buildBlockMap(leftSidebarMap["Global-Section"]);
+  await ensureBlocksExist(
+    leftSidebarMap["Global-Section"],
+    ["Children", "Settings"],
+    globalSectionMap,
+  );
+
+  const exportMap = buildBlockMap(pageBlockMap["export"]);
+  await ensureBlocksExist(
+    pageBlockMap["export"],
+    ["max filename length"],
+    exportMap,
+  );
+  const maxFilenameMap = buildBlockMap(exportMap["max filename length"]);
+  if (Object.keys(maxFilenameMap).length === 0) {
+    await createBlock({
+      parentUid: exportMap["max filename length"],
+      node: { text: "64" },
+    });
+  }
+};
+
 const initializeSettingsBlockProps = (
   pageUid: string,
   blockMap: Record<string, string>,
@@ -117,6 +182,8 @@ const initSettingsPageBlocks = async (): Promise<Record<string, string>> => {
 
   const topLevelBlocks = getTopLevelBlockPropsConfig().map(({ key }) => key);
   await ensureBlocksExist(pageUid, topLevelBlocks, blockMap);
+
+  await ensureLegacyConfigBlocks(pageUid);
 
   initializeSettingsBlockProps(pageUid, blockMap);
 

--- a/apps/roam/src/components/settings/utils/init.ts
+++ b/apps/roam/src/components/settings/utils/init.ts
@@ -7,7 +7,19 @@ import type { json } from "~/utils/getBlockProps";
 import INITIAL_NODE_VALUES from "~/data/defaultDiscourseNodes";
 import DEFAULT_RELATION_VALUES from "~/data/defaultDiscourseRelations";
 import DEFAULT_RELATIONS_BLOCK_PROPS from "~/components/settings/data/defaultRelationsBlockProps";
-import { getAllDiscourseNodes } from "./accessors";
+import {
+  getAllDiscourseNodes,
+  isNewSettingsStoreEnabled,
+  deepEqual,
+  getFeatureFlags,
+  getGlobalSettings,
+  getPersonalSettings,
+  getDiscourseNodeSettings,
+  readAllLegacyFeatureFlags,
+  readAllLegacyGlobalSettings,
+  readAllLegacyPersonalSettings,
+  readAllLegacyDiscourseNodeSettings,
+} from "./accessors";
 import {
   migrateGraphLevel,
   migratePersonalSettings,
@@ -324,10 +336,91 @@ export type InitSchemaResult = {
   nodePageUids: Record<string, string>;
 };
 
+const logDualReadComparison = (): void => {
+  if (!isNewSettingsStoreEnabled()) return;
+
+  const legacyFlags = readAllLegacyFeatureFlags();
+  const blockFlags = getFeatureFlags();
+  const omitStoreFlag = (
+    flags: Record<string, unknown>,
+  ): Record<string, unknown> =>
+    Object.fromEntries(
+      Object.entries(flags).filter(([k]) => k !== "Use new settings store"),
+    );
+  const flagsMatch = deepEqual(
+    omitStoreFlag(blockFlags),
+    omitStoreFlag(legacyFlags),
+  );
+
+  const legacyGlobal = readAllLegacyGlobalSettings();
+  const blockGlobal = getGlobalSettings();
+  const globalMatch = deepEqual(blockGlobal, legacyGlobal);
+
+  const legacyPersonal = readAllLegacyPersonalSettings();
+  const blockPersonal = getPersonalSettings();
+  const personalMatch = deepEqual(blockPersonal, legacyPersonal);
+
+  const nodes = getAllDiscourseNodes();
+  const nodeResults: {
+    name: string;
+    match: boolean;
+    legacy: unknown;
+    blockProps: unknown;
+  }[] = [];
+  for (const node of nodes) {
+    const legacy = readAllLegacyDiscourseNodeSettings(node.type, node.text);
+    const blockProps = getDiscourseNodeSettings(node.type);
+    nodeResults.push({
+      name: node.text,
+      match: deepEqual(blockProps, legacy),
+      legacy,
+      blockProps,
+    });
+  }
+
+  const mismatches = [
+    !flagsMatch && "Feature Flags",
+    !globalMatch && "Global",
+    !personalMatch && "Personal",
+    ...nodeResults.filter((n) => !n.match).map((n) => n.name),
+  ].filter((x): x is string => Boolean(x));
+
+  const summary =
+    mismatches.length === 0
+      ? "All settings match"
+      : `(${mismatches.length}) Settings don't match: ${mismatches.join(", ")}`;
+
+  const nodeMap = (key: "legacy" | "blockProps") =>
+    Object.fromEntries(nodeResults.map((n) => [n.name, n[key]]));
+
+  /* eslint-disable @typescript-eslint/naming-convention */
+  console.log(`[DG Dual-Read] ${summary}`);
+  console.log("[DG Dual-Read] Legacy:", {
+    "Feature Flags": legacyFlags,
+    Global: legacyGlobal,
+    Personal: legacyPersonal,
+    ...nodeMap("legacy"),
+  });
+  console.log("[DG Dual-Read] Block props:", {
+    "Feature Flags": blockFlags,
+    Global: blockGlobal,
+    Personal: blockPersonal,
+    ...nodeMap("blockProps"),
+  });
+  /* eslint-enable @typescript-eslint/naming-convention */
+};
+
 export const initSchema = async (): Promise<InitSchemaResult> => {
   const blockUids = await initSettingsPageBlocks();
   await migrateGraphLevel(blockUids);
   const nodePageUids = await initDiscourseNodePages();
   await migratePersonalSettings(blockUids);
+  try {
+    logDualReadComparison();
+  } catch (e) {
+    console.warn("[DG Dual-Read] Comparison failed:", e);
+  }
+  (window as unknown as Record<string, unknown>).dgDualReadLog =
+    logDualReadComparison;
   return { blockUids, nodePageUids };
 };

--- a/apps/roam/src/components/settings/utils/init.ts
+++ b/apps/roam/src/components/settings/utils/init.ts
@@ -336,6 +336,9 @@ export type InitSchemaResult = {
   nodePageUids: Record<string, string>;
 };
 
+// On-demand dual-read comparison. Not called automatically on init —
+// invoke from the console via window.dgDualReadLog() to inspect the legacy
+// settings tree vs. the block-prop store.
 const logDualReadComparison = (): void => {
   if (!isNewSettingsStoreEnabled()) return;
 
@@ -415,11 +418,6 @@ export const initSchema = async (): Promise<InitSchemaResult> => {
   await migrateGraphLevel(blockUids);
   const nodePageUids = await initDiscourseNodePages();
   await migratePersonalSettings(blockUids);
-  try {
-    logDualReadComparison();
-  } catch (e) {
-    console.warn("[DG Dual-Read] Comparison failed:", e);
-  }
   (window as unknown as Record<string, unknown>).dgDualReadLog =
     logDualReadComparison;
   return { blockUids, nodePageUids };

--- a/apps/roam/src/components/settings/utils/migrateLegacyToBlockProps.ts
+++ b/apps/roam/src/components/settings/utils/migrateLegacyToBlockProps.ts
@@ -1,7 +1,6 @@
 import getBlockProps from "~/utils/getBlockProps";
 import type { json } from "~/utils/getBlockProps";
 import setBlockProps from "~/utils/setBlockProps";
-import getBlockUidByTextOnPage from "roamjs-components/queries/getBlockUidByTextOnPage";
 import getPageUidByPageTitle from "roamjs-components/queries/getPageUidByPageTitle";
 import { createBlock } from "roamjs-components/writes";
 import { getSetting, setSetting } from "~/utils/extensionSettings";
@@ -29,11 +28,8 @@ const GRAPH_MIGRATION_MARKER = "Block props migrated";
 const PERSONAL_MIGRATION_MARKER = "dg-personal-settings-migrated";
 const MAX_ERROR_CONTEXT_LENGTH = 5000;
 
-const hasGraphMigrationMarker = (): boolean =>
-  !!getBlockUidByTextOnPage({
-    text: GRAPH_MIGRATION_MARKER,
-    title: DG_BLOCK_PROP_SETTINGS_PAGE_TITLE,
-  });
+const hasGraphMigrationMarker = (blockMap: Record<string, string>): boolean =>
+  !!blockMap[GRAPH_MIGRATION_MARKER];
 
 const isPropsValid = (
   schema: z.ZodTypeAny,
@@ -182,7 +178,7 @@ export const migrateGraphLevel = async (
     return;
   }
 
-  if (hasGraphMigrationMarker()) {
+  if (hasGraphMigrationMarker(blockUids)) {
     console.log(`${LOG_PREFIX} graph-level: skipped (already migrated)`);
     return;
   }

--- a/apps/roam/src/index.ts
+++ b/apps/roam/src/index.ts
@@ -34,10 +34,7 @@ import {
 import { initPluginTimer } from "./utils/pluginTimer";
 import { initPostHog } from "./utils/posthog";
 import { initSchema } from "./components/settings/utils/init";
-import {
-  getFeatureFlag,
-  getPersonalSetting,
-} from "./components/settings/utils/accessors";
+import { bulkReadSettings } from "./components/settings/utils/accessors";
 import { PERSONAL_KEYS } from "./components/settings/utils/settingKeys";
 import { setupPullWatchOnSettingsPage } from "./components/settings/utils/pullWatchers";
 import {
@@ -49,12 +46,11 @@ import { mountLeftSidebar } from "./components/LeftSidebarView";
 export const DEFAULT_CANVAS_PAGE_FORMAT = "Canvas/*";
 
 export default runExtension(async (onloadArgs) => {
-  const isEncrypted = window.roamAlphaAPI.graph.isEncrypted;
-  const isOffline = window.roamAlphaAPI.graph.type === "offline";
-  const disallowDiagnostics = getPersonalSetting<boolean>([
-    PERSONAL_KEYS.disableProductDiagnostics,
-  ]);
-  if (!isEncrypted && !isOffline && !disallowDiagnostics) {
+  const pluginLoadStart = performance.now();
+
+  const settings = bulkReadSettings();
+
+  if (!settings.personalSettings[PERSONAL_KEYS.disableProductDiagnostics]) {
     initPostHog();
   }
 
@@ -81,14 +77,16 @@ export default runExtension(async (onloadArgs) => {
 
   initPluginTimer();
 
-  await initializeDiscourseNodes();
-  refreshConfigTree();
+  await initializeDiscourseNodes(settings);
+
+  refreshConfigTree(settings);
 
   addGraphViewNodeStyling();
   registerCommandPaletteCommands(onloadArgs);
   createSettingsPanel(onloadArgs);
   registerSmartBlock(onloadArgs);
-  setInitialQueryPages(onloadArgs);
+
+  setInitialQueryPages(onloadArgs, settings);
 
   const style = addStyle(styles);
   const discourseGraphStyle = addStyle(discourseGraphStyles);
@@ -96,16 +94,18 @@ export default runExtension(async (onloadArgs) => {
   const discourseFloatingMenuStyle = addStyle(discourseFloatingMenuStyles);
 
   // Add streamline styling only if enabled
-  const isStreamlineStylingEnabled = getPersonalSetting<boolean>([
-    PERSONAL_KEYS.streamlineStyling,
-  ]);
+  const isStreamlineStylingEnabled =
+    settings.personalSettings[PERSONAL_KEYS.streamlineStyling];
   let streamlineStyleElement: HTMLStyleElement | null = null;
   if (isStreamlineStylingEnabled) {
     streamlineStyleElement = addStyle(streamlineStyling);
     streamlineStyleElement.id = "streamline-styling";
   }
 
-  const { observers, listeners, cleanups } = initObservers({ onloadArgs });
+  const { observers, listeners, cleanups } = initObservers({
+    onloadArgs,
+    settings,
+  });
   const {
     pageActionListener,
     hashChangeListener,
@@ -119,7 +119,7 @@ export default runExtension(async (onloadArgs) => {
   document.addEventListener("input", discourseNodeSearchTriggerListener);
   document.addEventListener("selectionchange", nodeCreationPopoverListener);
 
-  if (getFeatureFlag("Suggestive mode enabled")) {
+  if (settings.featureFlags["Suggestive mode enabled"]) {
     initializeSupabaseSync();
   }
 
@@ -150,7 +150,7 @@ export default runExtension(async (onloadArgs) => {
     getDiscourseNodes: getDiscourseNodes,
   };
 
-  installDiscourseFloatingMenu(onloadArgs);
+  installDiscourseFloatingMenu(onloadArgs, settings);
 
   const leftSidebarScript = document.querySelector<HTMLScriptElement>(
     'script#roam-left-sidebar[src="https://sid597.github.io/roam-left-sidebar/js/main.js"]',
@@ -176,7 +176,7 @@ export default runExtension(async (onloadArgs) => {
       if (!wrapper) return;
       if (enabled) {
         wrapper.style.padding = "0";
-        void mountLeftSidebar(wrapper, onloadArgs);
+        void mountLeftSidebar({ wrapper, onloadArgs });
       } else {
         const root = wrapper.querySelector("#dg-left-sidebar-root");
         if (root) {
@@ -191,6 +191,10 @@ export default runExtension(async (onloadArgs) => {
 
   const { blockUids } = await initSchema();
   const cleanupPullWatchers = setupPullWatchOnSettingsPage(blockUids);
+
+  console.log(
+    `[DG Plugin] Total load: ${Math.round(performance.now() - pluginLoadStart)}ms`,
+  );
 
   return {
     elements: [

--- a/apps/roam/src/utils/findDiscourseNode.ts
+++ b/apps/roam/src/utils/findDiscourseNode.ts
@@ -1,23 +1,27 @@
 import getDiscourseNodes, { type DiscourseNode } from "./getDiscourseNodes";
 import matchDiscourseNode from "./matchDiscourseNode";
+import type { SettingsSnapshot } from "~/components/settings/utils/accessors";
 
 const discourseNodeTypeCache: Record<string, DiscourseNode | false> = {};
 
 const findDiscourseNode = ({
   uid,
   title,
-  nodes = getDiscourseNodes(),
+  nodes,
+  snapshot,
 }: {
   uid: string;
   title?: string;
   nodes?: DiscourseNode[];
+  snapshot?: SettingsSnapshot;
 }): DiscourseNode | false => {
   if (typeof discourseNodeTypeCache[uid] !== "undefined") {
     return discourseNodeTypeCache[uid];
   }
 
+  const resolvedNodes = nodes ?? getDiscourseNodes(undefined, snapshot);
   const matchingNode =
-    nodes.find((node) =>
+    resolvedNodes.find((node) =>
       title === undefined
         ? matchDiscourseNode({ ...node, uid })
         : matchDiscourseNode({ ...node, title }),

--- a/apps/roam/src/utils/getDiscourseNodes.ts
+++ b/apps/roam/src/utils/getDiscourseNodes.ts
@@ -3,6 +3,7 @@ import getSubTree from "roamjs-components/util/getSubTree";
 import {
   isNewSettingsStoreEnabled,
   getAllDiscourseNodes,
+  type SettingsSnapshot,
 } from "~/components/settings/utils/accessors";
 import discourseConfigRef from "./discourseConfigRef";
 import getDiscourseRelations from "./getDiscourseRelations";
@@ -106,9 +107,16 @@ const getUidAndBooleanSetting = ({
   };
 };
 
-const getDiscourseNodes = (relations = getDiscourseRelations()) => {
+const getDiscourseNodes = (
+  relations?: ReturnType<typeof getDiscourseRelations>,
+  snapshot?: SettingsSnapshot,
+) => {
+  const resolvedRelations = relations ?? getDiscourseRelations(snapshot);
+  const newStoreEnabled = snapshot
+    ? snapshot.featureFlags["Use new settings store"]
+    : isNewSettingsStoreEnabled();
   const configuredNodes = (
-    isNewSettingsStoreEnabled()
+    newStoreEnabled
       ? getAllDiscourseNodes()
       : Object.entries(discourseConfigRef.nodes).map(
           ([type, { text, children }]): DiscourseNode => {
@@ -158,7 +166,7 @@ const getDiscourseNodes = (relations = getDiscourseRelations()) => {
           },
         )
   ).concat(
-    relations
+    resolvedRelations
       .filter((r) => r.triples.some((t) => t.some((n) => /anchor/i.test(n))))
       .map((r) => ({
         format: "",

--- a/apps/roam/src/utils/getDiscourseRelationLabels.ts
+++ b/apps/roam/src/utils/getDiscourseRelationLabels.ts
@@ -1,8 +1,17 @@
 import getDiscourseRelations from "./getDiscourseRelations";
+import type { SettingsSnapshot } from "~/components/settings/utils/accessors";
 
-const getDiscourseRelationLabels = (relations = getDiscourseRelations()) =>
-  Array.from(new Set(relations.flatMap((r) => [r.label, r.complement]))).filter(
-    (s) => !!s,
-  );
+const getDiscourseRelationLabels = (
+  relations?: ReturnType<typeof getDiscourseRelations>,
+  snapshot?: SettingsSnapshot,
+) =>
+  Array.from(
+    new Set(
+      (relations ?? getDiscourseRelations(snapshot)).flatMap((r) => [
+        r.label,
+        r.complement,
+      ]),
+    ),
+  ).filter((s) => !!s);
 
 export default getDiscourseRelationLabels;

--- a/apps/roam/src/utils/getDiscourseRelations.ts
+++ b/apps/roam/src/utils/getDiscourseRelations.ts
@@ -9,6 +9,7 @@ import DEFAULT_RELATION_VALUES from "~/data/defaultDiscourseRelations";
 import {
   isNewSettingsStoreEnabled,
   getAllRelations,
+  type SettingsSnapshot,
 } from "~/components/settings/utils/accessors";
 import discourseConfigRef from "./discourseConfigRef";
 
@@ -35,9 +36,12 @@ export const getRelationsNode = (grammarNode = getGrammarNode()) => {
   return grammarNode?.children.find(matchNodeText("relations"));
 };
 
-const getDiscourseRelations = () => {
-  if (isNewSettingsStoreEnabled()) {
-    return getAllRelations();
+const getDiscourseRelations = (snapshot?: SettingsSnapshot) => {
+  const newStoreEnabled = snapshot
+    ? snapshot.featureFlags["Use new settings store"]
+    : isNewSettingsStoreEnabled();
+  if (newStoreEnabled) {
+    return getAllRelations(snapshot);
   }
 
   const grammarNode = getGrammarNode();

--- a/apps/roam/src/utils/initializeDiscourseNodes.ts
+++ b/apps/roam/src/utils/initializeDiscourseNodes.ts
@@ -2,9 +2,12 @@ import getPageUidByPageTitle from "roamjs-components/queries/getPageUidByPageTit
 import { createPage } from "roamjs-components/writes";
 import INITIAL_NODE_VALUES from "~/data/defaultDiscourseNodes";
 import getDiscourseNodes, { excludeDefaultNodes } from "./getDiscourseNodes";
+import type { SettingsSnapshot } from "~/components/settings/utils/accessors";
 
-const initializeDiscourseNodes = async () => {
-  const nodes = getDiscourseNodes().filter(excludeDefaultNodes);
+const initializeDiscourseNodes = async (snapshot: SettingsSnapshot) => {
+  const nodes = getDiscourseNodes(undefined, snapshot).filter(
+    excludeDefaultNodes,
+  );
   if (nodes.length === 0) {
     await Promise.all(
       INITIAL_NODE_VALUES.map(

--- a/apps/roam/src/utils/initializeObserversAndListeners.ts
+++ b/apps/roam/src/utils/initializeObserversAndListeners.ts
@@ -25,7 +25,9 @@ import {
   onPageRefObserverChange,
   getSuggestiveOverlayHandler,
 } from "~/utils/pageRefObserverHandlers";
-import getDiscourseNodes from "~/utils/getDiscourseNodes";
+import getDiscourseNodes, {
+  type DiscourseNode,
+} from "~/utils/getDiscourseNodes";
 import { OnloadArgs } from "roamjs-components/types";
 import refreshConfigTree from "~/utils/refreshConfigTree";
 import { render as renderGraphOverviewExport } from "~/components/ExportDiscourseContext";
@@ -52,9 +54,8 @@ import getPageUidByPageTitle from "roamjs-components/queries/getPageUidByPageTit
 import getPageTitleByPageUid from "roamjs-components/queries/getPageTitleByPageUid";
 import findDiscourseNode from "./findDiscourseNode";
 import {
-  getPersonalSetting,
-  getFeatureFlag,
-  getGlobalSetting,
+  bulkReadSettings,
+  type SettingsSnapshot,
 } from "~/components/settings/utils/accessors";
 import {
   onSettingChange,
@@ -88,8 +89,10 @@ const getTitleAndUidFromHeader = (h1: HTMLHeadingElement) => {
 
 export const initObservers = ({
   onloadArgs,
+  settings,
 }: {
   onloadArgs: OnloadArgs;
+  settings: SettingsSnapshot;
 }): {
   observers: MutationObserver[];
   listeners: {
@@ -107,11 +110,18 @@ export const initObservers = ({
     callback: (e) => {
       const h1 = e as HTMLHeadingElement;
       const { title, uid } = getTitleAndUidFromHeader(h1);
+
+      const settings = bulkReadSettings();
+
       const props = { title, h1, onloadArgs };
 
-      const isSuggestiveModeEnabled = getFeatureFlag("Suggestive mode enabled");
-
-      const node = findDiscourseNode({ uid, title });
+      const isSuggestiveModeEnabled =
+        settings.featureFlags["Suggestive mode enabled"];
+      const node = findDiscourseNode({
+        uid,
+        title,
+        snapshot: settings,
+      });
       const isDiscourseNode = node && node.backedBy !== "default";
       if (isDiscourseNode) {
         renderDiscourseContext({ h1, uid });
@@ -125,10 +135,13 @@ export const initObservers = ({
           renderCanvasReferences(linkedReferencesDiv, uid, onloadArgs);
         }
       }
-
-      if (isQueryPage({ title })) renderQueryPage(props);
-      else if (isCurrentPageCanvas(props)) renderTldrawCanvas(props);
-      else if (isSidebarCanvas(props)) renderTldrawCanvasInSidebar(props);
+      if (isQueryPage({ title, snapshot: settings })) {
+        renderQueryPage(props);
+      } else if (isCurrentPageCanvas({ title, h1, snapshot: settings })) {
+        renderTldrawCanvas(props);
+      } else if (isSidebarCanvas({ title, h1, snapshot: settings })) {
+        renderTldrawCanvasInSidebar(props);
+      }
     },
   });
 
@@ -136,6 +149,18 @@ export const initObservers = ({
     attribute: "query-block",
     render: (b) => renderQueryBlock(b, onloadArgs),
   });
+
+  let batchedTagNodes: DiscourseNode[] | null = null;
+  const getNodesForTagBatch = (): DiscourseNode[] => {
+    if (batchedTagNodes === null) {
+      const settings = bulkReadSettings();
+      batchedTagNodes = getDiscourseNodes(undefined, settings);
+      queueMicrotask(() => {
+        batchedTagNodes = null;
+      });
+    }
+    return batchedTagNodes;
+  };
 
   const nodeTagPopupButtonObserver = createHTMLObserver({
     className: "rm-page-ref--tag",
@@ -145,7 +170,7 @@ export const initObservers = ({
       if (tag) {
         const normalizedTag = getCleanTagText(tag);
 
-        for (const node of getDiscourseNodes()) {
+        for (const node of getNodesForTagBatch()) {
           const normalizedNodeTag = node.tag ? getCleanTagText(node.tag) : "";
           if (normalizedTag === normalizedNodeTag) {
             renderNodeTagPopupButton(s, node, onloadArgs.extensionAPI);
@@ -203,7 +228,7 @@ export const initObservers = ({
 
   const suggestiveHandler = getSuggestiveOverlayHandler(onloadArgs);
   const toggleSuggestiveOverlay = onPageRefObserverChange(suggestiveHandler);
-  if (getPersonalSetting<boolean>([PERSONAL_KEYS.suggestiveModeOverlay])) {
+  if (settings.personalSettings[PERSONAL_KEYS.suggestiveModeOverlay]) {
     addPageRefObserver(suggestiveHandler);
   }
 
@@ -233,34 +258,40 @@ export const initObservers = ({
     },
   });
 
-  if (getPersonalSetting<boolean>([PERSONAL_KEYS.pagePreview]))
+  if (settings.personalSettings[PERSONAL_KEYS.pagePreview])
     addPageRefObserver(previewPageRefHandler);
-  if (getPersonalSetting<boolean>([PERSONAL_KEYS.discourseContextOverlay])) {
+
+  if (settings.personalSettings[PERSONAL_KEYS.discourseContextOverlay]) {
     const overlayHandler = getOverlayHandler(onloadArgs);
     onPageRefObserverChange(overlayHandler)(true);
   }
+
   if (getPageRefObserversSize()) enablePageRefObserver();
 
   const configPageUid = getPageUidByPageTitle(DISCOURSE_CONFIG_PAGE_TITLE);
 
   const hashChangeListener = (e: Event) => {
     const evt = e as HashChangeEvent;
+    const settings = bulkReadSettings();
     // Attempt to refresh config navigating away from config page
     // doesn't work if they update via sidebar
     if (
       (configPageUid && evt.oldURL.endsWith(configPageUid)) ||
-      getDiscourseNodes().some(({ type }) => evt.oldURL.endsWith(type))
+      getDiscourseNodes(undefined, settings).some(({ type }) =>
+        evt.oldURL.endsWith(type),
+      )
     ) {
-      refreshConfigTree();
+      refreshConfigTree(settings);
     }
   };
 
-  let globalTrigger = (
-    getGlobalSetting<string>([GLOBAL_KEYS.trigger]) ?? "\\"
-  ).trim();
-  const personalTriggerCombo = getPersonalSetting<IKeyCombo>([
-    PERSONAL_KEYS.personalNodeMenuTrigger,
-  ]);
+  let globalTrigger = settings.globalSettings[GLOBAL_KEYS.trigger].trim();
+  const personalTriggerComboRaw =
+    settings.personalSettings[PERSONAL_KEYS.personalNodeMenuTrigger];
+  const personalTriggerCombo =
+    typeof personalTriggerComboRaw === "object"
+      ? personalTriggerComboRaw
+      : undefined;
   let personalTrigger = personalTriggerCombo?.key;
   let personalModifiers = personalTriggerCombo
     ? getModifiersFromCombo(personalTriggerCombo)
@@ -291,11 +322,17 @@ export const initObservers = ({
     className: "starred-pages-wrapper",
     callback: (el) => {
       void (async () => {
-        const isLeftSidebarEnabled = getFeatureFlag("Enable left sidebar");
+        const settings = bulkReadSettings();
+        const isLeftSidebarEnabled =
+          settings.featureFlags["Enable left sidebar"];
         const container = el as HTMLDivElement;
         if (isLeftSidebarEnabled) {
           container.style.padding = "0";
-          await mountLeftSidebar(container, onloadArgs);
+          await mountLeftSidebar({
+            wrapper: container,
+            onloadArgs,
+            initialSnapshot: settings,
+          });
         }
       })();
     },
@@ -343,7 +380,7 @@ export const initObservers = ({
   };
 
   let customTrigger =
-    getPersonalSetting<string>([PERSONAL_KEYS.nodeSearchMenuTrigger]) ?? "@";
+    settings.personalSettings[PERSONAL_KEYS.nodeSearchMenuTrigger];
 
   const unsubSearchTrigger = onSettingChange(
     settingKeys.nodeSearchMenuTrigger,
@@ -403,10 +440,8 @@ export const initObservers = ({
   };
 
   const nodeCreationPopoverListener = debounce(() => {
-    const isTextSelectionPopupEnabled =
-      getPersonalSetting<boolean>([PERSONAL_KEYS.textSelectionPopup]) !== false;
-
-    if (!isTextSelectionPopupEnabled) return;
+    const settings = bulkReadSettings();
+    if (!settings.personalSettings[PERSONAL_KEYS.textSelectionPopup]) return;
 
     const selection = window.getSelection();
 

--- a/apps/roam/src/utils/isCanvasPage.ts
+++ b/apps/roam/src/utils/isCanvasPage.ts
@@ -1,10 +1,21 @@
 import { DEFAULT_CANVAS_PAGE_FORMAT } from "..";
-import { getGlobalSetting } from "~/components/settings/utils/accessors";
+import {
+  getGlobalSetting,
+  type SettingsSnapshot,
+} from "~/components/settings/utils/accessors";
 import { GLOBAL_KEYS } from "~/components/settings/utils/settingKeys";
 
-export const isCanvasPage = ({ title }: { title: string }) => {
+export const isCanvasPage = ({
+  title,
+  snapshot,
+}: {
+  title: string;
+  snapshot?: SettingsSnapshot;
+}) => {
   const format =
-    getGlobalSetting<string>([GLOBAL_KEYS.canvasPageFormat]) ||
+    (snapshot
+      ? snapshot.globalSettings[GLOBAL_KEYS.canvasPageFormat]
+      : getGlobalSetting<string>([GLOBAL_KEYS.canvasPageFormat])) ||
     DEFAULT_CANVAS_PAGE_FORMAT;
   const canvasRegex = new RegExp(`^${format}$`.replace(/\*/g, ".+"));
   return canvasRegex.test(title);
@@ -13,19 +24,25 @@ export const isCanvasPage = ({ title }: { title: string }) => {
 export const isCurrentPageCanvas = ({
   title,
   h1,
+  snapshot,
 }: {
   title: string;
   h1: HTMLHeadingElement;
+  snapshot: SettingsSnapshot;
 }) => {
-  return isCanvasPage({ title }) && !!h1.closest(".roam-article");
+  return isCanvasPage({ title, snapshot }) && !!h1.closest(".roam-article");
 };
 
 export const isSidebarCanvas = ({
   title,
   h1,
+  snapshot,
 }: {
   title: string;
   h1: HTMLHeadingElement;
+  snapshot: SettingsSnapshot;
 }) => {
-  return isCanvasPage({ title }) && !!h1.closest(".rm-sidebar-outline");
+  return (
+    isCanvasPage({ title, snapshot }) && !!h1.closest(".rm-sidebar-outline")
+  );
 };

--- a/apps/roam/src/utils/isQueryPage.ts
+++ b/apps/roam/src/utils/isQueryPage.ts
@@ -1,7 +1,14 @@
 import { getQueryPages } from "~/components/settings/QueryPagesPanel";
+import type { SettingsSnapshot } from "~/components/settings/utils/accessors";
 
-export const isQueryPage = ({ title }: { title: string }): boolean => {
-  const queryPages = getQueryPages();
+export const isQueryPage = ({
+  title,
+  snapshot,
+}: {
+  title: string;
+  snapshot: SettingsSnapshot;
+}): boolean => {
+  const queryPages = getQueryPages(snapshot);
 
   const matchesQueryPage = queryPages.some((queryPage) => {
     const escapedPattern = queryPage

--- a/apps/roam/src/utils/posthog.ts
+++ b/apps/roam/src/utils/posthog.ts
@@ -2,13 +2,13 @@ import getCurrentUserUid from "roamjs-components/queries/getCurrentUserUid";
 import { getVersionWithDate } from "./getVersion";
 import posthog from "posthog-js";
 import type { CaptureResult } from "posthog-js";
-import { getPersonalSetting } from "~/components/settings/utils/accessors";
-import { PERSONAL_KEYS } from "~/components/settings/utils/settingKeys";
 
 let initialized = false;
 
-const doInitPostHog = (): void => {
+export const initPostHog = (): void => {
   if (initialized) return;
+  if (window.roamAlphaAPI.graph.isEncrypted) return;
+  if (window.roamAlphaAPI.graph.type === "offline") return;
   const propertyDenylist = new Set([
     "$ip",
     "$device_id",
@@ -58,19 +58,10 @@ const doInitPostHog = (): void => {
 };
 
 export const enablePostHog = (): void => {
-  doInitPostHog();
+  initPostHog();
   posthog.opt_in_capturing();
 };
 
 export const disablePostHog = (): void => {
   if (initialized) posthog.opt_out_capturing();
-};
-
-export const initPostHog = (): void => {
-  const disabled = getPersonalSetting<boolean>([
-    PERSONAL_KEYS.disableProductDiagnostics,
-  ]);
-  if (!disabled) {
-    doInitPostHog();
-  }
 };

--- a/apps/roam/src/utils/refreshConfigTree.ts
+++ b/apps/roam/src/utils/refreshConfigTree.ts
@@ -6,6 +6,7 @@ import registerDiscourseDatalogTranslators from "./registerDiscourseDatalogTrans
 import { unregisterDatalogTranslator } from "./conditionToDatalog";
 import type { PullBlock } from "roamjs-components/types/native";
 import { DISCOURSE_CONFIG_PAGE_TITLE } from "~/data/constants";
+import type { SettingsSnapshot } from "~/components/settings/utils/accessors";
 
 const getPagesStartingWithPrefix = (prefix: string) =>
   (
@@ -17,8 +18,8 @@ const getPagesStartingWithPrefix = (prefix: string) =>
     uid: r[0][":block/uid"] || "",
   }));
 
-const refreshConfigTree = () => {
-  getDiscourseRelationLabels().forEach((key) =>
+const refreshConfigTree = (snapshot?: SettingsSnapshot) => {
+  getDiscourseRelationLabels(undefined, snapshot).forEach((key) =>
     unregisterDatalogTranslator({ key }),
   );
   discourseConfigRef.tree = getBasicTreeByParentUid(
@@ -36,7 +37,7 @@ const refreshConfigTree = () => {
       ];
     }),
   );
-  registerDiscourseDatalogTranslators();
+  registerDiscourseDatalogTranslators(snapshot);
 };
 
 export default refreshConfigTree;

--- a/apps/roam/src/utils/registerDiscourseDatalogTranslators.ts
+++ b/apps/roam/src/utils/registerDiscourseDatalogTranslators.ts
@@ -21,6 +21,7 @@ import { fireQuerySync, getWhereClauses } from "./fireQuery";
 import { toVar } from "./compileDatalog";
 import { getExistingRelationPageUid } from "./createReifiedBlock";
 import { getStoredRelationsEnabled } from "./storedRelations";
+import type { SettingsSnapshot } from "~/components/settings/utils/accessors";
 
 const hasTag = (node: DiscourseNode): node is DiscourseNode & { tag: string } =>
   !!node.tag;
@@ -87,9 +88,9 @@ const collectVariables = (clauses: DatalogClause[]): Set<string> =>
 
 const ANY_DISCOURSE_NODE = "Any discourse node";
 
-const registerDiscourseDatalogTranslators = () => {
-  const discourseRelations = getDiscourseRelations();
-  const discourseNodes = getDiscourseNodes(discourseRelations);
+const registerDiscourseDatalogTranslators = (snapshot?: SettingsSnapshot) => {
+  const discourseRelations = getDiscourseRelations(snapshot);
+  const discourseNodes = getDiscourseNodes(discourseRelations, snapshot);
 
   const isACallback: Parameters<
     typeof registerDatalogTranslator

--- a/apps/roam/src/utils/setQueryPages.ts
+++ b/apps/roam/src/utils/setQueryPages.ts
@@ -1,25 +1,19 @@
 import { OnloadArgs } from "roamjs-components/types";
 import {
-  getPersonalSetting,
   setPersonalSetting,
+  type SettingsSnapshot,
 } from "~/components/settings/utils/accessors";
 import {
   PERSONAL_KEYS,
   QUERY_KEYS,
 } from "~/components/settings/utils/settingKeys";
 
-export const setInitialQueryPages = (onloadArgs: OnloadArgs) => {
-  // Legacy extensionAPI stored query-pages as string | string[] | Record<string, string>.
-  // Coerce to string[] for backward compatibility with old stored formats.
-  const raw = getPersonalSetting<string[] | string | Record<string, string>>([
-    PERSONAL_KEYS.query,
-    QUERY_KEYS.queryPages,
-  ]);
-  const queryPageArray = Array.isArray(raw)
-    ? raw
-    : typeof raw === "string" && raw
-      ? [raw]
-      : [];
+export const setInitialQueryPages = (
+  onloadArgs: OnloadArgs,
+  snapshot: SettingsSnapshot,
+) => {
+  const queryPageArray =
+    snapshot.personalSettings[PERSONAL_KEYS.query][QUERY_KEYS.queryPages];
   if (!queryPageArray.includes("discourse-graph/queries/*")) {
     const updated = [...queryPageArray, "discourse-graph/queries/*"];
     void onloadArgs.extensionAPI.settings.set("query-pages", updated);

--- a/apps/roam/src/utils/storedRelations.ts
+++ b/apps/roam/src/utils/storedRelations.ts
@@ -3,8 +3,8 @@
 // ENG-1521: Update internal terminology to use "stored" instead of "reified"
 
 import { USE_STORED_RELATIONS } from "~/data/userSettings";
+import { DISCOURSE_CONFIG_PAGE_TITLE } from "~/data/constants";
 import { getSetting, setSetting } from "./extensionSettings";
-import { DISCOURSE_CONFIG_PAGE_TITLE } from "./renderNodeConfigPage";
 
 const INSTALL_CUTOFF = Date.parse("2026-03-01T00:00:00.000Z");
 


### PR DESCRIPTION
3 level of setting groups:  

Global settings:
https://www.loom.com/share/d0e897acb01b4749858168a9174d1170

Personal settings:
https://www.loom.com/share/9f2a4ebce81241ba80199e56d08e8215
https://www.loom.com/share/fe3dce71ac4a474c8fed5788d597a1ad

Discourse nodes:
https://www.loom.com/share/2015b72b749e4af59ae57a2e6e3d9e8c


Bugs, warns already fixed:

Bugs, warns already fixed:

 | Issue from matrix | Status |
  |---|---|
  | Legacy blocks not created on fresh graph | Fixed (`ensureLegacyConfigBlocks`) |
  | Duplicate Page Groups blocks | Fixed (pre-created in init) |
  | Duplicate Folded blocks | Fixed (lookup-based delete) |
  | Duplicate scratch/enabled blocks | Fixed (switched to tree-based reads) |
  | Key order mismatch (keyboard shortcuts) | Fixed (`deepEqual`) |
  | `undefined` vs `""` / `false` mismatches | Fixed (`deepEqual`) |
  | `null` vs `undefined`/`false`/`""` mismatches | Fixed (`null` added to `deepEqual.isEmpty`) |
  | Stale cache during setting writes | Fixed (await → refresh → write pattern) |
  | Erroneous "Folded" block on section creation | Fixed (removed from `convertToComplexSection`) |
  | "Parent entity doesn't exist" on fold/unfold | Fixed (Settings block created in init) |
  | storedRelations broken import | Fixed |
  | Specification > enabled mismatch on toggle | Fixed (`setTimeout` on `onChange` in `BaseFlagPanel`) |
  | Suggestive mode enabled mismatch (4x fire) | Fixed (lazy `useState` initializer in `FeatureFlagsTab`) |
  | Legacy `specification.enabled` over-reports true | Fixed (removed `conditions.length > 0` fallback) |
  | ZodError on discourse node parse (ENG-1490) | Fixed (`isRecord` guard in `getRawDiscourseNodeBlockProps`) |
  | Key-image mismatch on toggle | Fixed (`setTimeout` on `setIsKeyImage` in canvas settings) |
  | Alias mismatch on edit (pull watcher timing) | Fixed (`setTimeout` on `refreshConfigTree + setter` in `BaseTextPanel`) |


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/896" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
