### PR TITLE
ENG-1267: Separate duplicate node alert feature flag from suggestivemode

### DIFF
--- a/apps/roam/src/components/settings/AdminPanel.tsx
+++ b/apps/roam/src/components/settings/AdminPanel.tsx
@@ -356,8 +356,6 @@ const FeatureFlagsTab = (): React.ReactElement => {
         featureKey="Duplicate node alert enabled"
         initialValue={getFeatureFlag("Duplicate node alert enabled")}
         disabled={!suggestiveModeEnabled}
-        order={0}
-        parentUid={settings.settingsUid}
       />
 
       <Button

--- a/apps/roam/src/components/settings/AdminPanel.tsx
+++ b/apps/roam/src/components/settings/AdminPanel.tsx
@@ -271,6 +271,7 @@ const FeatureFlagsTab = (): React.ReactElement => {
   );
   const [isAlertOpen, setIsAlertOpen] = useState(false);
   const [isInstructionOpen, setIsInstructionOpen] = useState(false);
+
   return (
     <div className="flex flex-col gap-4 p-4">
       <Checkbox

--- a/apps/roam/src/components/settings/AdminPanel.tsx
+++ b/apps/roam/src/components/settings/AdminPanel.tsx
@@ -354,6 +354,7 @@ const FeatureFlagsTab = (): React.ReactElement => {
         description="Show possible duplicate nodes when viewing a discourse node page. Requires Suggestive mode to be enabled."
         featureKey="Duplicate node alert enabled"
         initialValue={getFeatureFlag("Duplicate node alert enabled")}
+        disabled={!suggestiveModeEnabled}
         order={0}
         parentUid={settings.settingsUid}
       />

--- a/apps/roam/src/components/settings/AdminPanel.tsx
+++ b/apps/roam/src/components/settings/AdminPanel.tsx
@@ -33,7 +33,11 @@ import { getFormattedConfigTree } from "~/utils/discourseConfigRef";
 import refreshConfigTree from "~/utils/refreshConfigTree";
 import createBlock from "roamjs-components/writes/createBlock";
 import deleteBlock from "roamjs-components/writes/deleteBlock";
-import { setFeatureFlag } from "~/components/settings/utils/accessors";
+import {
+  setFeatureFlag,
+  getFeatureFlag,
+} from "~/components/settings/utils/accessors";
+import { FeatureFlagPanel } from "./components/BlockPropSettingPanels";
 
 const NodeRow = ({ node }: { node: PConceptFull }) => {
   return (
@@ -267,7 +271,6 @@ const FeatureFlagsTab = (): React.ReactElement => {
   );
   const [isAlertOpen, setIsAlertOpen] = useState(false);
   const [isInstructionOpen, setIsInstructionOpen] = useState(false);
-
   return (
     <div className="flex flex-col gap-4 p-4">
       <Checkbox
@@ -345,6 +348,15 @@ const FeatureFlagsTab = (): React.ReactElement => {
           {"-> Sync Config -> Click on 'Generate & Upload All Node Embeddings'"}
         </p>
       </Alert>
+
+      <FeatureFlagPanel
+        title="Duplicate node alert"
+        description="Show possible duplicate nodes when viewing a discourse node page. Requires Suggestive mode to be enabled."
+        featureKey="Duplicate node alert enabled"
+        initialValue={getFeatureFlag("Duplicate node alert enabled")}
+        order={0}
+        parentUid={settings.settingsUid}
+      />
 
       <Button
         className="w-96"

--- a/apps/roam/src/components/settings/components/BlockPropSettingPanels.tsx
+++ b/apps/roam/src/components/settings/components/BlockPropSettingPanels.tsx
@@ -501,6 +501,7 @@ export const FeatureFlagPanel = ({
   description,
   featureKey,
   initialValue,
+  disabled,
   onBeforeEnable,
   onAfterChange,
   parentUid,
@@ -511,6 +512,7 @@ export const FeatureFlagPanel = ({
   description: string;
   featureKey: keyof FeatureFlags;
   initialValue?: boolean;
+  disabled?: boolean;
   onBeforeEnable?: () => Promise<boolean>;
   onAfterChange?: (checked: boolean) => void;
 } & RoamBlockSyncProps) => {
@@ -532,6 +534,7 @@ export const FeatureFlagPanel = ({
       settingKeys={[featureKey as string]}
       setter={featureFlagSetter}
       initialValue={initialValue}
+      disabled={disabled}
       onBeforeChange={handleBeforeChange}
       onChange={onAfterChange}
       parentUid={parentUid}

--- a/apps/roam/src/components/settings/utils/zodSchema.example.ts
+++ b/apps/roam/src/components/settings/utils/zodSchema.example.ts
@@ -95,7 +95,7 @@ const featureFlags: FeatureFlags = {
 const defaultFeatureFlags: FeatureFlags = {
   "Enable left sidebar": false,
   "Suggestive mode enabled": false,
-  "Duplicate node alert enabled": true,
+  "Duplicate node alert enabled": false,
 };
 
 const exportSettings: ExportSettings = {

--- a/apps/roam/src/components/settings/utils/zodSchema.example.ts
+++ b/apps/roam/src/components/settings/utils/zodSchema.example.ts
@@ -89,11 +89,13 @@ const discourseNodeSettings: DiscourseNodeSettings = {
 const featureFlags: FeatureFlags = {
   "Enable left sidebar": true,
   "Suggestive mode enabled": true,
+  "Duplicate node alert enabled": true,
 };
 
 const defaultFeatureFlags: FeatureFlags = {
   "Enable left sidebar": false,
   "Suggestive mode enabled": false,
+  "Duplicate node alert enabled": true,
 };
 
 const exportSettings: ExportSettings = {

--- a/apps/roam/src/components/settings/utils/zodSchema.ts
+++ b/apps/roam/src/components/settings/utils/zodSchema.ts
@@ -156,7 +156,7 @@ export const DiscourseRelationSchema = z.object({
 export const FeatureFlagsSchema = z.object({
   "Enable left sidebar": z.boolean().default(false),
   "Suggestive mode enabled": z.boolean().default(false),
-  "Duplicate node alert enabled": z.boolean().default(true),
+  "Duplicate node alert enabled": z.boolean().default(false),
 });
 
 export const ExportSettingsSchema = z.object({

--- a/apps/roam/src/components/settings/utils/zodSchema.ts
+++ b/apps/roam/src/components/settings/utils/zodSchema.ts
@@ -156,6 +156,7 @@ export const DiscourseRelationSchema = z.object({
 export const FeatureFlagsSchema = z.object({
   "Enable left sidebar": z.boolean().default(false),
   "Suggestive mode enabled": z.boolean().default(false),
+  "Duplicate node alert enabled": z.boolean().default(true),
 });
 
 export const ExportSettingsSchema = z.object({

--- a/apps/roam/src/utils/initializeObserversAndListeners.ts
+++ b/apps/roam/src/utils/initializeObserversAndListeners.ts
@@ -54,6 +54,7 @@ import { formatHexColor } from "~/components/settings/DiscourseNodeCanvasSetting
 import { getSetting } from "./extensionSettings";
 import { mountLeftSidebar } from "~/components/LeftSidebarView";
 import { getUidAndBooleanSetting } from "./getExportSettings";
+import { getFeatureFlag } from "~/components/settings/utils/accessors";
 import { getCleanTagText } from "~/components/settings/NodeConfig";
 import getPleasingColors from "@repo/utils/getPleasingColors";
 import { colord } from "colord";
@@ -105,18 +106,11 @@ export const initObservers = async ({
       const { title, uid } = getTitleAndUidFromHeader(h1);
       const props = { title, h1, onloadArgs };
 
-      const isSuggestiveModeEnabled = getUidAndBooleanSetting({
-        tree: getBasicTreeByParentUid(
-          getPageUidByPageTitle(DISCOURSE_CONFIG_PAGE_TITLE),
-        ),
-        text: "(BETA) Suggestive Mode Enabled",
-      }).value;
-
       const node = findDiscourseNode({ uid, title });
       const isDiscourseNode = node && node.backedBy !== "default";
       if (isDiscourseNode) {
         renderDiscourseContext({ h1, uid });
-        if (isSuggestiveModeEnabled) {
+        if (getFeatureFlag("Duplicate node alert enabled")) {
           renderPossibleDuplicates(h1, title, node);
         }
         const linkedReferencesDiv = document.querySelector(

--- a/apps/roam/src/utils/initializeObserversAndListeners.ts
+++ b/apps/roam/src/utils/initializeObserversAndListeners.ts
@@ -106,11 +106,21 @@ export const initObservers = async ({
       const { title, uid } = getTitleAndUidFromHeader(h1);
       const props = { title, h1, onloadArgs };
 
+      const isSuggestiveModeEnabled = getUidAndBooleanSetting({
+        tree: getBasicTreeByParentUid(
+          getPageUidByPageTitle(DISCOURSE_CONFIG_PAGE_TITLE),
+        ),
+        text: "(BETA) Suggestive Mode Enabled",
+      }).value;
+
       const node = findDiscourseNode({ uid, title });
       const isDiscourseNode = node && node.backedBy !== "default";
       if (isDiscourseNode) {
         renderDiscourseContext({ h1, uid });
-        if (getFeatureFlag("Duplicate node alert enabled")) {
+        if (
+          isSuggestiveModeEnabled &&
+          getFeatureFlag("Duplicate node alert enabled")
+        ) {
           renderPossibleDuplicates(h1, title, node);
         }
         const linkedReferencesDiv = document.querySelector(


### PR DESCRIPTION
https://www.loom.com/share/f6dfe1c8355a47bc81f71007de87567c

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/898" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a "Duplicate node alert" toggle in the Admin settings panel, allowing users to control duplicate node detection functionality. The toggle is available when suggestive mode is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->