### PR TITLE
ENG-1574: Add dual-read console logs to setting setters

### DIFF
--- a/apps/roam/src/components/settings/utils/accessors.ts
+++ b/apps/roam/src/components/settings/utils/accessors.ts
@@ -777,6 +777,18 @@ export const setFeatureFlag = (
 ): void => {
   const validatedValue = z.boolean().parse(value);
 
+  const legacyReader = FEATURE_FLAG_LEGACY_MAP[key];
+  const legacyValue = legacyReader ? legacyReader() : undefined;
+  const currentBlockProps = getFeatureFlags()[key];
+  const match = currentBlockProps === legacyValue;
+  console.groupCollapsed(
+    `[DG Dual-Read] Set Feature Flag > ${key} — ${match ? "Settings match" : "Settings don't match"}`,
+  );
+  console.log("Legacy:", legacyValue);
+  console.log("Block props:", currentBlockProps);
+  console.log("New value:", validatedValue);
+  console.groupEnd();
+
   setBlockPropBasedSettings({
     keys: [TOP_LEVEL_BLOCK_PROP_KEYS.featureFlags, key],
     value: validatedValue,
@@ -831,6 +843,18 @@ export const setGlobalSetting = (keys: string[], value: json): void => {
   ) {
     return;
   }
+
+  const currentBlockProps = readPathValue(getGlobalSettings(), keys);
+  const legacyValue = getLegacyGlobalSetting(keys);
+  const match =
+    JSON.stringify(currentBlockProps) === JSON.stringify(legacyValue);
+  console.groupCollapsed(
+    `[DG Dual-Read] Set Global > ${formatSettingPath(keys)} — ${match ? "Settings match" : "Settings don't match"}`,
+  );
+  console.log("Legacy:", legacyValue);
+  console.log("Block props:", currentBlockProps);
+  console.log("New value:", value);
+  console.groupEnd();
 
   setBlockPropBasedSettings({
     keys: [TOP_LEVEL_BLOCK_PROP_KEYS.global, ...keys],
@@ -905,6 +929,18 @@ export const setPersonalSetting = (keys: string[], value: json): void => {
   ) {
     return;
   }
+
+  const currentBlockProps = readPathValue(getPersonalSettings(), keys);
+  const legacyValue = getLegacyPersonalSetting(keys);
+  const match =
+    JSON.stringify(currentBlockProps) === JSON.stringify(legacyValue);
+  console.groupCollapsed(
+    `[DG Dual-Read] Set Personal > ${formatSettingPath(keys)} — ${match ? "Settings match" : "Settings don't match"}`,
+  );
+  console.log("Legacy:", legacyValue);
+  console.log("Block props:", currentBlockProps);
+  console.log("New value:", value);
+  console.groupEnd();
 
   setBlockPropBasedSettings({
     keys: [personalKey, ...keys],
@@ -1012,6 +1048,21 @@ export const setDiscourseNodeSetting = (
     });
     return;
   }
+
+  const currentSettings = getDiscourseNodeSettings(nodeType);
+  const currentBlockPropsValue = currentSettings
+    ? readPathValue(currentSettings, keys)
+    : undefined;
+  const legacyValue = getLegacyDiscourseNodeSetting(nodeType, keys);
+  const match =
+    JSON.stringify(currentBlockPropsValue) === JSON.stringify(legacyValue);
+  console.groupCollapsed(
+    `[DG Dual-Read] Set Discourse Node (${nodeType}) > ${formatSettingPath(keys)} — ${match ? "Settings match" : "Settings don't match"}`,
+  );
+  console.log("Legacy:", legacyValue);
+  console.log("Block props:", currentBlockPropsValue);
+  console.log("New value:", value);
+  console.groupEnd();
 
   setBlockPropAtPath(pageUid, keys, value);
 };

--- a/apps/roam/src/components/settings/utils/accessors.ts
+++ b/apps/roam/src/components/settings/utils/accessors.ts
@@ -802,18 +802,6 @@ export const setFeatureFlag = (
 ): void => {
   const validatedValue = z.boolean().parse(value);
 
-  const legacyReader = FEATURE_FLAG_LEGACY_MAP[key];
-  const legacyValue = legacyReader ? legacyReader() : undefined;
-  const currentBlockProps = getFeatureFlags()[key];
-  const match = currentBlockProps === legacyValue;
-  console.groupCollapsed(
-    `[DG Dual-Read] Set Feature Flag > ${key} — ${match ? "Settings match" : "Settings don't match"}`,
-  );
-  console.log("Legacy:", legacyValue);
-  console.log("Block props:", currentBlockProps);
-  console.log("New value:", validatedValue);
-  console.groupEnd();
-
   setBlockPropBasedSettings({
     keys: [TOP_LEVEL_BLOCK_PROP_KEYS.featureFlags, key],
     value: validatedValue,
@@ -868,18 +856,6 @@ export const setGlobalSetting = (keys: string[], value: json): void => {
   ) {
     return;
   }
-
-  const currentBlockProps = readPathValue(getGlobalSettings(), keys);
-  const legacyValue = getLegacyGlobalSetting(keys);
-  const match =
-    JSON.stringify(currentBlockProps) === JSON.stringify(legacyValue);
-  console.groupCollapsed(
-    `[DG Dual-Read] Set Global > ${formatSettingPath(keys)} — ${match ? "Settings match" : "Settings don't match"}`,
-  );
-  console.log("Legacy:", legacyValue);
-  console.log("Block props:", currentBlockProps);
-  console.log("New value:", value);
-  console.groupEnd();
 
   setBlockPropBasedSettings({
     keys: [TOP_LEVEL_BLOCK_PROP_KEYS.global, ...keys],
@@ -954,18 +930,6 @@ export const setPersonalSetting = (keys: string[], value: json): void => {
   ) {
     return;
   }
-
-  const currentBlockProps = readPathValue(getPersonalSettings(), keys);
-  const legacyValue = getLegacyPersonalSetting(keys);
-  const match =
-    JSON.stringify(currentBlockProps) === JSON.stringify(legacyValue);
-  console.groupCollapsed(
-    `[DG Dual-Read] Set Personal > ${formatSettingPath(keys)} — ${match ? "Settings match" : "Settings don't match"}`,
-  );
-  console.log("Legacy:", legacyValue);
-  console.log("Block props:", currentBlockProps);
-  console.log("New value:", value);
-  console.groupEnd();
 
   setBlockPropBasedSettings({
     keys: [personalKey, ...keys],
@@ -1077,21 +1041,6 @@ export const setDiscourseNodeSetting = (
     });
     return;
   }
-
-  const currentSettings = getDiscourseNodeSettings(nodeType);
-  const currentBlockPropsValue = currentSettings
-    ? readPathValue(currentSettings, keys)
-    : undefined;
-  const legacyValue = getLegacyDiscourseNodeSetting(nodeType, keys);
-  const match =
-    JSON.stringify(currentBlockPropsValue) === JSON.stringify(legacyValue);
-  console.groupCollapsed(
-    `[DG Dual-Read] Set Discourse Node (${nodeType}) > ${formatSettingPath(keys)} — ${match ? "Settings match" : "Settings don't match"}`,
-  );
-  console.log("Legacy:", legacyValue);
-  console.log("Block props:", currentBlockPropsValue);
-  console.log("New value:", value);
-  console.groupEnd();
 
   setBlockPropAtPath(pageUid, keys, value);
 };

--- a/apps/roam/src/components/settings/utils/accessors.ts
+++ b/apps/roam/src/components/settings/utils/accessors.ts
@@ -45,7 +45,7 @@ import { PERSONAL_KEYS, QUERY_KEYS, GLOBAL_KEYS } from "./settingKeys";
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
-const deepEqual = (a: unknown, b: unknown): boolean => {
+export const deepEqual = (a: unknown, b: unknown): boolean => {
   if (a === b) return true;
   const isEmpty = (v: unknown) =>
     v === undefined || v === null || v === "" || v === false;

--- a/apps/roam/src/components/settings/utils/init.ts
+++ b/apps/roam/src/components/settings/utils/init.ts
@@ -10,6 +10,7 @@ import DEFAULT_RELATIONS_BLOCK_PROPS from "~/components/settings/data/defaultRel
 import {
   getAllDiscourseNodes,
   isNewSettingsStoreEnabled,
+  deepEqual,
   getFeatureFlags,
   getGlobalSettings,
   getPersonalSettings,
@@ -340,17 +341,15 @@ const logDualReadComparison = (): void => {
 
   const legacyFlags = readAllLegacyFeatureFlags();
   const blockFlags = getFeatureFlags();
-  const flagsMatch = JSON.stringify(blockFlags) === JSON.stringify(legacyFlags);
+  const flagsMatch = deepEqual(blockFlags, legacyFlags);
 
   const legacyGlobal = readAllLegacyGlobalSettings();
   const blockGlobal = getGlobalSettings();
-  const globalMatch =
-    JSON.stringify(blockGlobal) === JSON.stringify(legacyGlobal);
+  const globalMatch = deepEqual(blockGlobal, legacyGlobal);
 
   const legacyPersonal = readAllLegacyPersonalSettings();
   const blockPersonal = getPersonalSettings();
-  const personalMatch =
-    JSON.stringify(blockPersonal) === JSON.stringify(legacyPersonal);
+  const personalMatch = deepEqual(blockPersonal, legacyPersonal);
 
   const nodes = getAllDiscourseNodes();
   const nodeResults: {
@@ -364,7 +363,7 @@ const logDualReadComparison = (): void => {
     const blockProps = getDiscourseNodeSettings(node.type);
     nodeResults.push({
       name: node.text,
-      match: JSON.stringify(blockProps) === JSON.stringify(legacy),
+      match: deepEqual(blockProps, legacy),
       legacy,
       blockProps,
     });

--- a/apps/roam/src/components/settings/utils/init.ts
+++ b/apps/roam/src/components/settings/utils/init.ts
@@ -341,7 +341,16 @@ const logDualReadComparison = (): void => {
 
   const legacyFlags = readAllLegacyFeatureFlags();
   const blockFlags = getFeatureFlags();
-  const flagsMatch = deepEqual(blockFlags, legacyFlags);
+  const omitStoreFlag = (
+    flags: Record<string, unknown>,
+  ): Record<string, unknown> =>
+    Object.fromEntries(
+      Object.entries(flags).filter(([k]) => k !== "Use new settings store"),
+    );
+  const flagsMatch = deepEqual(
+    omitStoreFlag(blockFlags),
+    omitStoreFlag(legacyFlags),
+  );
 
   const legacyGlobal = readAllLegacyGlobalSettings();
   const blockGlobal = getGlobalSettings();
@@ -374,7 +383,7 @@ const logDualReadComparison = (): void => {
     !globalMatch && "Global",
     !personalMatch && "Personal",
     ...nodeResults.filter((n) => !n.match).map((n) => n.name),
-  ].filter(Boolean) as string[];
+  ].filter((x): x is string => Boolean(x));
 
   const summary =
     mismatches.length === 0
@@ -406,7 +415,11 @@ export const initSchema = async (): Promise<InitSchemaResult> => {
   await migrateGraphLevel(blockUids);
   const nodePageUids = await initDiscourseNodePages();
   await migratePersonalSettings(blockUids);
-  logDualReadComparison();
+  try {
+    logDualReadComparison();
+  } catch (e) {
+    console.warn("[DG Dual-Read] Comparison failed:", e);
+  }
   (window as unknown as Record<string, unknown>).dgDualReadLog =
     logDualReadComparison;
   return { blockUids, nodePageUids };

--- a/apps/roam/src/components/settings/utils/init.ts
+++ b/apps/roam/src/components/settings/utils/init.ts
@@ -7,7 +7,18 @@ import type { json } from "~/utils/getBlockProps";
 import INITIAL_NODE_VALUES from "~/data/defaultDiscourseNodes";
 import DEFAULT_RELATION_VALUES from "~/data/defaultDiscourseRelations";
 import DEFAULT_RELATIONS_BLOCK_PROPS from "~/components/settings/data/defaultRelationsBlockProps";
-import { getAllDiscourseNodes } from "./accessors";
+import {
+  getAllDiscourseNodes,
+  isNewSettingsStoreEnabled,
+  getFeatureFlags,
+  getGlobalSettings,
+  getPersonalSettings,
+  getDiscourseNodeSettings,
+  readAllLegacyFeatureFlags,
+  readAllLegacyGlobalSettings,
+  readAllLegacyPersonalSettings,
+  readAllLegacyDiscourseNodeSettings,
+} from "./accessors";
 import {
   migrateGraphLevel,
   migratePersonalSettings,
@@ -324,10 +335,94 @@ export type InitSchemaResult = {
   nodePageUids: Record<string, string>;
 };
 
+const logDualReadComparison = (): void => {
+  if (!isNewSettingsStoreEnabled()) return;
+
+  const legacyFlags = readAllLegacyFeatureFlags();
+  const blockFlags = getFeatureFlags();
+  const flagsMatch = JSON.stringify(blockFlags) === JSON.stringify(legacyFlags);
+
+  const legacyGlobal = readAllLegacyGlobalSettings();
+  const blockGlobal = getGlobalSettings();
+  const globalMatch =
+    JSON.stringify(blockGlobal) === JSON.stringify(legacyGlobal);
+
+  const legacyPersonal = readAllLegacyPersonalSettings();
+  const blockPersonal = getPersonalSettings();
+  const personalMatch =
+    JSON.stringify(blockPersonal) === JSON.stringify(legacyPersonal);
+
+  const nodes = getAllDiscourseNodes();
+  const nodeResults: {
+    name: string;
+    match: boolean;
+    legacy: unknown;
+    blockProps: unknown;
+  }[] = [];
+  for (const node of nodes) {
+    const legacy = readAllLegacyDiscourseNodeSettings(node.type, node.text);
+    const blockProps = getDiscourseNodeSettings(node.type);
+    nodeResults.push({
+      name: node.text,
+      match: JSON.stringify(blockProps) === JSON.stringify(legacy),
+      legacy,
+      blockProps,
+    });
+  }
+
+  const mismatches = [
+    !flagsMatch && "Feature Flags",
+    !globalMatch && "Global",
+    !personalMatch && "Personal",
+    ...nodeResults.filter((n) => !n.match).map((n) => n.name),
+  ].filter(Boolean) as string[];
+
+  const summary =
+    mismatches.length === 0
+      ? "All settings match"
+      : `(${mismatches.length}) Settings don't match: ${mismatches.join(", ")}`;
+
+  const nodeLegacy: Record<string, unknown> = {};
+  const nodeBlockProps: Record<string, unknown> = {};
+  for (const node of nodeResults) {
+    nodeLegacy[node.name] = node.legacy;
+    nodeBlockProps[node.name] = node.blockProps;
+  }
+
+  console.log(`[DG Dual-Read] ${summary}`);
+  console.log("[DG Dual-Read] Legacy:", {
+    "Feature Flags": legacyFlags,
+    Global: legacyGlobal,
+    Personal: legacyPersonal,
+    ...nodeResults.reduce(
+      (acc, n) => {
+        acc[n.name] = n.legacy;
+        return acc;
+      },
+      {} as Record<string, unknown>,
+    ),
+  });
+  console.log("[DG Dual-Read] Block props:", {
+    "Feature Flags": blockFlags,
+    Global: blockGlobal,
+    Personal: blockPersonal,
+    ...nodeResults.reduce(
+      (acc, n) => {
+        acc[n.name] = n.blockProps;
+        return acc;
+      },
+      {} as Record<string, unknown>,
+    ),
+  });
+};
+
 export const initSchema = async (): Promise<InitSchemaResult> => {
   const blockUids = await initSettingsPageBlocks();
   await migrateGraphLevel(blockUids);
   const nodePageUids = await initDiscourseNodePages();
   await migratePersonalSettings(blockUids);
+  logDualReadComparison();
+  (window as unknown as Record<string, unknown>).dgDualReadLog =
+    logDualReadComparison;
   return { blockUids, nodePageUids };
 };

--- a/apps/roam/src/components/settings/utils/init.ts
+++ b/apps/roam/src/components/settings/utils/init.ts
@@ -389,6 +389,7 @@ const logDualReadComparison = (): void => {
     nodeBlockProps[node.name] = node.blockProps;
   }
 
+  /* eslint-disable @typescript-eslint/naming-convention */
   console.log(`[DG Dual-Read] ${summary}`);
   console.log("[DG Dual-Read] Legacy:", {
     "Feature Flags": legacyFlags,
@@ -414,6 +415,7 @@ const logDualReadComparison = (): void => {
       {} as Record<string, unknown>,
     ),
   });
+  /* eslint-enable @typescript-eslint/naming-convention */
 };
 
 export const initSchema = async (): Promise<InitSchemaResult> => {

--- a/apps/roam/src/components/settings/utils/init.ts
+++ b/apps/roam/src/components/settings/utils/init.ts
@@ -381,12 +381,8 @@ const logDualReadComparison = (): void => {
       ? "All settings match"
       : `(${mismatches.length}) Settings don't match: ${mismatches.join(", ")}`;
 
-  const nodeLegacy: Record<string, unknown> = {};
-  const nodeBlockProps: Record<string, unknown> = {};
-  for (const node of nodeResults) {
-    nodeLegacy[node.name] = node.legacy;
-    nodeBlockProps[node.name] = node.blockProps;
-  }
+  const nodeMap = (key: "legacy" | "blockProps") =>
+    Object.fromEntries(nodeResults.map((n) => [n.name, n[key]]));
 
   /* eslint-disable @typescript-eslint/naming-convention */
   console.log(`[DG Dual-Read] ${summary}`);
@@ -394,25 +390,13 @@ const logDualReadComparison = (): void => {
     "Feature Flags": legacyFlags,
     Global: legacyGlobal,
     Personal: legacyPersonal,
-    ...nodeResults.reduce(
-      (acc, n) => {
-        acc[n.name] = n.legacy;
-        return acc;
-      },
-      {} as Record<string, unknown>,
-    ),
+    ...nodeMap("legacy"),
   });
   console.log("[DG Dual-Read] Block props:", {
     "Feature Flags": blockFlags,
     Global: blockGlobal,
     Personal: blockPersonal,
-    ...nodeResults.reduce(
-      (acc, n) => {
-        acc[n.name] = n.blockProps;
-        return acc;
-      },
-      {} as Record<string, unknown>,
-    ),
+    ...nodeMap("blockProps"),
   });
   /* eslint-enable @typescript-eslint/naming-convention */
 };

--- a/apps/roam/src/utils/storedRelations.ts
+++ b/apps/roam/src/utils/storedRelations.ts
@@ -4,7 +4,7 @@
 
 import { USE_STORED_RELATIONS } from "~/data/userSettings";
 import { getSetting, setSetting } from "./extensionSettings";
-import { DISCOURSE_CONFIG_PAGE_TITLE } from "./renderNodeConfigPage";
+import { DISCOURSE_CONFIG_PAGE_TITLE } from "~/data/constants";
 
 const INSTALL_CUTOFF = Date.parse("2026-03-01T00:00:00.000Z");
 


### PR DESCRIPTION
We now print all settings on init and then can call the `window.dgDualReadLog()` whenever we want to.

<img width="1308" height="681" alt="image" src="https://github.com/user-attachments/assets/5fd7becd-d451-4802-a5ce-ff74c7142f17" />


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/914" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added diagnostic logging capabilities to verify settings consistency and identify potential configuration issues for improved troubleshooting.

* **Refactor**
  * Improved internal code organization and modularity to enhance maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->