### PR TITLE
ENG-1551 - Fixing "Serverless function has exceeded ..."

### DIFF
--- a/apps/website/app/(home)/blog/[slug]/page.tsx
+++ b/apps/website/app/(home)/blog/[slug]/page.tsx
@@ -1,10 +1,9 @@
 import fs from "fs/promises";
-import path from "path";
 import { notFound } from "next/navigation";
 import { Metadata } from "next";
 import { getProcessedMarkdownFile } from "~/utils/getProcessedMarkdownFile";
-import { BLOG_PATH } from "~/data/constants";
 import { getFileMetadata } from "~/utils/getFileMetadata";
+import { BLOG_DIRECTORY } from "~/(home)/blog/blogDirectory";
 
 type Params = {
   params: Promise<{
@@ -17,7 +16,7 @@ const BlogPost = async ({ params }: Params) => {
     const { slug } = await params;
     const { data, contentHtml } = await getProcessedMarkdownFile({
       slug,
-      directory: BLOG_PATH,
+      directory: BLOG_DIRECTORY,
     });
 
     return (
@@ -46,9 +45,8 @@ const BlogPost = async ({ params }: Params) => {
 
 export const generateStaticParams = async () => {
   try {
-    const blogPath = path.resolve(process.cwd(), BLOG_PATH);
     const directoryExists = await fs
-      .stat(blogPath)
+      .stat(BLOG_DIRECTORY)
       .then((stats) => stats.isDirectory())
       .catch(() => false);
 
@@ -59,7 +57,7 @@ export const generateStaticParams = async () => {
       return [];
     }
 
-    const files = await fs.readdir(blogPath);
+    const files = await fs.readdir(BLOG_DIRECTORY);
 
     const mdFiles = files.filter((filename) => filename.endsWith(".md"));
 
@@ -68,7 +66,7 @@ export const generateStaticParams = async () => {
         try {
           const { published } = await getFileMetadata({
             filename,
-            directory: BLOG_PATH,
+            directory: BLOG_DIRECTORY,
           });
           return { filename, published };
         } catch (error) {
@@ -100,7 +98,7 @@ export const generateMetadata = async ({
     const { slug } = await params;
     const { data } = await getProcessedMarkdownFile({
       slug,
-      directory: BLOG_PATH,
+      directory: BLOG_DIRECTORY,
     });
 
     return {

--- a/apps/website/app/(home)/blog/blogDirectory.ts
+++ b/apps/website/app/(home)/blog/blogDirectory.ts
@@ -1,0 +1,9 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const BLOG_MODULE_PATH = fileURLToPath(import.meta.url);
+
+export const BLOG_DIRECTORY = path.join(
+  path.dirname(BLOG_MODULE_PATH),
+  "posts",
+);

--- a/apps/website/app/(home)/blog/readBlogs.tsx
+++ b/apps/website/app/(home)/blog/readBlogs.tsx
@@ -1,10 +1,8 @@
 import path from "path";
 import fs from "fs/promises";
 import matter from "gray-matter";
-import { BLOG_PATH } from "~/data/constants";
 import { PageSchema, type PageData } from "~/types/schema";
-
-const BLOG_DIRECTORY = path.join(process.cwd(), BLOG_PATH);
+import { BLOG_DIRECTORY } from "./blogDirectory";
 
 async function validateBlogDirectory(): Promise<boolean> {
   try {

--- a/apps/website/app/data/constants.ts
+++ b/apps/website/app/data/constants.ts
@@ -4,7 +4,6 @@ export const DESCRIPTION =
   "Discourse Graphs are a tool and ecosystem for collaborative knowledge synthesis, enabling researchers to map ideas and arguments in a modular, composable graph format.";
 export const SHORT_DESCRIPTION =
   "A tool and ecosystem for collaborative knowledge synthesis";
-export const BLOG_PATH = "app/(home)/blog/posts";
 
 export const TEAM_MEMBERS: TeamMember[] = [
   {


### PR DESCRIPTION
- Introduced a new blogDirectory.ts file to centralize the blog directory path management.
- Updated readBlogs.tsx and page.tsx to import and use BLOG_DIRECTORY instead of the previously hardcoded BLOG_PATH.
- Removed the BLOG_PATH constant from constants.ts to streamline the codebase.
<!-- devin-review-badge-begin -->

" Root cause was the blog filesystem lookup used by / and /blog. It was resolving the blog directory from process.cwd(), which made Next/Vercel’s file tracer over-approximate the dependency set and pull in most of apps/website/.next including webpack cache packs, plus all of apps/website/public. That matches your Vercel log: .next ~228.5 MB + public ~49 MB, and it also explains why a redeploy sometimes passes, since the .next/cache contents vary between builds."
  
 "...the home/blog traces dropped from roughly 573 MB each to about 1.8 MB, which is exactly the Vercel issue we were trying to eliminate."

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/927" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored blog directory path resolution for improved modularity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->