### PR TITLE
[ENG-1546] Relation creation via drag handles (Roam)

### DIFF
--- a/apps/roam/src/components/canvas/DiscourseRelationShape/DiscourseRelationUtil.tsx
+++ b/apps/roam/src/components/canvas/DiscourseRelationShape/DiscourseRelationUtil.tsx
@@ -107,6 +107,7 @@ import {
   BaseDiscourseNodeUtil,
   DiscourseNodeShape,
 } from "~/components/canvas/DiscourseNodeUtil";
+import { checkConnectionType } from "~/components/canvas/canvasUtils";
 import getPageTitleByPageUid from "roamjs-components/queries/getPageTitleByPageUid";
 import { AddReferencedNodeType } from "./DiscourseRelationTool";
 import { dispatchToastEvent } from "~/components/canvas/ToastListener";
@@ -1705,15 +1706,7 @@ export class BaseDiscourseRelationUtil extends ShapeUtil<DiscourseRelationShape>
     sourceNodeType: string,
     targetNodeType: string,
   ): { isDirect: boolean; isReverse: boolean } {
-    const isDirect =
-      sourceNodeType === relation.source &&
-      targetNodeType === relation.destination;
-
-    const isReverse =
-      sourceNodeType === relation.destination &&
-      targetNodeType === relation.source;
-
-    return { isDirect, isReverse };
+    return checkConnectionType(relation, sourceNodeType, targetNodeType);
   }
 
   checkConnectionTypeAcrossLabel(

--- a/apps/roam/src/components/canvas/Tldraw.tsx
+++ b/apps/roam/src/components/canvas/Tldraw.tsx
@@ -56,6 +56,7 @@ import {
 import "tldraw/tldraw.css";
 import tldrawStyles from "./tldrawStyles";
 import { DragHandleOverlay } from "./overlays/DragHandleOverlay";
+import { isDiscourseNodeShape } from "./canvasUtils";
 import getDiscourseNodes, { DiscourseNode } from "~/utils/getDiscourseNodes";
 import getDiscourseRelations, {
   DiscourseRelation,
@@ -507,12 +508,6 @@ const TldrawCanvasShared = ({
     );
   };
 
-  const isDiscourseNodeShape = (
-    shape: TLShape,
-  ): shape is DiscourseNodeShape => {
-    return allNodes.some((node) => node.type === shape.type);
-  };
-
   // Add state for tracking relation creation
   const relationCreationRef = useRef<{
     isCreating: boolean;
@@ -537,7 +532,7 @@ const TldrawCanvasShared = ({
         relationCreationRef.current.toolType = currentToolId;
 
         // If we clicked on a discourse node, record it as the source
-        if (shapeAtPoint && isDiscourseNodeShape(shapeAtPoint)) {
+        if (shapeAtPoint && isDiscourseNodeShape(app, shapeAtPoint)) {
           relationCreationRef.current.sourceShapeId = shapeAtPoint.id;
         }
       }
@@ -562,7 +557,7 @@ const TldrawCanvasShared = ({
           relationCreationRef.current.relationShapeId = relationShape.id;
 
           // Check if we have a target shape
-          if (shapeAtPoint && isDiscourseNodeShape(shapeAtPoint)) {
+          if (shapeAtPoint && isDiscourseNodeShape(app, shapeAtPoint)) {
             posthog.capture("Canvas: Relation Created", {
               relationType: relationShape.type,
               toolType: relationCreationRef.current.toolType || "",

--- a/apps/roam/src/components/canvas/Tldraw.tsx
+++ b/apps/roam/src/components/canvas/Tldraw.tsx
@@ -55,6 +55,7 @@ import {
 } from "tldraw";
 import "tldraw/tldraw.css";
 import tldrawStyles from "./tldrawStyles";
+import { DragHandleOverlay } from "./overlays/DragHandleOverlay";
 import getDiscourseNodes, { DiscourseNode } from "~/utils/getDiscourseNodes";
 import getDiscourseRelations, {
   DiscourseRelation,
@@ -666,6 +667,7 @@ const TldrawCanvasShared = ({
   const editorComponents: TLEditorComponents = {
     ...defaultEditorComponents,
     OnTheCanvas: ToastListener,
+    InFrontOfTheCanvas: DragHandleOverlay,
   };
   const customUiComponents: TLUiComponents = createUiComponents({
     allNodes,

--- a/apps/roam/src/components/canvas/canvasUtils.ts
+++ b/apps/roam/src/components/canvas/canvasUtils.ts
@@ -19,6 +19,19 @@ export const isDiscourseNodeShape = (
 export const getAllRelations = () =>
   Object.values(discourseContext.relations).flat();
 
+export const checkConnectionType = (
+  relation: { source: string; destination: string },
+  sourceNodeType: string,
+  targetNodeType: string,
+): { isDirect: boolean; isReverse: boolean } => ({
+  isDirect:
+    sourceNodeType === relation.source &&
+    targetNodeType === relation.destination,
+  isReverse:
+    sourceNodeType === relation.destination &&
+    targetNodeType === relation.source,
+});
+
 export const hasValidRelationTypes = (
   sourceNodeType: string,
   targetNodeType: string,

--- a/apps/roam/src/components/canvas/canvasUtils.ts
+++ b/apps/roam/src/components/canvas/canvasUtils.ts
@@ -1,0 +1,30 @@
+import { Editor, TLShape } from "tldraw";
+import {
+  BaseDiscourseNodeUtil,
+  DiscourseNodeShape,
+} from "~/components/canvas/DiscourseNodeUtil";
+import { discourseContext } from "~/components/canvas/Tldraw";
+
+export const isDiscourseNodeShape = (
+  editor: Editor,
+  shape: TLShape,
+): shape is DiscourseNodeShape => {
+  try {
+    return editor.getShapeUtil(shape) instanceof BaseDiscourseNodeUtil;
+  } catch {
+    return false;
+  }
+};
+
+export const getAllRelations = () =>
+  Object.values(discourseContext.relations).flat();
+
+export const hasValidRelationTypes = (
+  sourceNodeType: string,
+  targetNodeType: string,
+): boolean =>
+  getAllRelations().some(
+    (r) =>
+      (r.source === sourceNodeType && r.destination === targetNodeType) ||
+      (r.source === targetNodeType && r.destination === sourceNodeType),
+  );

--- a/apps/roam/src/components/canvas/overlays/DragHandleOverlay.tsx
+++ b/apps/roam/src/components/canvas/overlays/DragHandleOverlay.tsx
@@ -8,6 +8,7 @@ import {
 } from "~/components/canvas/DiscourseRelationShape/DiscourseRelationUtil";
 import { createOrUpdateArrowBinding } from "~/components/canvas/DiscourseRelationShape/helpers";
 import {
+  checkConnectionType,
   getAllRelations,
   hasValidRelationTypes,
   isDiscourseNodeShape,
@@ -266,6 +267,20 @@ export const DragHandleOverlay = () => {
 
       const color = getRelationColor(selectedRelation.label);
 
+      // Determine direction: if we dragged from the relation's destination type,
+      // the arrow is in reverse and should display the complement label.
+      const sourceNode = editor.getShape(pending.sourceId);
+      const targetNode = editor.getShape(pending.targetId);
+      const { isReverse } = checkConnectionType(
+        selectedRelation,
+        sourceNode?.type ?? "",
+        targetNode?.type ?? "",
+      );
+      const label =
+        isReverse && selectedRelation.complement
+          ? selectedRelation.complement
+          : selectedRelation.label;
+
       // Get source bounds for arrow positioning
       const sourceBounds = editor.getShapePageBounds(pending.sourceId);
       if (!sourceBounds) {
@@ -283,8 +298,7 @@ export const DragHandleOverlay = () => {
         y: sourceBounds.midY,
         props: {
           color,
-          labelColor: color,
-          text: selectedRelation.label,
+          text: label,
           dash: "draw",
           size: "m",
           fill: "none",

--- a/apps/roam/src/components/canvas/overlays/DragHandleOverlay.tsx
+++ b/apps/roam/src/components/canvas/overlays/DragHandleOverlay.tsx
@@ -23,6 +23,7 @@ type HandlePosition = {
   x: number;
   y: number;
   anchor: { x: number; y: number };
+  direction: { x: number; y: number };
 };
 
 /** Pending connection: source + target nodes identified, waiting for relation type pick */
@@ -41,23 +42,27 @@ const getEdgeMidpoints = (bounds: {
 }): HandlePosition[] => [
   {
     x: (bounds.minX + bounds.maxX) / 2,
-    y: bounds.minY - HANDLE_PADDING,
+    y: bounds.minY,
     anchor: { x: 0.5, y: 0 },
+    direction: { x: 0, y: -1 },
   },
   {
-    x: bounds.maxX + HANDLE_PADDING,
+    x: bounds.maxX,
     y: (bounds.minY + bounds.maxY) / 2,
     anchor: { x: 1, y: 0.5 },
+    direction: { x: 1, y: 0 },
   },
   {
     x: (bounds.minX + bounds.maxX) / 2,
-    y: bounds.maxY + HANDLE_PADDING,
+    y: bounds.maxY,
     anchor: { x: 0.5, y: 1 },
+    direction: { x: 0, y: 1 },
   },
   {
-    x: bounds.minX - HANDLE_PADDING,
+    x: bounds.minX,
     y: (bounds.minY + bounds.maxY) / 2,
     anchor: { x: 0, y: 0.5 },
+    direction: { x: -1, y: 0 },
   },
 ];
 
@@ -110,7 +115,11 @@ export const DragHandleOverlay = () => {
       const midpoints = getEdgeMidpoints(bounds);
       return midpoints.map((mp) => {
         const vp = editor.pageToViewport({ x: mp.x, y: mp.y });
-        return { left: vp.x, top: vp.y, anchor: mp.anchor };
+        return {
+          left: vp.x + mp.direction.x * HANDLE_PADDING,
+          top: vp.y + mp.direction.y * HANDLE_PADDING,
+          anchor: mp.anchor,
+        };
       });
     },
     [editor, selectedNode?.id, pending, isDragging],

--- a/apps/roam/src/components/canvas/overlays/DragHandleOverlay.tsx
+++ b/apps/roam/src/components/canvas/overlays/DragHandleOverlay.tsx
@@ -91,7 +91,7 @@ export const DragHandleOverlay = () => {
       if (isDragging || pending) return sourceNodeRef.current;
       const shape = editor.getOnlySelectedShape();
       if (shape && isDiscourseNodeShape(editor, shape)) {
-        return shape as DiscourseNodeShape;
+        return shape;
       }
       return null;
     },
@@ -117,7 +117,7 @@ export const DragHandleOverlay = () => {
   );
 
   const handlePointerDown = useCallback(
-    (e: React.PointerEvent, _anchor: { x: number; y: number }) => {
+    (e: React.PointerEvent) => {
       if (!selectedNode) return;
       e.preventDefault();
       e.stopPropagation();
@@ -315,9 +315,15 @@ export const DragHandleOverlay = () => {
       const util = editor.getShapeUtil(newArrow);
       if (
         util instanceof BaseDiscourseRelationUtil &&
-        typeof (util as any).handleCreateRelationsInRoam === "function"
+        "handleCreateRelationsInRoam" in util
       ) {
-        void (util as any).handleCreateRelationsInRoam({
+        type UtilWithRoamPersistence = BaseDiscourseRelationUtil & {
+          handleCreateRelationsInRoam: (args: {
+            arrow: DiscourseRelationShape;
+            targetId: TLShapeId;
+          }) => Promise<void>;
+        };
+        void (util as UtilWithRoamPersistence).handleCreateRelationsInRoam({
           arrow: editor.getShape<DiscourseRelationShape>(arrowId) ?? newArrow,
           targetId: pending.targetId,
         });
@@ -347,7 +353,7 @@ export const DragHandleOverlay = () => {
         handlePositions.map((pos, i) => (
           <div
             key={i}
-            onPointerDown={(e) => handlePointerDown(e, pos.anchor)}
+            onPointerDown={handlePointerDown}
             style={{
               position: "absolute",
               left: `${pos.left}px`,

--- a/apps/roam/src/components/canvas/overlays/DragHandleOverlay.tsx
+++ b/apps/roam/src/components/canvas/overlays/DragHandleOverlay.tsx
@@ -1,23 +1,17 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
-import {
-  TLShapeId,
-  createShapeId,
-  useEditor,
-  useValue,
-} from "tldraw";
-import {
-  BaseDiscourseNodeUtil,
-  DiscourseNodeShape,
-} from "~/components/canvas/DiscourseNodeUtil";
+import { TLShapeId, createShapeId, useEditor, useValue } from "tldraw";
+import { DiscourseNodeShape } from "~/components/canvas/DiscourseNodeUtil";
 import {
   BaseDiscourseRelationUtil,
   DiscourseRelationShape,
   getRelationColor,
 } from "~/components/canvas/DiscourseRelationShape/DiscourseRelationUtil";
+import { createOrUpdateArrowBinding } from "~/components/canvas/DiscourseRelationShape/helpers";
 import {
-  createOrUpdateArrowBinding,
-} from "~/components/canvas/DiscourseRelationShape/helpers";
-import { discourseContext } from "~/components/canvas/Tldraw";
+  getAllRelations,
+  hasValidRelationTypes,
+  isDiscourseNodeShape,
+} from "~/components/canvas/canvasUtils";
 import { dispatchToastEvent } from "~/components/canvas/ToastListener";
 import { RelationTypeDropdown } from "./RelationTypeDropdown";
 
@@ -67,30 +61,6 @@ const getEdgeMidpoints = (bounds: {
   },
 ];
 
-const isDiscourseNode = (
-  editor: ReturnType<typeof useEditor>,
-  shapeType: string,
-): boolean => {
-  try {
-    const util = editor.getShapeUtil(shapeType);
-    return util instanceof BaseDiscourseNodeUtil;
-  } catch {
-    return false;
-  }
-};
-
-const hasValidRelationTypes = (
-  sourceNodeType: string,
-  targetNodeType: string,
-): boolean => {
-  const allRelations = Object.values(discourseContext.relations).flat();
-  return allRelations.some(
-    (r) =>
-      (r.source === sourceNodeType && r.destination === targetNodeType) ||
-      (r.source === targetNodeType && r.destination === sourceNodeType),
-  );
-};
-
 export const DragHandleOverlay = () => {
   const editor = useEditor();
 
@@ -120,7 +90,7 @@ export const DragHandleOverlay = () => {
     () => {
       if (isDragging || pending) return sourceNodeRef.current;
       const shape = editor.getOnlySelectedShape();
-      if (shape && isDiscourseNode(editor, shape.type)) {
+      if (shape && isDiscourseNodeShape(editor, shape)) {
         return shape as DiscourseNodeShape;
       }
       return null;
@@ -187,7 +157,7 @@ export const DragHandleOverlay = () => {
           hitFrameInside: true,
           margin: 0,
           filter: (s) =>
-            isDiscourseNode(editor, s.type) &&
+            isDiscourseNodeShape(editor, s) &&
             s.id !== selectedNode.id &&
             !s.isLocked,
         });
@@ -215,7 +185,7 @@ export const DragHandleOverlay = () => {
           hitFrameInside: true,
           margin: 0,
           filter: (s) =>
-            isDiscourseNode(editor, s.type) &&
+            isDiscourseNodeShape(editor, s) &&
             s.id !== selectedNode.id &&
             !s.isLocked,
         });
@@ -276,8 +246,9 @@ export const DragHandleOverlay = () => {
     (relationId: string) => {
       if (!pending) return;
 
-      const allRelations = Object.values(discourseContext.relations).flat();
-      const selectedRelation = allRelations.find((r) => r.id === relationId);
+      const selectedRelation = getAllRelations().find(
+        (r) => r.id === relationId,
+      );
       if (!selectedRelation) {
         setPending(null);
         sourceNodeRef.current = null;

--- a/apps/roam/src/components/canvas/overlays/DragHandleOverlay.tsx
+++ b/apps/roam/src/components/canvas/overlays/DragHandleOverlay.tsx
@@ -1,0 +1,449 @@
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import {
+  TLShapeId,
+  createShapeId,
+  useEditor,
+  useValue,
+} from "tldraw";
+import {
+  BaseDiscourseNodeUtil,
+  DiscourseNodeShape,
+} from "~/components/canvas/DiscourseNodeUtil";
+import {
+  BaseDiscourseRelationUtil,
+  DiscourseRelationShape,
+  getRelationColor,
+} from "~/components/canvas/DiscourseRelationShape/DiscourseRelationUtil";
+import {
+  createOrUpdateArrowBinding,
+} from "~/components/canvas/DiscourseRelationShape/helpers";
+import { discourseContext } from "~/components/canvas/Tldraw";
+import { dispatchToastEvent } from "~/components/canvas/ToastListener";
+import { RelationTypeDropdown } from "./RelationTypeDropdown";
+
+const HANDLE_RADIUS = 5;
+const HANDLE_HIT_AREA = 12;
+const HANDLE_PADDING = 8;
+
+type HandlePosition = {
+  x: number;
+  y: number;
+  anchor: { x: number; y: number };
+};
+
+/** Pending connection: source + target nodes identified, waiting for relation type pick */
+type PendingConnection = {
+  sourceId: TLShapeId;
+  targetId: TLShapeId;
+  /** Viewport coords for dropdown positioning (midpoint between nodes) */
+  dropdownPos: { x: number; y: number };
+};
+
+const getEdgeMidpoints = (bounds: {
+  minX: number;
+  minY: number;
+  maxX: number;
+  maxY: number;
+}): HandlePosition[] => [
+  {
+    x: (bounds.minX + bounds.maxX) / 2,
+    y: bounds.minY - HANDLE_PADDING,
+    anchor: { x: 0.5, y: 0 },
+  },
+  {
+    x: bounds.maxX + HANDLE_PADDING,
+    y: (bounds.minY + bounds.maxY) / 2,
+    anchor: { x: 1, y: 0.5 },
+  },
+  {
+    x: (bounds.minX + bounds.maxX) / 2,
+    y: bounds.maxY + HANDLE_PADDING,
+    anchor: { x: 0.5, y: 1 },
+  },
+  {
+    x: bounds.minX - HANDLE_PADDING,
+    y: (bounds.minY + bounds.maxY) / 2,
+    anchor: { x: 0, y: 0.5 },
+  },
+];
+
+const isDiscourseNode = (
+  editor: ReturnType<typeof useEditor>,
+  shapeType: string,
+): boolean => {
+  try {
+    const util = editor.getShapeUtil(shapeType);
+    return util instanceof BaseDiscourseNodeUtil;
+  } catch {
+    return false;
+  }
+};
+
+const hasValidRelationTypes = (
+  sourceNodeType: string,
+  targetNodeType: string,
+): boolean => {
+  const allRelations = Object.values(discourseContext.relations).flat();
+  return allRelations.some(
+    (r) =>
+      (r.source === sourceNodeType && r.destination === targetNodeType) ||
+      (r.source === targetNodeType && r.destination === sourceNodeType),
+  );
+};
+
+export const DragHandleOverlay = () => {
+  const editor = useEditor();
+
+  // Drag state: track the drag line in viewport coords (no tldraw shapes)
+  const [isDragging, setIsDragging] = useState(false);
+  const [dragStart, setDragStart] = useState<{ x: number; y: number } | null>(
+    null,
+  );
+  const [dragEnd, setDragEnd] = useState<{ x: number; y: number } | null>(null);
+  const [hoveredTarget, setHoveredTarget] = useState<TLShapeId | null>(null);
+
+  // After a successful drop, show the relation type dropdown
+  const [pending, setPending] = useState<PendingConnection | null>(null);
+
+  const sourceNodeRef = useRef<DiscourseNodeShape | null>(null);
+  const dragCleanupRef = useRef<(() => void) | null>(null);
+
+  useEffect(() => {
+    return () => {
+      dragCleanupRef.current?.();
+    };
+  }, []);
+
+  // Track the single selected discourse node
+  const selectedNode = useValue<DiscourseNodeShape | null>(
+    "dragHandleSelectedNode",
+    () => {
+      if (isDragging || pending) return sourceNodeRef.current;
+      const shape = editor.getOnlySelectedShape();
+      if (shape && isDiscourseNode(editor, shape.type)) {
+        return shape as DiscourseNodeShape;
+      }
+      return null;
+    },
+    [editor, isDragging, pending],
+  );
+
+  // Compute handle positions in viewport space
+  const handlePositions = useValue<
+    { left: number; top: number; anchor: { x: number; y: number } }[] | null
+  >(
+    "dragHandlePositions",
+    () => {
+      if (!selectedNode || pending || isDragging) return null;
+      const bounds = editor.getShapePageBounds(selectedNode.id);
+      if (!bounds) return null;
+      const midpoints = getEdgeMidpoints(bounds);
+      return midpoints.map((mp) => {
+        const vp = editor.pageToViewport({ x: mp.x, y: mp.y });
+        return { left: vp.x, top: vp.y, anchor: mp.anchor };
+      });
+    },
+    [editor, selectedNode?.id, pending, isDragging],
+  );
+
+  const handlePointerDown = useCallback(
+    (e: React.PointerEvent, _anchor: { x: number; y: number }) => {
+      if (!selectedNode) return;
+      e.preventDefault();
+      e.stopPropagation();
+      e.nativeEvent.stopImmediatePropagation();
+
+      sourceNodeRef.current = selectedNode;
+      setIsDragging(true);
+
+      const startVp = { x: e.clientX, y: e.clientY };
+      // Get container bounding rect to convert client coords to overlay-relative
+      const containerRect = editor.getContainer().getBoundingClientRect();
+      setDragStart({
+        x: startVp.x - containerRect.left,
+        y: startVp.y - containerRect.top,
+      });
+      setDragEnd({
+        x: startVp.x - containerRect.left,
+        y: startVp.y - containerRect.top,
+      });
+
+      const containerEl = editor.getContainer();
+
+      const onPointerMove = (moveEvent: PointerEvent) => {
+        const rect = containerEl.getBoundingClientRect();
+        setDragEnd({
+          x: moveEvent.clientX - rect.left,
+          y: moveEvent.clientY - rect.top,
+        });
+
+        // Check for target node under cursor
+        const pagePoint = editor.screenToPage({
+          x: moveEvent.clientX,
+          y: moveEvent.clientY,
+        });
+        const target = editor.getShapeAtPoint(pagePoint, {
+          hitInside: true,
+          hitFrameInside: true,
+          margin: 0,
+          filter: (s) =>
+            isDiscourseNode(editor, s.type) &&
+            s.id !== selectedNode.id &&
+            !s.isLocked,
+        });
+        setHoveredTarget(target?.id ?? null);
+        editor.setHintingShapes(target ? [target.id] : []);
+      };
+
+      const onPointerUp = (upEvent: PointerEvent) => {
+        containerEl.removeEventListener("pointermove", onPointerMove);
+        containerEl.removeEventListener("pointerup", onPointerUp);
+        dragCleanupRef.current = null;
+        editor.setHintingShapes([]);
+        setIsDragging(false);
+        setDragStart(null);
+        setDragEnd(null);
+        setHoveredTarget(null);
+
+        // Check what we dropped on
+        const pagePoint = editor.screenToPage({
+          x: upEvent.clientX,
+          y: upEvent.clientY,
+        });
+        const target = editor.getShapeAtPoint(pagePoint, {
+          hitInside: true,
+          hitFrameInside: true,
+          margin: 0,
+          filter: (s) =>
+            isDiscourseNode(editor, s.type) &&
+            s.id !== selectedNode.id &&
+            !s.isLocked,
+        });
+
+        if (!target) {
+          dispatchToastEvent({
+            id: "tldraw-drag-handle-warning",
+            title: "Drop on a discourse node to create a relation",
+            severity: "warning",
+          });
+          sourceNodeRef.current = null;
+          return;
+        }
+
+        // Validate that relation types exist between these node types
+        if (!hasValidRelationTypes(selectedNode.type, target.type)) {
+          dispatchToastEvent({
+            id: "tldraw-no-valid-relation",
+            title: "No relation types are defined between these node types",
+            severity: "warning",
+          });
+          sourceNodeRef.current = null;
+          return;
+        }
+
+        // Compute dropdown position: midpoint between source and target in viewport space
+        const sourceBounds = editor.getShapePageBounds(selectedNode.id);
+        const targetBounds = editor.getShapePageBounds(target.id);
+        if (!sourceBounds || !targetBounds) {
+          sourceNodeRef.current = null;
+          return;
+        }
+        const midPage = {
+          x: (sourceBounds.midX + targetBounds.midX) / 2,
+          y: (sourceBounds.midY + targetBounds.midY) / 2,
+        };
+        const midVp = editor.pageToViewport(midPage);
+
+        setPending({
+          sourceId: selectedNode.id,
+          targetId: target.id,
+          dropdownPos: midVp,
+        });
+      };
+
+      containerEl.addEventListener("pointermove", onPointerMove);
+      containerEl.addEventListener("pointerup", onPointerUp);
+      dragCleanupRef.current = () => {
+        containerEl.removeEventListener("pointermove", onPointerMove);
+        containerEl.removeEventListener("pointerup", onPointerUp);
+        dragCleanupRef.current = null;
+      };
+    },
+    [selectedNode, editor],
+  );
+
+  const handleDropdownSelect = useCallback(
+    (relationId: string) => {
+      if (!pending) return;
+
+      const allRelations = Object.values(discourseContext.relations).flat();
+      const selectedRelation = allRelations.find((r) => r.id === relationId);
+      if (!selectedRelation) {
+        setPending(null);
+        sourceNodeRef.current = null;
+        return;
+      }
+
+      const color = getRelationColor(selectedRelation.label);
+
+      // Get source bounds for arrow positioning
+      const sourceBounds = editor.getShapePageBounds(pending.sourceId);
+      if (!sourceBounds) {
+        setPending(null);
+        sourceNodeRef.current = null;
+        return;
+      }
+
+      // Create the real relation shape with the correct type
+      const arrowId = createShapeId();
+      editor.createShape<DiscourseRelationShape>({
+        id: arrowId,
+        type: relationId,
+        x: sourceBounds.midX,
+        y: sourceBounds.midY,
+        props: {
+          color,
+          labelColor: color,
+          text: selectedRelation.label,
+          dash: "draw",
+          size: "m",
+          fill: "none",
+          bend: 0,
+          start: { x: 0, y: 0 },
+          end: { x: 0, y: 0 },
+          arrowheadStart: "none",
+          arrowheadEnd: "arrow",
+          labelPosition: 0.5,
+          font: "draw",
+          scale: 1,
+        },
+      });
+
+      const newArrow = editor.getShape<DiscourseRelationShape>(arrowId);
+      if (!newArrow) {
+        setPending(null);
+        sourceNodeRef.current = null;
+        return;
+      }
+
+      // Bind start and end
+      createOrUpdateArrowBinding(editor, newArrow, pending.sourceId, {
+        terminal: "start",
+        normalizedAnchor: { x: 0.5, y: 0.5 },
+        isPrecise: false,
+        isExact: false,
+      });
+      createOrUpdateArrowBinding(editor, newArrow, pending.targetId, {
+        terminal: "end",
+        normalizedAnchor: { x: 0.5, y: 0.5 },
+        isPrecise: false,
+        isExact: false,
+      });
+
+      // Persist via handleCreateRelationsInRoam
+      const util = editor.getShapeUtil(newArrow);
+      if (
+        util instanceof BaseDiscourseRelationUtil &&
+        typeof (util as any).handleCreateRelationsInRoam === "function"
+      ) {
+        void (util as any).handleCreateRelationsInRoam({
+          arrow: editor.getShape<DiscourseRelationShape>(arrowId) ?? newArrow,
+          targetId: pending.targetId,
+        });
+      }
+
+      editor.select(arrowId);
+      setPending(null);
+      sourceNodeRef.current = null;
+    },
+    [editor, pending],
+  );
+
+  const handleDropdownDismiss = useCallback(() => {
+    setPending(null);
+    if (sourceNodeRef.current) {
+      editor.select(sourceNodeRef.current.id);
+    }
+    sourceNodeRef.current = null;
+  }, [editor]);
+
+  const showHandles = !!handlePositions && !pending && !isDragging;
+
+  return (
+    <div style={{ position: "absolute", inset: 0, pointerEvents: "none" }}>
+      {/* Drag handle dots */}
+      {showHandles &&
+        handlePositions.map((pos, i) => (
+          <div
+            key={i}
+            onPointerDown={(e) => handlePointerDown(e, pos.anchor)}
+            style={{
+              position: "absolute",
+              left: `${pos.left}px`,
+              top: `${pos.top}px`,
+              transform: "translate(-50%, -50%)",
+              width: `${HANDLE_HIT_AREA * 2}px`,
+              height: `${HANDLE_HIT_AREA * 2}px`,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              cursor: "crosshair",
+              pointerEvents: "all",
+              zIndex: 20,
+            }}
+          >
+            <div
+              style={{
+                width: `${HANDLE_RADIUS * 2}px`,
+                height: `${HANDLE_RADIUS * 2}px`,
+                borderRadius: "50%",
+                backgroundColor: "#adb5bd",
+              }}
+            />
+          </div>
+        ))}
+
+      {/* SVG drag line while dragging */}
+      {isDragging && dragStart && dragEnd && (
+        <svg
+          style={{
+            position: "absolute",
+            inset: 0,
+            width: "100%",
+            height: "100%",
+            pointerEvents: "none",
+            zIndex: 19,
+          }}
+        >
+          <line
+            x1={dragStart.x}
+            y1={dragStart.y}
+            x2={dragEnd.x}
+            y2={dragEnd.y}
+            stroke={hoveredTarget ? "#339af0" : "#adb5bd"}
+            strokeWidth={2}
+            strokeDasharray={hoveredTarget ? "none" : "6 4"}
+          />
+          {/* Arrowhead */}
+          <circle
+            cx={dragEnd.x}
+            cy={dragEnd.y}
+            r={4}
+            fill={hoveredTarget ? "#339af0" : "#adb5bd"}
+          />
+        </svg>
+      )}
+
+      {/* Relation type dropdown */}
+      {pending && (
+        <RelationTypeDropdown
+          sourceId={pending.sourceId}
+          targetId={pending.targetId}
+          dropdownPos={pending.dropdownPos}
+          onSelect={handleDropdownSelect}
+          onDismiss={handleDropdownDismiss}
+        />
+      )}
+    </div>
+  );
+};

--- a/apps/roam/src/components/canvas/overlays/DragHandleOverlay.tsx
+++ b/apps/roam/src/components/canvas/overlays/DragHandleOverlay.tsx
@@ -376,20 +376,15 @@ export const DragHandleOverlay = () => {
         handlePositions.map((pos, i) => (
           <div
             key={i}
+            className="absolute z-20 flex cursor-crosshair items-center justify-center"
             onPointerDown={handlePointerDown}
             style={{
-              position: "absolute",
               left: `${pos.left}px`,
               top: `${pos.top}px`,
-              transform: "translate(-50%, -50%)",
               width: `${HANDLE_HIT_AREA * 2}px`,
               height: `${HANDLE_HIT_AREA * 2}px`,
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-              cursor: "crosshair",
+              transform: "translate(-50%, -50%)",
               pointerEvents: "all",
-              zIndex: 20,
             }}
           >
             <div

--- a/apps/roam/src/components/canvas/overlays/RelationTypeDropdown.tsx
+++ b/apps/roam/src/components/canvas/overlays/RelationTypeDropdown.tsx
@@ -1,12 +1,10 @@
 import React, { useCallback, useEffect, useMemo, useRef } from "react";
-import {
-  TLShapeId,
-  useEditor,
-  DefaultColorThemePalette,
-} from "tldraw";
-import { discourseContext } from "~/components/canvas/Tldraw";
-import { BaseDiscourseNodeUtil } from "~/components/canvas/DiscourseNodeUtil";
+import { TLShapeId, useEditor, DefaultColorThemePalette } from "tldraw";
 import { getRelationColor } from "~/components/canvas/DiscourseRelationShape/DiscourseRelationUtil";
+import {
+  getAllRelations,
+  isDiscourseNodeShape,
+} from "~/components/canvas/canvasUtils";
 
 type RelationTypeDropdownProps = {
   sourceId: TLShapeId;
@@ -36,21 +34,15 @@ export const RelationTypeDropdown = ({
     const endNodeType = endNode.type;
 
     // Verify both are discourse nodes
-    try {
-      const startUtil = editor.getShapeUtil(startNode);
-      const endUtil = editor.getShapeUtil(endNode);
-      if (
-        !(startUtil instanceof BaseDiscourseNodeUtil) ||
-        !(endUtil instanceof BaseDiscourseNodeUtil)
-      )
-        return [];
-    } catch {
+    if (
+      !isDiscourseNodeShape(editor, startNode) ||
+      !isDiscourseNodeShape(editor, endNode)
+    )
       return [];
-    }
 
     const colorPalette = DefaultColorThemePalette.lightMode;
     const validTypes: { id: string; label: string; color: string }[] = [];
-    const allRelations = Object.values(discourseContext.relations).flat();
+    const allRelations = getAllRelations();
     const seenLabels = new Set<string>();
 
     for (const relation of allRelations) {

--- a/apps/roam/src/components/canvas/overlays/RelationTypeDropdown.tsx
+++ b/apps/roam/src/components/canvas/overlays/RelationTypeDropdown.tsx
@@ -1,0 +1,200 @@
+import React, { useCallback, useEffect, useMemo, useRef } from "react";
+import {
+  TLShapeId,
+  useEditor,
+  DefaultColorThemePalette,
+} from "tldraw";
+import { discourseContext } from "~/components/canvas/Tldraw";
+import { BaseDiscourseNodeUtil } from "~/components/canvas/DiscourseNodeUtil";
+import { getRelationColor } from "~/components/canvas/DiscourseRelationShape/DiscourseRelationUtil";
+
+type RelationTypeDropdownProps = {
+  sourceId: TLShapeId;
+  targetId: TLShapeId;
+  dropdownPos: { x: number; y: number };
+  onSelect: (relationId: string) => void;
+  onDismiss: () => void;
+};
+
+export const RelationTypeDropdown = ({
+  sourceId,
+  targetId,
+  dropdownPos,
+  onSelect,
+  onDismiss,
+}: RelationTypeDropdownProps) => {
+  const editor = useEditor();
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  // Get valid relation types based on source/target node types
+  const validRelationTypes = useMemo(() => {
+    const startNode = editor.getShape(sourceId);
+    const endNode = editor.getShape(targetId);
+    if (!startNode || !endNode) return [];
+
+    const startNodeType = startNode.type;
+    const endNodeType = endNode.type;
+
+    // Verify both are discourse nodes
+    try {
+      const startUtil = editor.getShapeUtil(startNode);
+      const endUtil = editor.getShapeUtil(endNode);
+      if (
+        !(startUtil instanceof BaseDiscourseNodeUtil) ||
+        !(endUtil instanceof BaseDiscourseNodeUtil)
+      )
+        return [];
+    } catch {
+      return [];
+    }
+
+    const colorPalette = DefaultColorThemePalette.lightMode;
+    const validTypes: { id: string; label: string; color: string }[] = [];
+    const allRelations = Object.values(discourseContext.relations).flat();
+    const seenLabels = new Set<string>();
+
+    for (const relation of allRelations) {
+      const matches =
+        (relation.source === startNodeType &&
+          relation.destination === endNodeType) ||
+        (relation.source === endNodeType &&
+          relation.destination === startNodeType);
+
+      if (matches && !seenLabels.has(relation.label)) {
+        seenLabels.add(relation.label);
+        const tldrawColor = getRelationColor(relation.label);
+        const hexColor = colorPalette[tldrawColor]?.solid ?? "#333";
+        validTypes.push({
+          id: relation.id,
+          label: relation.label,
+          color: hexColor,
+        });
+      }
+    }
+
+    return validTypes;
+  }, [editor, sourceId, targetId]);
+
+  // Handle click outside
+  useEffect(() => {
+    const handlePointerDown = (e: PointerEvent) => {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(e.target as Node)
+      ) {
+        onDismiss();
+      }
+    };
+
+    const timer = setTimeout(() => {
+      window.addEventListener("pointerdown", handlePointerDown, true);
+    }, 100);
+
+    return () => {
+      clearTimeout(timer);
+      window.removeEventListener("pointerdown", handlePointerDown, true);
+    };
+  }, [onDismiss]);
+
+  // Handle Escape key
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onDismiss();
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown, true);
+    return () => window.removeEventListener("keydown", handleKeyDown, true);
+  }, [onDismiss]);
+
+  const handleSelect = useCallback(
+    (relationId: string) => {
+      onSelect(relationId);
+    },
+    [onSelect],
+  );
+
+  if (validRelationTypes.length === 0) return null;
+
+  return (
+    <div
+      ref={dropdownRef}
+      style={{
+        position: "absolute",
+        left: `${dropdownPos.x}px`,
+        top: `${dropdownPos.y}px`,
+        transform: "translate(-50%, -50%)",
+        pointerEvents: "all",
+        zIndex: 30,
+      }}
+      onPointerDown={(e) => e.stopPropagation()}
+      onPointerUp={(e) => e.stopPropagation()}
+      onClick={(e) => e.stopPropagation()}
+    >
+      <div
+        style={{
+          backgroundColor: "#fff",
+          border: "1px solid #e0e0e0",
+          borderRadius: "8px",
+          boxShadow: "0 2px 12px rgba(0,0,0,0.15)",
+          padding: "4px",
+          minWidth: "160px",
+          maxHeight: "240px",
+          overflowY: "auto",
+        }}
+      >
+        <div
+          style={{
+            padding: "4px 8px",
+            fontSize: "11px",
+            color: "#999",
+            fontWeight: 500,
+            textTransform: "uppercase",
+            letterSpacing: "0.5px",
+          }}
+        >
+          Relation Type
+        </div>
+        {validRelationTypes.map((rt) => (
+          <button
+            key={rt.id}
+            onClick={() => handleSelect(rt.id)}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "8px",
+              width: "100%",
+              padding: "6px 8px",
+              border: "none",
+              borderRadius: "4px",
+              backgroundColor: "transparent",
+              cursor: "pointer",
+              fontSize: "13px",
+              color: "#333",
+              textAlign: "left",
+            }}
+            onMouseEnter={(e) => {
+              (e.currentTarget as HTMLElement).style.backgroundColor =
+                "#f0f0f0";
+            }}
+            onMouseLeave={(e) => {
+              (e.currentTarget as HTMLElement).style.backgroundColor =
+                "transparent";
+            }}
+          >
+            <span
+              style={{
+                width: "8px",
+                height: "8px",
+                borderRadius: "50%",
+                backgroundColor: rt.color,
+                flexShrink: 0,
+              }}
+            />
+            {rt.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/apps/roam/src/components/canvas/overlays/RelationTypeDropdown.tsx
+++ b/apps/roam/src/components/canvas/overlays/RelationTypeDropdown.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useMemo, useRef } from "react";
 import { TLShapeId, useEditor, DefaultColorThemePalette } from "tldraw";
 import { getRelationColor } from "~/components/canvas/DiscourseRelationShape/DiscourseRelationUtil";
 import {
+  checkConnectionType,
   getAllRelations,
   isDiscourseNodeShape,
 } from "~/components/canvas/canvasUtils";
@@ -46,21 +47,22 @@ export const RelationTypeDropdown = ({
     const seenLabels = new Set<string>();
 
     for (const relation of allRelations) {
-      const matches =
-        (relation.source === startNodeType &&
-          relation.destination === endNodeType) ||
-        (relation.source === endNodeType &&
-          relation.destination === startNodeType);
+      const { isDirect: isForward, isReverse } = checkConnectionType(
+        relation,
+        startNodeType,
+        endNodeType,
+      );
 
-      if (matches && !seenLabels.has(relation.label)) {
-        seenLabels.add(relation.label);
+      if (!isForward && !isReverse) continue;
+
+      const label =
+        isReverse && relation.complement ? relation.complement : relation.label;
+
+      if (!seenLabels.has(label)) {
+        seenLabels.add(label);
         const tldrawColor = getRelationColor(relation.label);
         const hexColor = colorPalette[tldrawColor]?.solid ?? "#333";
-        validTypes.push({
-          id: relation.id,
-          label: relation.label,
-          color: hexColor,
-        });
+        validTypes.push({ id: relation.id, label, color: hexColor });
       }
     }
 

--- a/apps/roam/src/components/canvas/overlays/RelationTypeDropdown.tsx
+++ b/apps/roam/src/components/canvas/overlays/RelationTypeDropdown.tsx
@@ -125,48 +125,15 @@ export const RelationTypeDropdown = ({
       onPointerUp={(e) => e.stopPropagation()}
       onClick={(e) => e.stopPropagation()}
     >
-      <div
-        style={{
-          backgroundColor: "#fff",
-          border: "1px solid #e0e0e0",
-          borderRadius: "8px",
-          boxShadow: "0 2px 12px rgba(0,0,0,0.15)",
-          padding: "4px",
-          minWidth: "160px",
-          maxHeight: "240px",
-          overflowY: "auto",
-        }}
-      >
-        <div
-          style={{
-            padding: "4px 8px",
-            fontSize: "11px",
-            color: "#999",
-            fontWeight: 500,
-            textTransform: "uppercase",
-            letterSpacing: "0.5px",
-          }}
-        >
+      <div className="max-h-[240px] min-w-[160px] overflow-y-auto rounded-lg border border-gray-200 bg-white p-4 shadow-lg">
+        <div className="px-2 py-1 text-xs font-semibold uppercase tracking-wide text-gray-500">
           Relation Type
         </div>
         {validRelationTypes.map((rt) => (
           <button
             key={rt.id}
             onClick={() => handleSelect(rt.id)}
-            style={{
-              display: "flex",
-              alignItems: "center",
-              gap: "8px",
-              width: "100%",
-              padding: "6px 8px",
-              border: "none",
-              borderRadius: "4px",
-              backgroundColor: "transparent",
-              cursor: "pointer",
-              fontSize: "13px",
-              color: "#333",
-              textAlign: "left",
-            }}
+            className="flex w-full cursor-pointer items-center gap-2 rounded-md border-none bg-transparent px-3 py-2 text-left text-[13px] text-[#333] hover:bg-[#f0f0f0]"
             onMouseEnter={(e) => {
               (e.currentTarget as HTMLElement).style.backgroundColor =
                 "#f0f0f0";
@@ -178,12 +145,9 @@ export const RelationTypeDropdown = ({
           >
             <span
               style={{
-                width: "8px",
-                height: "8px",
-                borderRadius: "50%",
                 backgroundColor: rt.color,
-                flexShrink: 0,
               }}
+              className="h-2 w-2 flex-shrink-0 rounded-full bg-[#333]"
             />
             {rt.label}
           </button>


### PR DESCRIPTION
https://www.loom.com/share/253732c148ca4cb39907c564e6b53e77

## Summary
- Adds drag handle dots on selected discourse nodes (4 edge midpoints) for creating relations by dragging to another node
- Shows a relation type dropdown at the midpoint between source/target nodes after a successful drag
- On type selection, creates the relation shape with correct type and bindings, and persists via `handleCreateRelationsInRoam` (supports both stored/reified relations and legacy triple-based approach)
- Adapted from the Obsidian implementation (#909) to fit Roam's per-relation-type shape architecture — uses SVG overlay line during drag instead of temporary tldraw shapes

## Test plan
- [x] Select a single discourse node — 4 drag handle dots appear at edge midpoints
- [x] Drag from a handle to another discourse node — SVG line follows cursor, turns blue on hover over valid target
- [x] Release on a valid target — relation type dropdown appears at midpoint
- [x] Select a relation type — arrow shape created with correct color/label, relation persisted (check stored relations page or triple blocks)
- [x] Release on empty space — toast warning, no arrow created
- [x] Release on a node with no valid relation types — toast warning, no arrow created
- [x] Escape or click outside dropdown — dropdown dismissed, no arrow created
- [x] Handles reappear when selecting a different discourse node after any flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/923" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
