### PR TITLE
ENG-1563: Add Datacore dependency callout in settings

### DIFF
--- a/apps/obsidian/src/components/DatacoreCallout.tsx
+++ b/apps/obsidian/src/components/DatacoreCallout.tsx
@@ -1,0 +1,33 @@
+import { useState, useEffect, useCallback } from "react";
+import { useApp } from "./AppContext";
+import { AppWithPlugins } from "~/services/QueryEngine";
+
+export const DatacoreCallout = () => {
+  const app = useApp();
+
+  const datacorePlugin = (app as AppWithPlugins)?.plugins?.plugins?.[
+    "datacore"
+  ];
+
+  if (datacorePlugin) return null;
+
+  return (
+    <div className="callout callout-warning mb-4 rounded-md border border-solid border-yellow-500/30 bg-yellow-500/10 p-4">
+      <div className="callout-title flex items-center gap-2 font-semibold">
+        ⚠️ Datacore plugin required
+      </div>
+      <div className="callout-content mt-2">
+        <p>
+          The Datacore plugin is required for Discourse Graphs to function.
+          Please install and enable it.
+        </p>
+        <a
+          href="obsidian://show-plugin?id=datacore"
+          className="text-accent mt-2 inline-block underline"
+        >
+          Install Datacore
+        </a>
+      </div>
+    </div>
+  );
+};

--- a/apps/obsidian/src/components/DatacoreCallout.tsx
+++ b/apps/obsidian/src/components/DatacoreCallout.tsx
@@ -1,4 +1,3 @@
-import { useState, useEffect, useCallback } from "react";
 import { useApp } from "./AppContext";
 import { AppWithPlugins } from "~/services/QueryEngine";
 

--- a/apps/obsidian/src/components/Settings.tsx
+++ b/apps/obsidian/src/components/Settings.tsx
@@ -9,6 +9,7 @@ import NodeTypeSettings from "./NodeTypeSettings";
 import GeneralSettings from "./GeneralSettings";
 import { AdminPanelSettings } from "./AdminPanelSettings";
 import { PluginProvider } from "./PluginContext";
+import { DatacoreCallout } from "./DatacoreCallout";
 
 const Settings = () => {
   const [activeTab, setActiveTab] = useState("general");
@@ -29,6 +30,7 @@ const Settings = () => {
 
   return (
     <div className="flex flex-col gap-4">
+      <DatacoreCallout />
       <div className="border-modifier-border flex w-full overflow-x-auto border-b p-2">
         <button
           onClick={() => setActiveTab("general")}

--- a/apps/obsidian/src/services/QueryEngine.ts
+++ b/apps/obsidian/src/services/QueryEngine.ts
@@ -6,7 +6,7 @@ import { extractContentFromTitle } from "~/utils/extractContentFromTitle";
 
 // This is a workaround to get the datacore API.
 // TODO: Remove once we can use datacore npm package
-type AppWithPlugins = App & {
+export type AppWithPlugins = App & {
   plugins: {
     plugins: {
       [key: string]: {


### PR DESCRIPTION
## Summary
- Adds a warning callout banner at the top of the Discourse Graphs plugin settings when Datacore is not installed/enabled
- Includes a link to install Datacore directly from the callout (`obsidian://show-plugin?id=datacore`)
- Exports `AppWithPlugins` type from `QueryEngine.ts` for reuse

## Test plan

https://www.loom.com/share/e993c36c02ef47dcbd98b4dbaff23eae

- [x] Open Obsidian without Datacore installed — verify warning callout appears at top of DG settings
- [x] Click "Install Datacore" link — verify it opens the Datacore plugin page
- [x] Install/enable Datacore, reopen settings — verify callout disappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/912" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
