### PR TITLE
ENG-739 Move color selector from Canvas to General tab

### DIFF
--- a/apps/roam/src/components/settings/DiscourseNodeCanvasSettings.tsx
+++ b/apps/roam/src/components/settings/DiscourseNodeCanvasSettings.tsx
@@ -1,11 +1,9 @@
 import {
   InputGroup,
-  Label,
   Radio,
   RadioGroup,
   Tooltip,
   Icon,
-  ControlGroup,
 } from "@blueprintjs/core";
 import React, { useState, useMemo } from "react";
 import getBasicTreeByParentUid from "roamjs-components/queries/getBasicTreeByParentUid";
@@ -37,10 +35,6 @@ const DiscourseNodeCanvasSettings = ({
   uid: string;
 }) => {
   const tree = useMemo(() => getBasicTreeByParentUid(uid), [uid]);
-  const [color, setColor] = useState<string>(() => {
-    const color = getSettingValueFromTree({ tree, key: "color" });
-    return formatHexColor(color);
-  });
   const alias = getSettingValueFromTree({ tree, key: "alias" });
   const [queryBuilderAlias, setQueryBuilderAlias] = useState<string>(() =>
     getSettingValueFromTree({ tree, key: "query-builder-alias" }),
@@ -54,49 +48,6 @@ const DiscourseNodeCanvasSettings = ({
 
   return (
     <div>
-      <div className="mb-4">
-        <Label style={{ marginBottom: "4px" }}>Color picker</Label>
-        <ControlGroup>
-          <InputGroup
-            style={{ width: 120 }}
-            type={"color"}
-            value={color}
-            onChange={(e) => {
-              const colorValue = e.target.value.replace("#", ""); // remove hash to not create roam link
-              setColor(e.target.value);
-              void setInputSetting({
-                blockUid: uid,
-                key: "color",
-                value: colorValue,
-              });
-              setDiscourseNodeSetting(
-                nodeType,
-                ["canvasSettings", "color"],
-                colorValue,
-              );
-            }}
-          />
-          <Tooltip content={color ? "Unset" : "Color not set"}>
-            <Icon
-              className={"ml-2 align-middle opacity-80"}
-              icon={color ? "delete" : "info-sign"}
-              onClick={() => {
-                setColor("");
-                void setInputSetting({
-                  blockUid: uid,
-                  key: "color",
-                  value: "",
-                });
-                setDiscourseNodeSetting(
-                  nodeType,
-                  ["canvasSettings", "color"],
-                  "",
-                );
-              }}
-            />
-          </Tooltip>
-        </ControlGroup>
-      </div>
       <DiscourseNodeTextPanel
         nodeType={nodeType}
         title="Display alias"

--- a/apps/roam/src/components/settings/NodeConfig.tsx
+++ b/apps/roam/src/components/settings/NodeConfig.tsx
@@ -12,7 +12,6 @@ import {
   ControlGroup,
   Tooltip,
   Icon,
-  Tag,
 } from "@blueprintjs/core";
 import DiscourseNodeSpecification from "./DiscourseNodeSpecification";
 import DiscourseNodeAttributes from "./DiscourseNodeAttributes";

--- a/apps/roam/src/components/settings/NodeConfig.tsx
+++ b/apps/roam/src/components/settings/NodeConfig.tsx
@@ -3,13 +3,27 @@ import { DiscourseNode } from "~/utils/getDiscourseNodes";
 import DualWriteBlocksPanel from "./components/EphemeralBlocksPanel";
 import { getSubTree } from "roamjs-components/util";
 import Description from "roamjs-components/components/Description";
-import { Label, Tabs, Tab, TabId } from "@blueprintjs/core";
+import {
+  Label,
+  Tabs,
+  Tab,
+  TabId,
+  InputGroup,
+  ControlGroup,
+  Tooltip,
+  Icon,
+} from "@blueprintjs/core";
 import DiscourseNodeSpecification from "./DiscourseNodeSpecification";
 import DiscourseNodeAttributes from "./DiscourseNodeAttributes";
-import DiscourseNodeCanvasSettings from "./DiscourseNodeCanvasSettings";
+import DiscourseNodeCanvasSettings, {
+  formatHexColor,
+} from "./DiscourseNodeCanvasSettings";
 import DiscourseNodeIndex from "./DiscourseNodeIndex";
 import { OnloadArgs } from "roamjs-components/types";
 import getBasicTreeByParentUid from "roamjs-components/queries/getBasicTreeByParentUid";
+import getSettingValueFromTree from "roamjs-components/util/getSettingValueFromTree";
+import setInputSetting from "roamjs-components/util/setInputSetting";
+import { setDiscourseNodeSetting } from "~/components/settings/utils/accessors";
 import DiscourseNodeSuggestiveRules from "./DiscourseNodeSuggestiveRules";
 import { getFormattedConfigTree } from "~/utils/discourseConfigRef";
 import refreshConfigTree from "~/utils/refreshConfigTree";
@@ -68,6 +82,18 @@ const NodeConfig = ({
   const attributeNode = getSubTree({
     parentUid: node.type,
     key: "Attributes",
+  });
+
+  const canvasTree = useMemo(
+    () => getBasicTreeByParentUid(canvasUid),
+    [canvasUid],
+  );
+  const [color, setColor] = useState<string>(() => {
+    const colorValue = getSettingValueFromTree({
+      tree: canvasTree,
+      key: "color",
+    });
+    return formatHexColor(colorValue);
   });
 
   const [selectedTabId, setSelectedTabId] = useState<TabId>("general");
@@ -181,6 +207,49 @@ const NodeConfig = ({
                 parentUid={node.type}
                 uid={tagUid}
               />
+              <div>
+                <Label style={{ marginBottom: "4px" }}>Color</Label>
+                <ControlGroup>
+                  <InputGroup
+                    style={{ width: 120 }}
+                    type={"color"}
+                    value={color}
+                    onChange={(e) => {
+                      const colorValue = e.target.value.replace("#", ""); // remove hash to not create roam link
+                      setColor(e.target.value);
+                      void setInputSetting({
+                        blockUid: canvasUid,
+                        key: "color",
+                        value: colorValue,
+                      });
+                      setDiscourseNodeSetting(
+                        node.type,
+                        ["canvasSettings", "color"],
+                        colorValue,
+                      );
+                    }}
+                  />
+                  <Tooltip content={color ? "Unset" : "Color not set"}>
+                    <Icon
+                      className={"ml-2 align-middle opacity-80"}
+                      icon={color ? "delete" : "info-sign"}
+                      onClick={() => {
+                        setColor("");
+                        void setInputSetting({
+                          blockUid: canvasUid,
+                          key: "color",
+                          value: "",
+                        });
+                        setDiscourseNodeSetting(
+                          node.type,
+                          ["canvasSettings", "color"],
+                          "",
+                        );
+                      }}
+                    />
+                  </Tooltip>
+                </ControlGroup>
+              </div>
             </div>
           }
         />

--- a/apps/roam/src/components/settings/NodeConfig.tsx
+++ b/apps/roam/src/components/settings/NodeConfig.tsx
@@ -12,6 +12,7 @@ import {
   ControlGroup,
   Tooltip,
   Icon,
+  Tag,
 } from "@blueprintjs/core";
 import DiscourseNodeSpecification from "./DiscourseNodeSpecification";
 import DiscourseNodeAttributes from "./DiscourseNodeAttributes";
@@ -206,6 +207,7 @@ const NodeConfig = ({
                 order={2}
                 parentUid={node.type}
                 uid={tagUid}
+                inputStyle={color ? { color } : undefined}
               />
               <div>
                 <Label style={{ marginBottom: "4px" }}>Color</Label>

--- a/apps/roam/src/components/settings/NodeConfig.tsx
+++ b/apps/roam/src/components/settings/NodeConfig.tsx
@@ -10,6 +10,8 @@ import {
   TabId,
   InputGroup,
   ControlGroup,
+  Tooltip,
+  Icon,
 } from "@blueprintjs/core";
 import DiscourseNodeSpecification from "./DiscourseNodeSpecification";
 import DiscourseNodeAttributes from "./DiscourseNodeAttributes";
@@ -19,7 +21,6 @@ import DiscourseNodeCanvasSettings, {
 import DiscourseNodeIndex from "./DiscourseNodeIndex";
 import { OnloadArgs } from "roamjs-components/types";
 import getBasicTreeByParentUid from "roamjs-components/queries/getBasicTreeByParentUid";
-import getSettingValueFromTree from "roamjs-components/util/getSettingValueFromTree";
 import setInputSetting from "roamjs-components/util/setInputSetting";
 import { setDiscourseNodeSetting } from "~/components/settings/utils/accessors";
 import DiscourseNodeSuggestiveRules from "./DiscourseNodeSuggestiveRules";
@@ -82,17 +83,9 @@ const NodeConfig = ({
     key: "Attributes",
   });
 
-  const canvasTree = useMemo(
-    () => getBasicTreeByParentUid(canvasUid),
-    [canvasUid],
+  const [color, setColor] = useState<string>(() =>
+    formatHexColor(node.canvasSettings?.color ?? ""),
   );
-  const [color, setColor] = useState<string>(() => {
-    const colorValue = getSettingValueFromTree({
-      tree: canvasTree,
-      key: "color",
-    });
-    return formatHexColor(colorValue);
-  });
 
   const [selectedTabId, setSelectedTabId] = useState<TabId>("general");
   const [tagError, setTagError] = useState("");
@@ -229,6 +222,25 @@ const NodeConfig = ({
                         );
                       }}
                     />
+                    <Tooltip content={color ? "Unset" : "Color not set"}>
+                      <Icon
+                        className={"ml-2 align-middle opacity-80"}
+                        icon={color ? "delete" : "info-sign"}
+                        onClick={() => {
+                          setColor("");
+                          void setInputSetting({
+                            blockUid: canvasUid,
+                            key: "color",
+                            value: "",
+                          });
+                          setDiscourseNodeSetting(
+                            node.type,
+                            ["canvasSettings", "color"],
+                            "",
+                          );
+                        }}
+                      />
+                    </Tooltip>
                   </ControlGroup>
                 </Label>
               </>

--- a/apps/roam/src/components/settings/NodeConfig.tsx
+++ b/apps/roam/src/components/settings/NodeConfig.tsx
@@ -10,8 +10,6 @@ import {
   TabId,
   InputGroup,
   ControlGroup,
-  Tooltip,
-  Icon,
 } from "@blueprintjs/core";
 import DiscourseNodeSpecification from "./DiscourseNodeSpecification";
 import DiscourseNodeAttributes from "./DiscourseNodeAttributes";

--- a/apps/roam/src/components/settings/NodeConfig.tsx
+++ b/apps/roam/src/components/settings/NodeConfig.tsx
@@ -206,10 +206,12 @@ const NodeConfig = ({
                 order={2}
                 parentUid={node.type}
                 uid={tagUid}
-                inputStyle={color ? { color } : undefined}
               />
-              <div>
-                <Label style={{ marginBottom: "4px" }}>Color</Label>
+              <>
+                <Label>
+                  Color
+                  <Description description="Changes the color of tags and canvas nodes" />
+                </Label>
                 <ControlGroup>
                   <InputGroup
                     style={{ width: 120 }}
@@ -250,7 +252,7 @@ const NodeConfig = ({
                     />
                   </Tooltip>
                 </ControlGroup>
-              </div>
+              </>
             </div>
           }
         />

--- a/apps/roam/src/components/settings/NodeConfig.tsx
+++ b/apps/roam/src/components/settings/NodeConfig.tsx
@@ -211,47 +211,28 @@ const NodeConfig = ({
                 <Label>
                   Color
                   <Description description="Changes the color of tags and canvas nodes" />
-                </Label>
-                <ControlGroup>
-                  <InputGroup
-                    style={{ width: 120 }}
-                    type={"color"}
-                    value={color}
-                    onChange={(e) => {
-                      const colorValue = e.target.value.replace("#", ""); // remove hash to not create roam link
-                      setColor(e.target.value);
-                      void setInputSetting({
-                        blockUid: canvasUid,
-                        key: "color",
-                        value: colorValue,
-                      });
-                      setDiscourseNodeSetting(
-                        node.type,
-                        ["canvasSettings", "color"],
-                        colorValue,
-                      );
-                    }}
-                  />
-                  <Tooltip content={color ? "Unset" : "Color not set"}>
-                    <Icon
-                      className={"ml-2 align-middle opacity-80"}
-                      icon={color ? "delete" : "info-sign"}
-                      onClick={() => {
-                        setColor("");
+                  <ControlGroup>
+                    <InputGroup
+                      style={{ width: 120 }}
+                      type={"color"}
+                      value={color}
+                      onChange={(e) => {
+                        const colorValue = e.target.value.replace("#", ""); // remove hash to not create roam link
+                        setColor(e.target.value);
                         void setInputSetting({
                           blockUid: canvasUid,
                           key: "color",
-                          value: "",
+                          value: colorValue,
                         });
                         setDiscourseNodeSetting(
                           node.type,
                           ["canvasSettings", "color"],
-                          "",
+                          colorValue,
                         );
                       }}
                     />
-                  </Tooltip>
-                </ControlGroup>
+                  </ControlGroup>
+                </Label>
               </>
             </div>
           }

--- a/apps/roam/src/components/settings/components/BlockPropSettingPanels.tsx
+++ b/apps/roam/src/components/settings/components/BlockPropSettingPanels.tsx
@@ -50,7 +50,6 @@ type BaseTextPanelProps = {
   multiline?: boolean;
   error?: string;
   onChange?: (value: string) => void;
-  inputStyle?: React.CSSProperties;
 } & RoamBlockSyncProps;
 
 type BaseFlagPanelProps = {
@@ -106,7 +105,6 @@ const BaseTextPanel = ({
   multiline,
   error,
   onChange,
-  inputStyle,
   parentUid,
   uid,
   order,
@@ -164,7 +162,6 @@ const BaseTextPanel = ({
             value={value}
             onChange={handleChange}
             placeholder={placeholder || initialValue}
-            style={inputStyle}
           />
         )}
       </Label>
@@ -615,7 +612,6 @@ export const DiscourseNodeTextPanel = ({
     multiline?: boolean;
     error?: string;
     onChange?: (value: string) => void;
-    inputStyle?: React.CSSProperties;
   }) => (
   <BaseTextPanel {...props} setter={createDiscourseNodeSetter(nodeType)} />
 );

--- a/apps/roam/src/components/settings/components/BlockPropSettingPanels.tsx
+++ b/apps/roam/src/components/settings/components/BlockPropSettingPanels.tsx
@@ -50,6 +50,7 @@ type BaseTextPanelProps = {
   multiline?: boolean;
   error?: string;
   onChange?: (value: string) => void;
+  inputStyle?: React.CSSProperties;
 } & RoamBlockSyncProps;
 
 type BaseFlagPanelProps = {
@@ -105,6 +106,7 @@ const BaseTextPanel = ({
   multiline,
   error,
   onChange,
+  inputStyle,
   parentUid,
   uid,
   order,
@@ -162,6 +164,7 @@ const BaseTextPanel = ({
             value={value}
             onChange={handleChange}
             placeholder={placeholder || initialValue}
+            style={inputStyle}
           />
         )}
       </Label>
@@ -612,6 +615,7 @@ export const DiscourseNodeTextPanel = ({
     multiline?: boolean;
     error?: string;
     onChange?: (value: string) => void;
+    inputStyle?: React.CSSProperties;
   }) => (
   <BaseTextPanel {...props} setter={createDiscourseNodeSetter(nodeType)} />
 );


### PR DESCRIPTION
## Summary
- Moves the color picker from the **Canvas** tab to the **General** tab in node type settings
-  Tag now also has previewed color
<img width="1728" height="1117" alt="Screenshot 2026-04-08 at 15 25 02" src="https://github.com/user-attachments/assets/2ca02434-136e-412b-ae76-adb9341f359c" />

After changing setting, node tag and node menu reflects the changes fron General tab
<img width="507" height="447" alt="Screenshot 2026-04-08 at 15 25 25" src="https://github.com/user-attachments/assets/5a7d0725-446e-4758-843b-a3289b3d0dc8" />

Canvas no longer has color picker
<img width="1728" height="1117" alt="Screenshot 2026-04-08 at 15 24 37" src="https://github.com/user-attachments/assets/31b7fb22-6878-4dd1-ac6b-c87cc2774a5f" />

Closes ENG-739

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/945" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
