### PR TITLE
ENG-906 Add node tag preview below tag input in settings

### DIFF
--- a/apps/roam/src/components/settings/NodeConfig.tsx
+++ b/apps/roam/src/components/settings/NodeConfig.tsx
@@ -24,6 +24,7 @@ import getBasicTreeByParentUid from "roamjs-components/queries/getBasicTreeByPar
 import setInputSetting from "roamjs-components/util/setInputSetting";
 import { setDiscourseNodeSetting } from "~/components/settings/utils/accessors";
 import DiscourseNodeSuggestiveRules from "./DiscourseNodeSuggestiveRules";
+import { getNodeTagStyles } from "~/utils/getDiscourseNodeColors";
 import { isSyncEnabled } from "~/components/settings/utils/accessors";
 import {
   DiscourseNodeTextPanel,
@@ -180,19 +181,31 @@ const NodeConfig = ({
                 parentUid={node.type}
                 uid={shortcutUid}
               />
-              <DiscourseNodeTextPanel
-                nodeType={node.type}
-                title="Tag"
-                description={`Designate a hashtag for marking potential ${node.text}.`}
-                settingKeys={["tag"]}
-                initialValue={node.tag}
-                placeholder={generateTagPlaceholder(node)}
-                error={tagError}
-                onChange={setTagValue}
-                order={2}
-                parentUid={node.type}
-                uid={tagUid}
-              />
+              <div>
+                <DiscourseNodeTextPanel
+                  nodeType={node.type}
+                  title="Tag"
+                  description={`Designate a hashtag for marking potential ${node.text}.`}
+                  settingKeys={["tag"]}
+                  initialValue={node.tag}
+                  placeholder={generateTagPlaceholder(node)}
+                  error={tagError}
+                  onChange={setTagValue}
+                  order={2}
+                  parentUid={node.type}
+                  uid={tagUid}
+                />
+                {tagValue && (
+                  <div className="flex items-center gap-1.5 pl-1">
+                    <span className="text-xs italic text-gray-400">
+                      Preview:
+                    </span>
+                    <span style={getNodeTagStyles(color)}>
+                      #{tagValue.replace(/^#/, "")}
+                    </span>
+                  </div>
+                )}
+              </div>
               <>
                 <Label>
                   Color

--- a/apps/roam/src/components/settings/NodeConfig.tsx
+++ b/apps/roam/src/components/settings/NodeConfig.tsx
@@ -200,7 +200,7 @@ const NodeConfig = ({
                     <span className="text-xs italic text-gray-400">
                       Preview:
                     </span>
-                    <span style={getNodeTagStyles(color)}>
+                    <span style={color ? getNodeTagStyles(color) : undefined}>
                       #{tagValue.replace(/^#/, "")}
                     </span>
                   </div>

--- a/apps/roam/src/utils/getDiscourseNodeColors.ts
+++ b/apps/roam/src/utils/getDiscourseNodeColors.ts
@@ -1,3 +1,4 @@
+import { CSSProperties } from "react";
 import { colord } from "colord";
 import getPleasingColors from "@repo/utils/getPleasingColors";
 import {
@@ -5,6 +6,7 @@ import {
   COLOR_PALETTE,
 } from "~/components/canvas/DiscourseNodeUtil";
 import getDiscourseNodes, { DiscourseNode } from "./getDiscourseNodes";
+import { formatHexColor } from "~/components/settings/DiscourseNodeCanvasSettings";
 
 type GetDiscourseNodeColorsParams = {
   nodeType?: string;
@@ -38,4 +40,26 @@ export const getDiscourseNodeColors = ({
   const backgroundColor = pleasingColors.background;
   const textColor = pleasingColors.text;
   return { backgroundColor, textColor };
+};
+
+export const getNodeTagStyles = (color: string): CSSProperties | undefined => {
+  const formattedColor = formatHexColor(color);
+  if (!formattedColor) return undefined;
+  const { background, text, border } = getPleasingColors(
+    colord(formattedColor),
+  );
+  return {
+    backgroundColor: background,
+    color: text,
+    border: `1px solid ${border}`,
+    fontWeight: "500",
+    padding: "2px 6px",
+    borderRadius: "12px",
+    margin: "0 2px",
+    fontSize: "0.9em",
+    whiteSpace: "nowrap",
+    boxShadow: "0 1px 2px rgba(0, 0, 0, 0.05)",
+    display: "inline-block",
+    cursor: "pointer",
+  };
 };

--- a/apps/roam/src/utils/initializeObserversAndListeners.ts
+++ b/apps/roam/src/utils/initializeObserversAndListeners.ts
@@ -143,9 +143,8 @@ export const initObservers = async ({
           const normalizedNodeTag = node.tag ? getCleanTagText(node.tag) : "";
           if (normalizedTag === normalizedNodeTag) {
             renderNodeTagPopupButton(s, node, onloadArgs.extensionAPI);
-            const tagStyles = getNodeTagStyles(
-              node.canvasSettings?.color ?? "",
-            );
+            const color = node.canvasSettings?.color ?? "";
+            const tagStyles = color ? getNodeTagStyles(color) : {};
             if (tagStyles) {
               Object.assign(s.style, tagStyles);
             }

--- a/apps/roam/src/utils/initializeObserversAndListeners.ts
+++ b/apps/roam/src/utils/initializeObserversAndListeners.ts
@@ -50,14 +50,12 @@ import {
 } from "~/utils/renderTextSelectionPopup";
 import { renderNodeTagPopupButton } from "./renderNodeTagPopup";
 import { renderImageToolsMenu } from "./renderImageToolsMenu";
-import { formatHexColor } from "~/components/settings/DiscourseNodeCanvasSettings";
 import { getSetting } from "./extensionSettings";
 import { mountLeftSidebar } from "~/components/LeftSidebarView";
 import { getUidAndBooleanSetting } from "./getExportSettings";
 import { getFeatureFlag } from "~/components/settings/utils/accessors";
 import { getCleanTagText } from "~/components/settings/NodeConfig";
-import getPleasingColors from "@repo/utils/getPleasingColors";
-import { colord } from "colord";
+import { getNodeTagStyles } from "~/utils/getDiscourseNodeColors";
 import { renderPossibleDuplicates } from "~/components/VectorDuplicateMatches";
 import getPageUidByPageTitle from "roamjs-components/queries/getPageUidByPageTitle";
 import getPageTitleByPageUid from "roamjs-components/queries/getPageTitleByPageUid";
@@ -145,29 +143,11 @@ export const initObservers = async ({
           const normalizedNodeTag = node.tag ? getCleanTagText(node.tag) : "";
           if (normalizedTag === normalizedNodeTag) {
             renderNodeTagPopupButton(s, node, onloadArgs.extensionAPI);
-            if (node.canvasSettings?.color) {
-              const formattedColor = formatHexColor(node.canvasSettings.color);
-              if (!formattedColor) {
-                break;
-              }
-              const contrastingColor = getPleasingColors(
-                colord(formattedColor),
-              );
-
-              Object.assign(s.style, {
-                backgroundColor: contrastingColor.background,
-                color: contrastingColor.text,
-                border: `1px solid ${contrastingColor.border}`,
-                fontWeight: "500",
-                padding: "2px 6px",
-                borderRadius: "12px",
-                margin: "0 2px",
-                fontSize: "0.9em",
-                whiteSpace: "nowrap",
-                boxShadow: "0 1px 2px rgba(0, 0, 0, 0.05)",
-                display: "inline-block",
-                cursor: "pointer",
-              });
+            const tagStyles = getNodeTagStyles(
+              node.canvasSettings?.color ?? "",
+            );
+            if (tagStyles) {
+              Object.assign(s.style, tagStyles);
             }
             break;
           }


### PR DESCRIPTION
https://www.loom.com/share/7eaa1ccd091d4103885d2c2524b17154

## Summary
- Adds a live tag preview directly below the tag input field in node settings (General tab)
- Extracts tag styling logic into a shared `getNodeTagStyles` util to avoid duplication with the live Roam tag observer
- Refactors `initializeObserversAndListeners.ts` to use the shared util

## Test plan
- [x] Open node settings → General tab for a node with a tag set
- [x] Verify the tag preview appears below the input, styled as a colored pill matching the node's canvas color
- [x] Verify the preview updates live as you type
- [x] Verify with no canvas color set: preview shows unstyled (no color)
- [x] Verify live Roam tags (in blocks) still render with the same colored pill style
<img width="243" height="129" alt="Screenshot 2026-04-17 at 13 11 13" src="https://github.com/user-attachments/assets/c3a45b6c-0f19-48c4-9fae-2c74d0dae425" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/967" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
