### PR TITLE
ENG-797: Handle multiple canvases loaded at the same time

### DIFF
--- a/apps/roam/src/components/Export.tsx
+++ b/apps/roam/src/components/Export.tsx
@@ -65,7 +65,7 @@ import {
   createNodeShapeUtils,
   DiscourseNodeShape,
 } from "~/components/canvas/DiscourseNodeUtil";
-import { discourseContext, MAX_WIDTH } from "~/components/canvas/Tldraw";
+import { MAX_WIDTH } from "~/components/canvas/Tldraw";
 import internalError from "~/utils/internalError";
 import { getSetting, setSetting } from "~/utils/extensionSettings";
 import { isTLStoreSnapshot } from "./canvas/useRoamStore";
@@ -79,9 +79,7 @@ import {
   createAllReferencedNodeUtils,
 } from "./canvas/DiscourseRelationShape/DiscourseRelationUtil";
 import getDiscourseNodes from "~/utils/getDiscourseNodes";
-import getDiscourseRelations, {
-  DiscourseRelation,
-} from "~/utils/getDiscourseRelations";
+import getDiscourseRelations from "~/utils/getDiscourseRelations";
 import { AddReferencedNodeType } from "./canvas/DiscourseRelationShape/DiscourseRelationTool";
 import posthog from "posthog-js";
 
@@ -312,17 +310,6 @@ const ExportDialog: ExportDialogComponent = ({
     // TODO lots of this is reused in tldraw.tsx, use a function to avoid duplication
     if (!isTLStore) {
       const relations = getDiscourseRelations();
-      discourseContext.relations = relations.reduce(
-        (acc, r) => {
-          if (acc[r.label]) {
-            acc[r.label].push(r);
-          } else {
-            acc[r.label] = [r];
-          }
-          return acc;
-        },
-        {} as Record<string, DiscourseRelation[]>,
-      );
       const allRelations = relations;
       const allRelationIds = allRelations.map((r) => r.id);
       const allNodes = getDiscourseNodes(allRelations);

--- a/apps/roam/src/components/Export.tsx
+++ b/apps/roam/src/components/Export.tsx
@@ -65,7 +65,7 @@ import {
   createNodeShapeUtils,
   DiscourseNodeShape,
 } from "~/components/canvas/DiscourseNodeUtil";
-import { MAX_WIDTH } from "~/components/canvas/Tldraw";
+import { discourseContext, MAX_WIDTH } from "~/components/canvas/Tldraw";
 import internalError from "~/utils/internalError";
 import { getSetting, setSetting } from "~/utils/extensionSettings";
 import { isTLStoreSnapshot } from "./canvas/useRoamStore";
@@ -79,7 +79,9 @@ import {
   createAllReferencedNodeUtils,
 } from "./canvas/DiscourseRelationShape/DiscourseRelationUtil";
 import getDiscourseNodes from "~/utils/getDiscourseNodes";
-import getDiscourseRelations from "~/utils/getDiscourseRelations";
+import getDiscourseRelations, {
+  DiscourseRelation,
+} from "~/utils/getDiscourseRelations";
 import { AddReferencedNodeType } from "./canvas/DiscourseRelationShape/DiscourseRelationTool";
 import posthog from "posthog-js";
 
@@ -310,6 +312,17 @@ const ExportDialog: ExportDialogComponent = ({
     // TODO lots of this is reused in tldraw.tsx, use a function to avoid duplication
     if (!isTLStore) {
       const relations = getDiscourseRelations();
+      discourseContext.relations = relations.reduce(
+        (acc, r) => {
+          if (acc[r.label]) {
+            acc[r.label].push(r);
+          } else {
+            acc[r.label] = [r];
+          }
+          return acc;
+        },
+        {} as Record<string, DiscourseRelation[]>,
+      );
       const allRelations = relations;
       const allRelationIds = allRelations.map((r) => r.id);
       const allNodes = getDiscourseNodes(allRelations);

--- a/apps/roam/src/components/canvas/Tldraw.tsx
+++ b/apps/roam/src/components/canvas/Tldraw.tsx
@@ -864,7 +864,7 @@ const TldrawCanvasShared = ({
         actionListener,
       );
     };
-  }, [appRef, allNodes]);
+  }, [appRef, allNodes, pageUid]);
 
   // Catch a custom event we used patch-package to add
   useEffect(() => {

--- a/apps/roam/src/components/canvas/Tldraw.tsx
+++ b/apps/roam/src/components/canvas/Tldraw.tsx
@@ -749,7 +749,8 @@ const TldrawCanvasShared = ({
 
   useEffect(() => {
     return () => {
-      if (activeCanvasPageUid === pageUid) {
+      const editor = appRef.current;
+      if (activeCanvasPageUid === pageUid && activeCanvasEditor === editor) {
         activeCanvasEditor?.blur();
         activeCanvasPageUid = null;
         activeCanvasEditor = null;
@@ -953,6 +954,7 @@ const TldrawCanvasShared = ({
       onDragOver={handleDragOver}
       onDrop={handleDrop}
       onPointerDownCapture={() => {
+        if (!appRef.current) return;
         setActiveCanvas({ pageUid, editor: appRef.current });
       }}
     >

--- a/apps/roam/src/components/canvas/Tldraw.tsx
+++ b/apps/roam/src/components/canvas/Tldraw.tsx
@@ -129,11 +129,15 @@ export type DiscourseContextType = {
   nodes: Record<string, DiscourseNode & { index: number }>;
   // { [Relation.Label] => DiscourseRelation[] }
   relations: Record<string, DiscourseRelation[]>;
+  lastAppEvent: string;
+  lastActions: HistoryEntry<TLRecord>[];
 };
 
 export const discourseContext: DiscourseContextType = {
   nodes: {},
   relations: {},
+  lastAppEvent: "",
+  lastActions: [],
 };
 
 let activeCanvasPageUid: string | null = null;
@@ -381,7 +385,9 @@ const TldrawCanvasShared = ({
   const appRef = useRef<Editor | null>(null);
   const lastInsertRef = useRef<VecModel>();
   const containerRef = useRef<HTMLDivElement>(null);
-  const lastActionsRef = useRef<HistoryEntry<TLRecord>[]>([]);
+  const lastActionsRef = useRef<HistoryEntry<TLRecord>[]>(
+    discourseContext.lastActions,
+  );
 
   const [isConvertToDialogOpen, setConvertToDialogOpen] = useState(false);
 
@@ -1066,6 +1072,8 @@ const TldrawCanvasShared = ({
 
               app.on("event", (event) => {
                 const e = event as TLPointerEventInfo;
+
+                discourseContext.lastAppEvent = e.name;
 
                 // Handle relation creation on pointer_down
                 handleRelationCreation(app, e);

--- a/apps/roam/src/components/canvas/Tldraw.tsx
+++ b/apps/roam/src/components/canvas/Tldraw.tsx
@@ -129,15 +129,38 @@ export type DiscourseContextType = {
   nodes: Record<string, DiscourseNode & { index: number }>;
   // { [Relation.Label] => DiscourseRelation[] }
   relations: Record<string, DiscourseRelation[]>;
-  lastAppEvent: string;
-  lastActions: HistoryEntry<TLRecord>[];
 };
 
 export const discourseContext: DiscourseContextType = {
   nodes: {},
   relations: {},
-  lastAppEvent: "",
-  lastActions: [],
+};
+
+let activeCanvasPageUid: string | null = null;
+let activeCanvasEditor: Editor | null = null;
+
+const setActiveCanvas = ({
+  pageUid,
+  editor,
+}: {
+  pageUid: string;
+  editor: Editor | null;
+}) => {
+  if (activeCanvasPageUid === pageUid && activeCanvasEditor === editor) {
+    if (editor && !editor.getInstanceState().isFocused) editor.focus();
+    return;
+  }
+
+  if (activeCanvasEditor && activeCanvasEditor !== editor) {
+    activeCanvasEditor.blur();
+  }
+
+  activeCanvasPageUid = pageUid;
+  activeCanvasEditor = editor;
+
+  if (editor && !editor.getInstanceState().isFocused) {
+    editor.focus();
+  }
 };
 
 export const DEFAULT_WIDTH = 160;
@@ -358,9 +381,7 @@ const TldrawCanvasShared = ({
   const appRef = useRef<Editor | null>(null);
   const lastInsertRef = useRef<VecModel>();
   const containerRef = useRef<HTMLDivElement>(null);
-  const lastActionsRef = useRef<HistoryEntry<TLRecord>[]>(
-    discourseContext.lastActions,
-  );
+  const lastActionsRef = useRef<HistoryEntry<TLRecord>[]>([]);
 
   const [isConvertToDialogOpen, setConvertToDialogOpen] = useState(false);
 
@@ -725,6 +746,16 @@ const TldrawCanvasShared = ({
       inSidebar: !!containerRef.current?.closest(".rm-sidebar-outline"),
     });
   }, [pageUid]);
+
+  useEffect(() => {
+    return () => {
+      if (activeCanvasPageUid === pageUid) {
+        activeCanvasEditor?.blur();
+        activeCanvasPageUid = null;
+        activeCanvasEditor = null;
+      }
+    };
+  }, [pageUid]);
   const { store, needsUpgrade, performUpgrade, error, isLoading } =
     useStoreAdapter(storeAdapterArgs);
   const migratedCloudStoreRef = useRef<string | null>(null);
@@ -788,10 +819,14 @@ const TldrawCanvasShared = ({
         uid?: string;
         val?: string;
         shapeId?: TLShapeId;
+        targetCanvasPageUid?: string;
         onRefresh: () => void;
       }>,
     ) => {
       if (!/canvas/i.test(e.detail.action)) return;
+      const targetCanvasPageUid =
+        e.detail.targetCanvasPageUid ?? activeCanvasPageUid;
+      if (targetCanvasPageUid !== pageUid) return;
       const app = appRef.current;
       if (!app) return;
       const { x, y } = app.getViewportScreenCenter();
@@ -917,6 +952,9 @@ const TldrawCanvasShared = ({
       tabIndex={-1}
       onDragOver={handleDragOver}
       onDrop={handleDrop}
+      onPointerDownCapture={() => {
+        setActiveCanvas({ pageUid, editor: appRef.current });
+      }}
     >
       {isCloudflareSync && (
         <div
@@ -987,6 +1025,7 @@ const TldrawCanvasShared = ({
           <TldrawEditor
             // baseUrl="https://samepage.network/assets/tldraw/"
             // instanceId={initialState.instanceId}
+            autoFocus={false}
             initialState="select"
             shapeUtils={[...defaultShapeUtils, ...customShapeUtils]}
             tools={[...defaultTools, ...defaultShapeTools, ...customTools]}
@@ -1001,6 +1040,10 @@ const TldrawCanvasShared = ({
               }
 
               appRef.current = app;
+
+              if (!activeCanvasPageUid || activeCanvasPageUid === pageUid) {
+                setActiveCanvas({ pageUid, editor: app });
+              }
 
               void syncCanvasNodeTitlesOnLoad(
                 app,
@@ -1021,8 +1064,6 @@ const TldrawCanvasShared = ({
 
               app.on("event", (event) => {
                 const e = event as TLPointerEventInfo;
-
-                discourseContext.lastAppEvent = e.name;
 
                 // Handle relation creation on pointer_down
                 handleRelationCreation(app, e);

--- a/apps/roam/src/components/results-view/ResultsTable.tsx
+++ b/apps/roam/src/components/results-view/ResultsTable.tsx
@@ -231,9 +231,9 @@ const ResultRow = ({
           {...buttonProps}
           onClick={(event) => {
             const targetCanvasPageUid =
-              event.currentTarget
-                .closest<HTMLElement>("[data-page-uid]")
-                ?.dataset.pageUid || undefined;
+              event.currentTarget.closest<HTMLElement>(
+                ".roamjs-tldraw-canvas-container[data-page-uid]",
+              )?.dataset.pageUid || undefined;
             document.dispatchEvent(
               new CustomEvent("roamjs:query-builder:action", {
                 detail: {

--- a/apps/roam/src/components/results-view/ResultsTable.tsx
+++ b/apps/roam/src/components/results-view/ResultsTable.tsx
@@ -229,7 +229,11 @@ const ResultRow = ({
       return (
         <Button
           {...buttonProps}
-          onClick={() => {
+          onClick={(event) => {
+            const targetCanvasPageUid =
+              event.currentTarget
+                .closest<HTMLElement>("[data-page-uid]")
+                ?.dataset.pageUid || undefined;
             document.dispatchEvent(
               new CustomEvent("roamjs:query-builder:action", {
                 detail: {
@@ -238,6 +242,7 @@ const ResultRow = ({
                   val: r["text"],
                   onRefresh,
                   queryUid: parentUid,
+                  targetCanvasPageUid,
                 },
               }),
             );


### PR DESCRIPTION
https://www.loom.com/share/8af7d98fbab74f429a8c7a4e4982c260

Scope active canvas focus so clipboard, query builder actions, and shared context don't leak across simultaneously open canvases.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/928" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved canvas focus and blur handling when working with multiple canvases
  * Enhanced action routing to support targeted canvas page selection
  * Disabled auto-focus behavior on Tldraw editor initialization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->