### PR TITLE
ENG-1579: Fix plugin init performance

### DIFF
--- a/apps/roam/src/components/LeftSidebarView.tsx
+++ b/apps/roam/src/components/LeftSidebarView.tsx
@@ -52,9 +52,8 @@ import deleteBlock from "roamjs-components/writes/deleteBlock";
 import getTextByBlockUid from "roamjs-components/queries/getTextByBlockUid";
 import refreshConfigTree from "~/utils/refreshConfigTree";
 import { Dispatch, SetStateAction } from "react";
-import { SettingsDialog } from "./settings/Settings";
+import { openSettingsDialog } from "./settings/Settings";
 import { OnloadArgs } from "roamjs-components/types";
-import renderOverlay from "roamjs-components/util/renderOverlay";
 import getBasicTreeByParentUid from "roamjs-components/queries/getBasicTreeByParentUid";
 import { DISCOURSE_CONFIG_PAGE_TITLE } from "~/data/constants";
 import getPageTitleByPageUid from "roamjs-components/queries/getPageTitleByPageUid";
@@ -445,12 +444,9 @@ const FavoritesPopover = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
   }, [handleGlobalPointerDownCapture, isMenuOpen]);
 
   const renderSettingsDialog = (tabId: TabId) => {
-    renderOverlay({
-      Overlay: SettingsDialog,
-      props: {
-        onloadArgs,
-        selectedTabId: tabId,
-      },
+    openSettingsDialog({
+      onloadArgs,
+      selectedTabId: tabId,
     });
   };
 

--- a/apps/roam/src/components/settings/Settings.tsx
+++ b/apps/roam/src/components/settings/Settings.tsx
@@ -72,6 +72,7 @@ export const SettingsDialog = ({
   onClose?: () => void;
   selectedTabId?: TabId;
 }) => {
+  console.time("[DG Perf] SettingsDialog render setup");
   const extensionAPI = onloadArgs.extensionAPI;
   const grammarNode = discourseConfigRef.tree.find(
     (node) => node.text === "grammar",
@@ -87,6 +88,7 @@ export const SettingsDialog = ({
   const [showAdminPanel, setShowAdminPanel] = useState(
     window.roamAlphaAPI.graph.name === "discourse-graphs" || false,
   );
+  console.timeEnd("[DG Perf] SettingsDialog render setup");
 
   useEffect(() => {
     posthog.capture("Settings: Dialog Opened", {
@@ -282,10 +284,14 @@ export const SettingsDialog = ({
 type Props = {
   onloadArgs: OnloadArgs;
 };
-export const render = (props: Props) =>
-  renderOverlay({
+export const render = (props: Props) => {
+  console.time("[DG Perf] Settings: renderOverlay");
+  const result = renderOverlay({
     Overlay: SettingsDialog,
     props: {
       onloadArgs: props.onloadArgs,
     },
   });
+  console.timeEnd("[DG Perf] Settings: renderOverlay");
+  return result;
+};

--- a/apps/roam/src/components/settings/Settings.tsx
+++ b/apps/roam/src/components/settings/Settings.tsx
@@ -300,7 +300,9 @@ type Props = {
   selectedTabId?: TabId;
 };
 
-export const openSettingsDialog = (props: Props) => {
+export const openSettingsDialog = (
+  props: Props,
+): ReturnType<typeof renderOverlay> => {
   const openedAt = performance.now();
   return renderOverlay({
     Overlay: SettingsDialog,

--- a/apps/roam/src/components/settings/Settings.tsx
+++ b/apps/roam/src/components/settings/Settings.tsx
@@ -50,7 +50,7 @@ export const SettingsPanel = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
       <Button
         onClick={() => {
           posthog.capture("Settings: Opened from Roam Settings Panel");
-          render({
+          openSettingsDialog({
             onloadArgs,
           });
         }}
@@ -66,13 +66,14 @@ export const SettingsDialog = ({
   isOpen,
   onClose,
   selectedTabId,
+  openedAt,
 }: {
   onloadArgs: OnloadArgs;
   isOpen?: boolean;
   onClose?: () => void;
   selectedTabId?: TabId;
+  openedAt?: number;
 }) => {
-  console.time("[DG Perf] SettingsDialog render setup");
   const extensionAPI = onloadArgs.extensionAPI;
   const grammarNode = discourseConfigRef.tree.find(
     (node) => node.text === "grammar",
@@ -88,7 +89,6 @@ export const SettingsDialog = ({
   const [showAdminPanel, setShowAdminPanel] = useState(
     window.roamAlphaAPI.graph.name === "discourse-graphs" || false,
   );
-  console.timeEnd("[DG Perf] SettingsDialog render setup");
 
   useEffect(() => {
     posthog.capture("Settings: Dialog Opened", {
@@ -110,6 +110,20 @@ export const SettingsDialog = ({
     window.addEventListener("keydown", handleKeyPress);
     return () => window.removeEventListener("keydown", handleKeyPress);
   }, []);
+
+  useEffect(() => {
+    if (!isOpen || openedAt === undefined) {
+      return;
+    }
+
+    const rafId = window.requestAnimationFrame(() => {
+      console.log(
+        `[DG Perf] Settings open: ${performance.now() - openedAt} ms`,
+      );
+    });
+
+    return () => window.cancelAnimationFrame(rafId);
+  }, [isOpen, openedAt]);
   return (
     <Dialog
       isOpen={isOpen}
@@ -283,15 +297,18 @@ export const SettingsDialog = ({
 
 type Props = {
   onloadArgs: OnloadArgs;
+  selectedTabId?: TabId;
 };
-export const render = (props: Props) => {
-  console.time("[DG Perf] Settings: renderOverlay");
-  const result = renderOverlay({
+
+export const openSettingsDialog = (props: Props) => {
+  const openedAt = performance.now();
+  return renderOverlay({
     Overlay: SettingsDialog,
     props: {
-      onloadArgs: props.onloadArgs,
+      ...props,
+      openedAt,
     },
   });
-  console.timeEnd("[DG Perf] Settings: renderOverlay");
-  return result;
 };
+
+export const render = openSettingsDialog;

--- a/apps/roam/src/components/settings/utils/accessors.ts
+++ b/apps/roam/src/components/settings/utils/accessors.ts
@@ -320,18 +320,22 @@ const getTopLevelSettingsBlockUid = (key: string): string => {
   return blockUid || "";
 };
 
-export const invalidateSettingsAccessorCaches = (): void => {
-  settingsBlockUidCache.clear();
+export const invalidateSettingsValueCaches = (): void => {
   featureFlagsCache = null;
   globalSettingsCache = null;
   personalSettingsCache = null;
   newSettingsStoreCache = null;
-  legacyGlobalSettingsCache = null;
-  legacyPersonalSettingsCache = null;
-  legacyDiscourseNodeSettingsCache.clear();
   rawDiscourseNodeBlockPropsCache.clear();
   allDiscourseNodesCache = null;
   bumpConfigCacheVersion();
+};
+
+export const invalidateSettingsAccessorCaches = (): void => {
+  settingsBlockUidCache.clear();
+  legacyGlobalSettingsCache = null;
+  legacyPersonalSettingsCache = null;
+  legacyDiscourseNodeSettingsCache.clear();
+  invalidateSettingsValueCaches();
 };
 
 const buildLegacyPersonalSettings = (): Record<string, unknown> => {
@@ -725,7 +729,7 @@ const setBlockPropAtPath = (
   }, updatedProps);
 
   setBlockProps(blockUid, updatedProps, false);
-  invalidateSettingsAccessorCaches();
+  invalidateSettingsValueCaches();
 };
 
 const getBlockPropBasedSettings = ({

--- a/apps/roam/src/components/settings/utils/accessors.ts
+++ b/apps/roam/src/components/settings/utils/accessors.ts
@@ -24,6 +24,7 @@ import {
 } from "~/utils/getExportSettings";
 import { getSuggestiveModeConfigAndUids } from "~/utils/getSuggestiveModeConfigSettings";
 import { getLeftSidebarSettings } from "~/utils/getLeftSidebarSettings";
+import { bumpConfigCacheVersion } from "~/utils/configCacheVersion";
 
 import {
   DG_BLOCK_PROP_SETTINGS_PAGE_TITLE,
@@ -283,25 +284,26 @@ const getLegacyPersonalLeftSidebarSetting = (): unknown[] => {
   /* eslint-enable @typescript-eslint/naming-convention */
 };
 
-const _settingsBlockUidCache = new Map<string, string>();
-let _featureFlagsCache: FeatureFlags | null = null;
-let _globalSettingsCache: GlobalSettings | null = null;
-let _personalSettingsCache: PersonalSettings | null = null;
-let _newSettingsStoreCache: boolean | null = null;
-let _legacyGlobalSettingsCache: Record<string, unknown> | null = null;
-let _legacyPersonalSettingsCache: Record<string, unknown> | null = null;
-const _legacyDiscourseNodeSettingsCache = new Map<
+const settingsBlockUidCache = new Map<string, string>();
+let featureFlagsCache: FeatureFlags | null = null;
+let globalSettingsCache: GlobalSettings | null = null;
+let personalSettingsCache: PersonalSettings | null = null;
+let newSettingsStoreCache: boolean | null = null;
+// TODO(ENG-1471): Remove legacy dual-read caches once the legacy settings path is deleted.
+let legacyGlobalSettingsCache: Record<string, unknown> | null = null;
+let legacyPersonalSettingsCache: Record<string, unknown> | null = null;
+const legacyDiscourseNodeSettingsCache = new Map<
   string,
   Record<string, unknown> | undefined
 >();
-const _rawDiscourseNodeBlockPropsCache = new Map<
+const rawDiscourseNodeBlockPropsCache = new Map<
   string,
   Record<string, json> | undefined
 >();
-let _allDiscourseNodesCache: DiscourseNode[] | null = null;
+let allDiscourseNodesCache: DiscourseNode[] | null = null;
 
 const getTopLevelSettingsBlockUid = (key: string): string => {
-  const cachedUid = _settingsBlockUidCache.get(key);
+  const cachedUid = settingsBlockUidCache.get(key);
   if (cachedUid) {
     return cachedUid;
   }
@@ -312,23 +314,24 @@ const getTopLevelSettingsBlockUid = (key: string): string => {
   });
 
   if (blockUid) {
-    _settingsBlockUidCache.set(key, blockUid);
+    settingsBlockUidCache.set(key, blockUid);
   }
 
   return blockUid || "";
 };
 
 export const invalidateSettingsAccessorCaches = (): void => {
-  _settingsBlockUidCache.clear();
-  _featureFlagsCache = null;
-  _globalSettingsCache = null;
-  _personalSettingsCache = null;
-  _newSettingsStoreCache = null;
-  _legacyGlobalSettingsCache = null;
-  _legacyPersonalSettingsCache = null;
-  _legacyDiscourseNodeSettingsCache.clear();
-  _rawDiscourseNodeBlockPropsCache.clear();
-  _allDiscourseNodesCache = null;
+  settingsBlockUidCache.clear();
+  featureFlagsCache = null;
+  globalSettingsCache = null;
+  personalSettingsCache = null;
+  newSettingsStoreCache = null;
+  legacyGlobalSettingsCache = null;
+  legacyPersonalSettingsCache = null;
+  legacyDiscourseNodeSettingsCache.clear();
+  rawDiscourseNodeBlockPropsCache.clear();
+  allDiscourseNodesCache = null;
+  bumpConfigCacheVersion();
 };
 
 const buildLegacyPersonalSettings = (): Record<string, unknown> => {
@@ -361,11 +364,11 @@ const buildLegacyPersonalSettings = (): Record<string, unknown> => {
 const getLegacyPersonalSetting = (keys: string[]): unknown => {
   if (keys.length === 0) return undefined;
 
-  if (!_legacyPersonalSettingsCache) {
-    _legacyPersonalSettingsCache = buildLegacyPersonalSettings();
+  if (!legacyPersonalSettingsCache) {
+    legacyPersonalSettingsCache = buildLegacyPersonalSettings();
   }
 
-  return readPathValue(_legacyPersonalSettingsCache, keys);
+  return readPathValue(legacyPersonalSettingsCache, keys);
 };
 
 const getLegacyRelationsSetting = (): Record<string, unknown> => {
@@ -440,6 +443,7 @@ const buildLegacyGlobalSettings = (): Record<string, unknown> => {
   const exp = getExportSettingsAndUids();
   const sm = getSuggestiveModeConfigAndUids(tree);
 
+  /* eslint-disable @typescript-eslint/naming-convention */
   return {
     [GLOBAL_KEYS.trigger]:
       getUidAndStringSetting({ tree, text: "trigger" }).value ||
@@ -497,17 +501,18 @@ const buildLegacyGlobalSettings = (): Record<string, unknown> => {
     },
     [GLOBAL_KEYS.relations]: getLegacyRelationsSetting(),
   };
+  /* eslint-enable @typescript-eslint/naming-convention */
 };
 
 // Reconstructs global settings from legacy Roam tree to match block-props schema shape
 const getLegacyGlobalSetting = (keys: string[]): unknown => {
   if (keys.length === 0) return undefined;
 
-  if (!_legacyGlobalSettingsCache) {
-    _legacyGlobalSettingsCache = buildLegacyGlobalSettings();
+  if (!legacyGlobalSettingsCache) {
+    legacyGlobalSettingsCache = buildLegacyGlobalSettings();
   }
 
-  return readPathValue(_legacyGlobalSettingsCache, keys);
+  return readPathValue(legacyGlobalSettingsCache, keys);
 };
 
 const getLegacyQuerySettingByParentUid = (parentUid: string) => {
@@ -629,20 +634,20 @@ const getLegacyDiscourseNodeSetting = (
   nodeType: string,
   keys: string[],
 ): unknown => {
-  if (!_legacyDiscourseNodeSettingsCache.has(nodeType)) {
+  if (!legacyDiscourseNodeSettingsCache.has(nodeType)) {
     const legacySettings = buildLegacyDiscourseNodeSettings(nodeType);
-    _legacyDiscourseNodeSettingsCache.set(nodeType, legacySettings);
+    legacyDiscourseNodeSettingsCache.set(nodeType, legacySettings);
 
     const resolvedNodeType =
       legacySettings && typeof legacySettings.type === "string"
         ? legacySettings.type
         : undefined;
     if (resolvedNodeType && resolvedNodeType !== nodeType) {
-      _legacyDiscourseNodeSettingsCache.set(resolvedNodeType, legacySettings);
+      legacyDiscourseNodeSettingsCache.set(resolvedNodeType, legacySettings);
     }
   }
 
-  const legacySettings = _legacyDiscourseNodeSettingsCache.get(nodeType);
+  const legacySettings = legacyDiscourseNodeSettingsCache.get(nodeType);
   if (!legacySettings) return undefined;
 
   return keys.length === 0
@@ -776,16 +781,16 @@ const setBlockPropBasedSettings = ({
 };
 
 export const getFeatureFlags = (): FeatureFlags => {
-  if (_featureFlagsCache) {
-    return _featureFlagsCache;
+  if (featureFlagsCache) {
+    return featureFlagsCache;
   }
 
   const { blockProps } = getBlockPropBasedSettings({
     keys: [TOP_LEVEL_BLOCK_PROP_KEYS.featureFlags],
   });
 
-  _featureFlagsCache = FeatureFlagsSchema.parse(blockProps || {});
-  return _featureFlagsCache;
+  featureFlagsCache = FeatureFlagsSchema.parse(blockProps || {});
+  return featureFlagsCache;
 };
 
 /* eslint-disable @typescript-eslint/naming-convention */
@@ -831,13 +836,9 @@ export const getFeatureFlag = (key: keyof FeatureFlags): boolean => {
 };
 
 export const isNewSettingsStoreEnabled = (): boolean => {
-  if (_newSettingsStoreCache !== null) return _newSettingsStoreCache;
-  _newSettingsStoreCache = getFeatureFlag("Use new settings store");
-  return _newSettingsStoreCache;
-};
-
-export const invalidateNewSettingsStoreCache = (): void => {
-  invalidateSettingsAccessorCaches();
+  if (newSettingsStoreCache !== null) return newSettingsStoreCache;
+  newSettingsStoreCache = getFeatureFlag("Use new settings store");
+  return newSettingsStoreCache;
 };
 
 export const readAllLegacyFeatureFlags = (): Partial<FeatureFlags> => {
@@ -884,23 +885,19 @@ export const setFeatureFlag = (
     keys: [TOP_LEVEL_BLOCK_PROP_KEYS.featureFlags, key],
     value: validatedValue,
   });
-
-  if (key === "Use new settings store") {
-    invalidateNewSettingsStoreCache();
-  }
 };
 
 export const getGlobalSettings = (): GlobalSettings => {
-  if (_globalSettingsCache) {
-    return _globalSettingsCache;
+  if (globalSettingsCache) {
+    return globalSettingsCache;
   }
 
   const { blockProps } = getBlockPropBasedSettings({
     keys: [TOP_LEVEL_BLOCK_PROP_KEYS.global],
   });
 
-  _globalSettingsCache = GlobalSettingsSchema.parse(blockProps || {});
-  return _globalSettingsCache;
+  globalSettingsCache = GlobalSettingsSchema.parse(blockProps || {});
+  return globalSettingsCache;
 };
 
 export const getGlobalSetting = <T = unknown>(
@@ -966,8 +963,8 @@ export const getAllRelations = (): DiscourseRelation[] => {
 };
 
 export const getPersonalSettings = (): PersonalSettings => {
-  if (_personalSettingsCache) {
-    return _personalSettingsCache;
+  if (personalSettingsCache) {
+    return personalSettingsCache;
   }
 
   const personalKey = getPersonalSettingsKey();
@@ -976,8 +973,8 @@ export const getPersonalSettings = (): PersonalSettings => {
     keys: [personalKey],
   });
 
-  _personalSettingsCache = PersonalSettingsSchema.parse(blockProps || {});
-  return _personalSettingsCache;
+  personalSettingsCache = PersonalSettingsSchema.parse(blockProps || {});
+  return personalSettingsCache;
 };
 
 export const getPersonalSetting = <T = unknown>(
@@ -1032,8 +1029,8 @@ export const setPersonalSetting = (keys: string[], value: json): void => {
 const getRawDiscourseNodeBlockProps = (
   nodeType: string,
 ): Record<string, json> | undefined => {
-  if (_rawDiscourseNodeBlockPropsCache.has(nodeType)) {
-    return _rawDiscourseNodeBlockPropsCache.get(nodeType);
+  if (rawDiscourseNodeBlockPropsCache.has(nodeType)) {
+    return rawDiscourseNodeBlockPropsCache.get(nodeType);
   }
 
   let pageUid = nodeType;
@@ -1054,9 +1051,9 @@ const getRawDiscourseNodeBlockProps = (
       ? (blockProps as Record<string, json>)
       : undefined;
 
-  _rawDiscourseNodeBlockPropsCache.set(nodeType, result);
+  rawDiscourseNodeBlockPropsCache.set(nodeType, result);
   if (pageUid !== nodeType) {
-    _rawDiscourseNodeBlockPropsCache.set(pageUid, result);
+    rawDiscourseNodeBlockPropsCache.set(pageUid, result);
   }
 
   return result;
@@ -1256,8 +1253,8 @@ const migrateNodeBlockProps = (
 };
 
 export const getAllDiscourseNodes = (): DiscourseNode[] => {
-  if (_allDiscourseNodesCache) {
-    return _allDiscourseNodesCache;
+  if (allDiscourseNodesCache) {
+    return allDiscourseNodesCache;
   }
 
   const results = window.roamAlphaAPI.data.fast.q(`
@@ -1319,6 +1316,6 @@ export const getAllDiscourseNodes = (): DiscourseNode[] => {
     }
   }
 
-  _allDiscourseNodesCache = nodes;
+  allDiscourseNodesCache = nodes;
   return nodes;
 };

--- a/apps/roam/src/components/settings/utils/accessors.ts
+++ b/apps/roam/src/components/settings/utils/accessors.ts
@@ -155,6 +155,31 @@ const readPathValue = (root: unknown, keys: string[]): unknown =>
     return current[key];
   }, root);
 
+const setPathValue = (
+  root: Record<string, unknown>,
+  keys: string[],
+  value: unknown,
+): void => {
+  if (keys.length === 0) return;
+
+  let current: Record<string, unknown> = root;
+  const lastIndex = keys.length - 1;
+
+  keys.forEach((key, index) => {
+    if (index === lastIndex) {
+      current[key] = value;
+      return;
+    }
+
+    const next = current[key];
+    if (!isRecord(next)) {
+      current[key] = {};
+    }
+
+    current = current[key] as Record<string, unknown>;
+  });
+};
+
 const pathKey = (keys: string[]): string => keys.join("::");
 
 const validateSettingValue = ({
@@ -258,45 +283,89 @@ const getLegacyPersonalLeftSidebarSetting = (): unknown[] => {
   /* eslint-enable @typescript-eslint/naming-convention */
 };
 
-const getLegacyPersonalSetting = (keys: string[]): unknown => {
-  if (keys.length === 0) return undefined;
+const _settingsBlockUidCache = new Map<string, string>();
+let _featureFlagsCache: FeatureFlags | null = null;
+let _globalSettingsCache: GlobalSettings | null = null;
+let _personalSettingsCache: PersonalSettings | null = null;
+let _newSettingsStoreCache: boolean | null = null;
+let _legacyGlobalSettingsCache: Record<string, unknown> | null = null;
+let _legacyPersonalSettingsCache: Record<string, unknown> | null = null;
+const _legacyDiscourseNodeSettingsCache = new Map<
+  string,
+  Record<string, unknown> | undefined
+>();
+const _rawDiscourseNodeBlockPropsCache = new Map<
+  string,
+  Record<string, json> | undefined
+>();
+let _allDiscourseNodesCache: DiscourseNode[] | null = null;
 
-  const mappedOldKey = PERSONAL_SCHEMA_PATH_TO_LEGACY_KEY.get(pathKey(keys));
-  if (mappedOldKey) {
-    return getSetting<unknown>(
-      mappedOldKey,
-      readPathValue(DEFAULT_PERSONAL_SETTINGS, keys),
+const getTopLevelSettingsBlockUid = (key: string): string => {
+  const cachedUid = _settingsBlockUidCache.get(key);
+  if (cachedUid) {
+    return cachedUid;
+  }
+
+  const blockUid = getBlockUidByTextOnPage({
+    text: key,
+    title: DG_BLOCK_PROP_SETTINGS_PAGE_TITLE,
+  });
+
+  if (blockUid) {
+    _settingsBlockUidCache.set(key, blockUid);
+  }
+
+  return blockUid || "";
+};
+
+export const invalidateSettingsAccessorCaches = (): void => {
+  _settingsBlockUidCache.clear();
+  _featureFlagsCache = null;
+  _globalSettingsCache = null;
+  _personalSettingsCache = null;
+  _newSettingsStoreCache = null;
+  _legacyGlobalSettingsCache = null;
+  _legacyPersonalSettingsCache = null;
+  _legacyDiscourseNodeSettingsCache.clear();
+  _rawDiscourseNodeBlockPropsCache.clear();
+  _allDiscourseNodesCache = null;
+};
+
+const buildLegacyPersonalSettings = (): Record<string, unknown> => {
+  const personalSettings: Record<string, unknown> = {};
+
+  for (const [
+    path,
+    legacyKey,
+  ] of PERSONAL_SCHEMA_PATH_TO_LEGACY_KEY.entries()) {
+    const keys = path.split("::");
+    setPathValue(
+      personalSettings,
+      keys,
+      getSetting<unknown>(
+        legacyKey,
+        readPathValue(DEFAULT_PERSONAL_SETTINGS, keys),
+      ),
     );
   }
 
-  if (keys.length === 1 && keys[0] === "Query") {
-    const querySettings: Record<string, unknown> = {};
-    querySettings["Hide query metadata"] = getLegacyPersonalSetting([
-      "Query",
-      "Hide query metadata",
-    ]);
-    querySettings["Default page size"] = getLegacyPersonalSetting([
-      "Query",
-      "Default page size",
-    ]);
-    querySettings["Query pages"] = getLegacyPersonalSetting([
-      "Query",
-      "Query pages",
-    ]);
-    querySettings["Default filters"] = getLegacyPersonalSetting([
-      "Query",
-      "Default filters",
-    ]);
-    return querySettings;
+  setPathValue(
+    personalSettings,
+    [PERSONAL_KEYS.leftSidebar],
+    getLegacyPersonalLeftSidebarSetting(),
+  );
+
+  return personalSettings;
+};
+
+const getLegacyPersonalSetting = (keys: string[]): unknown => {
+  if (keys.length === 0) return undefined;
+
+  if (!_legacyPersonalSettingsCache) {
+    _legacyPersonalSettingsCache = buildLegacyPersonalSettings();
   }
 
-  if (keys[0] === "Left sidebar") {
-    const leftSidebarSettings = getLegacyPersonalLeftSidebarSetting();
-    if (keys.length === 1) return leftSidebarSettings;
-    return readPathValue(leftSidebarSettings, keys.slice(1));
-  }
-
-  return undefined;
+  return readPathValue(_legacyPersonalSettingsCache, keys);
 };
 
 const getLegacyRelationsSetting = (): Record<string, unknown> => {
@@ -365,101 +434,80 @@ const getLegacyRelationsSetting = (): Record<string, unknown> => {
   );
 };
 
+const buildLegacyGlobalSettings = (): Record<string, unknown> => {
+  const tree = discourseConfigRef.tree;
+  const sidebar = getLeftSidebarSettings(tree);
+  const exp = getExportSettingsAndUids();
+  const sm = getSuggestiveModeConfigAndUids(tree);
+
+  return {
+    [GLOBAL_KEYS.trigger]:
+      getUidAndStringSetting({ tree, text: "trigger" }).value ||
+      DEFAULT_GLOBAL_SETTINGS.Trigger,
+    [GLOBAL_KEYS.canvasPageFormat]:
+      getUidAndStringSetting({ tree, text: "Canvas Page Format" }).value ||
+      DEFAULT_GLOBAL_SETTINGS["Canvas page format"],
+    [GLOBAL_KEYS.leftSidebar]: {
+      Children: sidebar.global.children.map((c) => c.text),
+      Settings: {
+        Collapsable:
+          sidebar.global.settings?.collapsable.value ??
+          DEFAULT_GLOBAL_SETTINGS["Left sidebar"].Settings.Collapsable,
+        Folded:
+          sidebar.global.settings?.folded.value ??
+          DEFAULT_GLOBAL_SETTINGS["Left sidebar"].Settings.Folded,
+      },
+    },
+    [GLOBAL_KEYS.export]: {
+      "Remove special characters":
+        exp.removeSpecialCharacters.value ??
+        DEFAULT_GLOBAL_SETTINGS.Export["Remove special characters"],
+      "Resolve block references":
+        exp.optsRefs.value ??
+        DEFAULT_GLOBAL_SETTINGS.Export["Resolve block references"],
+      "Resolve block embeds":
+        exp.optsEmbeds.value ??
+        DEFAULT_GLOBAL_SETTINGS.Export["Resolve block embeds"],
+      "Append referenced node":
+        exp.appendRefNodeContext.value ??
+        DEFAULT_GLOBAL_SETTINGS.Export["Append referenced node"],
+      "Link type":
+        exp.linkType.value || DEFAULT_GLOBAL_SETTINGS.Export["Link type"],
+      "Max filename length":
+        exp.maxFilenameLength.value ??
+        DEFAULT_GLOBAL_SETTINGS.Export["Max filename length"],
+      Frontmatter:
+        exp.frontmatter.values ?? DEFAULT_GLOBAL_SETTINGS.Export.Frontmatter,
+    },
+    [GLOBAL_KEYS.suggestiveMode]: {
+      "Include current page relations":
+        sm.includePageRelations.value ??
+        DEFAULT_GLOBAL_SETTINGS["Suggestive mode"][
+          "Include current page relations"
+        ],
+      "Include parent and child blocks":
+        sm.includeParentAndChildren.value ??
+        DEFAULT_GLOBAL_SETTINGS["Suggestive mode"][
+          "Include parent and child blocks"
+        ],
+      "Page groups": sm.pageGroups.groups.map((group) => ({
+        name: group.name,
+        pages: group.pages.map((page) => page.name),
+      })),
+    },
+    [GLOBAL_KEYS.relations]: getLegacyRelationsSetting(),
+  };
+};
+
 // Reconstructs global settings from legacy Roam tree to match block-props schema shape
 const getLegacyGlobalSetting = (keys: string[]): unknown => {
   if (keys.length === 0) return undefined;
 
-  const tree = discourseConfigRef.tree;
-  const firstKey = keys[0];
-
-  if (firstKey === "Trigger") {
-    return (
-      getUidAndStringSetting({ tree, text: "trigger" }).value ||
-      DEFAULT_GLOBAL_SETTINGS.Trigger
-    );
+  if (!_legacyGlobalSettingsCache) {
+    _legacyGlobalSettingsCache = buildLegacyGlobalSettings();
   }
 
-  if (firstKey === "Canvas page format") {
-    return (
-      getUidAndStringSetting({ tree, text: "Canvas Page Format" }).value ||
-      DEFAULT_GLOBAL_SETTINGS["Canvas page format"]
-    );
-  }
-
-  if (firstKey === "Left sidebar") {
-    const sidebar = getLeftSidebarSettings(tree);
-    const leftSidebarSettings: Record<string, unknown> = {};
-    leftSidebarSettings["Children"] = sidebar.global.children.map(
-      (c) => c.text,
-    );
-    const sidebarSettingValues: Record<string, unknown> = {};
-    sidebarSettingValues["Collapsable"] =
-      sidebar.global.settings?.collapsable.value ??
-      DEFAULT_GLOBAL_SETTINGS["Left sidebar"].Settings.Collapsable;
-    sidebarSettingValues["Folded"] =
-      sidebar.global.settings?.folded.value ??
-      DEFAULT_GLOBAL_SETTINGS["Left sidebar"].Settings.Folded;
-    leftSidebarSettings["Settings"] = sidebarSettingValues;
-    if (keys.length === 1) return leftSidebarSettings;
-    return readPathValue(leftSidebarSettings, keys.slice(1));
-  }
-
-  if (firstKey === "Export") {
-    const exp = getExportSettingsAndUids();
-    const exportSettings: Record<string, unknown> = {};
-    exportSettings["Remove special characters"] =
-      exp.removeSpecialCharacters.value ??
-      DEFAULT_GLOBAL_SETTINGS.Export["Remove special characters"];
-    exportSettings["Resolve block references"] =
-      exp.optsRefs.value ??
-      DEFAULT_GLOBAL_SETTINGS.Export["Resolve block references"];
-    exportSettings["Resolve block embeds"] =
-      exp.optsEmbeds.value ??
-      DEFAULT_GLOBAL_SETTINGS.Export["Resolve block embeds"];
-    exportSettings["Append referenced node"] =
-      exp.appendRefNodeContext.value ??
-      DEFAULT_GLOBAL_SETTINGS.Export["Append referenced node"];
-    exportSettings["Link type"] =
-      exp.linkType.value || DEFAULT_GLOBAL_SETTINGS.Export["Link type"];
-    exportSettings["Max filename length"] =
-      exp.maxFilenameLength.value ??
-      DEFAULT_GLOBAL_SETTINGS.Export["Max filename length"];
-    exportSettings["Frontmatter"] =
-      exp.frontmatter.values ?? DEFAULT_GLOBAL_SETTINGS.Export.Frontmatter;
-    if (keys.length === 1) return exportSettings;
-    return readPathValue(exportSettings, keys.slice(1));
-  }
-
-  if (firstKey === "Suggestive mode") {
-    const sm = getSuggestiveModeConfigAndUids(tree);
-    const suggestiveModeSettings: Record<string, unknown> = {};
-    suggestiveModeSettings["Include current page relations"] =
-      sm.includePageRelations.value ??
-      DEFAULT_GLOBAL_SETTINGS["Suggestive mode"][
-        "Include current page relations"
-      ];
-    suggestiveModeSettings["Include parent and child blocks"] =
-      sm.includeParentAndChildren.value ??
-      DEFAULT_GLOBAL_SETTINGS["Suggestive mode"][
-        "Include parent and child blocks"
-      ];
-    suggestiveModeSettings["Page groups"] = sm.pageGroups.groups.map(
-      (group) => ({
-        name: group.name,
-        pages: group.pages.map((page) => page.name),
-      }),
-    );
-    if (keys.length === 1) return suggestiveModeSettings;
-    return readPathValue(suggestiveModeSettings, keys.slice(1));
-  }
-
-  if (firstKey === "Relations") {
-    const relationsSettings = getLegacyRelationsSetting();
-    if (keys.length === 1) return relationsSettings;
-    return readPathValue(relationsSettings, keys.slice(1));
-  }
-
-  return undefined;
+  return readPathValue(_legacyGlobalSettingsCache, keys);
 };
 
 const getLegacyQuerySettingByParentUid = (parentUid: string) => {
@@ -488,11 +536,9 @@ const getLegacyQuerySettingByParentUid = (parentUid: string) => {
   };
 };
 
-// Reconstructs per-node settings from Roam tree structure to match block-props schema shape
-const getLegacyDiscourseNodeSetting = (
+const buildLegacyDiscourseNodeSettings = (
   nodeType: string,
-  keys: string[],
-): unknown => {
+): Record<string, unknown> | undefined => {
   let nodeUid = nodeType;
   let tree = getBasicTreeByParentUid(nodeUid);
 
@@ -575,7 +621,33 @@ const getLegacyDiscourseNodeSetting = (
     },
   };
 
-  return readPathValue(legacySettings, keys);
+  return legacySettings;
+};
+
+// Reconstructs per-node settings from Roam tree structure to match block-props schema shape
+const getLegacyDiscourseNodeSetting = (
+  nodeType: string,
+  keys: string[],
+): unknown => {
+  if (!_legacyDiscourseNodeSettingsCache.has(nodeType)) {
+    const legacySettings = buildLegacyDiscourseNodeSettings(nodeType);
+    _legacyDiscourseNodeSettingsCache.set(nodeType, legacySettings);
+
+    const resolvedNodeType =
+      legacySettings && typeof legacySettings.type === "string"
+        ? legacySettings.type
+        : undefined;
+    if (resolvedNodeType && resolvedNodeType !== nodeType) {
+      _legacyDiscourseNodeSettingsCache.set(resolvedNodeType, legacySettings);
+    }
+  }
+
+  const legacySettings = _legacyDiscourseNodeSettingsCache.get(nodeType);
+  if (!legacySettings) return undefined;
+
+  return keys.length === 0
+    ? legacySettings
+    : readPathValue(legacySettings, keys);
 };
 
 const getBlockPropsByUid = (
@@ -648,6 +720,7 @@ const setBlockPropAtPath = (
   }, updatedProps);
 
   setBlockProps(blockUid, updatedProps, false);
+  invalidateSettingsAccessorCaches();
 };
 
 const getBlockPropBasedSettings = ({
@@ -663,10 +736,7 @@ const getBlockPropBasedSettings = ({
     return { blockProps: undefined, blockUid: "" };
   }
 
-  const blockUid = getBlockUidByTextOnPage({
-    text: keys[0],
-    title: DG_BLOCK_PROP_SETTINGS_PAGE_TITLE,
-  });
+  const blockUid = getTopLevelSettingsBlockUid(keys[0]);
 
   if (!blockUid) {
     return { blockProps: undefined, blockUid: "" };
@@ -692,10 +762,7 @@ const setBlockPropBasedSettings = ({
     return;
   }
 
-  const blockUid = getBlockUidByTextOnPage({
-    text: keys[0],
-    title: DG_BLOCK_PROP_SETTINGS_PAGE_TITLE,
-  });
+  const blockUid = getTopLevelSettingsBlockUid(keys[0]);
 
   if (!blockUid) {
     internalError({
@@ -709,11 +776,16 @@ const setBlockPropBasedSettings = ({
 };
 
 export const getFeatureFlags = (): FeatureFlags => {
+  if (_featureFlagsCache) {
+    return _featureFlagsCache;
+  }
+
   const { blockProps } = getBlockPropBasedSettings({
     keys: [TOP_LEVEL_BLOCK_PROP_KEYS.featureFlags],
   });
 
-  return FeatureFlagsSchema.parse(blockProps || {});
+  _featureFlagsCache = FeatureFlagsSchema.parse(blockProps || {});
+  return _featureFlagsCache;
 };
 
 /* eslint-disable @typescript-eslint/naming-convention */
@@ -759,7 +831,13 @@ export const getFeatureFlag = (key: keyof FeatureFlags): boolean => {
 };
 
 export const isNewSettingsStoreEnabled = (): boolean => {
-  return getFeatureFlag("Use new settings store");
+  if (_newSettingsStoreCache !== null) return _newSettingsStoreCache;
+  _newSettingsStoreCache = getFeatureFlag("Use new settings store");
+  return _newSettingsStoreCache;
+};
+
+export const invalidateNewSettingsStoreCache = (): void => {
+  invalidateSettingsAccessorCaches();
 };
 
 export const readAllLegacyFeatureFlags = (): Partial<FeatureFlags> => {
@@ -806,14 +884,23 @@ export const setFeatureFlag = (
     keys: [TOP_LEVEL_BLOCK_PROP_KEYS.featureFlags, key],
     value: validatedValue,
   });
+
+  if (key === "Use new settings store") {
+    invalidateNewSettingsStoreCache();
+  }
 };
 
 export const getGlobalSettings = (): GlobalSettings => {
+  if (_globalSettingsCache) {
+    return _globalSettingsCache;
+  }
+
   const { blockProps } = getBlockPropBasedSettings({
     keys: [TOP_LEVEL_BLOCK_PROP_KEYS.global],
   });
 
-  return GlobalSettingsSchema.parse(blockProps || {});
+  _globalSettingsCache = GlobalSettingsSchema.parse(blockProps || {});
+  return _globalSettingsCache;
 };
 
 export const getGlobalSetting = <T = unknown>(
@@ -879,13 +966,18 @@ export const getAllRelations = (): DiscourseRelation[] => {
 };
 
 export const getPersonalSettings = (): PersonalSettings => {
+  if (_personalSettingsCache) {
+    return _personalSettingsCache;
+  }
+
   const personalKey = getPersonalSettingsKey();
 
   const { blockProps } = getBlockPropBasedSettings({
     keys: [personalKey],
   });
 
-  return PersonalSettingsSchema.parse(blockProps || {});
+  _personalSettingsCache = PersonalSettingsSchema.parse(blockProps || {});
+  return _personalSettingsCache;
 };
 
 export const getPersonalSetting = <T = unknown>(
@@ -940,6 +1032,10 @@ export const setPersonalSetting = (keys: string[], value: json): void => {
 const getRawDiscourseNodeBlockProps = (
   nodeType: string,
 ): Record<string, json> | undefined => {
+  if (_rawDiscourseNodeBlockPropsCache.has(nodeType)) {
+    return _rawDiscourseNodeBlockPropsCache.get(nodeType);
+  }
+
   let pageUid = nodeType;
   let blockProps = getBlockPropsByUid(pageUid, []);
 
@@ -953,9 +1049,17 @@ const getRawDiscourseNodeBlockProps = (
     }
   }
 
-  return isRecord(blockProps) && Object.keys(blockProps).length > 0
-    ? (blockProps as Record<string, json>)
-    : undefined;
+  const result =
+    isRecord(blockProps) && Object.keys(blockProps).length > 0
+      ? (blockProps as Record<string, json>)
+      : undefined;
+
+  _rawDiscourseNodeBlockPropsCache.set(nodeType, result);
+  if (pageUid !== nodeType) {
+    _rawDiscourseNodeBlockPropsCache.set(pageUid, result);
+  }
+
+  return result;
 };
 
 export const getDiscourseNodeSettings = (
@@ -1152,6 +1256,10 @@ const migrateNodeBlockProps = (
 };
 
 export const getAllDiscourseNodes = (): DiscourseNode[] => {
+  if (_allDiscourseNodesCache) {
+    return _allDiscourseNodesCache;
+  }
+
   const results = window.roamAlphaAPI.data.fast.q(`
     [:find ?uid ?title (pull ?page [:block/props])
      :where
@@ -1211,5 +1319,6 @@ export const getAllDiscourseNodes = (): DiscourseNode[] => {
     }
   }
 
+  _allDiscourseNodesCache = nodes;
   return nodes;
 };

--- a/apps/roam/src/components/settings/utils/init.ts
+++ b/apps/roam/src/components/settings/utils/init.ts
@@ -181,7 +181,6 @@ const initializeSettingsBlockProps = (
 
 const initSettingsPageBlocks = async (): Promise<Record<string, string>> => {
   const pageUid = await ensurePageExists(DG_BLOCK_PROP_SETTINGS_PAGE_TITLE);
-
   const blockMap = buildBlockMap(pageUid);
 
   const topLevelBlocks = getTopLevelBlockPropsConfig().map(({ key }) => key);
@@ -330,14 +329,9 @@ export type InitSchemaResult = {
 
 export const initSchema = async (): Promise<InitSchemaResult> => {
   const blockUids = await initSettingsPageBlocks();
-
   await migrateGraphLevel(blockUids);
-
   const nodePageUids = await initDiscourseNodePages();
-
   await migratePersonalSettings(blockUids);
-
   invalidateSettingsAccessorCaches();
-
   return { blockUids, nodePageUids };
 };

--- a/apps/roam/src/components/settings/utils/init.ts
+++ b/apps/roam/src/components/settings/utils/init.ts
@@ -180,26 +180,16 @@ const initializeSettingsBlockProps = (
 };
 
 const initSettingsPageBlocks = async (): Promise<Record<string, string>> => {
-  console.time("[DG Perf] initSchema > ensurePageExists");
   const pageUid = await ensurePageExists(DG_BLOCK_PROP_SETTINGS_PAGE_TITLE);
-  console.timeEnd("[DG Perf] initSchema > ensurePageExists");
 
-  console.time("[DG Perf] initSchema > buildBlockMap");
   const blockMap = buildBlockMap(pageUid);
-  console.timeEnd("[DG Perf] initSchema > buildBlockMap");
 
-  console.time("[DG Perf] initSchema > ensureBlocksExist");
   const topLevelBlocks = getTopLevelBlockPropsConfig().map(({ key }) => key);
   await ensureBlocksExist(pageUid, topLevelBlocks, blockMap);
-  console.timeEnd("[DG Perf] initSchema > ensureBlocksExist");
 
-  console.time("[DG Perf] initSchema > ensureLegacyConfigBlocks");
   await ensureLegacyConfigBlocks(pageUid);
-  console.timeEnd("[DG Perf] initSchema > ensureLegacyConfigBlocks");
 
-  console.time("[DG Perf] initSchema > initializeSettingsBlockProps");
   initializeSettingsBlockProps(pageUid, blockMap);
-  console.timeEnd("[DG Perf] initSchema > initializeSettingsBlockProps");
 
   return blockMap;
 };
@@ -339,21 +329,13 @@ export type InitSchemaResult = {
 };
 
 export const initSchema = async (): Promise<InitSchemaResult> => {
-  console.time("[DG Perf] initSchema > initSettingsPageBlocks");
   const blockUids = await initSettingsPageBlocks();
-  console.timeEnd("[DG Perf] initSchema > initSettingsPageBlocks");
 
-  console.time("[DG Perf] initSchema > migrateGraphLevel");
   await migrateGraphLevel(blockUids);
-  console.timeEnd("[DG Perf] initSchema > migrateGraphLevel");
 
-  console.time("[DG Perf] initSchema > initDiscourseNodePages");
   const nodePageUids = await initDiscourseNodePages();
-  console.timeEnd("[DG Perf] initSchema > initDiscourseNodePages");
 
-  console.time("[DG Perf] initSchema > migratePersonalSettings");
   await migratePersonalSettings(blockUids);
-  console.timeEnd("[DG Perf] initSchema > migratePersonalSettings");
 
   invalidateSettingsAccessorCaches();
 

--- a/apps/roam/src/components/settings/utils/init.ts
+++ b/apps/roam/src/components/settings/utils/init.ts
@@ -7,7 +7,10 @@ import type { json } from "~/utils/getBlockProps";
 import INITIAL_NODE_VALUES from "~/data/defaultDiscourseNodes";
 import DEFAULT_RELATION_VALUES from "~/data/defaultDiscourseRelations";
 import DEFAULT_RELATIONS_BLOCK_PROPS from "~/components/settings/data/defaultRelationsBlockProps";
-import { getAllDiscourseNodes } from "./accessors";
+import {
+  getAllDiscourseNodes,
+  invalidateSettingsAccessorCaches,
+} from "./accessors";
 import {
   migrateGraphLevel,
   migratePersonalSettings,
@@ -177,15 +180,26 @@ const initializeSettingsBlockProps = (
 };
 
 const initSettingsPageBlocks = async (): Promise<Record<string, string>> => {
+  console.time("[DG Perf] initSchema > ensurePageExists");
   const pageUid = await ensurePageExists(DG_BLOCK_PROP_SETTINGS_PAGE_TITLE);
-  const blockMap = buildBlockMap(pageUid);
+  console.timeEnd("[DG Perf] initSchema > ensurePageExists");
 
+  console.time("[DG Perf] initSchema > buildBlockMap");
+  const blockMap = buildBlockMap(pageUid);
+  console.timeEnd("[DG Perf] initSchema > buildBlockMap");
+
+  console.time("[DG Perf] initSchema > ensureBlocksExist");
   const topLevelBlocks = getTopLevelBlockPropsConfig().map(({ key }) => key);
   await ensureBlocksExist(pageUid, topLevelBlocks, blockMap);
+  console.timeEnd("[DG Perf] initSchema > ensureBlocksExist");
 
+  console.time("[DG Perf] initSchema > ensureLegacyConfigBlocks");
   await ensureLegacyConfigBlocks(pageUid);
+  console.timeEnd("[DG Perf] initSchema > ensureLegacyConfigBlocks");
 
+  console.time("[DG Perf] initSchema > initializeSettingsBlockProps");
   initializeSettingsBlockProps(pageUid, blockMap);
+  console.timeEnd("[DG Perf] initSchema > initializeSettingsBlockProps");
 
   return blockMap;
 };
@@ -325,9 +339,23 @@ export type InitSchemaResult = {
 };
 
 export const initSchema = async (): Promise<InitSchemaResult> => {
+  console.time("[DG Perf] initSchema > initSettingsPageBlocks");
   const blockUids = await initSettingsPageBlocks();
+  console.timeEnd("[DG Perf] initSchema > initSettingsPageBlocks");
+
+  console.time("[DG Perf] initSchema > migrateGraphLevel");
   await migrateGraphLevel(blockUids);
+  console.timeEnd("[DG Perf] initSchema > migrateGraphLevel");
+
+  console.time("[DG Perf] initSchema > initDiscourseNodePages");
   const nodePageUids = await initDiscourseNodePages();
+  console.timeEnd("[DG Perf] initSchema > initDiscourseNodePages");
+
+  console.time("[DG Perf] initSchema > migratePersonalSettings");
   await migratePersonalSettings(blockUids);
+  console.timeEnd("[DG Perf] initSchema > migratePersonalSettings");
+
+  invalidateSettingsAccessorCaches();
+
   return { blockUids, nodePageUids };
 };

--- a/apps/roam/src/components/settings/utils/pullWatchers.ts
+++ b/apps/roam/src/components/settings/utils/pullWatchers.ts
@@ -13,10 +13,7 @@ import {
   type DiscourseNodeSettings,
 } from "./zodSchema";
 import { emitSettingChange, settingKeys } from "./settingsEmitter";
-import {
-  invalidateNewSettingsStoreCache,
-  invalidateSettingsAccessorCaches,
-} from "./accessors";
+import { invalidateSettingsAccessorCaches } from "./accessors";
 
 type PullWatchCallback = Parameters<AddPullWatch>[2];
 
@@ -98,9 +95,6 @@ export const featureFlagHandlers: Partial<
   >
 > = {
   /* eslint-disable @typescript-eslint/naming-convention */
-  "Use new settings store": () => {
-    invalidateNewSettingsStoreCache();
-  },
   "Enable left sidebar": (newValue, oldValue) => {
     emitSettingChange(settingKeys.leftSidebarFlag, newValue, oldValue);
   },

--- a/apps/roam/src/components/settings/utils/pullWatchers.ts
+++ b/apps/roam/src/components/settings/utils/pullWatchers.ts
@@ -13,6 +13,10 @@ import {
   type DiscourseNodeSettings,
 } from "./zodSchema";
 import { emitSettingChange, settingKeys } from "./settingsEmitter";
+import {
+  invalidateNewSettingsStoreCache,
+  invalidateSettingsAccessorCaches,
+} from "./accessors";
 
 type PullWatchCallback = Parameters<AddPullWatch>[2];
 
@@ -64,6 +68,8 @@ const createSettingsWatchCallback = <T>(
 
     if (!afterResult.success) return;
 
+    invalidateSettingsAccessorCaches();
+
     const oldSettings = beforeResult.success
       ? (beforeResult.data ?? null)
       : null;
@@ -92,6 +98,9 @@ export const featureFlagHandlers: Partial<
   >
 > = {
   /* eslint-disable @typescript-eslint/naming-convention */
+  "Use new settings store": () => {
+    invalidateNewSettingsStoreCache();
+  },
   "Enable left sidebar": (newValue, oldValue) => {
     emitSettingChange(settingKeys.leftSidebarFlag, newValue, oldValue);
   },

--- a/apps/roam/src/components/settings/utils/pullWatchers.ts
+++ b/apps/roam/src/components/settings/utils/pullWatchers.ts
@@ -13,7 +13,7 @@ import {
   type DiscourseNodeSettings,
 } from "./zodSchema";
 import { emitSettingChange, settingKeys } from "./settingsEmitter";
-import { invalidateSettingsAccessorCaches } from "./accessors";
+import { invalidateSettingsValueCaches } from "./accessors";
 
 type PullWatchCallback = Parameters<AddPullWatch>[2];
 
@@ -65,7 +65,7 @@ const createSettingsWatchCallback = <T>(
 
     if (!afterResult.success) return;
 
-    invalidateSettingsAccessorCaches();
+    invalidateSettingsValueCaches();
 
     const oldSettings = beforeResult.success
       ? (beforeResult.data ?? null)

--- a/apps/roam/src/index.ts
+++ b/apps/roam/src/index.ts
@@ -49,6 +49,9 @@ import { mountLeftSidebar } from "./components/LeftSidebarView";
 export const DEFAULT_CANVAS_PAGE_FORMAT = "Canvas/*";
 
 export default runExtension(async (onloadArgs) => {
+  console.time("[DG Perf] Total init");
+
+  console.time("[DG Perf] initPostHog");
   const isEncrypted = window.roamAlphaAPI.graph.isEncrypted;
   const isOffline = window.roamAlphaAPI.graph.type === "offline";
   const disallowDiagnostics = getPersonalSetting<boolean>([
@@ -57,8 +60,11 @@ export default runExtension(async (onloadArgs) => {
   if (!isEncrypted && !isOffline && !disallowDiagnostics) {
     initPostHog();
   }
+  console.timeEnd("[DG Perf] initPostHog");
 
+  console.time("[DG Perf] initFeedbackWidget");
   initFeedbackWidget();
+  console.timeEnd("[DG Perf] initFeedbackWidget");
 
   if (window?.roamjs?.loaded?.has("query-builder")) {
     renderToast({
@@ -81,21 +87,40 @@ export default runExtension(async (onloadArgs) => {
 
   initPluginTimer();
 
+  console.time("[DG Perf] initializeDiscourseNodes");
   await initializeDiscourseNodes();
+  console.timeEnd("[DG Perf] initializeDiscourseNodes");
+
+  console.time("[DG Perf] refreshConfigTree");
   refreshConfigTree();
+  console.timeEnd("[DG Perf] refreshConfigTree");
 
+  console.time("[DG Perf] addGraphViewNodeStyling");
   addGraphViewNodeStyling();
-  registerCommandPaletteCommands(onloadArgs);
-  createSettingsPanel(onloadArgs);
-  registerSmartBlock(onloadArgs);
-  setInitialQueryPages(onloadArgs);
+  console.timeEnd("[DG Perf] addGraphViewNodeStyling");
 
+  console.time("[DG Perf] registerCommandPaletteCommands");
+  registerCommandPaletteCommands(onloadArgs);
+  console.timeEnd("[DG Perf] registerCommandPaletteCommands");
+
+  console.time("[DG Perf] createSettingsPanel");
+  createSettingsPanel(onloadArgs);
+  console.timeEnd("[DG Perf] createSettingsPanel");
+
+  console.time("[DG Perf] registerSmartBlock");
+  registerSmartBlock(onloadArgs);
+  console.timeEnd("[DG Perf] registerSmartBlock");
+
+  console.time("[DG Perf] setInitialQueryPages");
+  setInitialQueryPages(onloadArgs);
+  console.timeEnd("[DG Perf] setInitialQueryPages");
+
+  console.time("[DG Perf] styles injection");
   const style = addStyle(styles);
   const discourseGraphStyle = addStyle(discourseGraphStyles);
   const settingsStyle = addStyle(settingsStyles);
   const discourseFloatingMenuStyle = addStyle(discourseFloatingMenuStyles);
 
-  // Add streamline styling only if enabled
   const isStreamlineStylingEnabled = getPersonalSetting<boolean>([
     PERSONAL_KEYS.streamlineStyling,
   ]);
@@ -104,8 +129,12 @@ export default runExtension(async (onloadArgs) => {
     streamlineStyleElement = addStyle(streamlineStyling);
     streamlineStyleElement.id = "streamline-styling";
   }
+  console.timeEnd("[DG Perf] styles injection");
 
+  console.time("[DG Perf] initObservers");
   const { observers, listeners, cleanups } = initObservers({ onloadArgs });
+  console.timeEnd("[DG Perf] initObservers");
+
   const {
     pageActionListener,
     hashChangeListener,
@@ -150,7 +179,9 @@ export default runExtension(async (onloadArgs) => {
     getDiscourseNodes: getDiscourseNodes,
   };
 
+  console.time("[DG Perf] installDiscourseFloatingMenu");
   installDiscourseFloatingMenu(onloadArgs);
+  console.timeEnd("[DG Perf] installDiscourseFloatingMenu");
 
   const leftSidebarScript = document.querySelector<HTMLScriptElement>(
     'script#roam-left-sidebar[src="https://sid597.github.io/roam-left-sidebar/js/main.js"]',
@@ -189,8 +220,15 @@ export default runExtension(async (onloadArgs) => {
     },
   );
 
+  console.time("[DG Perf] initSchema");
   const { blockUids } = await initSchema();
+  console.timeEnd("[DG Perf] initSchema");
+
+  console.time("[DG Perf] setupPullWatchOnSettingsPage");
   const cleanupPullWatchers = setupPullWatchOnSettingsPage(blockUids);
+  console.timeEnd("[DG Perf] setupPullWatchOnSettingsPage");
+
+  console.timeEnd("[DG Perf] Total init");
 
   return {
     elements: [

--- a/apps/roam/src/index.ts
+++ b/apps/roam/src/index.ts
@@ -49,9 +49,7 @@ import { mountLeftSidebar } from "./components/LeftSidebarView";
 export const DEFAULT_CANVAS_PAGE_FORMAT = "Canvas/*";
 
 export default runExtension(async (onloadArgs) => {
-  console.time("[DG Perf] Total init");
-
-  console.time("[DG Perf] initPostHog");
+  const initStartedAt = performance.now();
   const isEncrypted = window.roamAlphaAPI.graph.isEncrypted;
   const isOffline = window.roamAlphaAPI.graph.type === "offline";
   const disallowDiagnostics = getPersonalSetting<boolean>([
@@ -60,11 +58,7 @@ export default runExtension(async (onloadArgs) => {
   if (!isEncrypted && !isOffline && !disallowDiagnostics) {
     initPostHog();
   }
-  console.timeEnd("[DG Perf] initPostHog");
-
-  console.time("[DG Perf] initFeedbackWidget");
   initFeedbackWidget();
-  console.timeEnd("[DG Perf] initFeedbackWidget");
 
   if (window?.roamjs?.loaded?.has("query-builder")) {
     renderToast({
@@ -87,35 +81,20 @@ export default runExtension(async (onloadArgs) => {
 
   initPluginTimer();
 
-  console.time("[DG Perf] initializeDiscourseNodes");
   await initializeDiscourseNodes();
-  console.timeEnd("[DG Perf] initializeDiscourseNodes");
 
-  console.time("[DG Perf] refreshConfigTree");
   refreshConfigTree();
-  console.timeEnd("[DG Perf] refreshConfigTree");
 
-  console.time("[DG Perf] addGraphViewNodeStyling");
   addGraphViewNodeStyling();
-  console.timeEnd("[DG Perf] addGraphViewNodeStyling");
 
-  console.time("[DG Perf] registerCommandPaletteCommands");
   registerCommandPaletteCommands(onloadArgs);
-  console.timeEnd("[DG Perf] registerCommandPaletteCommands");
 
-  console.time("[DG Perf] createSettingsPanel");
   createSettingsPanel(onloadArgs);
-  console.timeEnd("[DG Perf] createSettingsPanel");
 
-  console.time("[DG Perf] registerSmartBlock");
   registerSmartBlock(onloadArgs);
-  console.timeEnd("[DG Perf] registerSmartBlock");
 
-  console.time("[DG Perf] setInitialQueryPages");
   setInitialQueryPages(onloadArgs);
-  console.timeEnd("[DG Perf] setInitialQueryPages");
 
-  console.time("[DG Perf] styles injection");
   const style = addStyle(styles);
   const discourseGraphStyle = addStyle(discourseGraphStyles);
   const settingsStyle = addStyle(settingsStyles);
@@ -129,11 +108,8 @@ export default runExtension(async (onloadArgs) => {
     streamlineStyleElement = addStyle(streamlineStyling);
     streamlineStyleElement.id = "streamline-styling";
   }
-  console.timeEnd("[DG Perf] styles injection");
 
-  console.time("[DG Perf] initObservers");
   const { observers, listeners, cleanups } = initObservers({ onloadArgs });
-  console.timeEnd("[DG Perf] initObservers");
 
   const {
     pageActionListener,
@@ -179,9 +155,7 @@ export default runExtension(async (onloadArgs) => {
     getDiscourseNodes: getDiscourseNodes,
   };
 
-  console.time("[DG Perf] installDiscourseFloatingMenu");
   installDiscourseFloatingMenu(onloadArgs);
-  console.timeEnd("[DG Perf] installDiscourseFloatingMenu");
 
   const leftSidebarScript = document.querySelector<HTMLScriptElement>(
     'script#roam-left-sidebar[src="https://sid597.github.io/roam-left-sidebar/js/main.js"]',
@@ -220,15 +194,11 @@ export default runExtension(async (onloadArgs) => {
     },
   );
 
-  console.time("[DG Perf] initSchema");
   const { blockUids } = await initSchema();
-  console.timeEnd("[DG Perf] initSchema");
 
-  console.time("[DG Perf] setupPullWatchOnSettingsPage");
   const cleanupPullWatchers = setupPullWatchOnSettingsPage(blockUids);
-  console.timeEnd("[DG Perf] setupPullWatchOnSettingsPage");
 
-  console.timeEnd("[DG Perf] Total init");
+  console.log(`[DG Perf] Total init: ${performance.now() - initStartedAt} ms`);
 
   return {
     elements: [

--- a/apps/roam/src/index.ts
+++ b/apps/roam/src/index.ts
@@ -58,6 +58,7 @@ export default runExtension(async (onloadArgs) => {
   if (!isEncrypted && !isOffline && !disallowDiagnostics) {
     initPostHog();
   }
+
   initFeedbackWidget();
 
   if (window?.roamjs?.loaded?.has("query-builder")) {
@@ -82,17 +83,12 @@ export default runExtension(async (onloadArgs) => {
   initPluginTimer();
 
   await initializeDiscourseNodes();
-
   refreshConfigTree();
 
   addGraphViewNodeStyling();
-
   registerCommandPaletteCommands(onloadArgs);
-
   createSettingsPanel(onloadArgs);
-
   registerSmartBlock(onloadArgs);
-
   setInitialQueryPages(onloadArgs);
 
   const style = addStyle(styles);
@@ -110,7 +106,6 @@ export default runExtension(async (onloadArgs) => {
   }
 
   const { observers, listeners, cleanups } = initObservers({ onloadArgs });
-
   const {
     pageActionListener,
     hashChangeListener,
@@ -195,9 +190,7 @@ export default runExtension(async (onloadArgs) => {
   );
 
   const { blockUids } = await initSchema();
-
   const cleanupPullWatchers = setupPullWatchOnSettingsPage(blockUids);
-
   console.log(`[DG Perf] Total init: ${performance.now() - initStartedAt} ms`);
 
   return {

--- a/apps/roam/src/utils/configCacheVersion.ts
+++ b/apps/roam/src/utils/configCacheVersion.ts
@@ -1,0 +1,9 @@
+let configCacheVersion = 0;
+
+export const getConfigCacheVersion = (): number => {
+  return configCacheVersion;
+};
+
+export const bumpConfigCacheVersion = (): void => {
+  configCacheVersion += 1;
+};

--- a/apps/roam/src/utils/findDiscourseNode.ts
+++ b/apps/roam/src/utils/findDiscourseNode.ts
@@ -6,7 +6,7 @@ const discourseNodeTypeCache: Record<string, DiscourseNode | false> = {};
 const findDiscourseNode = ({
   uid,
   title,
-  nodes = getDiscourseNodes(),
+  nodes,
 }: {
   uid: string;
   title?: string;
@@ -16,8 +16,9 @@ const findDiscourseNode = ({
     return discourseNodeTypeCache[uid];
   }
 
+  const resolvedNodes = nodes ?? getDiscourseNodes();
   const matchingNode =
-    nodes.find((node) =>
+    resolvedNodes.find((node) =>
       title === undefined
         ? matchDiscourseNode({ ...node, uid })
         : matchDiscourseNode({ ...node, title }),

--- a/apps/roam/src/utils/getDiscourseNodes.ts
+++ b/apps/roam/src/utils/getDiscourseNodes.ts
@@ -106,7 +106,18 @@ const getUidAndBooleanSetting = ({
   };
 };
 
-const getDiscourseNodes = (relations = getDiscourseRelations()) => {
+let cachedNodes: DiscourseNode[] | null = null;
+
+export const invalidateDiscourseNodesCache = () => {
+  cachedNodes = null;
+};
+
+const getDiscourseNodes = (
+  relations?: ReturnType<typeof getDiscourseRelations>,
+) => {
+  if (!relations && cachedNodes) return cachedNodes;
+
+  const resolvedRelations = relations ?? getDiscourseRelations();
   const configuredNodes = (
     isNewSettingsStoreEnabled()
       ? getAllDiscourseNodes()
@@ -158,7 +169,7 @@ const getDiscourseNodes = (relations = getDiscourseRelations()) => {
           },
         )
   ).concat(
-    relations
+    resolvedRelations
       .filter((r) => r.triples.some((t) => t.some((n) => /anchor/i.test(n))))
       .map((r) => ({
         format: "",
@@ -188,7 +199,11 @@ const getDiscourseNodes = (relations = getDiscourseRelations()) => {
   const defaultNodes = DEFAULT_NODES.filter(
     (n) => !configuredNodeTexts.has(n.text),
   );
-  return configuredNodes.concat(defaultNodes);
+  const result = configuredNodes.concat(defaultNodes);
+  if (!relations) {
+    cachedNodes = result;
+  }
+  return result;
 };
 
 export default getDiscourseNodes;

--- a/apps/roam/src/utils/getDiscourseNodes.ts
+++ b/apps/roam/src/utils/getDiscourseNodes.ts
@@ -110,11 +110,6 @@ const getUidAndBooleanSetting = ({
 let cachedNodes: DiscourseNode[] | null = null;
 let cachedNodesVersion = -1;
 
-export const invalidateDiscourseNodesCache = () => {
-  cachedNodes = null;
-  cachedNodesVersion = -1;
-};
-
 const getDiscourseNodes = (
   relations?: ReturnType<typeof getDiscourseRelations>,
 ) => {

--- a/apps/roam/src/utils/getDiscourseNodes.ts
+++ b/apps/roam/src/utils/getDiscourseNodes.ts
@@ -9,6 +9,7 @@ import getDiscourseRelations from "./getDiscourseRelations";
 import { roamNodeToCondition } from "./parseQuery";
 import { Condition } from "./types";
 import { InputTextNode, RoamBasicNode } from "roamjs-components/types";
+import { getConfigCacheVersion } from "./configCacheVersion";
 
 export const excludeDefaultNodes = (node: DiscourseNode) => {
   return node.backedBy !== "default";
@@ -107,15 +108,20 @@ const getUidAndBooleanSetting = ({
 };
 
 let cachedNodes: DiscourseNode[] | null = null;
+let cachedNodesVersion = -1;
 
 export const invalidateDiscourseNodesCache = () => {
   cachedNodes = null;
+  cachedNodesVersion = -1;
 };
 
 const getDiscourseNodes = (
   relations?: ReturnType<typeof getDiscourseRelations>,
 ) => {
-  if (!relations && cachedNodes) return cachedNodes;
+  const cacheVersion = getConfigCacheVersion();
+  if (!relations && cachedNodes && cachedNodesVersion === cacheVersion) {
+    return cachedNodes;
+  }
 
   const resolvedRelations = relations ?? getDiscourseRelations();
   const configuredNodes = (
@@ -202,6 +208,7 @@ const getDiscourseNodes = (
   const result = configuredNodes.concat(defaultNodes);
   if (!relations) {
     cachedNodes = result;
+    cachedNodesVersion = cacheVersion;
   }
   return result;
 };

--- a/apps/roam/src/utils/getDiscourseRelations.ts
+++ b/apps/roam/src/utils/getDiscourseRelations.ts
@@ -11,6 +11,7 @@ import {
   getAllRelations,
 } from "~/components/settings/utils/accessors";
 import discourseConfigRef from "./discourseConfigRef";
+import { getConfigCacheVersion } from "./configCacheVersion";
 
 export type Triple = readonly [string, string, string];
 export type DiscourseRelation = {
@@ -36,13 +37,18 @@ export const getRelationsNode = (grammarNode = getGrammarNode()) => {
 };
 
 let cachedRelations: DiscourseRelation[] | null = null;
+let cachedRelationsVersion = -1;
 
 export const invalidateDiscourseRelationsCache = () => {
   cachedRelations = null;
+  cachedRelationsVersion = -1;
 };
 
 const getDiscourseRelations = (): DiscourseRelation[] => {
-  if (cachedRelations) return cachedRelations;
+  const cacheVersion = getConfigCacheVersion();
+  if (cachedRelations && cachedRelationsVersion === cacheVersion) {
+    return cachedRelations;
+  }
 
   let result: DiscourseRelation[];
   if (isNewSettingsStoreEnabled()) {
@@ -74,6 +80,7 @@ const getDiscourseRelations = (): DiscourseRelation[] => {
   }
 
   cachedRelations = result;
+  cachedRelationsVersion = cacheVersion;
   return result;
 };
 

--- a/apps/roam/src/utils/getDiscourseRelations.ts
+++ b/apps/roam/src/utils/getDiscourseRelations.ts
@@ -35,16 +35,23 @@ export const getRelationsNode = (grammarNode = getGrammarNode()) => {
   return grammarNode?.children.find(matchNodeText("relations"));
 };
 
-const getDiscourseRelations = () => {
-  if (isNewSettingsStoreEnabled()) {
-    return getAllRelations();
-  }
+let cachedRelations: DiscourseRelation[] | null = null;
 
-  const grammarNode = getGrammarNode();
-  const relationsNode = getRelationsNode(grammarNode);
-  const relationNodes = relationsNode?.children || DEFAULT_RELATION_VALUES;
-  const discourseRelations = relationNodes.flatMap(
-    (r: InputTextNode, i: number) => {
+export const invalidateDiscourseRelationsCache = () => {
+  cachedRelations = null;
+};
+
+const getDiscourseRelations = (): DiscourseRelation[] => {
+  if (cachedRelations) return cachedRelations;
+
+  let result: DiscourseRelation[];
+  if (isNewSettingsStoreEnabled()) {
+    result = getAllRelations();
+  } else {
+    const grammarNode = getGrammarNode();
+    const relationsNode = getRelationsNode(grammarNode);
+    const relationNodes = relationsNode?.children || DEFAULT_RELATION_VALUES;
+    result = relationNodes.flatMap((r: InputTextNode, i: number) => {
       const tree = (r?.children || []) as TextNode[];
       const data = {
         id: r.uid || `${r.text}-${i}`,
@@ -63,10 +70,11 @@ const getDiscourseRelations = () => {
             return [t.text, t.children[0]?.text, target] as const;
           }),
       }));
-    },
-  );
+    });
+  }
 
-  return discourseRelations;
+  cachedRelations = result;
+  return result;
 };
 
 export default getDiscourseRelations;

--- a/apps/roam/src/utils/getDiscourseRelations.ts
+++ b/apps/roam/src/utils/getDiscourseRelations.ts
@@ -39,11 +39,6 @@ export const getRelationsNode = (grammarNode = getGrammarNode()) => {
 let cachedRelations: DiscourseRelation[] | null = null;
 let cachedRelationsVersion = -1;
 
-export const invalidateDiscourseRelationsCache = () => {
-  cachedRelations = null;
-  cachedRelationsVersion = -1;
-};
-
 const getDiscourseRelations = (): DiscourseRelation[] => {
   const cacheVersion = getConfigCacheVersion();
   if (cachedRelations && cachedRelationsVersion === cacheVersion) {

--- a/apps/roam/src/utils/initializeObserversAndListeners.ts
+++ b/apps/roam/src/utils/initializeObserversAndListeners.ts
@@ -101,6 +101,7 @@ export const initObservers = ({
   };
   cleanups: Array<() => void>;
 } => {
+  console.time("[DG Perf] observer: pageTitleObserver");
   const pageTitleObserver = createHTMLObserver({
     tag: "H1",
     className: "rm-title-display",
@@ -131,12 +132,16 @@ export const initObservers = ({
       else if (isSidebarCanvas(props)) renderTldrawCanvasInSidebar(props);
     },
   });
+  console.timeEnd("[DG Perf] observer: pageTitleObserver");
 
+  console.time("[DG Perf] observer: queryBlockObserver");
   const queryBlockObserver = createButtonObserver({
     attribute: "query-block",
     render: (b) => renderQueryBlock(b, onloadArgs),
   });
+  console.timeEnd("[DG Perf] observer: queryBlockObserver");
 
+  console.time("[DG Perf] observer: nodeTagPopupButtonObserver");
   const nodeTagPopupButtonObserver = createHTMLObserver({
     className: "rm-page-ref--tag",
     tag: "SPAN",
@@ -179,6 +184,7 @@ export const initObservers = ({
       }
     },
   });
+  console.timeEnd("[DG Perf] observer: nodeTagPopupButtonObserver");
 
   const pageActionListener = ((
     e: CustomEvent<{
@@ -201,6 +207,7 @@ export const initObservers = ({
       });
   }) as EventListener;
 
+  console.time("[DG Perf] observer: suggestiveOverlaySetup");
   const suggestiveHandler = getSuggestiveOverlayHandler(onloadArgs);
   const toggleSuggestiveOverlay = onPageRefObserverChange(suggestiveHandler);
   if (getPersonalSetting<boolean>([PERSONAL_KEYS.suggestiveModeOverlay])) {
@@ -213,7 +220,9 @@ export const initObservers = ({
       toggleSuggestiveOverlay(Boolean(newValue));
     },
   );
+  console.timeEnd("[DG Perf] observer: suggestiveOverlaySetup");
 
+  console.time("[DG Perf] observer: graphOverviewExportObserver");
   const graphOverviewExportObserver = createHTMLObserver({
     tag: "DIV",
     className: "rm-graph-view-control-panel__main-options",
@@ -222,7 +231,9 @@ export const initObservers = ({
       renderGraphOverviewExport(div);
     },
   });
+  console.timeEnd("[DG Perf] observer: graphOverviewExportObserver");
 
+  console.time("[DG Perf] observer: imageMenuObserver");
   const imageMenuObserver = createHTMLObserver({
     tag: "IMG",
     className: "rm-inline-img",
@@ -232,7 +243,9 @@ export const initObservers = ({
       }
     },
   });
+  console.timeEnd("[DG Perf] observer: imageMenuObserver");
 
+  console.time("[DG Perf] observer: pageRefObserverSetup");
   if (getPersonalSetting<boolean>([PERSONAL_KEYS.pagePreview]))
     addPageRefObserver(previewPageRefHandler);
   if (getPersonalSetting<boolean>([PERSONAL_KEYS.discourseContextOverlay])) {
@@ -240,7 +253,9 @@ export const initObservers = ({
     onPageRefObserverChange(overlayHandler)(true);
   }
   if (getPageRefObserversSize()) enablePageRefObserver();
+  console.timeEnd("[DG Perf] observer: pageRefObserverSetup");
 
+  console.time("[DG Perf] observer: listenersAndTriggerSetup");
   const configPageUid = getPageUidByPageTitle(DISCOURSE_CONFIG_PAGE_TITLE);
 
   const hashChangeListener = (e: Event) => {
@@ -285,6 +300,9 @@ export const initObservers = ({
     },
   );
 
+  console.timeEnd("[DG Perf] observer: listenersAndTriggerSetup");
+
+  console.time("[DG Perf] observer: leftSidebarObserver");
   const leftSidebarObserver = createHTMLObserver({
     tag: "DIV",
     useBody: true,
@@ -300,6 +318,7 @@ export const initObservers = ({
       })();
     },
   });
+  console.timeEnd("[DG Perf] observer: leftSidebarObserver");
 
   const handleNodeMenuRender = (target: HTMLElement, evt: KeyboardEvent) => {
     if (

--- a/apps/roam/src/utils/initializeObserversAndListeners.ts
+++ b/apps/roam/src/utils/initializeObserversAndListeners.ts
@@ -101,7 +101,6 @@ export const initObservers = ({
   };
   cleanups: Array<() => void>;
 } => {
-  console.time("[DG Perf] observer: pageTitleObserver");
   const pageTitleObserver = createHTMLObserver({
     tag: "H1",
     className: "rm-title-display",
@@ -132,16 +131,12 @@ export const initObservers = ({
       else if (isSidebarCanvas(props)) renderTldrawCanvasInSidebar(props);
     },
   });
-  console.timeEnd("[DG Perf] observer: pageTitleObserver");
 
-  console.time("[DG Perf] observer: queryBlockObserver");
   const queryBlockObserver = createButtonObserver({
     attribute: "query-block",
     render: (b) => renderQueryBlock(b, onloadArgs),
   });
-  console.timeEnd("[DG Perf] observer: queryBlockObserver");
 
-  console.time("[DG Perf] observer: nodeTagPopupButtonObserver");
   const nodeTagPopupButtonObserver = createHTMLObserver({
     className: "rm-page-ref--tag",
     tag: "SPAN",
@@ -184,7 +179,6 @@ export const initObservers = ({
       }
     },
   });
-  console.timeEnd("[DG Perf] observer: nodeTagPopupButtonObserver");
 
   const pageActionListener = ((
     e: CustomEvent<{
@@ -207,7 +201,6 @@ export const initObservers = ({
       });
   }) as EventListener;
 
-  console.time("[DG Perf] observer: suggestiveOverlaySetup");
   const suggestiveHandler = getSuggestiveOverlayHandler(onloadArgs);
   const toggleSuggestiveOverlay = onPageRefObserverChange(suggestiveHandler);
   if (getPersonalSetting<boolean>([PERSONAL_KEYS.suggestiveModeOverlay])) {
@@ -220,9 +213,7 @@ export const initObservers = ({
       toggleSuggestiveOverlay(Boolean(newValue));
     },
   );
-  console.timeEnd("[DG Perf] observer: suggestiveOverlaySetup");
 
-  console.time("[DG Perf] observer: graphOverviewExportObserver");
   const graphOverviewExportObserver = createHTMLObserver({
     tag: "DIV",
     className: "rm-graph-view-control-panel__main-options",
@@ -231,9 +222,7 @@ export const initObservers = ({
       renderGraphOverviewExport(div);
     },
   });
-  console.timeEnd("[DG Perf] observer: graphOverviewExportObserver");
 
-  console.time("[DG Perf] observer: imageMenuObserver");
   const imageMenuObserver = createHTMLObserver({
     tag: "IMG",
     className: "rm-inline-img",
@@ -243,9 +232,7 @@ export const initObservers = ({
       }
     },
   });
-  console.timeEnd("[DG Perf] observer: imageMenuObserver");
 
-  console.time("[DG Perf] observer: pageRefObserverSetup");
   if (getPersonalSetting<boolean>([PERSONAL_KEYS.pagePreview]))
     addPageRefObserver(previewPageRefHandler);
   if (getPersonalSetting<boolean>([PERSONAL_KEYS.discourseContextOverlay])) {
@@ -253,9 +240,7 @@ export const initObservers = ({
     onPageRefObserverChange(overlayHandler)(true);
   }
   if (getPageRefObserversSize()) enablePageRefObserver();
-  console.timeEnd("[DG Perf] observer: pageRefObserverSetup");
 
-  console.time("[DG Perf] observer: listenersAndTriggerSetup");
   const configPageUid = getPageUidByPageTitle(DISCOURSE_CONFIG_PAGE_TITLE);
 
   const hashChangeListener = (e: Event) => {
@@ -300,9 +285,6 @@ export const initObservers = ({
     },
   );
 
-  console.timeEnd("[DG Perf] observer: listenersAndTriggerSetup");
-
-  console.time("[DG Perf] observer: leftSidebarObserver");
   const leftSidebarObserver = createHTMLObserver({
     tag: "DIV",
     useBody: true,
@@ -318,7 +300,6 @@ export const initObservers = ({
       })();
     },
   });
-  console.timeEnd("[DG Perf] observer: leftSidebarObserver");
 
   const handleNodeMenuRender = (target: HTMLElement, evt: KeyboardEvent) => {
     if (

--- a/apps/roam/src/utils/refreshConfigTree.ts
+++ b/apps/roam/src/utils/refreshConfigTree.ts
@@ -6,6 +6,9 @@ import registerDiscourseDatalogTranslators from "./registerDiscourseDatalogTrans
 import { unregisterDatalogTranslator } from "./conditionToDatalog";
 import type { PullBlock } from "roamjs-components/types/native";
 import { DISCOURSE_CONFIG_PAGE_TITLE } from "~/data/constants";
+import { invalidateDiscourseRelationsCache } from "./getDiscourseRelations";
+import { invalidateDiscourseNodesCache } from "./getDiscourseNodes";
+import { invalidateSettingsAccessorCaches } from "~/components/settings/utils/accessors";
 
 const getPagesStartingWithPrefix = (prefix: string) =>
   (
@@ -18,6 +21,10 @@ const getPagesStartingWithPrefix = (prefix: string) =>
   }));
 
 const refreshConfigTree = () => {
+  invalidateSettingsAccessorCaches();
+  invalidateDiscourseRelationsCache();
+  invalidateDiscourseNodesCache();
+
   getDiscourseRelationLabels().forEach((key) =>
     unregisterDatalogTranslator({ key }),
   );

--- a/apps/roam/src/utils/refreshConfigTree.ts
+++ b/apps/roam/src/utils/refreshConfigTree.ts
@@ -21,13 +21,8 @@ const getPagesStartingWithPrefix = (prefix: string) =>
   }));
 
 const refreshConfigTree = () => {
-  invalidateSettingsAccessorCaches();
-  invalidateDiscourseRelationsCache();
-  invalidateDiscourseNodesCache();
+  const previousRelationLabels = getDiscourseRelationLabels();
 
-  getDiscourseRelationLabels().forEach((key) =>
-    unregisterDatalogTranslator({ key }),
-  );
   discourseConfigRef.tree = getBasicTreeByParentUid(
     getPageUidByPageTitle(DISCOURSE_CONFIG_PAGE_TITLE),
   );
@@ -43,6 +38,12 @@ const refreshConfigTree = () => {
       ];
     }),
   );
+
+  invalidateSettingsAccessorCaches();
+  invalidateDiscourseRelationsCache();
+  invalidateDiscourseNodesCache();
+
+  previousRelationLabels.forEach((key) => unregisterDatalogTranslator({ key }));
   registerDiscourseDatalogTranslators();
 };
 

--- a/apps/roam/src/utils/refreshConfigTree.ts
+++ b/apps/roam/src/utils/refreshConfigTree.ts
@@ -6,8 +6,6 @@ import registerDiscourseDatalogTranslators from "./registerDiscourseDatalogTrans
 import { unregisterDatalogTranslator } from "./conditionToDatalog";
 import type { PullBlock } from "roamjs-components/types/native";
 import { DISCOURSE_CONFIG_PAGE_TITLE } from "~/data/constants";
-import { invalidateDiscourseRelationsCache } from "./getDiscourseRelations";
-import { invalidateDiscourseNodesCache } from "./getDiscourseNodes";
 import { invalidateSettingsAccessorCaches } from "~/components/settings/utils/accessors";
 
 const getPagesStartingWithPrefix = (prefix: string) =>
@@ -40,8 +38,6 @@ const refreshConfigTree = () => {
   );
 
   invalidateSettingsAccessorCaches();
-  invalidateDiscourseRelationsCache();
-  invalidateDiscourseNodesCache();
 
   previousRelationLabels.forEach((key) => unregisterDatalogTranslator({ key }));
   registerDiscourseDatalogTranslators();


### PR DESCRIPTION
The regression was caused by repeated dual-read validation work during startup, not
  by block props themselves; we cached that path and fixed invalidation, which brought
  init from ~20s down to ~1.15s. This is the right migration-phase fix, and the long-
  term cleanup is to delete dual-read entirely.

```
[DG Perf] initPostHog: 331.548ms                                                                                                                                            
  [DG Perf] initFeedbackWidget: 0.052ms                                                                                                                                     
  [DG Perf] initializeDiscourseNodes: 0.810ms                                                                                                                                 
  [DG Perf] refreshConfigTree: 413.464ms                                                                                                                                      
  [DG Perf] addGraphViewNodeStyling: 0.242ms                                                                                                                                  
  [DG Perf] registerCommandPaletteCommands: 0.584ms                                                                                                                           
  [DG Perf] createSettingsPanel: 0.100ms                                                                                                                                      
  [DG Perf] registerSmartBlock: 0.085ms                                                                                                                                     
  [DG Perf] setInitialQueryPages: 0.263ms                                                                                                                                     
  [DG Perf] styles injection: 0.137ms                                                                                                                                         
  [DG Perf] observer: pageTitleObserver: 0.153ms                                                                                                                            
  [DG Perf] observer: queryBlockObserver: 2.748ms                                                                                                                             
  [DG Perf] observer: nodeTagPopupButtonObserver: 0.049ms                                                                                                                     
  [DG Perf] observer: suggestiveOverlaySetup: 0.037ms                                                                                                                       
  [DG Perf] observer: graphOverviewExportObserver: 0.046ms                                                                                                                    
  [DG Perf] observer: imageMenuObserver: 0.017ms                                                                                                                              
  [DG Perf] observer: pageRefObserverSetup: 0.007ms                                                                                                                         
  [DG Perf] observer: listenersAndTriggerSetup: 23.911ms                                                                                                                      
  [DG Perf] observer: leftSidebarObserver: 1.179ms                                                                                                                            
  [DG Perf] initObservers: 30.171ms                                                                                                                                         
  [DG Perf] installDiscourseFloatingMenu: 0.410ms                                                                                                                             
  [DG Perf] initSchema > ensurePageExists: 1.369ms                                                                                                                            
  [DG Perf] initSchema > buildBlockMap: 0.623ms                                                                                                                             
  [DG Perf] initSchema > ensureBlocksExist: 0.209ms                                                                                                                           
  [DG Perf] initSchema > ensureLegacyConfigBlocks: 2.327ms                                                                                                                    
  [DG Perf] initSchema > initializeSettingsBlockProps: 3.490ms                                                                                                              
  [DG Perf] initSchema > initSettingsPageBlocks: 8.196ms                                                                                                                      
  [DG BlockProps Migration] graph-level: skipped (already migrated)                                                                                                         
  [DG Perf] initSchema > migrateGraphLevel: 305.434ms                                                                                                                         
  [DG Perf] initSchema > initDiscourseNodePages: 71.149ms                                                                                                                     
  [DG BlockProps Migration] personal: skipped (already migrated)                                                                                                            
  [DG Perf] initSchema > migratePersonalSettings: 0.091ms                                                                                                                     
  [DG Perf] initSchema: 385.023ms                                                                                                                                             
  [DG Perf] setupPullWatchOnSettingsPage: 0.358ms                                                                                                                           
  [DG Perf] Total init: 1163.951ms                                
```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/915" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated settings dialog invocation from overlay-based rendering to direct function calls.
  * Introduced caching mechanisms for settings accessors, discourse nodes, relations, and configuration state with version tracking.
  * Implemented selective cache invalidation during settings updates and initialization.
  * Added performance timing tracking within the settings dialog.

* **Chores**
  * Added initialization timing metrics collection to the startup sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->