### PR TITLE
ENG 1630 - add posthog disable_session_recording

### DIFF
--- a/apps/roam/src/utils/posthog.ts
+++ b/apps/roam/src/utils/posthog.ts
@@ -20,8 +20,8 @@ const doInitPostHog = (): void => {
     "$referrer",
     "$referring_domain",
   ]);
+  /* eslint-disable @typescript-eslint/naming-convention  */
   posthog.init("phc_SNMmBqwNfcEpNduQ41dBUjtGNEUEKAy6jTn63Fzsrax", {
-    /* eslint-disable @typescript-eslint/naming-convention  */
     autocapture: false,
     disable_session_recording: true,
     api_host: "https://us.i.posthog.com",
@@ -38,7 +38,6 @@ const doInitPostHog = (): void => {
       }
       return result;
     },
-    /* eslint-enable @typescript-eslint/naming-convention  */
     loaded: (posthog) => {
       const { version, buildDate } = getVersionWithDate();
       const userUid = window.roamAlphaAPI.user.uid() || "";
@@ -53,6 +52,7 @@ const doInitPostHog = (): void => {
       initialized = true;
     },
   });
+  /* eslint-enable @typescript-eslint/naming-convention  */
 };
 
 export const enablePostHog = (): void => {

--- a/apps/roam/src/utils/posthog.ts
+++ b/apps/roam/src/utils/posthog.ts
@@ -1,4 +1,3 @@
-import getCurrentUserUid from "roamjs-components/queries/getCurrentUserUid";
 import { getVersionWithDate } from "./getVersion";
 import posthog from "posthog-js";
 import type { CaptureResult } from "posthog-js";
@@ -23,6 +22,8 @@ const doInitPostHog = (): void => {
   ]);
   posthog.init("phc_SNMmBqwNfcEpNduQ41dBUjtGNEUEKAy6jTn63Fzsrax", {
     /* eslint-disable @typescript-eslint/naming-convention  */
+    autocapture: false,
+    disable_session_recording: true,
     api_host: "https://us.i.posthog.com",
     person_profiles: "identified_only",
     capture_pageview: false,
@@ -38,15 +39,12 @@ const doInitPostHog = (): void => {
       return result;
     },
     /* eslint-enable @typescript-eslint/naming-convention  */
-    autocapture: false,
     loaded: (posthog) => {
       const { version, buildDate } = getVersionWithDate();
-      const userUid = getCurrentUserUid();
+      const userUid = window.roamAlphaAPI.user.uid() || "";
       const graphName = window.roamAlphaAPI.graph.name;
-      posthog.identify(userUid, {
-        graphName,
-      });
-      posthog.register({
+      posthog.identify(userUid);
+      posthog.register_for_session({
         version: version || "-",
         buildDate: buildDate || "-",
         graphName,

--- a/apps/roam/src/utils/posthog.ts
+++ b/apps/roam/src/utils/posthog.ts
@@ -42,7 +42,7 @@ const doInitPostHog = (): void => {
       const { version, buildDate } = getVersionWithDate();
       const userUid = window.roamAlphaAPI.user.uid() || "";
       const graphName = window.roamAlphaAPI.graph.name;
-      posthog.identify(userUid);
+      if (userUid) posthog.identify(userUid);
       posthog.register_for_session({
         version: version || "-",
         buildDate: buildDate || "-",


### PR DESCRIPTION
Wasn't enabled in account yet, but we are enabling it in the future to do some manual testing.

This PR ensures that when we enable globally in posthog dashboard that all sessions won't be recorded.

Also removed graph name from identity because a user can have multiple graphs, and changed register to register for this session, as version and build date and graph name can change each session. 
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/949" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated analytics initialization configuration to disable autocapture and session recording, and modified user identification and session tracking mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->