### PR TITLE
Eng 1552 enable ability to change discourse graph specific keyboard

### DIFF
--- a/apps/roam/src/components/canvas/uiOverrides.tsx
+++ b/apps/roam/src/components/canvas/uiOverrides.tsx
@@ -53,6 +53,7 @@ import { getRelationColor } from "./DiscourseRelationShape/DiscourseRelationUtil
 import DiscourseGraphPanel from "./DiscourseToolPanel";
 import { DISCOURSE_TOOL_SHORTCUT_KEY } from "~/data/userSettings";
 import { getSetting } from "~/utils/extensionSettings";
+import { getPersonalSetting } from "~/components/settings/utils/accessors";
 import { CustomDefaultToolbar } from "./CustomDefaultToolbar";
 import { renderModifyNodeDialog } from "~/components/ModifyNodeDialog";
 import { CanvasSyncMode } from "./canvasSyncMode";
@@ -396,13 +397,17 @@ export const createUiOverrides = ({
         editor.setCurrentTool("discourse-tool");
       },
     };
+    const canvasNodeShortcuts =
+      getPersonalSetting<Record<string, string>>(["Canvas node shortcuts"]) ??
+      {};
+
     allNodes.forEach((node, index) => {
       const nodeId = node.type;
       tools[nodeId] = {
         id: nodeId,
         icon: "color",
         label: `shape.node.${node.type}` as TLUiTranslationKey,
-        kbd: node.shortcut,
+        kbd: canvasNodeShortcuts[nodeId] ?? node.shortcut,
         onSelect: () => {
           editor.setCurrentTool(nodeId);
         },

--- a/apps/roam/src/components/canvas/uiOverrides.tsx
+++ b/apps/roam/src/components/canvas/uiOverrides.tsx
@@ -407,7 +407,7 @@ export const createUiOverrides = ({
         id: nodeId,
         icon: "color",
         label: `shape.node.${node.type}` as TLUiTranslationKey,
-        kbd: canvasNodeShortcuts[nodeId] ?? node.shortcut,
+        kbd: canvasNodeShortcuts[nodeId] || node.shortcut,
         onSelect: () => {
           editor.setCurrentTool(nodeId);
         },

--- a/apps/roam/src/components/canvas/uiOverrides.tsx
+++ b/apps/roam/src/components/canvas/uiOverrides.tsx
@@ -54,6 +54,7 @@ import DiscourseGraphPanel from "./DiscourseToolPanel";
 import { DISCOURSE_TOOL_SHORTCUT_KEY } from "~/data/userSettings";
 import { getSetting } from "~/utils/extensionSettings";
 import { getPersonalSetting } from "~/components/settings/utils/accessors";
+import type { CanvasNodeShortcuts } from "~/components/settings/utils/zodSchema";
 import { CustomDefaultToolbar } from "./CustomDefaultToolbar";
 import { renderModifyNodeDialog } from "~/components/ModifyNodeDialog";
 import { CanvasSyncMode } from "./canvasSyncMode";
@@ -398,16 +399,16 @@ export const createUiOverrides = ({
       },
     };
     const canvasNodeShortcuts =
-      getPersonalSetting<Record<string, string>>(["Canvas node shortcuts"]) ??
-      {};
+      getPersonalSetting<CanvasNodeShortcuts>(["Canvas node shortcuts"]) ?? {};
 
     allNodes.forEach((node, index) => {
       const nodeId = node.type;
+      const override = canvasNodeShortcuts[nodeId];
       tools[nodeId] = {
         id: nodeId,
         icon: "color",
         label: `shape.node.${node.type}` as TLUiTranslationKey,
-        kbd: canvasNodeShortcuts[nodeId] || node.shortcut,
+        kbd: override?.enabled ? override.value : node.shortcut,
         onSelect: () => {
           editor.setCurrentTool(nodeId);
         },

--- a/apps/roam/src/components/canvas/uiOverrides.tsx
+++ b/apps/roam/src/components/canvas/uiOverrides.tsx
@@ -51,9 +51,11 @@ import calcCanvasNodeSizeAndImg from "~/utils/calcCanvasNodeSizeAndImg";
 import { AddReferencedNodeType } from "./DiscourseRelationShape/DiscourseRelationTool";
 import { getRelationColor } from "./DiscourseRelationShape/DiscourseRelationUtil";
 import DiscourseGraphPanel from "./DiscourseToolPanel";
-import { DISCOURSE_TOOL_SHORTCUT_KEY } from "~/data/userSettings";
+import {
+  DISCOURSE_TOOL_SHORTCUT_KEY,
+  CANVAS_NODE_SHORTCUTS_KEY,
+} from "~/data/userSettings";
 import { getSetting } from "~/utils/extensionSettings";
-import { getPersonalSetting } from "~/components/settings/utils/accessors";
 import type { CanvasNodeShortcuts } from "~/components/settings/utils/zodSchema";
 import { CustomDefaultToolbar } from "./CustomDefaultToolbar";
 import { renderModifyNodeDialog } from "~/components/ModifyNodeDialog";
@@ -398,8 +400,10 @@ export const createUiOverrides = ({
         editor.setCurrentTool("discourse-tool");
       },
     };
-    const canvasNodeShortcuts =
-      getPersonalSetting<CanvasNodeShortcuts>(["Canvas node shortcuts"]) ?? {};
+    const canvasNodeShortcuts = getSetting<CanvasNodeShortcuts>(
+      CANVAS_NODE_SHORTCUTS_KEY,
+      {},
+    );
 
     allNodes.forEach((node, index) => {
       const nodeId = node.type;

--- a/apps/roam/src/components/settings/CanvasShortcutSettings.tsx
+++ b/apps/roam/src/components/settings/CanvasShortcutSettings.tsx
@@ -1,4 +1,6 @@
 import React, { useState } from "react";
+import { Checkbox, InputGroup, Tabs, Tab } from "@blueprintjs/core";
+import Description from "roamjs-components/components/Description";
 import getDiscourseNodes, {
   excludeDefaultNodes,
 } from "~/utils/getDiscourseNodes";
@@ -6,10 +8,6 @@ import { setPersonalSetting } from "~/components/settings/utils/accessors";
 import { getSetting, setSetting } from "~/utils/extensionSettings";
 import { CANVAS_NODE_SHORTCUTS_KEY } from "~/data/userSettings";
 import type { CanvasNodeShortcuts } from "./utils/zodSchema";
-import {
-  PersonalFlagPanel,
-  PersonalTextPanel,
-} from "./components/BlockPropSettingPanels";
 
 const BLOCK_PROP_KEY = "Canvas node shortcuts";
 
@@ -38,41 +36,54 @@ const ShortcutRow = ({
   const [enabled, setEnabled] = useState(initialEnabled);
   const [storedValue, setStoredValue] = useState(initialValue);
 
-  const handleEnabledChange = (checked: boolean) => {
+  const persistValue = (value: string) => {
+    setStoredValue(value);
+    setPersonalSetting(valueKey, value);
+    onValueChange(value);
+  };
+
+  const handleEnabledChange = (e: React.FormEvent<HTMLInputElement>) => {
+    const checked = e.currentTarget.checked;
     setEnabled(checked);
+    setPersonalSetting(enabledKey, checked);
     if (!checked) {
-      setStoredValue("");
-      setPersonalSetting(valueKey, "");
+      persistValue("");
     }
     onEnabledChange(checked);
   };
 
-  const handleValueChange = (value: string) => {
-    setStoredValue(value);
-    onValueChange(value);
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    e.preventDefault();
+    if (e.key === "Backspace" || e.key === "Delete") {
+      persistValue("");
+    } else if (e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey) {
+      persistValue(e.key);
+    }
   };
 
   return (
-    <div className="flex flex-col gap-1">
-      <PersonalFlagPanel
-        title={`Use custom ${nodeText} shortcut`}
-        description={`Override the canvas keyboard shortcut. Default: ${defaultShortcut || "none"}. Changes take effect next time a canvas is opened.`}
-        settingKeys={enabledKey}
-        value={enabled}
+    <div className="flex items-center gap-3">
+      <Checkbox
+        checked={enabled}
         onChange={handleEnabledChange}
+        className="mb-0"
+        labelElement={
+          <>
+            <span className="font-medium">{nodeText} node</span>{" "}
+            <Description
+              description={`Default: ${defaultShortcut || "none"}`}
+            />
+          </>
+        }
       />
-      <div className="ml-6 max-w-xs">
-        <PersonalTextPanel
-          key={String(enabled)}
-          title=""
-          description=""
-          settingKeys={valueKey}
-          initialValue={storedValue}
-          disabled={!enabled}
-          placeholder={defaultShortcut || "(no shortcut)"}
-          onChange={handleValueChange}
-        />
-      </div>
+      <InputGroup
+        value={enabled ? storedValue : ""}
+        onChange={() => {}}
+        onKeyDown={handleKeyDown}
+        disabled={!enabled}
+        placeholder={defaultShortcut || "(no shortcut)"}
+        className="ml-auto w-20"
+      />
     </div>
   );
 };
@@ -94,28 +105,46 @@ const CanvasShortcutSettings = () => {
   };
 
   return (
-    <div className="flex flex-col gap-4 p-1">
-      {nodes.map((node) => {
-        const override = shortcuts[node.type];
-        return (
-          <ShortcutRow
-            key={node.type}
-            nodeType={node.type}
-            nodeText={node.text}
-            defaultShortcut={node.shortcut}
-            initialEnabled={override?.enabled ?? false}
-            initialValue={override?.value ?? ""}
-            onEnabledChange={(enabled) =>
-              updateShortcut(node.type, {
-                enabled,
-                ...(enabled ? {} : { value: "" }),
-              })
-            }
-            onValueChange={(value) => updateShortcut(node.type, { value })}
-          />
-        );
-      })}
-    </div>
+    <Tabs renderActiveTabPanelOnly={true}>
+      <Tab
+        id="shortcuts"
+        title="Shortcuts"
+        panel={
+          <div className="flex flex-col gap-2 p-1">
+            <div className="mb-2">
+              <div className="text-base">
+                Override the canvas keyboard shortcuts
+              </div>
+              <div className="text-sm italic text-gray-500">
+                Changes take effect next time a canvas is opened
+              </div>
+            </div>
+            {nodes.map((node) => {
+              const override = shortcuts[node.type];
+              return (
+                <ShortcutRow
+                  key={node.type}
+                  nodeType={node.type}
+                  nodeText={node.text}
+                  defaultShortcut={node.shortcut}
+                  initialEnabled={override?.enabled ?? false}
+                  initialValue={override?.value ?? ""}
+                  onEnabledChange={(enabled) =>
+                    updateShortcut(node.type, {
+                      enabled,
+                      ...(enabled ? {} : { value: "" }),
+                    })
+                  }
+                  onValueChange={(value) =>
+                    updateShortcut(node.type, { value })
+                  }
+                />
+              );
+            })}
+          </div>
+        }
+      />
+    </Tabs>
   );
 };
 

--- a/apps/roam/src/components/settings/CanvasShortcutSettings.tsx
+++ b/apps/roam/src/components/settings/CanvasShortcutSettings.tsx
@@ -111,7 +111,7 @@ const CanvasShortcutSettings = () => {
         id="shortcuts"
         title="Shortcuts"
         panel={
-          <div className="inline-grid grid-cols-[auto_5rem] items-center gap-x-4 gap-y-2 p-1">
+          <div className="roamjs-canvas-shortcuts-grid inline-grid items-center gap-x-4 gap-y-2 p-1">
             <div className="col-span-2 mb-2">
               <div className="text-base">
                 Override the canvas keyboard shortcuts

--- a/apps/roam/src/components/settings/CanvasShortcutSettings.tsx
+++ b/apps/roam/src/components/settings/CanvasShortcutSettings.tsx
@@ -63,7 +63,7 @@ const ShortcutRow = ({
   };
 
   return (
-    <div className="flex items-center gap-3">
+    <>
       <Checkbox
         checked={enabled}
         onChange={handleEnabledChange}
@@ -83,9 +83,9 @@ const ShortcutRow = ({
         onKeyDown={handleKeyDown}
         disabled={!enabled}
         placeholder={defaultShortcut || "(no shortcut)"}
-        className="ml-auto w-20"
+        className="w-20"
       />
-    </div>
+    </>
   );
 };
 
@@ -111,8 +111,8 @@ const CanvasShortcutSettings = () => {
         id="shortcuts"
         title="Shortcuts"
         panel={
-          <div className="flex flex-col gap-2 p-1">
-            <div className="mb-2">
+          <div className="inline-grid grid-cols-[auto_5rem] items-center gap-x-4 gap-y-2 p-1">
+            <div className="col-span-2 mb-2">
               <div className="text-base">
                 Override the canvas keyboard shortcuts
               </div>

--- a/apps/roam/src/components/settings/CanvasShortcutSettings.tsx
+++ b/apps/roam/src/components/settings/CanvasShortcutSettings.tsx
@@ -63,20 +63,22 @@ const ShortcutRow = ({
   };
 
   return (
-    <>
-      <Checkbox
-        checked={enabled}
-        onChange={handleEnabledChange}
-        className="mb-0"
-        labelElement={
-          <>
-            <span className="font-medium">{nodeText} node</span>{" "}
-            <Description
-              description={`Default: ${defaultShortcut || "none"}`}
-            />
-          </>
-        }
-      />
+    <div className="roamjs-canvas-shortcut-row">
+      <div className="roamjs-canvas-shortcut-label">
+        <Checkbox
+          checked={enabled}
+          onChange={handleEnabledChange}
+          className="mb-0"
+          labelElement={
+            <>
+              <span className="font-medium">{nodeText} node</span>{" "}
+              <Description
+                description={`Default: ${defaultShortcut || "none"}`}
+              />
+            </>
+          }
+        />
+      </div>
       <InputGroup
         value={enabled ? storedValue : ""}
         onChange={() => {}}
@@ -85,12 +87,16 @@ const ShortcutRow = ({
         placeholder={defaultShortcut || "(no shortcut)"}
         className="roamjs-canvas-shortcut-input w-20"
       />
-    </>
+    </div>
   );
 };
 
 const CanvasShortcutSettings = () => {
   const nodes = getDiscourseNodes().filter(excludeDefaultNodes);
+  const labelColumnWidth = `calc(${Math.max(
+    ...nodes.map((node) => `${node.text} node`.length),
+    0,
+  )}ch + 52px)`;
   const [shortcuts, setShortcuts] = useState<CanvasNodeShortcuts>(() =>
     getSetting<CanvasNodeShortcuts>(CANVAS_NODE_SHORTCUTS_KEY, {}),
   );
@@ -111,8 +117,16 @@ const CanvasShortcutSettings = () => {
         id="shortcuts"
         title="Shortcuts"
         panel={
-          <div className="roamjs-canvas-shortcuts-grid inline-grid items-center gap-x-4 gap-y-2 p-1">
-            <div className="roamjs-canvas-shortcuts-header col-span-2 mb-2">
+          <div
+            className="roamjs-canvas-shortcuts"
+            style={
+              {
+                // eslint-disable-next-line @typescript-eslint/naming-convention
+                "--roamjs-canvas-shortcut-label-width": labelColumnWidth,
+              } as React.CSSProperties
+            }
+          >
+            <div className="roamjs-canvas-shortcuts-header mb-2">
               <div className="text-base">
                 Override the canvas keyboard shortcuts
               </div>

--- a/apps/roam/src/components/settings/CanvasShortcutSettings.tsx
+++ b/apps/roam/src/components/settings/CanvasShortcutSettings.tsx
@@ -63,40 +63,34 @@ const ShortcutRow = ({
   };
 
   return (
-    <div className="roamjs-canvas-shortcut-row">
-      <div className="roamjs-canvas-shortcut-label">
-        <Checkbox
-          checked={enabled}
-          onChange={handleEnabledChange}
-          className="mb-0"
-          labelElement={
-            <>
-              <span className="font-medium">{nodeText} node</span>{" "}
-              <Description
-                description={`Default: ${defaultShortcut || "none"}`}
-              />
-            </>
-          }
-        />
-      </div>
+    <>
+      <Checkbox
+        checked={enabled}
+        onChange={handleEnabledChange}
+        className="mb-0"
+        labelElement={
+          <>
+            <span className="font-medium">{nodeText} node</span>{" "}
+            <Description
+              description={`Default: ${defaultShortcut || "none"}`}
+            />
+          </>
+        }
+      />
       <InputGroup
         value={enabled ? storedValue : ""}
         onChange={() => {}}
         onKeyDown={handleKeyDown}
         disabled={!enabled}
         placeholder={defaultShortcut || "(no shortcut)"}
-        className="roamjs-canvas-shortcut-input w-20"
+        className="w-20"
       />
-    </div>
+    </>
   );
 };
 
 const CanvasShortcutSettings = () => {
   const nodes = getDiscourseNodes().filter(excludeDefaultNodes);
-  const labelColumnWidth = `calc(${Math.max(
-    ...nodes.map((node) => `${node.text} node`.length),
-    0,
-  )}ch + 52px)`;
   const [shortcuts, setShortcuts] = useState<CanvasNodeShortcuts>(() =>
     getSetting<CanvasNodeShortcuts>(CANVAS_NODE_SHORTCUTS_KEY, {}),
   );
@@ -117,16 +111,8 @@ const CanvasShortcutSettings = () => {
         id="shortcuts"
         title="Shortcuts"
         panel={
-          <div
-            className="roamjs-canvas-shortcuts"
-            style={
-              {
-                // eslint-disable-next-line @typescript-eslint/naming-convention
-                "--roamjs-canvas-shortcut-label-width": labelColumnWidth,
-              } as React.CSSProperties
-            }
-          >
-            <div className="roamjs-canvas-shortcuts-header mb-2">
+          <div className="roamjs-canvas-shortcuts-grid inline-grid items-center gap-x-4 gap-y-2 p-1">
+            <div className="col-span-2 mb-2">
               <div className="text-base">
                 Override the canvas keyboard shortcuts
               </div>

--- a/apps/roam/src/components/settings/CanvasShortcutSettings.tsx
+++ b/apps/roam/src/components/settings/CanvasShortcutSettings.tsx
@@ -83,7 +83,7 @@ const ShortcutRow = ({
         onKeyDown={handleKeyDown}
         disabled={!enabled}
         placeholder={defaultShortcut || "(no shortcut)"}
-        className="w-20"
+        className="roamjs-canvas-shortcut-input w-20"
       />
     </>
   );
@@ -112,7 +112,7 @@ const CanvasShortcutSettings = () => {
         title="Shortcuts"
         panel={
           <div className="roamjs-canvas-shortcuts-grid inline-grid items-center gap-x-4 gap-y-2 p-1">
-            <div className="col-span-2 mb-2">
+            <div className="roamjs-canvas-shortcuts-header col-span-2 mb-2">
               <div className="text-base">
                 Override the canvas keyboard shortcuts
               </div>

--- a/apps/roam/src/components/settings/CanvasShortcutSettings.tsx
+++ b/apps/roam/src/components/settings/CanvasShortcutSettings.tsx
@@ -1,0 +1,36 @@
+import React, { useMemo } from "react";
+import getDiscourseNodes, {
+  excludeDefaultNodes,
+} from "~/utils/getDiscourseNodes";
+import { getPersonalSetting } from "~/components/settings/utils/accessors";
+import { PersonalTextPanel } from "./components/BlockPropSettingPanels";
+
+const CANVAS_NODE_SHORTCUTS_KEY = "Canvas node shortcuts";
+
+const CanvasShortcutSettings = () => {
+  const nodes = useMemo(
+    () => getDiscourseNodes().filter(excludeDefaultNodes),
+    [],
+  );
+
+  return (
+    <div className="flex flex-col gap-4 p-1">
+      {nodes.map((node) => (
+        <PersonalTextPanel
+          key={node.type}
+          title={node.text}
+          description={`Default: ${node.shortcut || "none"}. Changes take effect next time a canvas is opened.`}
+          settingKeys={[CANVAS_NODE_SHORTCUTS_KEY, node.type]}
+          initialValue={
+            getPersonalSetting<string>([
+              CANVAS_NODE_SHORTCUTS_KEY,
+              node.type,
+            ]) || node.shortcut
+          }
+        />
+      ))}
+    </div>
+  );
+};
+
+export default CanvasShortcutSettings;

--- a/apps/roam/src/components/settings/CanvasShortcutSettings.tsx
+++ b/apps/roam/src/components/settings/CanvasShortcutSettings.tsx
@@ -1,11 +1,69 @@
-import React, { useMemo } from "react";
+import React, { useMemo, useState } from "react";
 import getDiscourseNodes, {
   excludeDefaultNodes,
 } from "~/utils/getDiscourseNodes";
-import { getPersonalSetting } from "~/components/settings/utils/accessors";
-import { PersonalTextPanel } from "./components/BlockPropSettingPanels";
+import {
+  getPersonalSetting,
+  setPersonalSetting,
+} from "~/components/settings/utils/accessors";
+import {
+  PersonalFlagPanel,
+  PersonalTextPanel,
+} from "./components/BlockPropSettingPanels";
 
 const CANVAS_NODE_SHORTCUTS_KEY = "Canvas node shortcuts";
+
+type ShortcutRowProps = {
+  nodeType: string;
+  nodeText: string;
+  defaultShortcut: string;
+};
+
+const ShortcutRow = ({
+  nodeType,
+  nodeText,
+  defaultShortcut,
+}: ShortcutRowProps) => {
+  const enabledKey = [CANVAS_NODE_SHORTCUTS_KEY, nodeType, "enabled"];
+  const valueKey = [CANVAS_NODE_SHORTCUTS_KEY, nodeType, "value"];
+
+  const [enabled, setEnabled] = useState(
+    () => getPersonalSetting<boolean>(enabledKey) ?? false,
+  );
+
+  const handleEnabledChange = (checked: boolean) => {
+    setEnabled(checked);
+    if (!checked) setPersonalSetting(valueKey, "");
+  };
+
+  // Read on every render so the text panel's remount (key={enabled}) sees the
+  // latest stored value after uncheck clears it.
+  const storedValue = getPersonalSetting<string>(valueKey) ?? "";
+  const inputInitialValue = enabled ? storedValue : "";
+
+  return (
+    <div className="flex flex-col gap-1">
+      <PersonalFlagPanel
+        title={`Use custom ${nodeText} shortcut`}
+        description={`Override the canvas keyboard shortcut. Default: ${defaultShortcut || "none"}. Changes take effect next time a canvas is opened.`}
+        settingKeys={enabledKey}
+        value={enabled}
+        onChange={handleEnabledChange}
+      />
+      <div className="ml-6 max-w-xs">
+        <PersonalTextPanel
+          key={String(enabled)}
+          title=""
+          description=""
+          settingKeys={valueKey}
+          initialValue={inputInitialValue}
+          disabled={!enabled}
+          placeholder={defaultShortcut || "(no shortcut)"}
+        />
+      </div>
+    </div>
+  );
+};
 
 const CanvasShortcutSettings = () => {
   const nodes = useMemo(
@@ -16,18 +74,11 @@ const CanvasShortcutSettings = () => {
   return (
     <div className="flex flex-col gap-4 p-1">
       {nodes.map((node) => (
-        <PersonalTextPanel
+        <ShortcutRow
           key={node.type}
-          title={node.text}
-          description={`Default: ${node.shortcut || "none"}. Changes take effect next time a canvas is opened.`}
-          settingKeys={[CANVAS_NODE_SHORTCUTS_KEY, node.type]}
-          initialValue={
-            getPersonalSetting<string>([
-              CANVAS_NODE_SHORTCUTS_KEY,
-              node.type,
-            ]) || node.shortcut
-          }
-          placeholder={node.shortcut}
+          nodeType={node.type}
+          nodeText={node.text}
+          defaultShortcut={node.shortcut}
         />
       ))}
     </div>

--- a/apps/roam/src/components/settings/CanvasShortcutSettings.tsx
+++ b/apps/roam/src/components/settings/CanvasShortcutSettings.tsx
@@ -111,7 +111,7 @@ const CanvasShortcutSettings = () => {
         id="shortcuts"
         title="Shortcuts"
         panel={
-          <div className="roamjs-canvas-shortcuts-grid inline-grid items-center gap-x-4 gap-y-2 p-1">
+          <div className="inline-grid grid-cols-[auto_auto] items-center gap-x-4 gap-y-2 p-1">
             <div className="col-span-2 mb-2">
               <div className="text-base">
                 Override the canvas keyboard shortcuts

--- a/apps/roam/src/components/settings/CanvasShortcutSettings.tsx
+++ b/apps/roam/src/components/settings/CanvasShortcutSettings.tsx
@@ -1,45 +1,56 @@
-import React, { useMemo, useState } from "react";
+import React, { useState } from "react";
 import getDiscourseNodes, {
   excludeDefaultNodes,
 } from "~/utils/getDiscourseNodes";
-import {
-  getPersonalSetting,
-  setPersonalSetting,
-} from "~/components/settings/utils/accessors";
+import { setPersonalSetting } from "~/components/settings/utils/accessors";
+import { getSetting, setSetting } from "~/utils/extensionSettings";
+import { CANVAS_NODE_SHORTCUTS_KEY } from "~/data/userSettings";
+import type { CanvasNodeShortcuts } from "./utils/zodSchema";
 import {
   PersonalFlagPanel,
   PersonalTextPanel,
 } from "./components/BlockPropSettingPanels";
 
-const CANVAS_NODE_SHORTCUTS_KEY = "Canvas node shortcuts";
+const BLOCK_PROP_KEY = "Canvas node shortcuts";
 
 type ShortcutRowProps = {
   nodeType: string;
   nodeText: string;
   defaultShortcut: string;
+  initialEnabled: boolean;
+  initialValue: string;
+  onEnabledChange: (enabled: boolean) => void;
+  onValueChange: (value: string) => void;
 };
 
 const ShortcutRow = ({
   nodeType,
   nodeText,
   defaultShortcut,
+  initialEnabled,
+  initialValue,
+  onEnabledChange,
+  onValueChange,
 }: ShortcutRowProps) => {
-  const enabledKey = [CANVAS_NODE_SHORTCUTS_KEY, nodeType, "enabled"];
-  const valueKey = [CANVAS_NODE_SHORTCUTS_KEY, nodeType, "value"];
+  const enabledKey = [BLOCK_PROP_KEY, nodeType, "enabled"];
+  const valueKey = [BLOCK_PROP_KEY, nodeType, "value"];
 
-  const [enabled, setEnabled] = useState(
-    () => getPersonalSetting<boolean>(enabledKey) ?? false,
-  );
+  const [enabled, setEnabled] = useState(initialEnabled);
+  const [storedValue, setStoredValue] = useState(initialValue);
 
   const handleEnabledChange = (checked: boolean) => {
     setEnabled(checked);
-    if (!checked) setPersonalSetting(valueKey, "");
+    if (!checked) {
+      setStoredValue("");
+      setPersonalSetting(valueKey, "");
+    }
+    onEnabledChange(checked);
   };
 
-  // Read on every render so the text panel's remount (key={enabled}) sees the
-  // latest stored value after uncheck clears it.
-  const storedValue = getPersonalSetting<string>(valueKey) ?? "";
-  const inputInitialValue = enabled ? storedValue : "";
+  const handleValueChange = (value: string) => {
+    setStoredValue(value);
+    onValueChange(value);
+  };
 
   return (
     <div className="flex flex-col gap-1">
@@ -56,9 +67,10 @@ const ShortcutRow = ({
           title=""
           description=""
           settingKeys={valueKey}
-          initialValue={inputInitialValue}
+          initialValue={storedValue}
           disabled={!enabled}
           placeholder={defaultShortcut || "(no shortcut)"}
+          onChange={handleValueChange}
         />
       </div>
     </div>
@@ -66,21 +78,43 @@ const ShortcutRow = ({
 };
 
 const CanvasShortcutSettings = () => {
-  const nodes = useMemo(
-    () => getDiscourseNodes().filter(excludeDefaultNodes),
-    [],
+  const nodes = getDiscourseNodes().filter(excludeDefaultNodes);
+  const [shortcuts, setShortcuts] = useState<CanvasNodeShortcuts>(() =>
+    getSetting<CanvasNodeShortcuts>(CANVAS_NODE_SHORTCUTS_KEY, {}),
   );
+
+  const updateShortcut = (
+    nodeType: string,
+    update: Partial<CanvasNodeShortcuts[string]>,
+  ) => {
+    const current = shortcuts[nodeType] ?? { value: "", enabled: false };
+    const next = { ...shortcuts, [nodeType]: { ...current, ...update } };
+    void setSetting(CANVAS_NODE_SHORTCUTS_KEY, next);
+    setShortcuts(next);
+  };
 
   return (
     <div className="flex flex-col gap-4 p-1">
-      {nodes.map((node) => (
-        <ShortcutRow
-          key={node.type}
-          nodeType={node.type}
-          nodeText={node.text}
-          defaultShortcut={node.shortcut}
-        />
-      ))}
+      {nodes.map((node) => {
+        const override = shortcuts[node.type];
+        return (
+          <ShortcutRow
+            key={node.type}
+            nodeType={node.type}
+            nodeText={node.text}
+            defaultShortcut={node.shortcut}
+            initialEnabled={override?.enabled ?? false}
+            initialValue={override?.value ?? ""}
+            onEnabledChange={(enabled) =>
+              updateShortcut(node.type, {
+                enabled,
+                ...(enabled ? {} : { value: "" }),
+              })
+            }
+            onValueChange={(value) => updateShortcut(node.type, { value })}
+          />
+        );
+      })}
     </div>
   );
 };

--- a/apps/roam/src/components/settings/CanvasShortcutSettings.tsx
+++ b/apps/roam/src/components/settings/CanvasShortcutSettings.tsx
@@ -53,6 +53,7 @@ const ShortcutRow = ({
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Tab" || e.key === "Escape") return;
     e.preventDefault();
     if (e.key === "Backspace" || e.key === "Delete") {
       persistValue("");

--- a/apps/roam/src/components/settings/CanvasShortcutSettings.tsx
+++ b/apps/roam/src/components/settings/CanvasShortcutSettings.tsx
@@ -27,6 +27,7 @@ const CanvasShortcutSettings = () => {
               node.type,
             ]) || node.shortcut
           }
+          placeholder={node.shortcut}
         />
       ))}
     </div>

--- a/apps/roam/src/components/settings/Settings.tsx
+++ b/apps/roam/src/components/settings/Settings.tsx
@@ -173,7 +173,7 @@ export const SettingsDialog = ({
           />
           <Tab
             id="canvas-shortcuts-personal-settings"
-            title="Canvas shortcuts"
+            title="Canvas"
             className="overflow-y-auto"
             panel={<CanvasShortcutSettings />}
           />

--- a/apps/roam/src/components/settings/Settings.tsx
+++ b/apps/roam/src/components/settings/Settings.tsx
@@ -23,6 +23,7 @@ import getDiscourseNodes, {
 } from "~/utils/getDiscourseNodes";
 import NodeConfig from "./NodeConfig";
 import HomePersonalSettings from "./HomePersonalSettings";
+import CanvasShortcutSettings from "./CanvasShortcutSettings";
 import refreshConfigTree from "~/utils/refreshConfigTree";
 import { FeedbackWidget } from "~/components/BirdEatsBugs";
 import { getVersionWithDate } from "~/utils/getVersion";
@@ -169,6 +170,12 @@ export const SettingsDialog = ({
             title="Queries"
             className="overflow-y-auto"
             panel={<QuerySettings extensionAPI={extensionAPI} />}
+          />
+          <Tab
+            id="canvas-shortcuts-personal-settings"
+            title="Canvas shortcuts"
+            className="overflow-y-auto"
+            panel={<CanvasShortcutSettings />}
           />
           <Tab
             id="left-sidebar-personal-settings"

--- a/apps/roam/src/components/settings/components/BlockPropSettingPanels.tsx
+++ b/apps/roam/src/components/settings/components/BlockPropSettingPanels.tsx
@@ -49,6 +49,7 @@ type BaseTextPanelProps = {
   placeholder?: string;
   multiline?: boolean;
   error?: string;
+  disabled?: boolean;
   onChange?: (value: string) => void;
 } & RoamBlockSyncProps;
 
@@ -104,6 +105,7 @@ const BaseTextPanel = ({
   placeholder,
   multiline,
   error,
+  disabled,
   onChange,
   parentUid,
   uid,
@@ -148,7 +150,7 @@ const BaseTextPanel = ({
     <div className="flex flex-col">
       <Label>
         {title}
-        <Description description={description} />
+        {description && <Description description={description} />}
         {multiline ? (
           <TextArea
             value={value}
@@ -156,12 +158,14 @@ const BaseTextPanel = ({
             placeholder={placeholder || initialValue}
             className="w-full"
             style={{ minHeight: 80, resize: "vertical" }}
+            disabled={disabled}
           />
         ) : (
           <InputGroup
             value={value}
             onChange={handleChange}
             placeholder={placeholder || initialValue}
+            disabled={disabled}
           />
         )}
       </Label>

--- a/apps/roam/src/components/settings/utils/zodSchema.example.ts
+++ b/apps/roam/src/components/settings/utils/zodSchema.example.ts
@@ -374,6 +374,7 @@ const personalSettings: PersonalSettings = {
   "Auto canvas relations": true,
   "Disable product diagnostics": false,
   "Reified relation triples": true,
+  "Canvas node shortcuts": { "_CLM-node": "X", "_QUE-node": "W" },
   Query: {
     "Hide query metadata": true,
     "Default page size": 25,
@@ -403,6 +404,7 @@ const defaultPersonalSettings: PersonalSettings = {
   "Auto canvas relations": false,
   "Disable product diagnostics": false,
   "Reified relation triples": false,
+  "Canvas node shortcuts": {},
   Query: {
     "Hide query metadata": false,
     "Default page size": 10,

--- a/apps/roam/src/components/settings/utils/zodSchema.example.ts
+++ b/apps/roam/src/components/settings/utils/zodSchema.example.ts
@@ -374,7 +374,10 @@ const personalSettings: PersonalSettings = {
   "Auto canvas relations": true,
   "Disable product diagnostics": false,
   "Reified relation triples": true,
-  "Canvas node shortcuts": { "_CLM-node": "X", "_QUE-node": "W" },
+  "Canvas node shortcuts": {
+    "_CLM-node": { value: "X", enabled: true },
+    "_QUE-node": { value: "", enabled: true },
+  },
   Query: {
     "Hide query metadata": true,
     "Default page size": 25,

--- a/apps/roam/src/components/settings/utils/zodSchema.ts
+++ b/apps/roam/src/components/settings/utils/zodSchema.ts
@@ -258,6 +258,7 @@ export const PersonalSettingsSchema = z.object({
   "Streamline styling": z.boolean().default(false),
   "Auto canvas relations": z.boolean().default(false),
   "Disable product diagnostics": z.boolean().default(false),
+  "Canvas node shortcuts": z.record(z.string(), z.string()).default({}),
   Query: QuerySettingsSchema.default({}),
 });
 

--- a/apps/roam/src/components/settings/utils/zodSchema.ts
+++ b/apps/roam/src/components/settings/utils/zodSchema.ts
@@ -258,7 +258,15 @@ export const PersonalSettingsSchema = z.object({
   "Streamline styling": z.boolean().default(false),
   "Auto canvas relations": z.boolean().default(false),
   "Disable product diagnostics": z.boolean().default(false),
-  "Canvas node shortcuts": z.record(z.string(), z.string()).default({}),
+  "Canvas node shortcuts": z
+    .record(
+      z.string(),
+      z.object({
+        value: z.string().default(""),
+        enabled: z.boolean().default(false),
+      }),
+    )
+    .default({}),
   Query: QuerySettingsSchema.default({}),
 });
 
@@ -316,6 +324,7 @@ export type LeftSidebarPersonalSettings = z.infer<
 export type StoredFilters = z.infer<typeof StoredFiltersSchema>;
 export type QuerySettings = z.infer<typeof QuerySettingsSchema>;
 export type PersonalSettings = z.infer<typeof PersonalSettingsSchema>;
+export type CanvasNodeShortcuts = PersonalSettings["Canvas node shortcuts"];
 export type GithubSettings = z.infer<typeof GithubSettingsSchema>;
 export type QueryCondition = z.infer<typeof ConditionSchema>;
 export type QuerySelection = z.infer<typeof SelectionSchema>;

--- a/apps/roam/src/data/userSettings.ts
+++ b/apps/roam/src/data/userSettings.ts
@@ -5,6 +5,7 @@ export const DEFAULT_FILTERS_KEY = "default-filters";
 export const QUERY_BUILDER_SETTINGS_KEY = "query-builder-settings";
 export const AUTO_CANVAS_RELATIONS_KEY = "auto-canvas-relations";
 export const DISCOURSE_TOOL_SHORTCUT_KEY = "discourse-tool-shortcut";
+export const CANVAS_NODE_SHORTCUTS_KEY = "canvas-node-shortcuts";
 export const DISCOURSE_CONTEXT_OVERLAY_IN_CANVAS_KEY =
   "discourse-context-overlay-in-canvas";
 export const STREAMLINE_STYLING_KEY = "streamline-styling";

--- a/apps/roam/src/styles/styles.css
+++ b/apps/roam/src/styles/styles.css
@@ -2,32 +2,8 @@
   outline-width: 2px;
 }
 
-.roamjs-canvas-shortcuts {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding: 4px;
-}
-
-.roamjs-canvas-shortcuts-header {
-  margin-bottom: 8px;
-}
-
-.roamjs-canvas-shortcut-row {
-  align-items: center;
-  column-gap: 16px;
-  display: grid;
-  grid-template-columns: var(--roamjs-canvas-shortcut-label-width) 5rem;
-  width: fit-content;
-}
-
-.roamjs-canvas-shortcut-label .bp3-control {
-  margin-bottom: 0;
-}
-
-.roamjs-canvas-shortcut-input {
-  max-width: 5rem;
-  width: 5rem;
+.roamjs-canvas-shortcuts-grid {
+  grid-template-columns: auto auto;
 }
 
 .roamjs-item-dirty,

--- a/apps/roam/src/styles/styles.css
+++ b/apps/roam/src/styles/styles.css
@@ -3,9 +3,22 @@
 }
 
 .roamjs-canvas-shortcuts-grid {
+  align-items: center;
+  column-gap: 16px;
   display: inline-grid;
   grid-template-columns: auto auto;
+  padding: 4px;
+  row-gap: 8px;
   width: fit-content;
+}
+
+.roamjs-canvas-shortcuts-header {
+  grid-column: 1 / -1;
+  margin-bottom: 8px;
+}
+
+.roamjs-canvas-shortcut-input {
+  width: 5rem;
 }
 
 .roamjs-item-dirty,

--- a/apps/roam/src/styles/styles.css
+++ b/apps/roam/src/styles/styles.css
@@ -2,6 +2,10 @@
   outline-width: 2px;
 }
 
+.roamjs-canvas-shortcuts-grid {
+  grid-template-columns: auto auto;
+}
+
 .roamjs-item-dirty,
 .roamjs-item-dirty.bp3-menu-item .bp3-icon,
 .roamjs-item-dirty.bp3-button .bp3-icon {

--- a/apps/roam/src/styles/styles.css
+++ b/apps/roam/src/styles/styles.css
@@ -2,10 +2,6 @@
   outline-width: 2px;
 }
 
-.roamjs-canvas-shortcuts-grid {
-  grid-template-columns: auto auto;
-}
-
 .roamjs-item-dirty,
 .roamjs-item-dirty.bp3-menu-item .bp3-icon,
 .roamjs-item-dirty.bp3-button .bp3-icon {

--- a/apps/roam/src/styles/styles.css
+++ b/apps/roam/src/styles/styles.css
@@ -2,22 +2,31 @@
   outline-width: 2px;
 }
 
-.roamjs-canvas-shortcuts-grid {
-  align-items: center;
-  column-gap: 16px;
-  display: inline-grid;
-  grid-template-columns: auto auto;
+.roamjs-canvas-shortcuts {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
   padding: 4px;
-  row-gap: 8px;
-  width: fit-content;
 }
 
 .roamjs-canvas-shortcuts-header {
-  grid-column: 1 / -1;
   margin-bottom: 8px;
 }
 
+.roamjs-canvas-shortcut-row {
+  align-items: center;
+  column-gap: 16px;
+  display: grid;
+  grid-template-columns: var(--roamjs-canvas-shortcut-label-width) 5rem;
+  width: fit-content;
+}
+
+.roamjs-canvas-shortcut-label .bp3-control {
+  margin-bottom: 0;
+}
+
 .roamjs-canvas-shortcut-input {
+  max-width: 5rem;
   width: 5rem;
 }
 

--- a/apps/roam/src/styles/styles.css
+++ b/apps/roam/src/styles/styles.css
@@ -3,7 +3,9 @@
 }
 
 .roamjs-canvas-shortcuts-grid {
+  display: inline-grid;
   grid-template-columns: auto auto;
+  width: fit-content;
 }
 
 .roamjs-item-dirty,

--- a/apps/roam/src/styles/styles.css
+++ b/apps/roam/src/styles/styles.css
@@ -2,7 +2,6 @@
   outline-width: 2px;
 }
 
-
 .roamjs-item-dirty,
 .roamjs-item-dirty.bp3-menu-item .bp3-icon,
 .roamjs-item-dirty.bp3-button .bp3-icon {

--- a/apps/roam/src/styles/styles.css
+++ b/apps/roam/src/styles/styles.css
@@ -2,6 +2,7 @@
   outline-width: 2px;
 }
 
+
 .roamjs-item-dirty,
 .roamjs-item-dirty.bp3-menu-item .bp3-icon,
 .roamjs-item-dirty.bp3-button .bp3-icon {


### PR DESCRIPTION
https://www.loom.com/share/c79b2d497a60482a8536dd9452b37868


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/952" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added customizable keyboard shortcuts for canvas nodes directly in Personal Settings, allowing personalization of node tool key bindings
  * New "Canvas" tab in the settings panel provides an easy way to configure your preferred keyboard shortcuts
  * Your shortcut customizations take effect the next time you open a canvas

<!-- end of auto-generated comment: release notes by coderabbit.ai -->