### PR TITLE
ENG-948: Add blocks to left sidebar via block context menu

### DIFF
--- a/apps/roam/src/components/settings/LeftSidebarPersonalSettings.tsx
+++ b/apps/roam/src/components/settings/LeftSidebarPersonalSettings.tsx
@@ -41,7 +41,9 @@ import getPageTitleByPageUid from "roamjs-components/queries/getPageTitleByPageU
 import posthog from "posthog-js";
 
 /* eslint-disable @typescript-eslint/naming-convention */
-const sectionsToBlockProps = (sections: LeftSidebarPersonalSectionConfig[]) =>
+export const sectionsToBlockProps = (
+  sections: LeftSidebarPersonalSectionConfig[],
+) =>
   sections.map((s) => ({
     name: s.text,
     Children: (s.children || []).map((c) => ({
@@ -72,6 +74,7 @@ const SectionItem = memo(
     isFirst,
     isLast,
     onMoveSection,
+    initiallyExpanded,
   }: {
     section: LeftSidebarPersonalSectionConfig;
     setSections: Dispatch<SetStateAction<LeftSidebarPersonalSectionConfig[]>>;
@@ -82,6 +85,7 @@ const SectionItem = memo(
     isFirst: boolean;
     isLast: boolean;
     onMoveSection: (index: number, direction: "up" | "down") => void;
+    initiallyExpanded?: boolean;
   }) => {
     const ref = extractRef(section.text);
     const blockText = getTextByBlockUid(ref);
@@ -90,7 +94,7 @@ const SectionItem = memo(
     const [childInputKey, setChildInputKey] = useState(0);
 
     const [expandedChildLists, setExpandedChildLists] = useState<Set<string>>(
-      new Set(),
+      new Set(initiallyExpanded ? [section.uid] : []),
     );
     const isExpanded = expandedChildLists.has(section.uid);
     const [childSettingsUid, setChildSettingsUid] = useState<string | null>(
@@ -561,8 +565,10 @@ SectionItem.displayName = "SectionItem";
 
 const LeftSidebarPersonalSectionsContent = ({
   leftSidebar,
+  expandedSectionUid,
 }: {
   leftSidebar: RoamBasicNode;
+  expandedSectionUid?: string;
 }) => {
   const [sections, setSections] = useState<LeftSidebarPersonalSectionConfig[]>(
     [],
@@ -736,6 +742,7 @@ const LeftSidebarPersonalSectionsContent = ({
               isFirst={index === 0}
               isLast={index === sections.length - 1}
               onMoveSection={moveSection}
+              initiallyExpanded={section.uid === expandedSectionUid}
             />
           </div>
         ))}
@@ -822,7 +829,11 @@ const LeftSidebarPersonalSectionsContent = ({
   );
 };
 
-export const LeftSidebarPersonalSections = () => {
+export const LeftSidebarPersonalSections = ({
+  expandedSectionUid,
+}: {
+  expandedSectionUid?: string;
+}) => {
   const [leftSidebar, setLeftSidebar] = useState<RoamBasicNode | null>(null);
 
   useEffect(() => {
@@ -850,5 +861,10 @@ export const LeftSidebarPersonalSections = () => {
     return null;
   }
 
-  return <LeftSidebarPersonalSectionsContent leftSidebar={leftSidebar} />;
+  return (
+    <LeftSidebarPersonalSectionsContent
+      leftSidebar={leftSidebar}
+      expandedSectionUid={expandedSectionUid}
+    />
+  );
 };

--- a/apps/roam/src/components/settings/Settings.tsx
+++ b/apps/roam/src/components/settings/Settings.tsx
@@ -66,11 +66,13 @@ export const SettingsDialog = ({
   isOpen,
   onClose,
   selectedTabId,
+  expandedSectionUid,
 }: {
   onloadArgs: OnloadArgs;
   isOpen?: boolean;
   onClose?: () => void;
   selectedTabId?: TabId;
+  expandedSectionUid?: string;
 }) => {
   const extensionAPI = onloadArgs.extensionAPI;
   const settings = getFormattedConfigTree();
@@ -172,7 +174,11 @@ export const SettingsDialog = ({
             id="left-sidebar-personal-settings"
             title="Left sidebar"
             className="overflow-y-auto"
-            panel={<LeftSidebarPersonalSections />}
+            panel={
+              <LeftSidebarPersonalSections
+                expandedSectionUid={expandedSectionUid}
+              />
+            }
           />
           <SectionHeader className="text-lg font-semibold text-neutral-dark">
             Global Settings
@@ -275,11 +281,15 @@ export const SettingsDialog = ({
 
 type Props = {
   onloadArgs: OnloadArgs;
+  selectedTabId?: TabId;
+  expandedSectionUid?: string;
 };
 export const render = (props: Props) =>
   renderOverlay({
     Overlay: SettingsDialog,
     props: {
       onloadArgs: props.onloadArgs,
+      selectedTabId: props.selectedTabId,
+      expandedSectionUid: props.expandedSectionUid,
     },
   });

--- a/apps/roam/src/utils/registerCommandPaletteCommands.ts
+++ b/apps/roam/src/utils/registerCommandPaletteCommands.ts
@@ -21,6 +21,15 @@ import {
 } from "./pageRefObserverHandlers";
 import { HIDE_METADATA_KEY } from "~/data/userSettings";
 import posthog from "posthog-js";
+import { extractRef } from "roamjs-components/util";
+import { getFormattedConfigTree } from "~/utils/discourseConfigRef";
+import refreshConfigTree from "~/utils/refreshConfigTree";
+import { refreshAndNotify } from "~/components/LeftSidebarView";
+import {
+  setPersonalSetting,
+  setGlobalSetting,
+} from "~/components/settings/utils/accessors";
+import { sectionsToBlockProps } from "~/components/settings/LeftSidebarPersonalSettings";
 
 export const registerCommandPaletteCommands = (onloadArgs: OnloadArgs) => {
   const { extensionAPI } = onloadArgs;
@@ -301,4 +310,143 @@ export const registerCommandPaletteCommands = (onloadArgs: OnloadArgs) => {
   );
   void addCommand("DG: Query block - Create", createQueryBlock);
   void addCommand("DG: Query block - Refresh", refreshCurrentQueryBuilder);
+
+  // Block context menu commands for left sidebar
+  const config = getFormattedConfigTree();
+  if (config.leftSidebarEnabled.value) {
+    const personalSections = config.leftSidebar.personal.sections;
+    const globalSection = config.leftSidebar.global;
+
+    for (const section of personalSections) {
+      if (!section.childrenUid) continue;
+
+      const sectionName = section.text.startsWith("((")
+        ? getTextByBlockUid(extractRef(section.text)) || section.text
+        : section.text;
+
+      window.roamAlphaAPI.ui.blockContextMenu.addCommand({
+        label: `DG: Left sidebar - Add to "${sectionName}" (personal)`,
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        callback: (props: { "block-uid": string }) => {
+          void addBlockToPersonalSection({
+            blockUid: props["block-uid"],
+            sectionUid: section.uid,
+            onloadArgs,
+          });
+        },
+      });
+    }
+
+    if (globalSection.childrenUid) {
+      window.roamAlphaAPI.ui.blockContextMenu.addCommand({
+        label: "DG: Left sidebar - Add to Global",
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        callback: (props: { "block-uid": string }) => {
+          void addBlockToGlobalSection({
+            blockUid: props["block-uid"],
+            onloadArgs,
+          });
+        },
+      });
+    }
+  }
+};
+
+const addBlockToPersonalSection = async ({
+  blockUid,
+  sectionUid,
+  onloadArgs,
+}: {
+  blockUid: string;
+  sectionUid: string;
+  onloadArgs: OnloadArgs;
+}) => {
+  refreshConfigTree();
+  const sections = getFormattedConfigTree().leftSidebar.personal.sections;
+  const section = sections.find((s) => s.uid === sectionUid);
+  if (!section?.childrenUid) return;
+
+  const blockRef = `((${blockUid}))`;
+
+  try {
+    const newChildBlockUid = await createBlock({
+      parentUid: section.childrenUid,
+      order: "last",
+      node: { text: blockRef },
+    });
+
+    const updatedSections = sections.map((s) =>
+      s.uid === sectionUid
+        ? {
+            ...s,
+            children: [
+              ...(s.children || []),
+              {
+                text: blockRef,
+                uid: newChildBlockUid,
+                children: [],
+                alias: { value: "" },
+              },
+            ],
+          }
+        : s,
+    );
+
+    setPersonalSetting(["Left sidebar"], sectionsToBlockProps(updatedSections));
+    refreshAndNotify();
+    renderSettings({
+      onloadArgs,
+      selectedTabId: "left-sidebar-personal-settings",
+      expandedSectionUid: sectionUid,
+    });
+  } catch {
+    renderToast({
+      content: "Failed to add block to section",
+      intent: "danger",
+      id: "add-block-to-section-error",
+    });
+  }
+};
+
+const addBlockToGlobalSection = async ({
+  blockUid,
+  onloadArgs,
+}: {
+  blockUid: string;
+  onloadArgs: OnloadArgs;
+}) => {
+  refreshConfigTree();
+  const globalSection = getFormattedConfigTree().leftSidebar.global;
+  if (!globalSection.childrenUid) return;
+
+  const blockRef = `((${blockUid}))`;
+
+  try {
+    const newChildBlockUid = await createBlock({
+      parentUid: globalSection.childrenUid,
+      order: "last",
+      node: { text: blockRef },
+    });
+
+    const updatedChildren = [
+      ...globalSection.children,
+      { text: blockRef, uid: newChildBlockUid, children: [] },
+    ];
+
+    setGlobalSetting(
+      ["Left sidebar", "Children"],
+      updatedChildren.map((c) => c.text),
+    );
+    refreshAndNotify();
+    renderSettings({
+      onloadArgs,
+      selectedTabId: "left-sidebar-global-settings",
+    });
+  } catch {
+    renderToast({
+      content: "Failed to add block to global section",
+      intent: "danger",
+      id: "add-block-to-global-section-error",
+    });
+  }
 };

--- a/apps/roam/src/utils/registerCommandPaletteCommands.ts
+++ b/apps/roam/src/utils/registerCommandPaletteCommands.ts
@@ -330,7 +330,7 @@ export const registerCommandPaletteCommands = (onloadArgs: OnloadArgs) => {
         : section.text;
 
       window.roamAlphaAPI.ui.blockContextMenu.addCommand({
-        label: `DG: Left sidebar - Add to "${sectionName}" (personal)`,
+        label: `DG: Favorites - Add to "${sectionName}" section`,
         // eslint-disable-next-line @typescript-eslint/naming-convention
         callback: (props: { "block-uid": string }) => {
           void addBlockToPersonalSection({

--- a/apps/roam/src/utils/registerCommandPaletteCommands.ts
+++ b/apps/roam/src/utils/registerCommandPaletteCommands.ts
@@ -22,13 +22,12 @@ import {
 import { HIDE_METADATA_KEY } from "~/data/userSettings";
 import posthog from "posthog-js";
 import { extractRef } from "roamjs-components/util";
-import { getFormattedConfigTree } from "~/utils/discourseConfigRef";
+import discourseConfigRef from "~/utils/discourseConfigRef";
+import { getLeftSidebarPersonalSectionConfig } from "~/utils/getLeftSidebarSettings";
+import { getUidAndBooleanSetting } from "~/utils/getExportSettings";
 import refreshConfigTree from "~/utils/refreshConfigTree";
 import { refreshAndNotify } from "~/components/LeftSidebarView";
-import {
-  setPersonalSetting,
-  setGlobalSetting,
-} from "~/components/settings/utils/accessors";
+import { setPersonalSetting } from "~/components/settings/utils/accessors";
 import { sectionsToBlockProps } from "~/components/settings/LeftSidebarPersonalSettings";
 
 export const registerCommandPaletteCommands = (onloadArgs: OnloadArgs) => {
@@ -311,11 +310,17 @@ export const registerCommandPaletteCommands = (onloadArgs: OnloadArgs) => {
   void addCommand("DG: Query block - Create", createQueryBlock);
   void addCommand("DG: Query block - Refresh", refreshCurrentQueryBuilder);
 
-  // Block context menu commands for left sidebar
-  const config = getFormattedConfigTree();
-  if (config.leftSidebarEnabled.value) {
-    const personalSections = config.leftSidebar.personal.sections;
-    const globalSection = config.leftSidebar.global;
+  const leftSidebarEnabled = getUidAndBooleanSetting({
+    tree: discourseConfigRef.tree,
+    text: "(BETA) Left Sidebar",
+  });
+  if (leftSidebarEnabled.value) {
+    const leftSidebarNode = discourseConfigRef.tree.find(
+      (node) => node.text === "Left Sidebar",
+    );
+    const personalSections = getLeftSidebarPersonalSectionConfig(
+      leftSidebarNode?.children || [],
+    ).sections;
 
     for (const section of personalSections) {
       if (!section.childrenUid) continue;
@@ -336,19 +341,6 @@ export const registerCommandPaletteCommands = (onloadArgs: OnloadArgs) => {
         },
       });
     }
-
-    if (globalSection.childrenUid) {
-      window.roamAlphaAPI.ui.blockContextMenu.addCommand({
-        label: "DG: Left sidebar - Add to Global",
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        callback: (props: { "block-uid": string }) => {
-          void addBlockToGlobalSection({
-            blockUid: props["block-uid"],
-            onloadArgs,
-          });
-        },
-      });
-    }
   }
 };
 
@@ -362,7 +354,12 @@ const addBlockToPersonalSection = async ({
   onloadArgs: OnloadArgs;
 }) => {
   refreshConfigTree();
-  const sections = getFormattedConfigTree().leftSidebar.personal.sections;
+  const leftSidebarNode = discourseConfigRef.tree.find(
+    (node) => node.text === "Left Sidebar",
+  );
+  const sections = getLeftSidebarPersonalSectionConfig(
+    leftSidebarNode?.children || [],
+  ).sections;
   const section = sections.find((s) => s.uid === sectionUid);
   if (!section?.childrenUid) return;
 
@@ -404,49 +401,6 @@ const addBlockToPersonalSection = async ({
       content: "Failed to add block to section",
       intent: "danger",
       id: "add-block-to-section-error",
-    });
-  }
-};
-
-const addBlockToGlobalSection = async ({
-  blockUid,
-  onloadArgs,
-}: {
-  blockUid: string;
-  onloadArgs: OnloadArgs;
-}) => {
-  refreshConfigTree();
-  const globalSection = getFormattedConfigTree().leftSidebar.global;
-  if (!globalSection.childrenUid) return;
-
-  const blockRef = `((${blockUid}))`;
-
-  try {
-    const newChildBlockUid = await createBlock({
-      parentUid: globalSection.childrenUid,
-      order: "last",
-      node: { text: blockRef },
-    });
-
-    const updatedChildren = [
-      ...globalSection.children,
-      { text: blockRef, uid: newChildBlockUid, children: [] },
-    ];
-
-    setGlobalSetting(
-      ["Left sidebar", "Children"],
-      updatedChildren.map((c) => c.text),
-    );
-    refreshAndNotify();
-    renderSettings({
-      onloadArgs,
-      selectedTabId: "left-sidebar-global-settings",
-    });
-  } catch {
-    renderToast({
-      content: "Failed to add block to global section",
-      intent: "danger",
-      id: "add-block-to-global-section-error",
     });
   }
 };


### PR DESCRIPTION
Register block context menu commands so users can right-click any block and add it to a left sidebar section. On click, the block is added (dual-write to tree + block props), and the settings panel opens to the relevant tab with the target section auto-expanded.

https://www.loom.com/share/bf3d36dead044d1b854d223d9ec6500a

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/902" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added context menu commands to add blocks to personal sections in the left sidebar
  * Personal sidebar sections now support initial expansion state
  * Settings interface enhanced to track and manage section expansion state
  * Relevant sections automatically expand when blocks are added to them

<!-- end of auto-generated comment: release notes by coderabbit.ai -->