### PR TITLE
ENG-1580 Fix command palette availability

### DIFF
--- a/apps/obsidian/src/utils/registerCommands.ts
+++ b/apps/obsidian/src/utils/registerCommands.ts
@@ -26,7 +26,7 @@ type ModifyNodeSubmitParams = {
 
 const createModifyNodeModalSubmitHandler = (
   plugin: DiscourseGraphPlugin,
-  editor: Editor,
+  editor?: Editor,
 ): ((params: ModifyNodeSubmitParams) => Promise<void>) => {
   return async ({
     nodeType,
@@ -36,7 +36,7 @@ const createModifyNodeModalSubmitHandler = (
     relationshipTargetFile,
   }: ModifyNodeSubmitParams) => {
     if (selectedExistingNode) {
-      editor.replaceSelection(`[[${selectedExistingNode.basename}]]`);
+      editor?.replaceSelection(`[[${selectedExistingNode.basename}]]`);
       await addRelationIfRequested(plugin, selectedExistingNode, {
         relationshipId,
         relationshipTargetFile,
@@ -91,10 +91,10 @@ export const registerCommands = (plugin: DiscourseGraphPlugin) => {
   plugin.addCommand({
     id: "create-discourse-node",
     name: "Create discourse node",
-    editorCallback: (editor: Editor) => {
-      const currentFile =
-        plugin.app.workspace.getActiveViewOfType(MarkdownView)?.file ||
-        undefined;
+    callback: () => {
+      const activeView = plugin.app.workspace.getActiveViewOfType(MarkdownView);
+      const editor = activeView?.editor;
+      const currentFile = activeView?.file || undefined;
       new ModifyNodeModal(plugin.app, {
         nodeTypes: plugin.settings.nodeTypes,
         plugin,

--- a/apps/obsidian/src/utils/templates.ts
+++ b/apps/obsidian/src/utils/templates.ts
@@ -127,10 +127,13 @@ export const applyTemplate = async ({
 
     // Read the actual current frontmatter inside processFrontMatter to avoid
     // stale metadata cache (newly created files may not be indexed yet).
-    await app.fileManager.processFrontMatter(targetFile, (fm) => {
-      const mergedFrontmatter = mergeFrontmatter(templateFrontmatter, fm);
-      Object.assign(fm, mergedFrontmatter);
-    });
+    await app.fileManager.processFrontMatter(
+      targetFile,
+      (fm: Record<string, unknown>) => {
+        const mergedFrontmatter = mergeFrontmatter(templateFrontmatter, fm);
+        Object.assign(fm, mergedFrontmatter);
+      },
+    );
 
     const frontmatterInfo = getFrontMatterInfo(templateContent);
     const templateBody = frontmatterInfo.exists

--- a/apps/obsidian/src/utils/templates.ts
+++ b/apps/obsidian/src/utils/templates.ts
@@ -124,15 +124,11 @@ export const applyTemplate = async ({
 
     const templateFrontmatter =
       app.metadataCache.getFileCache(templateFile)?.frontmatter || {};
-    const currentFrontmatter =
-      app.metadataCache.getFileCache(targetFile)?.frontmatter || {};
 
-    const mergedFrontmatter = mergeFrontmatter(
-      templateFrontmatter,
-      currentFrontmatter,
-    );
-
+    // Read the actual current frontmatter inside processFrontMatter to avoid
+    // stale metadata cache (newly created files may not be indexed yet).
     await app.fileManager.processFrontMatter(targetFile, (fm) => {
+      const mergedFrontmatter = mergeFrontmatter(templateFrontmatter, fm);
       Object.assign(fm, mergedFrontmatter);
     });
 


### PR DESCRIPTION
## Summary

- **Fix stale metadata cache**: `applyTemplate` was reading target file's frontmatter from `metadataCache` before computing the merge, but newly created files may not be indexed yet — causing template frontmatter to overwrite `nodeTypeId` and other fields. Fixed by computing the merge inside `processFrontMatter` where the live `fm` object is available.
- **Fix command palette availability**: `create-discourse-node` used `editorCallback`, which is only available when a markdown editor is active. Switched to `callback` so it's accessible from any view (canvas, graph, file explorer, etc.).
- **Simplify handler**: `createModifyNodeModalSubmitHandler` now accepts `editor?: Editor`, eliminating the duplicate inline fallback handler.

## Test plan

- [ ] Open command palette from a canvas view — "Create discourse node" should appear and work
- [ ] Open command palette from a markdown note — "Create discourse node" should work and insert `[[link]]` if creating from selected text
- [ ] Create a new discourse node with a template assigned — template frontmatter and body should be applied correctly without overwriting `nodeTypeId`
- [ ] Create a node via the `open-node-type-menu` command with a selection — template should still apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/939" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
