### PR TITLE
ENG-1652 Add .dg.metadata for stable import folder identification

### DIFF
--- a/apps/obsidian/src/components/ImportNodesModal.tsx
+++ b/apps/obsidian/src/components/ImportNodesModal.tsx
@@ -82,6 +82,20 @@ const ImportNodesContent = ({ plugin, onClose }: ImportNodesModalProps) => {
         getSpaceUris(client, uniqueSpaceIds),
       ]);
 
+      // Keep spaceNames in settings up to date for UI display (formatImportSource reads it)
+      if (uniqueSpaceIds.length > 0) {
+        if (!plugin.settings.spaceNames) plugin.settings.spaceNames = {};
+
+        for (const spaceId of uniqueSpaceIds) {
+          const spaceUri = spaceUris.get(spaceId);
+          const spaceName = spaceNames.get(spaceId);
+          if (spaceUri && spaceName) {
+            plugin.settings.spaceNames[spaceUri] = spaceName;
+          }
+        }
+        await plugin.saveSettings();
+      }
+
       const grouped: Map<string, GroupWithNodes> = new Map();
 
       for (const node of importableNodes) {

--- a/apps/obsidian/src/components/ImportNodesModal.tsx
+++ b/apps/obsidian/src/components/ImportNodesModal.tsx
@@ -82,20 +82,6 @@ const ImportNodesContent = ({ plugin, onClose }: ImportNodesModalProps) => {
         getSpaceUris(client, uniqueSpaceIds),
       ]);
 
-      // Populate plugin settings with current space names so they stay up to date
-      if (uniqueSpaceIds.length > 0) {
-        if (!plugin.settings.spaceNames) plugin.settings.spaceNames = {};
-
-        for (const spaceId of uniqueSpaceIds) {
-          const spaceUri = spaceUris.get(spaceId);
-          const spaceName = spaceNames.get(spaceId);
-          if (spaceUri && spaceName) {
-            plugin.settings.spaceNames[spaceUri] = spaceName;
-          }
-        }
-        await plugin.saveSettings();
-      }
-
       const grouped: Map<string, GroupWithNodes> = new Map();
 
       for (const node of importableNodes) {

--- a/apps/obsidian/src/index.ts
+++ b/apps/obsidian/src/index.ts
@@ -37,6 +37,7 @@ import {
   migrateFrontmatterRelationsToRelationsJson,
   mergeAllRelationsJsonToRoot,
 } from "~/utils/relationsStore";
+import { migrateImportFolderMetadata } from "./utils/importFolderMetadata";
 
 export default class DiscourseGraphPlugin extends Plugin {
   settings: Settings = { ...DEFAULT_SETTINGS };
@@ -55,6 +56,10 @@ export default class DiscourseGraphPlugin extends Plugin {
 
     await migrateFrontmatterRelationsToRelationsJson(this).catch((error) => {
       console.error("Failed to migrate frontmatter relations:", error);
+    });
+
+    await migrateImportFolderMetadata(this).catch((error) => {
+      console.error("Failed to migrate import folder metadata:", error);
     });
 
     if (this.settings.syncModeEnabled === true) {

--- a/apps/obsidian/src/types.ts
+++ b/apps/obsidian/src/types.ts
@@ -100,4 +100,10 @@ export type GroupWithNodes = {
   nodes: ImportableNode[];
 };
 
+export type ImportFolderMetadata = {
+  spaceUri: string;
+  spaceName: string;
+  userName?: string;
+};
+
 export const VIEW_TYPE_DISCOURSE_CONTEXT = "discourse-context-view";

--- a/apps/obsidian/src/utils/importFolderMetadata.ts
+++ b/apps/obsidian/src/utils/importFolderMetadata.ts
@@ -185,7 +185,7 @@ export const migrateImportFolderMetadata = async (
       await writeImportFolderMetadata({
         adapter,
         folderPath,
-        metadata: { spaceUri, spaceName: basename },
+        metadata: { spaceUri, spaceName: spaceNames[spaceUri] ?? basename },
       });
     } else {
       console.debug(

--- a/apps/obsidian/src/utils/importFolderMetadata.ts
+++ b/apps/obsidian/src/utils/importFolderMetadata.ts
@@ -170,7 +170,7 @@ export const migrateImportFolderMetadata = async (
   const spaceNames = plugin.settings.spaceNames ?? {};
   const nameToSpaceUri = new Map<string, string>();
   for (const [spaceUri, name] of Object.entries(spaceNames)) {
-    nameToSpaceUri.set(name, spaceUri);
+    nameToSpaceUri.set(sanitizeFileName(name), spaceUri);
   }
 
   for (const folderPath of folders) {

--- a/apps/obsidian/src/utils/importFolderMetadata.ts
+++ b/apps/obsidian/src/utils/importFolderMetadata.ts
@@ -1,4 +1,4 @@
-import { DataAdapter } from "obsidian";
+import { DataAdapter, Notice } from "obsidian";
 import type DiscourseGraphPlugin from "~/index";
 import type { ImportFolderMetadata } from "~/types";
 
@@ -196,11 +196,22 @@ export const migrateImportFolderMetadata = async (
 
   const { folders } = await adapter.list(IMPORT_ROOT);
 
-  // Invert spaceNames: Record<spaceUri, spaceName> → Map<spaceName, spaceUri>
+  // Invert spaceNames: Record<spaceUri, spaceName> → Map<sanitizedName, Set<spaceUri>>
+  // Using a Set per name to detect collisions — two different spaceUris can share
+  // the same sanitized folder name, making the mapping ambiguous.
   const spaceNames = plugin.settings.spaceNames ?? {};
-  const nameToSpaceUri = new Map<string, string>();
+  const nameToSpaceUris = new Map<string, Set<string>>();
   for (const [spaceUri, name] of Object.entries(spaceNames)) {
-    nameToSpaceUri.set(sanitizeFileName(name), spaceUri);
+    const sanitized = sanitizeFileName(name);
+    const existing = nameToSpaceUris.get(sanitized);
+    if (existing) {
+      existing.add(spaceUri);
+      new Notice(
+        `Discourse Graphs: ambiguous import folder name "${sanitized}" maps to multiple spaces — skipping migration for this folder.`,
+      );
+    } else {
+      nameToSpaceUris.set(sanitized, new Set([spaceUri]));
+    }
   }
 
   for (const folderPath of folders) {
@@ -209,9 +220,10 @@ export const migrateImportFolderMetadata = async (
     if (metadataExists) continue;
 
     const basename = folderPath.split("/").pop() ?? "";
-    const spaceUri = nameToSpaceUri.get(basename);
+    const spaceUris = nameToSpaceUris.get(basename);
 
-    if (spaceUri) {
+    if (spaceUris?.size === 1) {
+      const spaceUri = [...spaceUris][0];
       await writeImportFolderMetadata({
         adapter,
         folderPath,

--- a/apps/obsidian/src/utils/importFolderMetadata.ts
+++ b/apps/obsidian/src/utils/importFolderMetadata.ts
@@ -223,7 +223,7 @@ export const migrateImportFolderMetadata = async (
     const spaceUris = nameToSpaceUris.get(basename);
 
     if (spaceUris?.size === 1) {
-      const spaceUri = [...spaceUris][0];
+      const spaceUri = [...spaceUris][0]!;
       await writeImportFolderMetadata({
         adapter,
         folderPath,

--- a/apps/obsidian/src/utils/importFolderMetadata.ts
+++ b/apps/obsidian/src/utils/importFolderMetadata.ts
@@ -1,0 +1,196 @@
+import { DataAdapter } from "obsidian";
+import type DiscourseGraphPlugin from "~/index";
+import type { ImportFolderMetadata } from "~/types";
+
+const DG_METADATA_FILE = ".dg.metadata";
+const IMPORT_ROOT = "import";
+
+const sanitizeFileName = (fileName: string): string => {
+  return fileName
+    .replace(/[<>:"/\\|?*]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+};
+
+const generateShortId = (): string => Math.random().toString(36).slice(2, 8);
+
+const readImportFolderMetadata = async (
+  adapter: DataAdapter,
+  folderPath: string,
+): Promise<ImportFolderMetadata | null> => {
+  const metadataPath = `${folderPath}/${DG_METADATA_FILE}`;
+  try {
+    const exists = await adapter.exists(metadataPath);
+    if (!exists) return null;
+
+    const raw = await adapter.read(metadataPath);
+    const parsed: unknown = JSON.parse(raw);
+
+    if (
+      parsed !== null &&
+      typeof parsed === "object" &&
+      "spaceUri" in parsed &&
+      typeof (parsed as Record<string, unknown>).spaceUri === "string"
+    ) {
+      return parsed as ImportFolderMetadata;
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+};
+
+const writeImportFolderMetadata = async ({
+  adapter,
+  folderPath,
+  metadata,
+}: {
+  adapter: DataAdapter;
+  folderPath: string;
+  metadata: ImportFolderMetadata;
+}): Promise<void> => {
+  const metadataPath = `${folderPath}/${DG_METADATA_FILE}`;
+  await adapter.write(metadataPath, JSON.stringify(metadata, null, 2));
+};
+
+const buildSpaceUriToFolderMap = async (
+  adapter: DataAdapter,
+): Promise<Map<string, string>> => {
+  const map = new Map<string, string>();
+
+  const importExists = await adapter.exists(IMPORT_ROOT);
+  if (!importExists) return map;
+
+  const { folders } = await adapter.list(IMPORT_ROOT);
+
+  for (const folderPath of folders) {
+    const metadata = await readImportFolderMetadata(adapter, folderPath);
+    if (!metadata) continue;
+
+    if (map.has(metadata.spaceUri)) {
+      console.warn(
+        `[importFolderMetadata] Duplicate spaceUri "${metadata.spaceUri}" found in "${folderPath}". Using first occurrence.`,
+      );
+    } else {
+      map.set(metadata.spaceUri, folderPath);
+    }
+  }
+
+  return map;
+};
+
+export const resolveFolderForSpaceUri = async ({
+  adapter,
+  spaceUri,
+  spaceName,
+}: {
+  adapter: DataAdapter;
+  spaceUri: string;
+  spaceName: string;
+}): Promise<string> => {
+  const spaceUriToFolder = await buildSpaceUriToFolderMap(adapter);
+
+  // 1. Exact spaceUri match
+  if (spaceUriToFolder.has(spaceUri)) {
+    const folderPath = spaceUriToFolder.get(spaceUri)!;
+    const existingMetadata = await readImportFolderMetadata(
+      adapter,
+      folderPath,
+    );
+    if (existingMetadata && existingMetadata.spaceName !== spaceName) {
+      await writeImportFolderMetadata({
+        adapter,
+        folderPath,
+        metadata: { ...existingMetadata, spaceName },
+      });
+    }
+    return folderPath;
+  }
+
+  // 2. Fallback: scan for a folder whose basename matches the sanitized spaceName
+  //    but has no metadata yet
+  const { folders } = (await adapter.exists(IMPORT_ROOT))
+    ? await adapter.list(IMPORT_ROOT)
+    : { folders: [] };
+
+  const sanitized = sanitizeFileName(spaceName);
+
+  for (const folderPath of folders) {
+    const basename = folderPath.split("/").pop();
+    if (basename === sanitized) {
+      const existingMetadata = await readImportFolderMetadata(
+        adapter,
+        folderPath,
+      );
+      if (!existingMetadata) {
+        await writeImportFolderMetadata({
+          adapter,
+          folderPath,
+          metadata: { spaceUri, spaceName },
+        });
+        return folderPath;
+      }
+    }
+  }
+
+  // 3. Create a new folder, handling name collisions
+  const desiredPath = `${IMPORT_ROOT}/${sanitized}`;
+  const desiredExists = await adapter.exists(desiredPath);
+
+  let newPath: string;
+  if (desiredExists) {
+    // The existing folder has a different spaceUri (would have been returned above otherwise)
+    newPath = `${IMPORT_ROOT}/${sanitized}-${generateShortId()}`;
+  } else {
+    newPath = desiredPath;
+  }
+
+  await adapter.mkdir(newPath);
+  await writeImportFolderMetadata({
+    adapter,
+    folderPath: newPath,
+    metadata: { spaceUri, spaceName },
+  });
+
+  return newPath;
+};
+
+export const migrateImportFolderMetadata = async (
+  plugin: DiscourseGraphPlugin,
+): Promise<void> => {
+  const adapter = plugin.app.vault.adapter;
+
+  const importExists = await adapter.exists(IMPORT_ROOT);
+  if (!importExists) return;
+
+  const { folders } = await adapter.list(IMPORT_ROOT);
+
+  // Invert spaceNames: Record<spaceUri, spaceName> → Map<spaceName, spaceUri>
+  const spaceNames = plugin.settings.spaceNames ?? {};
+  const nameToSpaceUri = new Map<string, string>();
+  for (const [spaceUri, name] of Object.entries(spaceNames)) {
+    nameToSpaceUri.set(name, spaceUri);
+  }
+
+  for (const folderPath of folders) {
+    const metadataPath = `${folderPath}/${DG_METADATA_FILE}`;
+    const metadataExists = await adapter.exists(metadataPath);
+    if (metadataExists) continue;
+
+    const basename = folderPath.split("/").pop() ?? "";
+    const spaceUri = nameToSpaceUri.get(basename);
+
+    if (spaceUri) {
+      await writeImportFolderMetadata({
+        adapter,
+        folderPath,
+        metadata: { spaceUri, spaceName: basename },
+      });
+    } else {
+      console.debug(
+        `[importFolderMetadata] No spaceUri found for folder "${basename}", skipping migration.`,
+      );
+    }
+  }
+};

--- a/apps/obsidian/src/utils/importFolderMetadata.ts
+++ b/apps/obsidian/src/utils/importFolderMetadata.ts
@@ -54,6 +54,32 @@ const writeImportFolderMetadata = async ({
   await adapter.write(metadataPath, JSON.stringify(metadata, null, 2));
 };
 
+const resolveMetadataDuplicate = async ({
+  adapter,
+  existingFolderPath,
+  newFolderPath,
+}: {
+  adapter: DataAdapter;
+  existingFolderPath: string;
+  newFolderPath: string;
+}): Promise<string> => {
+  const existingMetadataPath = `${existingFolderPath}/${DG_METADATA_FILE}`;
+  const newMetadataPath = `${newFolderPath}/${DG_METADATA_FILE}`;
+
+  const existingStat = await adapter.stat(existingMetadataPath);
+  const newStat = await adapter.stat(newMetadataPath);
+
+  const newIsNewer =
+    existingStat && newStat && existingStat.mtime < newStat.mtime;
+  if (newIsNewer) {
+    await adapter.remove(existingMetadataPath);
+    return newFolderPath;
+  }
+
+  await adapter.remove(newMetadataPath);
+  return existingFolderPath;
+};
+
 const buildSpaceUriToFolderMap = async (
   adapter: DataAdapter,
 ): Promise<Map<string, string>> => {
@@ -69,9 +95,13 @@ const buildSpaceUriToFolderMap = async (
     if (!metadata) continue;
 
     if (map.has(metadata.spaceUri)) {
-      console.warn(
-        `[importFolderMetadata] Duplicate spaceUri "${metadata.spaceUri}" found in "${folderPath}". Using first occurrence.`,
-      );
+      const existingPath = map.get(metadata.spaceUri)!;
+      const keptPath = await resolveMetadataDuplicate({
+        adapter,
+        existingFolderPath: existingPath,
+        newFolderPath: folderPath,
+      });
+      map.set(metadata.spaceUri, keptPath);
     } else {
       map.set(metadata.spaceUri, folderPath);
     }
@@ -187,10 +217,6 @@ export const migrateImportFolderMetadata = async (
         folderPath,
         metadata: { spaceUri, spaceName: spaceNames[spaceUri] ?? basename },
       });
-    } else {
-      console.debug(
-        `[importFolderMetadata] No spaceUri found for folder "${basename}", skipping migration.`,
-      );
     }
   }
 };

--- a/apps/obsidian/src/utils/importNodes.ts
+++ b/apps/obsidian/src/utils/importNodes.ts
@@ -1222,6 +1222,9 @@ export const importSelectedNodes = async ({
   }
 
   const spaceUris = await getSpaceUris(client, [...nodesBySpace.keys()]);
+  const spaceNames = await getSpaceNameFromIds(client, [
+    ...nodesBySpace.keys(),
+  ]);
 
   // Process each space
   for (const [spaceId, nodes] of nodesBySpace.entries()) {
@@ -1235,7 +1238,7 @@ export const importSelectedNodes = async ({
       continue;
     }
 
-    const spaceName = await getSpaceNameFromId(client, spaceId);
+    const spaceName = spaceNames.get(spaceId) ?? `space-${spaceId}`;
     const importFolderPath = await resolveFolderForSpaceUri({
       adapter: plugin.app.vault.adapter,
       spaceUri,

--- a/apps/obsidian/src/utils/importNodes.ts
+++ b/apps/obsidian/src/utils/importNodes.ts
@@ -19,6 +19,7 @@ import {
   importRelationsForImportedNodes,
   type RemoteRelationInstance,
 } from "./importRelations";
+import { resolveFolderForSpaceUri } from "./importFolderMetadata";
 
 export const getAvailableGroupIds = async (
   client: DGSupabaseClient,
@@ -754,7 +755,7 @@ const importAssetsForNode = async ({
   client,
   spaceId,
   nodeInstanceId,
-  spaceName,
+  importBasePath,
   targetMarkdownFile,
   originalNodePath,
 }: {
@@ -762,7 +763,7 @@ const importAssetsForNode = async ({
   client: DGSupabaseClient;
   spaceId: number;
   nodeInstanceId: string;
-  spaceName: string;
+  importBasePath: string;
   targetMarkdownFile: TFile;
   /** Source vault path of the note (e.g. from Content metadata filePath). Used to place assets under import/{space}/ relative to note. */
   originalNodePath?: string;
@@ -793,8 +794,6 @@ const importAssetsForNode = async ({
   if (fileReferences.length === 0) {
     return { success: true, pathMapping, errors };
   }
-
-  const importBasePath = `import/${sanitizeFileName(spaceName)}`;
 
   // Get existing asset mappings from frontmatter
   const cache = plugin.app.metadataCache.getFileCache(targetMarkdownFile);
@@ -1226,8 +1225,6 @@ export const importSelectedNodes = async ({
 
   // Process each space
   for (const [spaceId, nodes] of nodesBySpace.entries()) {
-    const spaceName = await getSpaceNameFromId(client, spaceId);
-    const importFolderPath = `import/${sanitizeFileName(spaceName)}`;
     const spaceUri = spaceUris.get(spaceId);
     if (!spaceUri) {
       for (const _node of nodes) {
@@ -1238,12 +1235,12 @@ export const importSelectedNodes = async ({
       continue;
     }
 
-    // Ensure the import folder exists
-    const folderExists =
-      await plugin.app.vault.adapter.exists(importFolderPath);
-    if (!folderExists) {
-      await plugin.app.vault.createFolder(importFolderPath);
-    }
+    const spaceName = await getSpaceNameFromId(client, spaceId);
+    const importFolderPath = await resolveFolderForSpaceUri({
+      adapter: plugin.app.vault.adapter,
+      spaceUri,
+      spaceName,
+    });
 
     // Process each node in this space
     for (const node of nodes) {
@@ -1344,7 +1341,7 @@ export const importSelectedNodes = async ({
           client,
           spaceId,
           nodeInstanceId: node.nodeInstanceId,
-          spaceName,
+          importBasePath: importFolderPath,
           targetMarkdownFile: processedFile,
           originalNodePath,
         });


### PR DESCRIPTION
https://www.loom.com/share/eb8d0f513e0148bda7ee6bef730735cc

## Summary

- Replaces vault-name-based import folder matching with `spaceUri`-based matching, fixing issues with vault renames and vault name collisions
- Each imported folder gets a `.dg.metadata` file containing `spaceUri`, `spaceName`, and optional `userName`
- Adds one-time migration on `onLoad` to backfill `.dg.metadata` for existing import folders using `plugin.settings.spaceNames`

## Changes

- **New `importFolderMetadata.ts`**: utility functions to read/write `.dg.metadata`, build a `spaceUri → folderPath` map by scanning `import/`, and resolve folders by `spaceUri` with name-based fallback and collision-safe folder creation (`import/MyVault-{shortId}/`)
- **`importSelectedNodes`**: uses `resolveFolderForSpaceUri` instead of constructing `import/${sanitizedSpaceName}` directly; handles folder creation and metadata writing
- **`importAssetsForNode`**: accepts already-resolved `importBasePath` instead of recomputing from `spaceName`
- **`index.ts`**: calls `migrateImportFolderMetadata` in `onLoad`
- **`ImportNodesModal.tsx`**: stops writing new entries to `plugin.settings.spaceNames` (reads kept for migration path)

## Test plan

- [x] Import a vault → confirm `.dg.metadata` is written inside `import/<vaultName>/`
- [x] Rename source vault in DB → re-import → confirm files go into the existing folder, not a new one
- [x] Manually rename the imported folder → re-import → confirm scan still finds it by `spaceUri`

Closes ENG-1652

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/970" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
