### PR TITLE
ENG-226: Fix dot-tag (.#sticky, .#meeting) flashing in query table results

### DIFF
--- a/apps/roam/src/styles/styles.css
+++ b/apps/roam/src/styles/styles.css
@@ -75,9 +75,7 @@
   padding: 8px;
 }
 
-.roamjs-query-results-view
-  .roamjs-query-link-cell:not(:hover)
-  .rm-page-ref[data-tag^="."] {
+.roamjs-query-results-view td:not(:hover) .rm-page-ref[data-tag^="."] {
   display: none !important;
 }
 

--- a/apps/roam/src/styles/styles.css
+++ b/apps/roam/src/styles/styles.css
@@ -75,6 +75,12 @@
   padding: 8px;
 }
 
+.roamjs-query-results-view
+  .roamjs-query-link-cell:not(:hover)
+  .rm-page-ref[data-tag^="."] {
+  display: none !important;
+}
+
 .roamjs-view-select button {
   width: 100%;
   display: flex;

--- a/apps/roam/src/styles/styles.css
+++ b/apps/roam/src/styles/styles.css
@@ -75,6 +75,9 @@
   padding: 8px;
 }
 
+/* Solves dot-tags (.#sticky, .#meeting) flashing on when hovering anywhere on the
+   Query Table. Roam shows them via .rm-block__self:hover and the entire table lives
+   in one block, so we scope visibility to the individual cell instead. */
 .roamjs-query-results-view td:not(:hover) .rm-page-ref[data-tag^="."] {
   display: none !important;
 }


### PR DESCRIPTION
https://www.loom.com/share/57058df737784d07b543f1f34777b895
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/904" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Query results view now hides unnecessary elements in result cells when not hovering, improving visual clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->