### PR TITLE
ENG-1611 Add provisional status to imported relation schemas

### DIFF
--- a/apps/obsidian/src/components/ModifyNodeModal.tsx
+++ b/apps/obsidian/src/components/ModifyNodeModal.tsx
@@ -11,6 +11,7 @@ import {
 import { DiscourseNode } from "~/types";
 import type DiscourseGraphPlugin from "~/index";
 import { QueryEngine } from "~/services/QueryEngine";
+import { isProvisionalSchema } from "~/utils/typeUtils";
 
 type ModifyNodeFormProps = {
   nodeTypes: DiscourseNode[];
@@ -159,13 +160,17 @@ export const ModifyNodeForm = ({
       return [];
     }
 
-    // Find all relations that connect the current node type to the selected node type
+    // Find all accepted relations that connect the current node type to the selected node type
     const relevantRelations = plugin.settings.discourseRelations.filter(
-      (relation) =>
-        (relation.sourceId === currentNodeTypeId &&
-          relation.destinationId === selectedNodeType.id) ||
-        (relation.sourceId === selectedNodeType.id &&
-          relation.destinationId === currentNodeTypeId),
+      (relation) => {
+        if (isProvisionalSchema(relation)) return false;
+        return (
+          (relation.sourceId === currentNodeTypeId &&
+            relation.destinationId === selectedNodeType.id) ||
+          (relation.sourceId === selectedNodeType.id &&
+            relation.destinationId === currentNodeTypeId)
+        );
+      },
     );
 
     const relations = relevantRelations
@@ -173,7 +178,7 @@ export const ModifyNodeForm = ({
         const relationType = plugin.settings.relationTypes.find(
           (rt) => rt.id === relation.relationshipTypeId,
         );
-        if (!relationType) return null;
+        if (!relationType || isProvisionalSchema(relationType)) return null;
 
         const isCurrentFileSource = relation.sourceId === currentNodeTypeId;
         return {

--- a/apps/obsidian/src/components/RelationshipSection.tsx
+++ b/apps/obsidian/src/components/RelationshipSection.tsx
@@ -76,6 +76,7 @@ const AddRelationship = ({
 
     const relations = plugin.settings.discourseRelations.filter(
       (relation) =>
+        isAcceptedSchema(relation) &&
         relation.relationshipTypeId === selectedRelationType.id &&
         (selectedRelationType.isSource
           ? relation.sourceId === activeNodeTypeId

--- a/apps/obsidian/src/components/RelationshipSection.tsx
+++ b/apps/obsidian/src/components/RelationshipSection.tsx
@@ -11,7 +11,11 @@ import SearchBar from "./SearchBar";
 import { DiscourseNode } from "~/types";
 import DropdownSelect from "./DropdownSelect";
 import { usePlugin } from "./PluginContext";
-import { getNodeTypeById, getAndFormatImportSource } from "~/utils/typeUtils";
+import {
+  getNodeTypeById,
+  getAndFormatImportSource,
+  isAcceptedSchema,
+} from "~/utils/typeUtils";
 import type { RelationInstance } from "~/types";
 import {
   getNodeInstanceIdForFile,
@@ -100,8 +104,9 @@ const AddRelationship = ({
 
     const relevantRelations = plugin.settings.discourseRelations.filter(
       (relation) =>
-        relation.sourceId === activeNodeTypeId ||
-        relation.destinationId === activeNodeTypeId,
+        isAcceptedSchema(relation) &&
+        (relation.sourceId === activeNodeTypeId ||
+          relation.destinationId === activeNodeTypeId),
     );
 
     relevantRelations.forEach((relation) => {

--- a/apps/obsidian/src/components/RelationshipSettings.tsx
+++ b/apps/obsidian/src/components/RelationshipSettings.tsx
@@ -7,6 +7,8 @@ import {
   getNodeTypeById,
   getImportInfo,
   formatImportSource,
+  isAcceptedSchema,
+  isProvisionalSchema,
 } from "~/utils/typeUtils";
 import generateUid from "~/utils/generateUid";
 
@@ -25,7 +27,7 @@ const RelationshipSettings = () => {
 
   type EditableFieldKey = keyof Omit<
     DiscourseRelation,
-    "id" | "modified" | "created" | "importedFromRid"
+    "id" | "modified" | "created" | "importedFromRid" | "status"
   >;
 
   const saveSettings = (relations: DiscourseRelation[]): void => {
@@ -136,6 +138,33 @@ const RelationshipSettings = () => {
     modal.open();
   };
 
+  const handleAcceptRelation = async (index: number): Promise<void> => {
+    const updatedRelations = [...discourseRelations];
+    const relation = updatedRelations[index];
+    if (!relation) return;
+    updatedRelations[index] = { ...relation, status: "accepted" };
+
+    // Cascade: also accept the relation type if it is still provisional
+    const updatedRelationTypes = [...plugin.settings.relationTypes];
+    const relTypeIndex = updatedRelationTypes.findIndex(
+      (rt) => rt.id === relation.relationshipTypeId,
+    );
+    if (
+      relTypeIndex >= 0 &&
+      isProvisionalSchema(updatedRelationTypes[relTypeIndex]!)
+    ) {
+      updatedRelationTypes[relTypeIndex] = {
+        ...updatedRelationTypes[relTypeIndex]!,
+        status: "accepted",
+      };
+      plugin.settings.relationTypes = updatedRelationTypes;
+    }
+
+    setDiscourseRelations(updatedRelations);
+    plugin.settings.discourseRelations = updatedRelations;
+    await plugin.saveSettings();
+  };
+
   const handleDeleteRelation = async (index: number): Promise<void> => {
     const updatedRelations = discourseRelations.filter((_, i) => i !== index);
     setDiscourseRelations(updatedRelations);
@@ -154,6 +183,10 @@ const RelationshipSettings = () => {
   const renderRelationItem = (relation: DiscourseRelation, index: number) => {
     const importInfo = getImportInfo(relation.importedFromRid);
     const isImported = importInfo.isImported;
+    const isProvisional = isProvisionalSchema(relation);
+    const spaceName = importInfo.spaceUri
+      ? formatImportSource(importInfo.spaceUri, plugin.settings.spaceNames)
+      : "imported space";
     const error = errors[index];
 
     return (
@@ -189,7 +222,10 @@ const RelationshipSettings = () => {
               disabled={isImported}
             >
               <option value="">Relation Type</option>
-              {plugin.settings.relationTypes.map((relType) => (
+              {(isImported
+                ? plugin.settings.relationTypes
+                : plugin.settings.relationTypes.filter(isAcceptedSchema)
+              ).map((relType) => (
                 <option key={relType.id} value={relType.id}>
                   {relType.label} / {relType.complement}
                 </option>
@@ -212,7 +248,25 @@ const RelationshipSettings = () => {
               ))}
             </select>
 
-            {!isImported && (
+            {isImported ? (
+              <div className="flex gap-2">
+                {isProvisional && (
+                  <button
+                    onClick={() => void handleAcceptRelation(index)}
+                    className="p-2"
+                    title={`Accept this relation triplet from ${spaceName} to create instances of this relation`}
+                  >
+                    Accept
+                  </button>
+                )}
+                <button
+                  onClick={() => confirmDeleteRelation(index)}
+                  className="mod-warning p-2"
+                >
+                  Delete
+                </button>
+              </div>
+            ) : (
               <button
                 onClick={() => confirmDeleteRelation(index)}
                 className="mod-warning p-2"
@@ -224,6 +278,11 @@ const RelationshipSettings = () => {
           {error && <div className="text-error text-xs">{error}</div>}
           {isImported && (
             <div className="text-muted flex items-center gap-2 text-xs">
+              {isProvisional && (
+                <span className="rounded bg-yellow-100 px-1.5 py-0.5 text-xs font-medium text-yellow-800">
+                  Provisional
+                </span>
+              )}
               {importInfo.spaceUri && (
                 <span>
                   from{" "}

--- a/apps/obsidian/src/components/RelationshipTypeSettings.tsx
+++ b/apps/obsidian/src/components/RelationshipTypeSettings.tsx
@@ -12,7 +12,11 @@ import {
   type TldrawColorName,
 } from "~/utils/tldrawColors";
 import { getContrastColor } from "~/utils/colorUtils";
-import { getImportInfo, formatImportSource } from "~/utils/typeUtils";
+import {
+  getImportInfo,
+  formatImportSource,
+  isProvisionalSchema,
+} from "~/utils/typeUtils";
 
 type ColorPickerProps = {
   value: string;
@@ -105,7 +109,7 @@ const RelationshipTypeSettings = () => {
 
   type EditableFieldKey = keyof Omit<
     DiscourseRelationType,
-    "id" | "modified" | "created" | "importedFromRid"
+    "id" | "modified" | "created" | "importedFromRid" | "status"
   >;
 
   const saveSettings = (updatedRelationTypes: DiscourseRelationType[]) => {
@@ -242,6 +246,16 @@ const RelationshipTypeSettings = () => {
     new Notice("Relation type deleted successfully");
   };
 
+  const handleAcceptRelationType = async (index: number): Promise<void> => {
+    const updatedRelationTypes = [...relationTypes];
+    const relType = updatedRelationTypes[index];
+    if (!relType) return;
+    updatedRelationTypes[index] = { ...relType, status: "accepted" };
+    setRelationTypes(updatedRelationTypes);
+    plugin.settings.relationTypes = updatedRelationTypes;
+    await plugin.saveSettings();
+  };
+
   const localRelationTypes = relationTypes.filter(
     (relationType) => !relationType.importedFromRid,
   );
@@ -255,6 +269,10 @@ const RelationshipTypeSettings = () => {
   ) => {
     const importInfo = getImportInfo(relationType.importedFromRid);
     const isImported = importInfo.isImported;
+    const isProvisional = isProvisionalSchema(relationType);
+    const spaceName = importInfo.spaceUri
+      ? formatImportSource(importInfo.spaceUri, plugin.settings.spaceNames)
+      : "imported space";
 
     const error = errors[index];
 
@@ -291,7 +309,25 @@ const RelationshipTypeSettings = () => {
               }
               disabled={isImported}
             />
-            {!isImported && (
+            {isImported ? (
+              <div className="flex gap-2">
+                {isProvisional && (
+                  <button
+                    onClick={() => void handleAcceptRelationType(index)}
+                    className="p-2"
+                    title={`Accept this relation type from ${spaceName} to create relations of this type`}
+                  >
+                    Accept
+                  </button>
+                )}
+                <button
+                  onClick={() => confirmDeleteRelationType(index)}
+                  className="mod-warning p-2"
+                >
+                  Delete
+                </button>
+              </div>
+            ) : (
               <button
                 onClick={() => confirmDeleteRelationType(index)}
                 className="mod-warning p-2"
@@ -303,6 +339,11 @@ const RelationshipTypeSettings = () => {
           {error && <div className="text-error text-xs">{error}</div>}
           {isImported && (
             <div className="text-muted flex items-center gap-2 text-xs">
+              {isProvisional && (
+                <span className="rounded bg-yellow-100 px-1.5 py-0.5 text-xs font-medium text-yellow-800">
+                  Provisional
+                </span>
+              )}
               {importInfo.spaceUri && (
                 <span>
                   from{" "}

--- a/apps/obsidian/src/components/canvas/DiscourseRelationTool.ts
+++ b/apps/obsidian/src/components/canvas/DiscourseRelationTool.ts
@@ -2,7 +2,7 @@ import { StateNode, TLEventHandlers, TLStateNodeConstructor } from "tldraw";
 import { createShapeId } from "tldraw";
 import type { TFile } from "obsidian";
 import DiscourseGraphPlugin from "~/index";
-import { getRelationTypeById } from "~/utils/typeUtils";
+import { getRelationTypeById, isAcceptedSchema } from "~/utils/typeUtils";
 import { DiscourseRelationShape } from "./shapes/DiscourseRelationShape";
 import { getNodeTypeById } from "~/utils/typeUtils";
 import { showToast } from "./utils/toastUtils";
@@ -95,9 +95,10 @@ class Pointing extends StateNode {
   ): string[] => {
     const compatibleTypes: string[] = [];
 
-    // Find all discourse relations that match the relation type and source
+    // Find all accepted discourse relations that match the relation type and source
     const relations = plugin.settings.discourseRelations.filter(
       (relation) =>
+        isAcceptedSchema(relation) &&
         relation.relationshipTypeId === relationTypeId &&
         relation.sourceId === sourceNodeTypeId,
     );
@@ -109,6 +110,7 @@ class Pointing extends StateNode {
     // Also check reverse relations (where current node is destination)
     const reverseRelations = plugin.settings.discourseRelations.filter(
       (relation) =>
+        isAcceptedSchema(relation) &&
         relation.relationshipTypeId === relationTypeId &&
         relation.destinationId === sourceNodeTypeId,
     );

--- a/apps/obsidian/src/components/canvas/DiscourseToolPanel.tsx
+++ b/apps/obsidian/src/components/canvas/DiscourseToolPanel.tsx
@@ -10,7 +10,7 @@ import * as React from "react";
 import { TFile } from "obsidian";
 import DiscourseGraphPlugin from "~/index";
 import { openCreateDiscourseNodeAt } from "./utils/nodeCreationFlow";
-import { getNodeTypeById } from "~/utils/typeUtils";
+import { getNodeTypeById, isAcceptedSchema } from "~/utils/typeUtils";
 import { useEffect } from "react";
 import { setDiscourseNodeToolContext } from "./DiscourseNodeTool";
 import {
@@ -195,7 +195,7 @@ export const DiscourseToolPanel = ({
   );
 
   const nodeTypes = plugin.settings.nodeTypes;
-  const relationTypes = plugin.settings.relationTypes;
+  const relationTypes = plugin.settings.relationTypes.filter(isAcceptedSchema);
 
   useEffect(() => {
     if (!focusedNodeTypeId) return;

--- a/apps/obsidian/src/components/canvas/overlays/RelationPanel.tsx
+++ b/apps/obsidian/src/components/canvas/overlays/RelationPanel.tsx
@@ -17,7 +17,7 @@ import {
   getArrowBindings,
 } from "~/components/canvas/utils/relationUtils";
 import { getFrontmatterForFile } from "~/components/canvas/shapes/discourseNodeShapeUtils";
-import { getRelationTypeById } from "~/utils/typeUtils";
+import { getRelationTypeById, isAcceptedSchema } from "~/utils/typeUtils";
 import { showToast } from "~/components/canvas/utils/toastUtils";
 import { toTldrawColor } from "~/utils/tldrawColors";
 import {
@@ -534,8 +534,13 @@ const computeRelations = async (
   const relations = await getRelationsForNodeInstanceId(plugin, nodeInstanceId);
   const result = new Map<string, GroupedRelation>();
 
-  for (const relationType of plugin.settings.relationTypes) {
-    const typeLevelRelation = plugin.settings.discourseRelations.find(
+  const acceptedRelationTypes =
+    plugin.settings.relationTypes.filter(isAcceptedSchema);
+  const acceptedDiscourseRelations =
+    plugin.settings.discourseRelations.filter(isAcceptedSchema);
+
+  for (const relationType of acceptedRelationTypes) {
+    const typeLevelRelation = acceptedDiscourseRelations.find(
       (rel) =>
         (rel.sourceId === activeNodeTypeId ||
           rel.destinationId === activeNodeTypeId) &&

--- a/apps/obsidian/src/types.ts
+++ b/apps/obsidian/src/types.ts
@@ -17,6 +17,8 @@ export type DiscourseNode = {
   importedFromRid?: string;
 };
 
+export type ImportStatus = "provisional" | "accepted";
+
 export type DiscourseRelationType = {
   id: string;
   label: string;
@@ -25,6 +27,7 @@ export type DiscourseRelationType = {
   created: number;
   modified: number;
   importedFromRid?: string;
+  status?: ImportStatus;
 };
 
 export type DiscourseRelation = {
@@ -35,6 +38,7 @@ export type DiscourseRelation = {
   created: number;
   modified: number;
   importedFromRid?: string;
+  status?: ImportStatus;
 };
 
 export type RelationInstance = {

--- a/apps/obsidian/src/utils/conceptConversion.ts
+++ b/apps/obsidian/src/utils/conceptConversion.ts
@@ -89,7 +89,8 @@ export const discourseRelationTypeToLocalConcept = ({
     created,
     modified,
     importedFromRid,
-    status,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    status, //destructuring status to not upload it to the database
     ...otherData
   } = relationType;
   // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/apps/obsidian/src/utils/conceptConversion.ts
+++ b/apps/obsidian/src/utils/conceptConversion.ts
@@ -89,6 +89,7 @@ export const discourseRelationTypeToLocalConcept = ({
     created,
     modified,
     importedFromRid,
+    status,
     ...otherData
   } = relationType;
   // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/apps/obsidian/src/utils/importRelations.ts
+++ b/apps/obsidian/src/utils/importRelations.ts
@@ -98,6 +98,7 @@ const mapRelationTypeToLocal = async ({
     created: now,
     modified: now,
     importedFromRid,
+    status: "provisional",
   };
   plugin.settings.relationTypes = [
     ...(plugin.settings.relationTypes ?? []),
@@ -154,6 +155,7 @@ const findOrCreateTriple = async ({
     created,
     modified,
     ...(importedFromRid && { importedFromRid }),
+    status: "provisional",
   };
   plugin.settings.discourseRelations = [
     ...(plugin.settings.discourseRelations ?? []),

--- a/apps/obsidian/src/utils/publishNode.ts
+++ b/apps/obsidian/src/utils/publishNode.ts
@@ -16,6 +16,8 @@ import {
   syncAllNodesAndRelations,
   syncPublishedNodeAssets,
 } from "./syncDgNodesToSupabase";
+import { isProvisionalSchema } from "./typeUtils";
+
 import type { DiscourseNodeInVault } from "./getDiscourseNodes";
 import type { SupabaseContext } from "./supabaseContext";
 import type { TablesInsert } from "@repo/database/dbTypes";
@@ -127,6 +129,12 @@ export const publishNewRelation = async (
       triple.destinationId === destinationFm.nodeTypeId,
   );
   if (!triple) return false;
+  if (isProvisionalSchema(triple)) return false;
+  const relationType = plugin.settings.relationTypes.find(
+    (rt) => rt.id === relation.type,
+  );
+  if (relationType && isProvisionalSchema(relationType)) return false;
+  if (relation.tentative === false) return false;
   const resourceIds = [relation.id, relation.type, triple.id];
   const myGroups = await getAvailableGroupIds(client);
   const targetGroups = intersection(

--- a/apps/obsidian/src/utils/syncDgNodesToSupabase.ts
+++ b/apps/obsidian/src/utils/syncDgNodesToSupabase.ts
@@ -535,7 +535,7 @@ const convertDgToSupabaseConcepts = async ({
     .filter(
       (relationInstanceData) =>
         !relationInstanceData.importedFromRid &&
-        !relationInstanceData.provisional &&
+        relationInstanceData.tentative !== false &&
         (relationInstanceData.lastModified || relationInstanceData.created) >
           lastRelationsSync,
     )

--- a/apps/obsidian/src/utils/syncDgNodesToSupabase.ts
+++ b/apps/obsidian/src/utils/syncDgNodesToSupabase.ts
@@ -27,6 +27,7 @@ import {
   type DiscourseNodeInVault,
   collectDiscourseNodesFromVault,
 } from "./getDiscourseNodes";
+import { isAcceptedSchema } from "./typeUtils";
 
 const DEFAULT_TIME = "1970-01-01";
 export type ChangeType = "title" | "content";
@@ -456,8 +457,12 @@ const convertDgToSupabaseConcepts = async ({
     await getLastRelationSyncTime(supabaseClient, context.spaceId)
   ).getTime();
   const nodeTypes = plugin.settings.nodeTypes ?? [];
-  const relationTypes = plugin.settings.relationTypes ?? [];
-  const discourseRelations = plugin.settings.discourseRelations ?? [];
+  const relationTypes = (plugin.settings.relationTypes ?? []).filter(
+    isAcceptedSchema,
+  );
+  const discourseRelations = (plugin.settings.discourseRelations ?? []).filter(
+    isAcceptedSchema,
+  );
   allNodes = allNodes ?? (await collectDiscourseNodesFromVault(plugin, true));
   const allNodesById = Object.fromEntries(
     allNodes.map((n) => [n.nodeInstanceId, n]),
@@ -530,6 +535,7 @@ const convertDgToSupabaseConcepts = async ({
     .filter(
       (relationInstanceData) =>
         !relationInstanceData.importedFromRid &&
+        !relationInstanceData.provisional &&
         (relationInstanceData.lastModified || relationInstanceData.created) >
           lastRelationsSync,
     )

--- a/apps/obsidian/src/utils/typeUtils.ts
+++ b/apps/obsidian/src/utils/typeUtils.ts
@@ -1,5 +1,5 @@
 import type DiscourseGraphPlugin from "~/index";
-import { DiscourseNode, DiscourseRelationType } from "~/types";
+import { DiscourseNode, DiscourseRelationType, ImportStatus } from "~/types";
 import { ridToSpaceUriAndLocalId } from "./rid";
 
 export const getNodeTypeById = (
@@ -70,6 +70,16 @@ export const formatImportSource = (
 
   return spaceUri;
 };
+
+export const isAcceptedSchema = (schema: {
+  status?: ImportStatus;
+  importedFromRid?: string;
+}): boolean => !schema.importedFromRid || schema.status === "accepted";
+
+export const isProvisionalSchema = (schema: {
+  status?: ImportStatus;
+  importedFromRid?: string;
+}): boolean => !!schema.importedFromRid && schema.status !== "accepted";
 
 export const getAndFormatImportSource = (
   importedFromRid: string | undefined,


### PR DESCRIPTION
https://www.loom.com/share/8d9ac02487f74b54ac4a06893ca61ab5

## Summary

- Newly imported relation types and triplets are marked `provisional` and hidden from all creation UIs until the user explicitly accepts them
- Adds `ImportStatus` type and `status?` field to `DiscourseRelationType` and `DiscourseRelation`; backward-compatible (imported schemas with no `status` field are treated as provisional)
- Settings UI shows a **Provisional** badge with Accept + Delete buttons for unreviewed imported schemas; accepting a triplet cascades to also accept its relation type
- Guards `publishNewRelation` and the Supabase sync from sending provisional schemas

## Test plan

- [x] Import nodes from a remote space → relation types and triplets appear in Settings with "Provisional" badge and no Accept button shown yet for accepted ones
- [x] Provisional types/triplets absent from canvas relation tool, RelationshipSection, and RelationPanel dropdowns
- [x] Accept a triplet → triplet and its relation type both flip to accepted; both now appear in creation panels
- [x] Accept a relation type directly → type accepted, triplets remain provisional
- [x] Delete an imported provisional type/triplet → removed correctly
- [x] Sync to Supabase → provisional schemas not included in `upsert_concepts` payload
- [x] `publishNewRelation` returns false for provisional triple/type/instance
- [x] Existing imported schemas without a `status` field treated as provisional (not accepted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/948" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
