### PR TITLE
ENG-1638 Add view-only notice for imported nodes

### DIFF
--- a/apps/obsidian/src/components/DiscourseContextView.tsx
+++ b/apps/obsidian/src/components/DiscourseContextView.tsx
@@ -12,14 +12,52 @@ import { getDiscourseNodeFormatExpression } from "~/utils/getDiscourseNodeFormat
 import { RelationshipSection } from "~/components/RelationshipSection";
 import { VIEW_TYPE_DISCOURSE_CONTEXT } from "~/types";
 import { PluginProvider, usePlugin } from "~/components/PluginContext";
-import { getNodeTypeById } from "~/utils/typeUtils";
+import { getNodeTypeById, getAndFormatImportSource } from "~/utils/typeUtils";
 import { refreshImportedFile } from "~/utils/importNodes";
 import { publishNode } from "~/utils/publishNode";
 import { createBaseForNodeType } from "~/utils/baseForNodeType";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 
 type DiscourseContextProps = {
   activeFile: TFile | null;
+};
+
+type InfoTooltipProps = {
+  content: string;
+};
+
+const InfoTooltip = ({ content }: InfoTooltipProps) => {
+  const [visible, setVisible] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!visible) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setVisible(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [visible]);
+
+  return (
+    <div ref={ref} className="relative inline-flex items-center">
+      <button
+        className="clickable-icon text-muted hover:text-normal flex h-4 w-4 items-center justify-center"
+        onMouseEnter={() => setVisible(true)}
+        onMouseLeave={() => setVisible(false)}
+        onClick={() => setVisible((v) => !v)}
+      >
+        <div ref={(el) => (el && setIcon(el, "info")) || undefined} />
+      </button>
+      {visible && (
+        <div className="absolute left-6 top-0 z-50 w-56 rounded border border-gray-300 bg-gray-800 p-2 text-xs text-gray-100 shadow-md dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100">
+          {content}
+        </div>
+      )}
+    </div>
+  );
 };
 
 const DiscourseContext = ({ activeFile }: DiscourseContextProps) => {
@@ -206,8 +244,19 @@ const DiscourseContext = ({ activeFile }: DiscourseContextProps) => {
             )}
           </div>
 
+          {isImported && (
+            <div className="mt-3 flex items-center gap-1.5">
+              <span className="cursor-default rounded bg-amber-100 px-2 py-1 text-xs font-semibold text-amber-800 dark:bg-amber-900/40 dark:text-amber-300">
+                View only
+              </span>
+              <InfoTooltip
+                content={`Imported from ${getAndFormatImportSource(frontmatter.importedFromRid as string, plugin.settings.spaceNames)}. Direct edits will be overwritten when refreshed.`}
+              />
+            </div>
+          )}
+
           {nodeType.format && (
-            <div className="mb-1">
+            <div className="mb-1 mt-2">
               <span className="font-bold">Content: </span>
               {extractContentFromTitle(nodeType.format, activeFile.basename)}
             </div>

--- a/apps/obsidian/src/components/DiscourseContextView.tsx
+++ b/apps/obsidian/src/components/DiscourseContextView.tsx
@@ -45,8 +45,8 @@ const InfoTooltip = ({ content }: InfoTooltipProps) => {
     <div ref={ref} className="relative inline-flex items-center">
       <button
         className="clickable-icon text-muted hover:text-normal flex h-4 w-4 items-center justify-center"
-        onMouseEnter={() => setVisible(true)}
-        onMouseLeave={() => setVisible(false)}
+        onPointerEnter={(e) => e.pointerType === "mouse" && setVisible(true)}
+        onPointerLeave={(e) => e.pointerType === "mouse" && setVisible(false)}
         onClick={() => setVisible((v) => !v)}
       >
         <div ref={(el) => (el && setIcon(el, "info")) || undefined} />
@@ -246,7 +246,7 @@ const DiscourseContext = ({ activeFile }: DiscourseContextProps) => {
 
           {isImported && (
             <div className="mt-3 flex items-center gap-1.5">
-              <span className="cursor-default rounded bg-amber-100 px-2 py-1 text-xs font-semibold text-amber-800 dark:bg-amber-900/40 dark:text-amber-300">
+              <span className="cursor-default rounded bg-amber-300 px-2 py-1 text-xs font-semibold text-amber-950 dark:bg-amber-900/40 dark:text-amber-300">
                 View only
               </span>
               <InfoTooltip

--- a/apps/obsidian/src/components/DiscourseContextView.tsx
+++ b/apps/obsidian/src/components/DiscourseContextView.tsx
@@ -5,6 +5,7 @@ import {
   Notice,
   FrontMatterCache,
   setIcon,
+  setTooltip,
 } from "obsidian";
 import { createRoot, Root } from "react-dom/client";
 import DiscourseGraphPlugin from "~/index";
@@ -16,7 +17,7 @@ import { getNodeTypeById, getAndFormatImportSource } from "~/utils/typeUtils";
 import { refreshImportedFile } from "~/utils/importNodes";
 import { publishNode } from "~/utils/publishNode";
 import { createBaseForNodeType } from "~/utils/baseForNodeType";
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect } from "react";
 
 type DiscourseContextProps = {
   activeFile: TFile | null;
@@ -26,39 +27,16 @@ type InfoTooltipProps = {
   content: string;
 };
 
-const InfoTooltip = ({ content }: InfoTooltipProps) => {
-  const [visible, setVisible] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!visible) return;
-    const handleClickOutside = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) {
-        setVisible(false);
-      }
-    };
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, [visible]);
-
-  return (
-    <div ref={ref} className="relative inline-flex items-center">
-      <button
-        className="clickable-icon text-muted hover:text-normal flex h-4 w-4 items-center justify-center"
-        onPointerEnter={(e) => e.pointerType === "mouse" && setVisible(true)}
-        onPointerLeave={(e) => e.pointerType === "mouse" && setVisible(false)}
-        onClick={() => setVisible((v) => !v)}
-      >
-        <div ref={(el) => (el && setIcon(el, "info")) || undefined} />
-      </button>
-      {visible && (
-        <div className="absolute left-6 top-0 z-50 w-56 rounded border border-gray-300 bg-gray-800 p-2 text-xs text-gray-100 shadow-md dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100">
-          {content}
-        </div>
-      )}
-    </div>
-  );
-};
+const InfoTooltip = ({ content }: InfoTooltipProps) => (
+  <button
+    ref={(el) => {
+      if (el) setTooltip(el, content);
+    }}
+    className="clickable-icon text-muted hover:text-normal flex h-4 w-4 items-center justify-center"
+  >
+    <div ref={(el) => (el && setIcon(el, "info")) || undefined} />
+  </button>
+);
 
 const DiscourseContext = ({ activeFile }: DiscourseContextProps) => {
   const plugin = usePlugin();


### PR DESCRIPTION
## Summary

- Adds an amber **View only** badge to the Discourse context panel when the active file is an imported node
- Adds an `InfoTooltip` component (info icon via Obsidian's `setIcon`) that shows source space and a warning on hover/click
- Tooltip uses explicit dark/light-adaptive colours (`bg-gray-800` / `dark:bg-gray-700`) for readability in both Obsidian themes

<img width="828" height="388" alt="image" src="https://github.com/user-attachments/assets/430d2ace-79bb-45b0-9136-37136b30f275" />

<img width="394" height="240" alt="image" src="https://github.com/user-attachments/assets/1eb986c0-e514-4299-9256-bef0e6c392e5" />


Closes ENG-1638

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/966" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
