### PR TITLE
ENG-1491: Part of the discourse context query settings blocks appears in the page if you select "hide interface" in the discourse context menu at the top of the page

### DIFF
--- a/apps/roam/src/components/results-view/ResultsTable.tsx
+++ b/apps/roam/src/components/results-view/ResultsTable.tsx
@@ -619,6 +619,7 @@ const ResultsTable = ({
     });
     setColumnWidths(finalWidths);
 
+    if (preventSavingSettings) return;
     const layoutUid = getSubTree({ parentUid, key: "layout" }).uid;
     if (layoutUid) {
       setInputSettings({
@@ -627,7 +628,7 @@ const ResultsTable = ({
         values: Object.entries(finalWidths).map(([k, v]) => `${k} - ${v}`),
       });
     }
-  }, [parentUid, columnWidths, visibleColumns]);
+  }, [parentUid, columnWidths, visibleColumns, preventSavingSettings]);
 
   const resultHeaderSetFilters = React.useCallback(
     (fs: FilterData) => {

--- a/apps/roam/src/components/results-view/ResultsView.tsx
+++ b/apps/roam/src/components/results-view/ResultsView.tsx
@@ -1185,7 +1185,7 @@ const ResultsView: ResultsViewComponent = ({
                           setMoreMenuOpen(false);
                           setShowSearchFilter((s) => !s);
                           if (!preventSavingSettings) {
-                            setInputSetting({
+                            void setInputSetting({
                               blockUid: settings.resultNodeUid,
                               key: "showSearchFilter",
                               value: showSearchFilter ? "hide" : "show",
@@ -1261,7 +1261,7 @@ const ResultsView: ResultsViewComponent = ({
                           key: "results",
                           parentUid,
                         });
-                        setInputSetting({
+                        void setInputSetting({
                           key: "interface",
                           value: showInterface ? "hide" : "show",
                           blockUid: resultNode.uid,
@@ -1335,7 +1335,7 @@ const ResultsView: ResultsViewComponent = ({
                             .join("");
                         };
                         const tree = getBasicTreeByParentUid(parentUid);
-                        navigator.clipboard.writeText(
+                        void navigator.clipboard.writeText(
                           "- {{query block}}\n" +
                             getTextFromTreeToPaste(tree, 1),
                         );

--- a/apps/roam/src/components/results-view/ResultsView.tsx
+++ b/apps/roam/src/components/results-view/ResultsView.tsx
@@ -1149,120 +1149,128 @@ const ResultsView: ResultsViewComponent = ({
                       }}
                     />
                   )}
-                  <Divider />
-                  <MenuItem
-                    icon={"list"}
-                    text={"Results"}
-                    className={isMenuIconDirty ? "roamjs-item-dirty" : ""}
-                  >
+                  {(!preventSavingSettings || onEdit) && <Divider />}
+                  {!preventSavingSettings && (
                     <MenuItem
-                      icon={"layout"}
-                      text={"Layout"}
-                      onClick={() => {
-                        setIsEditLayout(true);
-                      }}
-                    />
-                    <MenuItem
-                      icon={"eye-open"}
-                      text={"Column Views"}
-                      className={isColumnViewsDirty ? "roamjs-item-dirty" : ""}
-                      onClick={() => {
-                        setIsEditViews(true);
-                      }}
-                    />
-                    <MenuItem
-                      icon={showSearchFilter ? "zoom-out" : "search"}
-                      text={showSearchFilter ? "Hide Search" : "Search"}
-                      className={
-                        searchFilter && !showSearchFilter
-                          ? "roamjs-item-dirty"
-                          : ""
-                      }
-                      onClick={() => {
-                        setMoreMenuOpen(false);
-                        setShowSearchFilter((s) => !s);
-                        if (!preventSavingSettings) {
+                      icon={"list"}
+                      text={"Results"}
+                      className={isMenuIconDirty ? "roamjs-item-dirty" : ""}
+                    >
+                      <MenuItem
+                        icon={"layout"}
+                        text={"Layout"}
+                        onClick={() => {
+                          setIsEditLayout(true);
+                        }}
+                      />
+                      <MenuItem
+                        icon={"eye-open"}
+                        text={"Column Views"}
+                        className={
+                          isColumnViewsDirty ? "roamjs-item-dirty" : ""
+                        }
+                        onClick={() => {
+                          setIsEditViews(true);
+                        }}
+                      />
+                      <MenuItem
+                        icon={showSearchFilter ? "zoom-out" : "search"}
+                        text={showSearchFilter ? "Hide Search" : "Search"}
+                        className={
+                          searchFilter && !showSearchFilter
+                            ? "roamjs-item-dirty"
+                            : ""
+                        }
+                        onClick={() => {
+                          setMoreMenuOpen(false);
+                          setShowSearchFilter((s) => !s);
+                          if (!preventSavingSettings) {
+                            setInputSetting({
+                              blockUid: settings.resultNodeUid,
+                              key: "showSearchFilter",
+                              value: showSearchFilter ? "hide" : "show",
+                            });
+                          }
+                        }}
+                      />
+                      <MenuItem
+                        icon={showInputs ? "minus" : "plus"}
+                        text={showInputs ? "Hide Inputs" : "Inputs"}
+                        onClick={() => {
+                          setMoreMenuOpen(false);
+                          setShowInputs(!showInputs);
                           setInputSetting({
                             blockUid: settings.resultNodeUid,
-                            key: "showSearchFilter",
-                            value: showSearchFilter ? "hide" : "show",
+                            key: "showInputs",
+                            value: showInputs ? "hide" : "show",
                           });
+                        }}
+                      />
+                      <MenuItem
+                        icon={"filter"}
+                        text={"Filters"}
+                        className={
+                          columnFilters.length ? "roamjs-item-dirty" : ""
                         }
-                      }}
-                    />
+                        onClick={() => {
+                          setIsEditColumnFilter(true);
+                        }}
+                      />
+                      <MenuItem
+                        icon={"sort"}
+                        text={"Sort"}
+                        className={activeSort.length ? "roamjs-item-dirty" : ""}
+                        onClick={() => {
+                          setIsEditColumnSort(true);
+                        }}
+                      />
+                      <MenuItem
+                        icon={"random"}
+                        text={"Get Random"}
+                        className={random.count ? "roamjs-item-dirty" : ""}
+                        onClick={() => setIsEditRandom(true)}
+                      />
+                      <MenuItem
+                        icon={"numbered-list"}
+                        text={"Rows per page"}
+                        onClick={() => setIsEditPageSize(true)}
+                      />
+                    </MenuItem>
+                  )}
+                  {!preventSavingSettings && (
                     <MenuItem
-                      icon={showInputs ? "minus" : "plus"}
-                      text={showInputs ? "Hide Inputs" : "Inputs"}
+                      icon={"tag"}
+                      text={showAlias ? "Hide Alias" : "Alias"}
                       onClick={() => {
-                        setMoreMenuOpen(false);
-                        setShowInputs(!showInputs);
                         setInputSetting({
                           blockUid: settings.resultNodeUid,
-                          key: "showInputs",
-                          value: showInputs ? "hide" : "show",
+                          key: "showAlias",
+                          value: showAlias ? "hide" : "show",
                         });
+                        setShowAlias(!showAlias);
+                        setMoreMenuOpen(false);
                       }}
                     />
+                  )}
+                  {!preventSavingSettings && (
                     <MenuItem
-                      icon={"filter"}
-                      text={"Filters"}
-                      className={
-                        columnFilters.length ? "roamjs-item-dirty" : ""
-                      }
+                      icon={showInterface ? "th-disconnect" : "th"}
+                      text={showInterface ? "Hide Interface" : "Show Interface"}
                       onClick={() => {
-                        setIsEditColumnFilter(true);
+                        const resultNode = getSubTree({
+                          key: "results",
+                          parentUid,
+                        });
+                        setInputSetting({
+                          key: "interface",
+                          value: showInterface ? "hide" : "show",
+                          blockUid: resultNode.uid,
+                        });
+                        setShowInterface((s) => !s);
+                        setMoreMenuOpen(false);
                       }}
                     />
-                    <MenuItem
-                      icon={"sort"}
-                      text={"Sort"}
-                      className={activeSort.length ? "roamjs-item-dirty" : ""}
-                      onClick={() => {
-                        setIsEditColumnSort(true);
-                      }}
-                    />
-                    <MenuItem
-                      icon={"random"}
-                      text={"Get Random"}
-                      className={random.count ? "roamjs-item-dirty" : ""}
-                      onClick={() => setIsEditRandom(true)}
-                    />
-                    <MenuItem
-                      icon={"numbered-list"}
-                      text={"Rows per page"}
-                      onClick={() => setIsEditPageSize(true)}
-                    />
-                  </MenuItem>
-                  <MenuItem
-                    icon={"tag"}
-                    text={showAlias ? "Hide Alias" : "Alias"}
-                    onClick={() => {
-                      setInputSetting({
-                        blockUid: settings.resultNodeUid,
-                        key: "showAlias",
-                        value: showAlias ? "hide" : "show",
-                      });
-                      setShowAlias(!showAlias);
-                      setMoreMenuOpen(false);
-                    }}
-                  />
-                  <MenuItem
-                    icon={showInterface ? "th-disconnect" : "th"}
-                    text={showInterface ? "Hide Interface" : "Show Interface"}
-                    onClick={() => {
-                      const resultNode = getSubTree({
-                        key: "results",
-                        parentUid,
-                      });
-                      setInputSetting({
-                        key: "interface",
-                        value: showInterface ? "hide" : "show",
-                        blockUid: resultNode.uid,
-                      });
-                      setShowInterface((s) => !s);
-                      setMoreMenuOpen(false);
-                    }}
-                  />
+                  )}
                   <MenuItem
                     icon={"export"}
                     text={"Share Data"}
@@ -1280,7 +1288,9 @@ const ResultsView: ResultsViewComponent = ({
                       setIsExportOpen(true);
                     }}
                   />
-                  <Divider />
+                  {(isEditBlock || !preventSavingSettings || onDeleteQuery) && (
+                    <Divider />
+                  )}
                   {isEditBlock && (
                     <MenuItem
                       icon={"edit"}
@@ -1300,40 +1310,43 @@ const ResultsView: ResultsViewComponent = ({
                       }}
                     />
                   )}
-                  <MenuItem
-                    icon={"clipboard"}
-                    text={"Copy Query"}
-                    onClick={() => {
-                      const getTextFromTreeToPaste = (
-                        items: RoamBasicNode[],
-                        indentLevel = 0,
-                      ): string => {
-                        const indentation = "    ".repeat(indentLevel);
+                  {!preventSavingSettings && (
+                    <MenuItem
+                      icon={"clipboard"}
+                      text={"Copy Query"}
+                      onClick={() => {
+                        const getTextFromTreeToPaste = (
+                          items: RoamBasicNode[],
+                          indentLevel = 0,
+                        ): string => {
+                          const indentation = "    ".repeat(indentLevel);
 
-                        return items
-                          .map((item) => {
-                            const childrenText =
-                              item.children.length > 0
-                                ? getTextFromTreeToPaste(
-                                    item.children,
-                                    indentLevel + 1,
-                                  )
-                                : "";
-                            return `${indentation}- ${item.text}\n${childrenText}`;
-                          })
-                          .join("");
-                      };
-                      const tree = getBasicTreeByParentUid(parentUid);
-                      navigator.clipboard.writeText(
-                        "- {{query block}}\n" + getTextFromTreeToPaste(tree, 1),
-                      );
-                      renderToast({
-                        id: "query-copy",
-                        content: "Copied Query",
-                        intent: Intent.PRIMARY,
-                      });
-                    }}
-                  />
+                          return items
+                            .map((item) => {
+                              const childrenText =
+                                item.children.length > 0
+                                  ? getTextFromTreeToPaste(
+                                      item.children,
+                                      indentLevel + 1,
+                                    )
+                                  : "";
+                              return `${indentation}- ${item.text}\n${childrenText}`;
+                            })
+                            .join("");
+                        };
+                        const tree = getBasicTreeByParentUid(parentUid);
+                        navigator.clipboard.writeText(
+                          "- {{query block}}\n" +
+                            getTextFromTreeToPaste(tree, 1),
+                        );
+                        renderToast({
+                          id: "query-copy",
+                          content: "Copied Query",
+                          intent: Intent.PRIMARY,
+                        });
+                      }}
+                    />
+                  )}
                   {onDeleteQuery && (
                     <>
                       <MenuItem

--- a/apps/roam/src/components/results-view/ResultsView.tsx
+++ b/apps/roam/src/components/results-view/ResultsView.tsx
@@ -1288,9 +1288,7 @@ const ResultsView: ResultsViewComponent = ({
                       setIsExportOpen(true);
                     }}
                   />
-                  {(isEditBlock || !preventSavingSettings || onDeleteQuery) && (
-                    <Divider />
-                  )}
+                  <Divider />
                   {isEditBlock && (
                     <MenuItem
                       icon={"edit"}
@@ -1310,43 +1308,40 @@ const ResultsView: ResultsViewComponent = ({
                       }}
                     />
                   )}
-                  {!preventSavingSettings && (
-                    <MenuItem
-                      icon={"clipboard"}
-                      text={"Copy Query"}
-                      onClick={() => {
-                        const getTextFromTreeToPaste = (
-                          items: RoamBasicNode[],
-                          indentLevel = 0,
-                        ): string => {
-                          const indentation = "    ".repeat(indentLevel);
+                  <MenuItem
+                    icon={"clipboard"}
+                    text={"Copy Query"}
+                    onClick={() => {
+                      const getTextFromTreeToPaste = (
+                        items: RoamBasicNode[],
+                        indentLevel = 0,
+                      ): string => {
+                        const indentation = "    ".repeat(indentLevel);
 
-                          return items
-                            .map((item) => {
-                              const childrenText =
-                                item.children.length > 0
-                                  ? getTextFromTreeToPaste(
-                                      item.children,
-                                      indentLevel + 1,
-                                    )
-                                  : "";
-                              return `${indentation}- ${item.text}\n${childrenText}`;
-                            })
-                            .join("");
-                        };
-                        const tree = getBasicTreeByParentUid(parentUid);
-                        void navigator.clipboard.writeText(
-                          "- {{query block}}\n" +
-                            getTextFromTreeToPaste(tree, 1),
-                        );
-                        renderToast({
-                          id: "query-copy",
-                          content: "Copied Query",
-                          intent: Intent.PRIMARY,
-                        });
-                      }}
-                    />
-                  )}
+                        return items
+                          .map((item) => {
+                            const childrenText =
+                              item.children.length > 0
+                                ? getTextFromTreeToPaste(
+                                    item.children,
+                                    indentLevel + 1,
+                                  )
+                                : "";
+                            return `${indentation}- ${item.text}\n${childrenText}`;
+                          })
+                          .join("");
+                      };
+                      const tree = getBasicTreeByParentUid(parentUid);
+                      void navigator.clipboard.writeText(
+                        "- {{query block}}\n" + getTextFromTreeToPaste(tree, 1),
+                      );
+                      renderToast({
+                        id: "query-copy",
+                        content: "Copied Query",
+                        intent: Intent.PRIMARY,
+                      });
+                    }}
+                  />
                   {onDeleteQuery && (
                     <>
                       <MenuItem

--- a/apps/roam/src/components/results-view/ResultsView.tsx
+++ b/apps/roam/src/components/results-view/ResultsView.tsx
@@ -1377,6 +1377,7 @@ const ResultsView: ResultsViewComponent = ({
                   setActiveSort={resultViewSetActiveSort}
                   filters={filters}
                   setFilters={setFilters}
+                  preventSavingSettings={preventSavingSettings}
                   views={views}
                   onRefresh={onRefresh}
                   allResults={results}


### PR DESCRIPTION
https://www.loom.com/share/ca2fa22b6a9e419abe811f8df4d4c4b0

NOTE: For review use hide whitespaces settings

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/953" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized the menu structure to consolidate results-related options (Layout, Column Views, Search, Inputs, Filters, Sort, Get Random, Rows per page) under a new "Results" submenu for improved navigation.
  * Updated settings menu visibility based on context and user interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->