### PR TITLE
docs: add documentation for customizing node menu hotkey

### DIFF
--- a/apps/website/app/(docs)/docs/obsidian/pages/command-palette.md
+++ b/apps/website/app/(docs)/docs/obsidian/pages/command-palette.md
@@ -13,11 +13,19 @@ The Command Palette is a powerful way to access all Discourse Graph features wit
 2. Type "Discourse" to see all available commands
    ![command palette](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2F5ybScaQISO.png?alt=media&token=2b36f0e7-4247-47b7-a53d-c784dfd4609b)
 
-## Customizing Commands
+## Customizing hotkeys
 
-You can customize how commands appear in the Command Palette:
+You can set custom hotkeys for Discourse Graph commands to speed up your workflow:
 
 1. Open Obsidian Settings
 2. Go to "Hotkeys"
-3. Search for "Discourse"
-4. Modify the commands or add hotkeys
+3. Search for "Discourse" to see all available commands
+4. Click on a command and set your preferred hotkey
+
+### Useful hotkeys to configure
+
+- **Open node type menu**: Create a new discourse node or convert selected text into a node
+- **Toggle discourse context**: Show or hide the discourse context view
+- **Create discourse node**: Create a new discourse node from scratch
+
+For example, setting a hotkey for "Open node type menu" allows you to quickly create new discourse nodes without using the mouse.

--- a/apps/website/app/(docs)/docs/obsidian/pages/creating-discourse-nodes.md
+++ b/apps/website/app/(docs)/docs/obsidian/pages/creating-discourse-nodes.md
@@ -13,13 +13,13 @@ To create a discourse node, first select the text you want to turn into a node:
 
 There are two ways you can create a node:
 
-### 1. Using command keys (recommended)
+### 1. Using a hotkey (recommended)
 
-The default hotkey is `Cmd + \` (or `Ctrl + \` on Windows/Linux). You can [customize this hotkey](./command-palette#customizing-hotkeys) in Obsidian's settings under Hotkeys → "Open node type menu".
+To use this method, first [set up a hotkey](./command-palette#customizing-hotkeys) in Obsidian's settings under Hotkeys → "Open node type menu".
 
 #### 1.1 Turn selected text into discourse node
 
-1. Press `Cmd + \` (or your configured hotkey)
+1. Press your configured hotkey
 2. The node menu will open as a popup
 ![node menu](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FS6eU6y70eX.png?alt=media&token=00e61ddf-877b-4752-a65b-272e80a0a19c)
 3. Select the node type you want to turn the text into
@@ -27,7 +27,7 @@ The default hotkey is `Cmd + \` (or `Ctrl + \` on Windows/Linux). You can [custo
 ![node created](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2F1VNkJC0aH8.png?alt=media&token=df9a26aa-997b-4b56-a307-87a80e350b28)
 
 #### 1.2 Creating new node from scratch
-1. Press `Cmd + \` (or your configured hotkey) without selecting any text
+1. Press your configured hotkey without selecting any text
 2. Enter the title and node type
 ![](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FyYxtLKkx6B.png?alt=media&token=7f4f02df-d1fe-4529-8530-90acb0dc74b8)
 

--- a/apps/website/app/(docs)/docs/obsidian/pages/creating-discourse-nodes.md
+++ b/apps/website/app/(docs)/docs/obsidian/pages/creating-discourse-nodes.md
@@ -14,17 +14,20 @@ To create a discourse node, first select the text you want to turn into a node:
 There are two ways you can create a node:
 
 ### 1. Using command keys (recommended)
+
+The default hotkey is `Cmd + \` (or `Ctrl + \` on Windows/Linux). You can [customize this hotkey](./command-palette#customizing-hotkeys) in Obsidian's settings under Hotkeys → "Open node type menu".
+
 #### 1.1 Turn selected text into discourse node
 
 1. Press `Cmd + \` (or your configured hotkey)
-2. The Node Menu will open as a popup
+2. The node menu will open as a popup
 ![node menu](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FS6eU6y70eX.png?alt=media&token=00e61ddf-877b-4752-a65b-272e80a0a19c)
 3. Select the node type you want to turn the text into
 4. A new discourse node will be created
 ![node created](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2F1VNkJC0aH8.png?alt=media&token=df9a26aa-997b-4b56-a307-87a80e350b28)
 
 #### 1.2 Creating new node from scratch
-1. Press `Cmd + \` (or your configured hotkey)
+1. Press `Cmd + \` (or your configured hotkey) without selecting any text
 2. Enter the title and node type
 ![](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FyYxtLKkx6B.png?alt=media&token=7f4f02df-d1fe-4529-8530-90acb0dc74b8)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR adds documentation to help users understand that they can set a custom hotkey to open the node menu for creating new discourse nodes.

## Changes

### Command Palette Documentation (`command-palette.md`)
- Renamed "Customizing Commands" section to "Customizing hotkeys" for clarity
- Expanded instructions to be more explicit about setting hotkeys
- Added a new "Useful hotkeys to configure" section highlighting key commands:
  - **Open node type menu**: Create new nodes or convert selected text
  - **Toggle discourse context**: Show/hide discourse context view
  - **Create discourse node**: Create new nodes from scratch
- Added example use case for the node menu hotkey

### Creating Discourse Nodes Documentation (`creating-discourse-nodes.md`)
- Added introductory paragraph explaining the default hotkey (`Cmd + \` / `Ctrl + \`)
- Added link to command palette documentation for hotkey customization
- Clarified that users can customize the hotkey in Obsidian settings under Hotkeys → "Open node type menu"
- Updated step 1.2 to explicitly state users should press the hotkey "without selecting any text"
- Changed "Node Menu" to "node menu" to follow sentence case style guide
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-1581](https://linear.app/discourse-graphs/issue/ENG-1581/add-to-documentation-that-users-can-set-hotkey-to-open-the-node-menu)

<div><a href="https://cursor.com/agents/bc-0307e40d-21ec-4fd7-b857-079a626ea867"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0307e40d-21ec-4fd7-b857-079a626ea867"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/922" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
