### PR TITLE
ENG-1610: Pre-fill create node dialog with highlighted text

### DIFF
--- a/apps/roam/src/utils/registerCommandPaletteCommands.ts
+++ b/apps/roam/src/utils/registerCommandPaletteCommands.ts
@@ -166,19 +166,48 @@ export const registerCommandPaletteCommands = (onloadArgs: OnloadArgs) => {
     renderSettings({ onloadArgs });
   };
 
-  const getSelectionStartForBlock = (uid: string): number => {
+  type BlockSelection = {
+    selectionStart: number;
+    selectionEnd: number;
+    selectedText: string;
+  };
+
+  const getBlockSelection = (uid: string): BlockSelection => {
     const activeElement = document.activeElement;
     const isFocusedTextarea =
       activeElement instanceof HTMLTextAreaElement &&
       activeElement.classList.contains("rm-block-input") &&
       getUids(activeElement).blockUid === uid;
-    if (isFocusedTextarea) return activeElement.selectionStart;
+    if (isFocusedTextarea) {
+      return {
+        selectionStart: activeElement.selectionStart,
+        selectionEnd: activeElement.selectionEnd,
+        selectedText: activeElement.value.substring(
+          activeElement.selectionStart,
+          activeElement.selectionEnd,
+        ),
+      };
+    }
     const textareas = document.querySelectorAll("textarea.rm-block-input");
     for (const el of textareas) {
       const textarea = el as HTMLTextAreaElement;
-      if (getUids(textarea).blockUid === uid) return textarea.selectionStart;
+      if (getUids(textarea).blockUid === uid) {
+        return {
+          selectionStart: textarea.selectionStart,
+          selectionEnd: textarea.selectionEnd,
+          selectedText: textarea.value.substring(
+            textarea.selectionStart,
+            textarea.selectionEnd,
+          ),
+        };
+      }
     }
-    return (getTextByBlockUid(uid) || "").length;
+    const textLength = (getTextByBlockUid(uid) || "").length;
+    return {
+      selectionStart: textLength,
+      selectionEnd: textLength,
+      selectedText: "",
+    };
   };
 
   const createDiscourseNodeFromCommand = () => {
@@ -187,12 +216,14 @@ export const registerCommandPaletteCommands = (onloadArgs: OnloadArgs) => {
     const uid = focusedBlock?.["block-uid"];
     const windowId = focusedBlock?.["window-id"] || "main-window";
 
-    const selectionStart = uid ? getSelectionStartForBlock(uid) : 0;
+    const { selectionStart, selectionEnd, selectedText } = uid
+      ? getBlockSelection(uid)
+      : { selectionStart: 0, selectionEnd: 0, selectedText: "" };
 
     renderModifyNodeDialog({
       mode: "create",
       nodeType: "",
-      initialValue: { text: "", uid: "" },
+      initialValue: { text: selectedText, uid: "" },
       extensionAPI,
       onSuccess: async (result) => {
         if (!uid) {
@@ -204,7 +235,7 @@ export const registerCommandPaletteCommands = (onloadArgs: OnloadArgs) => {
         }
         const originalText = getTextByBlockUid(uid) || "";
         const pageRef = `[[${result.text}]]`;
-        const newText = `${originalText.substring(0, selectionStart)}${pageRef}${originalText.substring(selectionStart)}`;
+        const newText = `${originalText.substring(0, selectionStart)}${pageRef}${originalText.substring(selectionEnd)}`;
         const newCursorPosition = selectionStart + pageRef.length;
 
         await updateBlock({ uid, text: newText });


### PR DESCRIPTION
https://www.loom.com/share/fda19d5e919543adba3aeb1683eb8415

## Summary
- When the "Create/Insert discourse node" command palette command is triggered with text selected in a block, the dialog title field is now pre-filled with that selected text
- On success, the selected text is replaced by the inserted `[[page reference]]` (previously it would insert at cursor without removing the original text)

## How it works
Replaced `getSelectionStartForBlock` with a new `getBlockSelection` helper that returns `selectionStart`, `selectionEnd`, and `selectedText`. The selected text is passed as `initialValue.text` to the dialog, and `selectionEnd` is used when splicing the new page ref into the block text.

## Test plan
- [x] Select some text in a Roam block, trigger "DG: Create/Insert discourse node" via command palette — dialog title should be pre-filled with the selected text
- [x] With no text selected, trigger the command — dialog title should be empty (unchanged behavior)
- [x] Confirm node creation with pre-filled text — selected text in the block should be replaced with `[[node name]]`
- [x] Confirm node creation with no selection — `[[node name]]` should be inserted at cursor position (unchanged behavior)

Closes ENG-1610

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/969" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
