### PR TITLE
ENG-1315: Disable node type change in canvas create-node modal

### DIFF
--- a/apps/roam/src/components/ModifyNodeDialog.tsx
+++ b/apps/roam/src/components/ModifyNodeDialog.tsx
@@ -47,6 +47,7 @@ export type ModifyNodeDialogProps = {
   extensionAPI?: OnloadArgs["extensionAPI"];
   includeDefaultNodes?: boolean; // Include default nodes (Page, Block) in node type selector
   imageUrl?: string; // For image conversion from canvas
+  disableNodeTypeChange?: boolean; // Disable node type selector (e.g. canvas contexts)
   onSuccess: (result: {
     text: string;
     uid: string;
@@ -65,6 +66,7 @@ const ModifyNodeDialog = ({
   extensionAPI,
   includeDefaultNodes = false,
   imageUrl,
+  disableNodeTypeChange = false,
   onSuccess,
   onClose,
 }: RoamOverlayProps<ModifyNodeDialogProps>) => {
@@ -520,8 +522,13 @@ const ModifyNodeDialog = ({
                     setReferencedNodeValue({ text: "", uid: "" });
                   }
                 }}
-                disabled={mode === "edit"}
+                disabled={mode === "edit" || disableNodeTypeChange}
                 popoverProps={{ openOnTargetFocus: false }}
+                className={
+                  mode === "edit" || disableNodeTypeChange
+                    ? "cursor-not-allowed opacity-50"
+                    : ""
+                }
               />
             </Label>
           </div>

--- a/apps/roam/src/components/canvas/DiscourseNodeUtil.tsx
+++ b/apps/roam/src/components/canvas/DiscourseNodeUtil.tsx
@@ -530,6 +530,7 @@ export class BaseDiscourseNodeUtil extends BaseBoxShapeUtil<DiscourseNodeShape> 
               : undefined,
           extensionAPI,
           includeDefaultNodes: true,
+          disableNodeTypeChange: true,
           onSuccess: async ({ text, uid, action }) => {
             if (action === "edit") {
               if (isPageUid(shape.props.uid))
@@ -651,6 +652,7 @@ export class BaseDiscourseNodeUtil extends BaseBoxShapeUtil<DiscourseNodeShape> 
                   initialValue: { text: cleanedText, uid: "" },
                   extensionAPI,
                   includeDefaultNodes: true,
+                  disableNodeTypeChange: true,
                   onSuccess: async ({ text, uid }) => {
                     if (!extensionAPI) return;
                     try {

--- a/apps/roam/src/components/canvas/uiOverrides.tsx
+++ b/apps/roam/src/components/canvas/uiOverrides.tsx
@@ -162,6 +162,7 @@ export const getOnSelectForShape = ({
       initialValue: { text: initialText, uid: "" },
       extensionAPI,
       includeDefaultNodes: true,
+      disableNodeTypeChange: true,
       imageUrl,
       onSuccess: async ({ text, uid }) => {
         editor.deleteShapes([shape.id]);


### PR DESCRIPTION
## Summary
- Adds `disableNodeTypeChange` prop to `ModifyNodeDialog` to lock the node type selector
- Passes `disableNodeTypeChange: true` from all three canvas call sites (`DiscourseNodeUtil.tsx` component, convert-to handler, `uiOverrides.tsx` shape select)
- Adds `opacity-50` + `cursor-not-allowed` Tailwind classes for visual disabled state
- Non-canvas flows (command palette, node tag popup) are unaffected — selector remains enabled

## Test plan

https://www.loom.com/share/c4e553847420405582464cfbd221d3a4

- [x] Open Canvas → click a node type in DiscourseNodeTools → modal node type selector should be **disabled** (grayed out)
- [x] Right-click canvas shape → "Convert to" → modal node type selector should be **disabled**
- [x] Select a tldraw text/image shape → convert to discourse node → selector **disabled**
- [x] Command palette → "Create Discourse Node" → selector should be **enabled**
- [x] Node tag popup in editor → selector should be **enabled**
- [x] Edit existing node on canvas → selector remains **disabled** (existing behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/906" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
