### PR TITLE
ENG-1629: Fix relations.json scattered across multiple locations

### DIFF
--- a/apps/obsidian/src/index.ts
+++ b/apps/obsidian/src/index.ts
@@ -32,7 +32,10 @@ import { InlineNodeTypePicker } from "~/components/InlineNodeTypePicker";
 import { initializeSupabaseSync } from "~/utils/syncDgNodesToSupabase";
 import { FileChangeListener } from "~/utils/fileChangeListener";
 import generateUid from "~/utils/generateUid";
-import { migrateFrontmatterRelationsToRelationsJson } from "~/utils/relationsStore";
+import {
+  migrateFrontmatterRelationsToRelationsJson,
+  mergeAllRelationsJsonToRoot,
+} from "~/utils/relationsStore";
 
 export default class DiscourseGraphPlugin extends Plugin {
   settings: Settings = { ...DEFAULT_SETTINGS };
@@ -44,6 +47,10 @@ export default class DiscourseGraphPlugin extends Plugin {
 
   async onload() {
     await this.loadSettings();
+
+    await mergeAllRelationsJsonToRoot(this).catch((error) => {
+      console.error("Failed to merge relations.json files:", error);
+    });
 
     await migrateFrontmatterRelationsToRelationsJson(this).catch((error) => {
       console.error("Failed to migrate frontmatter relations:", error);

--- a/apps/obsidian/src/utils/relationsStore.ts
+++ b/apps/obsidian/src/utils/relationsStore.ts
@@ -3,7 +3,6 @@ import { uuidv7 } from "uuidv7";
 import type { DGSupabaseClient } from "@repo/database/lib/client";
 import type DiscourseGraphPlugin from "~/index";
 import { ensureNodeInstanceId } from "~/utils/nodeInstanceId";
-import { checkAndCreateFolder } from "~/utils/file";
 import { getVaultId, getLocalSpaceUri } from "./supabaseContext";
 import type { RelationInstance } from "~/types";
 import { QueryEngine, getImportedNodesRaw } from "~/services/QueryEngine";
@@ -14,13 +13,9 @@ import { getSpaceIdsBySpaceUris } from "./spaceFromRid";
 const RELATIONS_FILE_NAME = "relations.json";
 const RELATIONS_FILE_VERSION = 1;
 
-/** Vault-relative path for relations.json, under the same folder as nodes (nodesFolderPath). */
-export const getRelationsFilePath = (plugin: DiscourseGraphPlugin): string => {
-  const folderPath = plugin.settings.nodesFolderPath.trim();
-  return folderPath
-    ? normalizePath(`${folderPath}/${RELATIONS_FILE_NAME}`)
-    : normalizePath(RELATIONS_FILE_NAME);
-};
+/** Vault-relative path for relations.json — always at vault root. */
+export const getRelationsFilePath = (): string =>
+  normalizePath(RELATIONS_FILE_NAME);
 
 export type RelationsFile = {
   version: number;
@@ -37,7 +32,7 @@ const defaultRelationsFile = (): RelationsFile => ({
 export const loadRelations = async (
   plugin: DiscourseGraphPlugin,
 ): Promise<RelationsFile> => {
-  const path = getRelationsFilePath(plugin);
+  const path = getRelationsFilePath();
   const file = plugin.app.vault.getAbstractFileByPath(path);
   if (!file || !(file instanceof TFile)) {
     return defaultRelationsFile();
@@ -67,11 +62,7 @@ export const saveRelations = async (
   plugin: DiscourseGraphPlugin,
   data: RelationsFile,
 ): Promise<void> => {
-  const folderPath = plugin.settings.nodesFolderPath.trim();
-  if (folderPath) {
-    await checkAndCreateFolder(folderPath, plugin.app.vault);
-  }
-  const path = getRelationsFilePath(plugin);
+  const path = getRelationsFilePath();
   const toWrite: RelationsFile = {
     ...data,
     lastModified: Date.now(),
@@ -82,6 +73,50 @@ export const saveRelations = async (
     await plugin.app.vault.modify(file, content);
   } else {
     await plugin.app.vault.create(path, content);
+  }
+};
+
+/**
+ * On plugin load, finds all relations.json files in the vault and merges them
+ * into the canonical location at vault root, then deletes the non-root copies.
+ * Handles the case where a user changed nodesFolderPath, leaving old files behind.
+ */
+export const mergeAllRelationsJsonToRoot = async (
+  plugin: DiscourseGraphPlugin,
+): Promise<void> => {
+  const allFiles = plugin.app.vault.getFiles();
+  const relationsFiles = allFiles.filter((f) => f.name === RELATIONS_FILE_NAME);
+
+  if (relationsFiles.length <= 1) return;
+
+  const merged = defaultRelationsFile();
+  for (const file of relationsFiles) {
+    try {
+      const content = await plugin.app.vault.read(file);
+      const data = JSON.parse(content) as RelationsFile;
+      if (
+        typeof data.version !== "number" ||
+        typeof data.relations !== "object" ||
+        data.relations === null
+      )
+        continue;
+      Object.assign(merged.relations, data.relations);
+      merged.lastModified = Math.max(
+        merged.lastModified,
+        data.lastModified ?? 0,
+      );
+    } catch {
+      // skip unreadable or unparseable files
+    }
+  }
+
+  await saveRelations(plugin, merged);
+
+  const rootPath = normalizePath(RELATIONS_FILE_NAME);
+  for (const file of relationsFiles) {
+    if (file.path !== rootPath) {
+      await plugin.app.vault.delete(file);
+    }
   }
 };
 

--- a/apps/obsidian/src/utils/relationsStore.ts
+++ b/apps/obsidian/src/utils/relationsStore.ts
@@ -93,7 +93,7 @@ export const mergeAllRelationsJsonToRoot = async (
 
   // Process non-root files first so root values win on duplicate IDs.
   const sortedFiles = [
-    ...relationsFiles.filter((f) => f.path !== rootPath),
+    ...nonRootFiles,
     ...relationsFiles.filter((f) => f.path === rootPath),
   ];
   const merged = defaultRelationsFile();

--- a/apps/obsidian/src/utils/relationsStore.ts
+++ b/apps/obsidian/src/utils/relationsStore.ts
@@ -86,8 +86,10 @@ export const mergeAllRelationsJsonToRoot = async (
 ): Promise<void> => {
   const allFiles = plugin.app.vault.getFiles();
   const relationsFiles = allFiles.filter((f) => f.name === RELATIONS_FILE_NAME);
+  const rootPath = normalizePath(RELATIONS_FILE_NAME);
+  const nonRootFiles = relationsFiles.filter((f) => f.path !== rootPath);
 
-  if (relationsFiles.length <= 1) return;
+  if (nonRootFiles.length === 0) return;
 
   const merged = defaultRelationsFile();
   for (const file of relationsFiles) {
@@ -112,11 +114,8 @@ export const mergeAllRelationsJsonToRoot = async (
 
   await saveRelations(plugin, merged);
 
-  const rootPath = normalizePath(RELATIONS_FILE_NAME);
-  for (const file of relationsFiles) {
-    if (file.path !== rootPath) {
-      await plugin.app.vault.delete(file);
-    }
+  for (const file of nonRootFiles) {
+    await plugin.app.vault.delete(file);
   }
 };
 

--- a/apps/obsidian/src/utils/relationsStore.ts
+++ b/apps/obsidian/src/utils/relationsStore.ts
@@ -91,8 +91,14 @@ export const mergeAllRelationsJsonToRoot = async (
 
   if (nonRootFiles.length === 0) return;
 
+  // Process non-root files first so root values win on duplicate IDs.
+  const sortedFiles = [
+    ...relationsFiles.filter((f) => f.path !== rootPath),
+    ...relationsFiles.filter((f) => f.path === rootPath),
+  ];
   const merged = defaultRelationsFile();
-  for (const file of relationsFiles) {
+  const validatedNonRootFiles: TFile[] = [];
+  for (const file of sortedFiles) {
     try {
       const content = await plugin.app.vault.read(file);
       const data = JSON.parse(content) as RelationsFile;
@@ -107,6 +113,7 @@ export const mergeAllRelationsJsonToRoot = async (
         merged.lastModified,
         data.lastModified ?? 0,
       );
+      if (file.path !== rootPath) validatedNonRootFiles.push(file);
     } catch {
       // skip unreadable or unparseable files
     }
@@ -114,7 +121,7 @@ export const mergeAllRelationsJsonToRoot = async (
 
   await saveRelations(plugin, merged);
 
-  for (const file of nonRootFiles) {
+  for (const file of validatedNonRootFiles) {
     await plugin.app.vault.delete(file);
   }
 };


### PR DESCRIPTION
https://www.loom.com/share/22b4cdcb5bbd4c97bb3bee5c511b62ba

https://www.loom.com/share/f16841a6e6364864bf293418b096f957

## Summary

- `getRelationsFilePath()` now always returns vault root (`relations.json`), removing the `nodesFolderPath`-dependent path logic
- `saveRelations()` no longer creates a folder under `nodesFolderPath` since root always exists
- New `mergeAllRelationsJsonToRoot()` runs on every plugin load: finds all `relations.json` files in the vault, merges valid DG relation data into the root copy, and deletes non-root copies

## Test plan

- [x] Set `nodesFolderPath` to a folder, add a relation → `relations.json` exists in that folder. Reload plugin → file is now at vault root, old file deleted
- [x] Manually create `relations.json` files at multiple locations with different relations → reload plugin → single merged `relations.json` at root, others deleted
- [x] Reload plugin a second time → `mergeAllRelationsJsonToRoot` returns immediately (≤1 file), no extra work
- [x] Place an unrelated `relations.json` (missing `version`/`relations` fields) → migration skips it, doesn't merge or delete it
- [x] Add/remove a relation after migration → reads/writes to `relations.json` at vault root

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/947" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
