### PR TITLE
ENG-1640 Add custom sidebar commands, starting with Create Node

### DIFF
--- a/apps/roam/src/components/LeftSidebarCommands.tsx
+++ b/apps/roam/src/components/LeftSidebarCommands.tsx
@@ -4,9 +4,13 @@ import { OnloadArgs } from "roamjs-components/types";
 import { createDiscourseNodeFromCommand } from "~/utils/registerCommandPaletteCommands";
 
 export const commands: Record<string, (ola: OnloadArgs) => Promise<void>> = {
+  /* eslint-disable @typescript-eslint/require-await */
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   "Create Node": async (ola: OnloadArgs) => {
     createDiscourseNodeFromCommand(ola.extensionAPI);
+    // typescript-eslint/naming-convention
   },
+  /* eslint-enable @typescript-eslint/require-await */
 };
 
 export const sidebarCommandPopover = (onSelect: (value: string) => void) => {

--- a/apps/roam/src/components/LeftSidebarCommands.tsx
+++ b/apps/roam/src/components/LeftSidebarCommands.tsx
@@ -1,4 +1,4 @@
-import React, { MouseEvent } from "react";
+import React from "react";
 import { Popover, Position, Button, Menu, MenuItem } from "@blueprintjs/core";
 import { OnloadArgs } from "roamjs-components/types";
 import { createDiscourseNodeFromCommand } from "~/utils/registerCommandPaletteCommands";

--- a/apps/roam/src/components/LeftSidebarCommands.tsx
+++ b/apps/roam/src/components/LeftSidebarCommands.tsx
@@ -25,7 +25,11 @@ export const commands: Record<
   /* eslint-enable @typescript-eslint/require-await */
 };
 
-export const sidebarCommandPopover = (onSelect: (value: string) => void) => {
+export const SidebarCommandPopover = ({
+  onSelect,
+}: {
+  onSelect: (value: string) => void;
+}) => {
   return (
     <Popover
       content={

--- a/apps/roam/src/components/LeftSidebarCommands.tsx
+++ b/apps/roam/src/components/LeftSidebarCommands.tsx
@@ -6,7 +6,9 @@ import { createDiscourseNodeFromCommand } from "~/utils/registerCommandPaletteCo
 export const cleanCommandName = (name: string): string => {
   if (name.startsWith("{") && name.endsWith("}"))
     name = name.substring(1, name.length - 1);
-  // Should we make it title case as well?
+  name = name.trim();
+  // sentence case
+  name = name.charAt(0).toUpperCase() + name.slice(1);
   return name;
 };
 

--- a/apps/roam/src/components/LeftSidebarCommands.tsx
+++ b/apps/roam/src/components/LeftSidebarCommands.tsx
@@ -3,6 +3,13 @@ import { Popover, Position, Button, Menu, MenuItem } from "@blueprintjs/core";
 import { OnloadArgs } from "roamjs-components/types";
 import { createDiscourseNodeFromCommand } from "~/utils/registerCommandPaletteCommands";
 
+export const cleanCommandName = (name: string): string => {
+  if (name.startsWith("{") && name.endsWith("}"))
+    name = name.substring(1, name.length - 1);
+  // Should we make it title case as well?
+  return name;
+};
+
 export const commands: Record<
   string,
   (onloadArgs: OnloadArgs) => Promise<void>

--- a/apps/roam/src/components/LeftSidebarCommands.tsx
+++ b/apps/roam/src/components/LeftSidebarCommands.tsx
@@ -3,11 +3,14 @@ import { Popover, Position, Button, Menu, MenuItem } from "@blueprintjs/core";
 import { OnloadArgs } from "roamjs-components/types";
 import { createDiscourseNodeFromCommand } from "~/utils/registerCommandPaletteCommands";
 
-export const commands: Record<string, (ola: OnloadArgs) => Promise<void>> = {
+export const commands: Record<
+  string,
+  (onloadArgs: OnloadArgs) => Promise<void>
+> = {
   /* eslint-disable @typescript-eslint/require-await */
   // eslint-disable-next-line @typescript-eslint/naming-convention
-  "Create Node": async (ola: OnloadArgs) => {
-    createDiscourseNodeFromCommand(ola.extensionAPI);
+  "{create node}": async (onloadArgs: OnloadArgs) => {
+    createDiscourseNodeFromCommand(onloadArgs.extensionAPI);
     // typescript-eslint/naming-convention
   },
   /* eslint-enable @typescript-eslint/require-await */

--- a/apps/roam/src/components/LeftSidebarCommands.tsx
+++ b/apps/roam/src/components/LeftSidebarCommands.tsx
@@ -14,10 +14,6 @@ export const commands: Record<string, (ola: OnloadArgs) => Promise<void>> = {
 };
 
 export const sidebarCommandPopover = (onSelect: (value: string) => void) => {
-  const handleClick = (event: MouseEvent) => {
-    onSelect((event.target as Node).textContent!);
-  };
-
   return (
     <Popover
       content={
@@ -26,7 +22,7 @@ export const sidebarCommandPopover = (onSelect: (value: string) => void) => {
             <MenuItem
               key={commandName}
               text={commandName}
-              onClick={handleClick}
+              onClick={() => onSelect(commandName)}
             />
           ))}
         </Menu>

--- a/apps/roam/src/components/LeftSidebarCommands.tsx
+++ b/apps/roam/src/components/LeftSidebarCommands.tsx
@@ -1,3 +1,5 @@
+import React, { MouseEvent } from "react";
+import { Popover, Position, Button, Menu, MenuItem } from "@blueprintjs/core";
 import { OnloadArgs } from "roamjs-components/types";
 import { createDiscourseNodeFromCommand } from "~/utils/registerCommandPaletteCommands";
 
@@ -5,4 +7,29 @@ export const commands: Record<string, (ola: OnloadArgs) => Promise<void>> = {
   "Create Node": async (ola: OnloadArgs) => {
     createDiscourseNodeFromCommand(ola.extensionAPI);
   },
+};
+
+export const sidebarCommandPopover = (onSelect: (value: string) => void) => {
+  const handleClick = (event: MouseEvent) => {
+    onSelect((event.target as Node).textContent!);
+  };
+
+  return (
+    <Popover
+      content={
+        <Menu>
+          {Object.keys(commands).map((commandName) => (
+            <MenuItem
+              key={commandName}
+              text={commandName}
+              onClick={handleClick}
+            />
+          ))}
+        </Menu>
+      }
+      position={Position.BOTTOM_LEFT}
+    >
+      <Button icon="cog" small minimal title="Commands" />
+    </Popover>
+  );
 };

--- a/apps/roam/src/components/LeftSidebarCommands.tsx
+++ b/apps/roam/src/components/LeftSidebarCommands.tsx
@@ -1,0 +1,8 @@
+import { OnloadArgs } from "roamjs-components/types";
+import { createDiscourseNodeFromCommand } from "~/utils/registerCommandPaletteCommands";
+
+export const commands: Record<string, (ola: OnloadArgs) => Promise<void>> = {
+  "Create Node": async (ola: OnloadArgs) => {
+    createDiscourseNodeFromCommand(ola.extensionAPI);
+  },
+};

--- a/apps/roam/src/components/LeftSidebarView.tsx
+++ b/apps/roam/src/components/LeftSidebarView.tsx
@@ -158,9 +158,9 @@ const SectionChildren = ({
           return void openTarget(e, child.text, onloadArgs);
         };
         return (
-          <div key={child.uid} className="pl-8 pr-2.5">
+          <div key={child.uid} className="bp3-dark pl-8 pr-2.5">
             {ref.type === "command" ? (
-              <Button onClick={onClick} minimal>
+              <Button onClick={onClick} minimal className="m-px">
                 {label}
               </Button>
             ) : (

--- a/apps/roam/src/components/LeftSidebarView.tsx
+++ b/apps/roam/src/components/LeftSidebarView.tsx
@@ -8,6 +8,7 @@ import React, {
 } from "react";
 import ReactDOM from "react-dom";
 import {
+  Button,
   Collapse,
   Icon,
   Popover,
@@ -43,10 +44,13 @@ import { DISCOURSE_CONFIG_PAGE_TITLE } from "~/utils/renderNodeConfigPage";
 import getPageTitleByPageUid from "roamjs-components/queries/getPageTitleByPageUid";
 import { migrateLeftSidebarSettings } from "~/utils/migrateLeftSidebarSettings";
 import posthog from "posthog-js";
+import { commands } from "~/components/LeftSidebarCommands";
 
 const parseReference = (text: string) => {
   const extracted = extractRef(text);
-  if (text.startsWith("((") && text.endsWith("))")) {
+  if (commands[text]) {
+    return { type: "command" as const, uid: text, display: text };
+  } else if (text.startsWith("((") && text.endsWith("))")) {
     return { type: "block" as const, uid: extracted, display: text };
   } else {
     return { type: "page" as const, display: text };
@@ -58,7 +62,11 @@ const truncate = (s: string, max: number | undefined): string => {
   return s.length > max ? `${s.slice(0, max)}...` : s;
 };
 
-const openTarget = async (e: React.MouseEvent, targetUid: string) => {
+const openTarget = async (
+  e: React.MouseEvent,
+  targetUid: string,
+  onloadArgs: OnloadArgs,
+) => {
   e.preventDefault();
   e.stopPropagation();
   const target = parseReference(targetUid);
@@ -66,6 +74,10 @@ const openTarget = async (e: React.MouseEvent, targetUid: string) => {
     targetType: target.type,
     openInSidebar: e.shiftKey,
   });
+  if (target.type === "command") {
+    await commands[target.uid](onloadArgs);
+    return;
+  }
   if (target.type === "block") {
     if (e.shiftKey) {
       await openBlockInSidebar(target.uid);
@@ -123,9 +135,11 @@ const toggleFoldedState = ({
 const SectionChildren = ({
   childrenNodes,
   truncateAt,
+  onloadArgs,
 }: {
   childrenNodes: { uid: string; text: string; alias?: { value: string } }[];
   truncateAt?: number;
+  onloadArgs: OnloadArgs;
 }) => {
   if (!childrenNodes?.length) return null;
   return (
@@ -134,23 +148,31 @@ const SectionChildren = ({
         const ref = parseReference(child.text);
         const alias = child.alias?.value;
         const display =
-          ref.type === "page"
-            ? getPageTitleByPageUid(ref.display)
-            : getTextByBlockUid(ref.uid);
+          ref.type === "command"
+            ? ref.display
+            : ref.type === "page"
+              ? getPageTitleByPageUid(ref.display)
+              : getTextByBlockUid(ref.uid);
         const label = alias || truncate(display, truncateAt);
         const onClick = (e: React.MouseEvent) => {
-          return void openTarget(e, child.text);
+          return void openTarget(e, child.text, onloadArgs);
         };
         return (
           <div key={child.uid} className="pl-8 pr-2.5">
-            <div
-              className={
-                "section-child-item page cursor-pointer rounded-sm leading-normal text-gray-600"
-              }
-              onClick={onClick}
-            >
-              {label}
-            </div>
+            {ref.type === "command" ? (
+              <Button onClick={onClick} minimal>
+                {label}
+              </Button>
+            ) : (
+              <div
+                className={
+                  "section-child-item page cursor-pointer rounded-sm leading-normal text-gray-600"
+                }
+                onClick={onClick}
+              >
+                {label}
+              </div>
+            )}
           </div>
         );
       })}
@@ -160,8 +182,10 @@ const SectionChildren = ({
 
 const PersonalSectionItem = ({
   section,
+  onloadArgs,
 }: {
   section: LeftSidebarPersonalSectionConfig;
+  onloadArgs: OnloadArgs;
 }) => {
   const titleRef = parseReference(section.text);
   const blockText = useMemo(
@@ -213,13 +237,20 @@ const PersonalSectionItem = ({
         <SectionChildren
           childrenNodes={section.children || []}
           truncateAt={truncateAt}
+          onloadArgs={onloadArgs}
         />
       </Collapse>
     </>
   );
 };
 
-const PersonalSections = ({ config }: { config: LeftSidebarConfig }) => {
+const PersonalSections = ({
+  config,
+  onloadArgs,
+}: {
+  config: LeftSidebarConfig;
+  onloadArgs: OnloadArgs;
+}) => {
   const sections = config.personal.sections || [];
 
   if (!sections.length) return null;
@@ -228,14 +259,20 @@ const PersonalSections = ({ config }: { config: LeftSidebarConfig }) => {
     <div className="personal-left-sidebar-sections">
       {sections.map((section) => (
         <div key={section.uid}>
-          <PersonalSectionItem section={section} />
+          <PersonalSectionItem section={section} onloadArgs={onloadArgs} />
         </div>
       ))}
     </div>
   );
 };
 
-const GlobalSection = ({ config }: { config: LeftSidebarConfig["global"] }) => {
+const GlobalSection = ({
+  config,
+  onloadArgs,
+}: {
+  config: LeftSidebarConfig["global"];
+  onloadArgs: OnloadArgs;
+}) => {
   const [isOpen, setIsOpen] = useState<boolean>(
     !!config.settings?.folded.value,
   );
@@ -267,10 +304,16 @@ const GlobalSection = ({ config }: { config: LeftSidebarConfig["global"] }) => {
       </div>
       {isCollapsable ? (
         <Collapse isOpen={isOpen}>
-          <SectionChildren childrenNodes={config.children} />
+          <SectionChildren
+            childrenNodes={config.children}
+            onloadArgs={onloadArgs}
+          />
         </Collapse>
       ) : (
-        <SectionChildren childrenNodes={config.children} />
+        <SectionChildren
+          childrenNodes={config.children}
+          onloadArgs={onloadArgs}
+        />
       )}
     </>
   );
@@ -413,8 +456,8 @@ const LeftSidebarView = ({ onloadArgs }: { onloadArgs: OnloadArgs }) => {
   return (
     <>
       <FavoritesPopover onloadArgs={onloadArgs} />
-      <GlobalSection config={config.global} />
-      <PersonalSections config={config} />
+      <GlobalSection config={config.global} onloadArgs={onloadArgs} />
+      <PersonalSections config={config} onloadArgs={onloadArgs} />
     </>
   );
 };
@@ -444,7 +487,7 @@ const migrateFavorites = async () => {
   }
 
   const results = window.roamAlphaAPI.q(`
-    [:find ?uid 
+    [:find ?uid
      :where [?e :page/sidebar]
             [?e :block/uid ?uid]]
   `);

--- a/apps/roam/src/components/LeftSidebarView.tsx
+++ b/apps/roam/src/components/LeftSidebarView.tsx
@@ -158,11 +158,13 @@ const SectionChildren = ({
           return void openTarget(e, child.text, onloadArgs);
         };
         return (
-          <div key={child.uid} className="bp3-dark pl-8 pr-2.5">
+          <div key={child.uid} className="pl-8 pr-2.5">
             {ref.type === "command" ? (
-              <Button onClick={onClick} minimal className="m-px">
-                {cleanCommandName(label)}
-              </Button>
+              <span className="bp3-dark">
+                <Button onClick={onClick} minimal className="m-px">
+                  {cleanCommandName(label)}
+                </Button>
+              </span>
             ) : (
               <div
                 className={

--- a/apps/roam/src/components/LeftSidebarView.tsx
+++ b/apps/roam/src/components/LeftSidebarView.tsx
@@ -44,7 +44,7 @@ import { DISCOURSE_CONFIG_PAGE_TITLE } from "~/utils/renderNodeConfigPage";
 import getPageTitleByPageUid from "roamjs-components/queries/getPageTitleByPageUid";
 import { migrateLeftSidebarSettings } from "~/utils/migrateLeftSidebarSettings";
 import posthog from "posthog-js";
-import { commands } from "~/components/LeftSidebarCommands";
+import { commands, cleanCommandName } from "~/components/LeftSidebarCommands";
 
 const parseReference = (text: string) => {
   const extracted = extractRef(text);
@@ -161,7 +161,7 @@ const SectionChildren = ({
           <div key={child.uid} className="bp3-dark pl-8 pr-2.5">
             {ref.type === "command" ? (
               <Button onClick={onClick} minimal className="m-px">
-                {label}
+                {cleanCommandName(label)}
               </Button>
             ) : (
               <div

--- a/apps/roam/src/components/settings/LeftSidebarGlobalSettings.tsx
+++ b/apps/roam/src/components/settings/LeftSidebarGlobalSettings.tsx
@@ -98,7 +98,7 @@ const LeftSidebarGlobalSectionsContent = ({
 
   const commandNames = useMemo(() => Object.keys(commands), []);
   const pageAndCommandNames = useMemo(
-    () => [...getAllPageNames(), ...commandNames],
+    () => [...commandNames, ...getAllPageNames()],
     [commandNames],
   );
 

--- a/apps/roam/src/components/settings/LeftSidebarGlobalSettings.tsx
+++ b/apps/roam/src/components/settings/LeftSidebarGlobalSettings.tsx
@@ -222,8 +222,7 @@ const LeftSidebarGlobalSectionsContent = ({
           pagesToUids(updatedPages),
         );
 
-        setNewPageInput("");
-        setAutocompleteKey((prev) => prev + 1);
+        resetAutocomplete("");
         posthog.capture("Left Sidebar Global Settings: Page Added", {
           pageName,
         });
@@ -266,10 +265,15 @@ const LeftSidebarGlobalSectionsContent = ({
     setNewPageInput(value);
   }, []);
 
-  const setPageValue = useCallback((value: string) => {
-    setNewPageInput(value);
+  const resetAutocomplete = useCallback((nextValue = "") => {
+    setNewPageInput(nextValue);
+
+    // AutocompleteInput renders from its internal `query` state, which is only
+    // initialized from the external `value` prop on mount. Bump the key to remount
+    // it so the displayed input reflects the new parent state.
     setAutocompleteKey((prev) => prev + 1);
   }, []);
+
   const toggleChildren = useCallback(() => {
     setIsExpanded((prev) => !prev);
   }, []);
@@ -364,7 +368,7 @@ const LeftSidebarGlobalSectionsContent = ({
                 onClick={() => void addPage(newPageInput)}
                 title="Add page"
               />
-              {sidebarCommandPopover(setPageValue)}
+              {sidebarCommandPopover(resetAutocomplete)}
             </div>
             {pages.length > 0 ? (
               <div className="space-y-1">

--- a/apps/roam/src/components/settings/LeftSidebarGlobalSettings.tsx
+++ b/apps/roam/src/components/settings/LeftSidebarGlobalSettings.tsx
@@ -285,8 +285,9 @@ const LeftSidebarGlobalSectionsContent = ({
 
   const isAddButtonDisabled = useMemo(() => {
     if (!newPageInput) return true;
-    if (commands[newPageInput]) return false;
-    const targetUid = getPageUidByPageTitle(newPageInput);
+    const targetUid = commands[newPageInput]
+      ? newPageInput
+      : getPageUidByPageTitle(newPageInput);
     return !targetUid || pages.some((p) => p.text === targetUid);
   }, [newPageInput, pages]);
 

--- a/apps/roam/src/components/settings/LeftSidebarGlobalSettings.tsx
+++ b/apps/roam/src/components/settings/LeftSidebarGlobalSettings.tsx
@@ -19,6 +19,7 @@ import { refreshAndNotify } from "~/components/LeftSidebarView";
 import getPageTitleByPageUid from "roamjs-components/queries/getPageTitleByPageUid";
 import getTextByBlockUid from "roamjs-components/queries/getTextByBlockUid";
 import posthog from "posthog-js";
+import { commands } from "~/components/LeftSidebarCommands";
 
 const pagesToUids = (pages: RoamBasicNode[]) => pages.map((p) => p.text);
 
@@ -93,6 +94,10 @@ const LeftSidebarGlobalSectionsContent = ({
   const [isExpanded, setIsExpanded] = useState(true);
 
   const pageNames = useMemo(() => getAllPageNames(), []);
+  const pageAndCommandNames = useMemo(
+    () => [...pageNames, ...Object.keys(commands)],
+    [pageNames],
+  );
 
   useEffect(() => {
     const initialize = async () => {
@@ -185,8 +190,9 @@ const LeftSidebarGlobalSectionsContent = ({
   const addPage = useCallback(
     async (pageName: string) => {
       if (!pageName || !childrenUid) return;
-
-      const targetUid = getPageUidByPageTitle(pageName);
+      const targetUid = commands[pageName]
+        ? pageName
+        : getPageUidByPageTitle(pageName);
       if (pages.some((p) => p.text === targetUid)) {
         console.warn(`Page "${pageName}" already exists in global section`);
         return;
@@ -262,6 +268,7 @@ const LeftSidebarGlobalSectionsContent = ({
 
   const isAddButtonDisabled = useMemo(() => {
     if (!newPageInput) return true;
+    if (commands[newPageInput]) return false;
     const targetUid = getPageUidByPageTitle(newPageInput);
     return !targetUid || pages.some((p) => p.text === targetUid);
   }, [newPageInput, pages]);
@@ -335,7 +342,7 @@ const LeftSidebarGlobalSectionsContent = ({
                 value={newPageInput}
                 setValue={handlePageInputChange}
                 placeholder="Add page…"
-                options={pageNames}
+                options={pageAndCommandNames}
                 maxItemsDisplayed={50}
                 autoFocus
                 onConfirm={() => void addPage(newPageInput)}

--- a/apps/roam/src/components/settings/LeftSidebarGlobalSettings.tsx
+++ b/apps/roam/src/components/settings/LeftSidebarGlobalSettings.tsx
@@ -23,7 +23,6 @@ import {
   commands,
   sidebarCommandPopover,
 } from "~/components/LeftSidebarCommands";
-import { getRoamElements } from "~/utils/suggestiveModeSidebarSizing";
 
 const pagesToUids = (pages: RoamBasicNode[]) => pages.map((p) => p.text);
 
@@ -102,7 +101,7 @@ const LeftSidebarGlobalSectionsContent = ({
   const commandNames = Object.keys(commands);
   const pageAndCommandNames = useMemo(
     () => [...pageNames, ...commandNames],
-    [pageNames],
+    [pageNames, commandNames],
   );
 
   useEffect(() => {

--- a/apps/roam/src/components/settings/LeftSidebarGlobalSettings.tsx
+++ b/apps/roam/src/components/settings/LeftSidebarGlobalSettings.tsx
@@ -19,7 +19,11 @@ import { refreshAndNotify } from "~/components/LeftSidebarView";
 import getPageTitleByPageUid from "roamjs-components/queries/getPageTitleByPageUid";
 import getTextByBlockUid from "roamjs-components/queries/getTextByBlockUid";
 import posthog from "posthog-js";
-import { commands } from "~/components/LeftSidebarCommands";
+import {
+  commands,
+  sidebarCommandPopover,
+} from "~/components/LeftSidebarCommands";
+import { getRoamElements } from "~/utils/suggestiveModeSidebarSizing";
 
 const pagesToUids = (pages: RoamBasicNode[]) => pages.map((p) => p.text);
 
@@ -92,10 +96,12 @@ const LeftSidebarGlobalSectionsContent = ({
   const [autocompleteKey, setAutocompleteKey] = useState(0);
   const [isInitializing, setIsInitializing] = useState(true);
   const [isExpanded, setIsExpanded] = useState(true);
+  const addPageInputId = "globalAddPageId";
 
   const pageNames = useMemo(() => getAllPageNames(), []);
+  const commandNames = Object.keys(commands);
   const pageAndCommandNames = useMemo(
-    () => [...pageNames, ...Object.keys(commands)],
+    () => [...pageNames, ...commandNames],
     [pageNames],
   );
 
@@ -262,6 +268,17 @@ const LeftSidebarGlobalSectionsContent = ({
     setNewPageInput(value);
   }, []);
 
+  const setPageValue = useCallback(
+    (value: string) => {
+      const input = document.getElementById(addPageInputId) as HTMLInputElement;
+      if (input) {
+        input.value = value;
+        handlePageInputChange(value);
+      }
+    },
+    [handlePageInputChange],
+  );
+
   const toggleChildren = useCallback(() => {
     setIsExpanded((prev) => !prev);
   }, []);
@@ -336,8 +353,9 @@ const LeftSidebarGlobalSectionsContent = ({
             <div className="mb-2 text-sm text-gray-600">
               Add pages that will appear for all users
             </div>
-            <div className="mb-3 flex items-center gap-2">
+            <div className="sidebarCommandPopoverContainer mb-3 flex items-center gap-2">
               <AutocompleteInput
+                id={addPageInputId}
                 key={autocompleteKey}
                 value={newPageInput}
                 setValue={handlePageInputChange}
@@ -355,6 +373,7 @@ const LeftSidebarGlobalSectionsContent = ({
                 onClick={() => void addPage(newPageInput)}
                 title="Add page"
               />
+              {sidebarCommandPopover(setPageValue)}
             </div>
             {pages.length > 0 ? (
               <div className="space-y-1">

--- a/apps/roam/src/components/settings/LeftSidebarGlobalSettings.tsx
+++ b/apps/roam/src/components/settings/LeftSidebarGlobalSettings.tsx
@@ -95,7 +95,6 @@ const LeftSidebarGlobalSectionsContent = ({
   const [autocompleteKey, setAutocompleteKey] = useState(0);
   const [isInitializing, setIsInitializing] = useState(true);
   const [isExpanded, setIsExpanded] = useState(true);
-  const addPageInputId = "globalAddPageId";
 
   const pageNames = useMemo(() => getAllPageNames(), []);
   const commandNames = Object.keys(commands);
@@ -267,17 +266,10 @@ const LeftSidebarGlobalSectionsContent = ({
     setNewPageInput(value);
   }, []);
 
-  const setPageValue = useCallback(
-    (value: string) => {
-      const input = document.getElementById(addPageInputId) as HTMLInputElement;
-      if (input) {
-        input.value = value;
-        handlePageInputChange(value);
-      }
-    },
-    [handlePageInputChange],
-  );
-
+  const setPageValue = useCallback((value: string) => {
+    setNewPageInput(value);
+    setAutocompleteKey((prev) => prev + 1);
+  }, []);
   const toggleChildren = useCallback(() => {
     setIsExpanded((prev) => !prev);
   }, []);
@@ -355,7 +347,6 @@ const LeftSidebarGlobalSectionsContent = ({
             </div>
             <div className="sidebarCommandPopoverContainer mb-3 flex items-center gap-2">
               <AutocompleteInput
-                id={addPageInputId}
                 key={autocompleteKey}
                 value={newPageInput}
                 setValue={handlePageInputChange}

--- a/apps/roam/src/components/settings/LeftSidebarGlobalSettings.tsx
+++ b/apps/roam/src/components/settings/LeftSidebarGlobalSettings.tsx
@@ -96,11 +96,10 @@ const LeftSidebarGlobalSectionsContent = ({
   const [isInitializing, setIsInitializing] = useState(true);
   const [isExpanded, setIsExpanded] = useState(true);
 
-  const pageNames = useMemo(() => getAllPageNames(), []);
-  const commandNames = Object.keys(commands);
+  const commandNames = useMemo(() => Object.keys(commands), []);
   const pageAndCommandNames = useMemo(
-    () => [...pageNames, ...commandNames],
-    [pageNames, commandNames],
+    () => [...getAllPageNames(), ...commandNames],
+    [commandNames],
   );
 
   useEffect(() => {
@@ -191,6 +190,15 @@ const LeftSidebarGlobalSectionsContent = ({
     [pages, childrenUid],
   );
 
+  const resetAutocomplete = useCallback((nextValue = "") => {
+    setNewPageInput(nextValue);
+
+    // AutocompleteInput renders from its internal `query` state, which is only
+    // initialized from the external `value` prop on mount. Bump the key to remount
+    // it so the displayed input reflects the new parent state.
+    setAutocompleteKey((prev) => prev + 1);
+  }, []);
+
   const addPage = useCallback(
     async (pageName: string) => {
       if (!pageName || !childrenUid) return;
@@ -235,7 +243,7 @@ const LeftSidebarGlobalSectionsContent = ({
         });
       }
     },
-    [childrenUid, pages],
+    [childrenUid, pages, resetAutocomplete],
   );
 
   const removePage = useCallback(
@@ -263,15 +271,6 @@ const LeftSidebarGlobalSectionsContent = ({
 
   const handlePageInputChange = useCallback((value: string) => {
     setNewPageInput(value);
-  }, []);
-
-  const resetAutocomplete = useCallback((nextValue = "") => {
-    setNewPageInput(nextValue);
-
-    // AutocompleteInput renders from its internal `query` state, which is only
-    // initialized from the external `value` prop on mount. Bump the key to remount
-    // it so the displayed input reflects the new parent state.
-    setAutocompleteKey((prev) => prev + 1);
   }, []);
 
   const toggleChildren = useCallback(() => {

--- a/apps/roam/src/components/settings/LeftSidebarGlobalSettings.tsx
+++ b/apps/roam/src/components/settings/LeftSidebarGlobalSettings.tsx
@@ -21,7 +21,7 @@ import getTextByBlockUid from "roamjs-components/queries/getTextByBlockUid";
 import posthog from "posthog-js";
 import {
   commands,
-  sidebarCommandPopover,
+  SidebarCommandPopover,
 } from "~/components/LeftSidebarCommands";
 
 const pagesToUids = (pages: RoamBasicNode[]) => pages.map((p) => p.text);
@@ -348,7 +348,7 @@ const LeftSidebarGlobalSectionsContent = ({
             <div className="mb-2 text-sm text-gray-600">
               Add pages that will appear for all users
             </div>
-            <div className="sidebarCommandPopoverContainer mb-3 flex items-center gap-2">
+            <div className="mb-3 flex items-center gap-2">
               <AutocompleteInput
                 key={autocompleteKey}
                 value={newPageInput}
@@ -367,7 +367,7 @@ const LeftSidebarGlobalSectionsContent = ({
                 onClick={() => void addPage(newPageInput)}
                 title="Add page"
               />
-              {sidebarCommandPopover(resetAutocomplete)}
+              <SidebarCommandPopover onSelect={resetAutocomplete} />
             </div>
             {pages.length > 0 ? (
               <div className="space-y-1">

--- a/apps/roam/src/components/settings/LeftSidebarPersonalSettings.tsx
+++ b/apps/roam/src/components/settings/LeftSidebarPersonalSettings.tsx
@@ -39,6 +39,7 @@ import { refreshAndNotify } from "~/components/LeftSidebarView";
 import { memo, Dispatch, SetStateAction } from "react";
 import getPageTitleByPageUid from "roamjs-components/queries/getPageTitleByPageUid";
 import posthog from "posthog-js";
+import { commands } from "~/components/LeftSidebarCommands";
 
 /* eslint-disable @typescript-eslint/naming-convention */
 export const sectionsToBlockProps = (
@@ -693,6 +694,10 @@ const LeftSidebarPersonalSectionsContent = ({
   }, [sections, settingsDialogSectionUid]);
 
   const pageNames = useMemo(() => getAllPageNames(), []);
+  const pageAndCommandNames = useMemo(
+    () => [...pageNames, ...Object.keys(commands)],
+    [pageNames],
+  );
 
   if (!personalSectionUid) {
     return null;
@@ -735,7 +740,7 @@ const LeftSidebarPersonalSectionsContent = ({
             <SectionItem
               section={section}
               setSettingsDialogSectionUid={setSettingsDialogSectionUid}
-              pageNames={pageNames}
+              pageNames={pageAndCommandNames}
               setSections={setSections}
               sectionsRef={sectionsRef}
               index={index}

--- a/apps/roam/src/components/settings/LeftSidebarPersonalSettings.tsx
+++ b/apps/roam/src/components/settings/LeftSidebarPersonalSettings.tsx
@@ -707,7 +707,7 @@ const LeftSidebarPersonalSectionsContent = ({
 
   const pageNames = useMemo(() => getAllPageNames(), []);
   const pageAndCommandNames = useMemo(
-    () => [...pageNames, ...Object.keys(commands)],
+    () => [...Object.keys(commands), ...pageNames],
     [pageNames],
   );
 

--- a/apps/roam/src/components/settings/LeftSidebarPersonalSettings.tsx
+++ b/apps/roam/src/components/settings/LeftSidebarPersonalSettings.tsx
@@ -333,14 +333,6 @@ const SectionItem = memo(
       [setSections, sectionsRef],
     );
 
-    const handleAddChild = useCallback(async () => {
-      if (childInput && section.childrenUid) {
-        await addChildToSection(section, section.childrenUid, childInput);
-        resetAutocomplete("");
-        refreshAndNotify();
-      }
-    }, [childInput, section, addChildToSection]);
-
     const resetAutocomplete = useCallback((nextValue = "") => {
       setChildInput(nextValue);
 
@@ -349,6 +341,14 @@ const SectionItem = memo(
       // it so the displayed input reflects the new parent state.
       setChildInputKey((prev) => prev + 1);
     }, []);
+
+    const handleAddChild = useCallback(async () => {
+      if (childInput && section.childrenUid) {
+        await addChildToSection(section, section.childrenUid, childInput);
+        resetAutocomplete("");
+        refreshAndNotify();
+      }
+    }, [childInput, section, addChildToSection, resetAutocomplete]);
 
     const sectionWithoutSettingsAndChildren =
       (!section.settings && section.children?.length === 0) ||

--- a/apps/roam/src/components/settings/LeftSidebarPersonalSettings.tsx
+++ b/apps/roam/src/components/settings/LeftSidebarPersonalSettings.tsx
@@ -342,18 +342,10 @@ const SectionItem = memo(
       }
     }, [childInput, section, addChildToSection]);
 
-    const setPageValue = useCallback(
-      (value: string) => {
-        const input = document.getElementById(
-          `sectionPageInput-${section.uid}`,
-        ) as HTMLInputElement;
-        if (input) {
-          input.value = value;
-          setChildInput(value);
-        }
-      },
-      [section],
-    );
+    const setPageValue = useCallback((value: string) => {
+      setChildInput(value);
+      setChildInputKey((prev) => prev + 1);
+    }, []);
 
     const sectionWithoutSettingsAndChildren =
       (!section.settings && section.children?.length === 0) ||
@@ -432,7 +424,6 @@ const SectionItem = memo(
             <div className="ml-6 mt-3">
               <div className="mb-2 flex items-center gap-2">
                 <AutocompleteInput
-                  id={`sectionPageInput-${section.uid}`}
                   key={childInputKey}
                   value={childInput}
                   setValue={setChildInput}

--- a/apps/roam/src/components/settings/LeftSidebarPersonalSettings.tsx
+++ b/apps/roam/src/components/settings/LeftSidebarPersonalSettings.tsx
@@ -336,14 +336,17 @@ const SectionItem = memo(
     const handleAddChild = useCallback(async () => {
       if (childInput && section.childrenUid) {
         await addChildToSection(section, section.childrenUid, childInput);
-        setChildInput("");
-        setChildInputKey((prev) => prev + 1);
+        resetAutocomplete("");
         refreshAndNotify();
       }
     }, [childInput, section, addChildToSection]);
 
-    const setPageValue = useCallback((value: string) => {
-      setChildInput(value);
+    const resetAutocomplete = useCallback((nextValue = "") => {
+      setChildInput(nextValue);
+
+      // AutocompleteInput renders from its internal `query` state, which is only
+      // initialized from the external `value` prop on mount. Bump the key to remount
+      // it so the displayed input reflects the new parent state.
       setChildInputKey((prev) => prev + 1);
     }, []);
 
@@ -441,7 +444,7 @@ const SectionItem = memo(
                   onClick={() => void handleAddChild()}
                   title="Add child"
                 />
-                {sidebarCommandPopover(setPageValue)}
+                {sidebarCommandPopover(resetAutocomplete)}
               </div>
 
               {(section.children || []).length > 0 && (

--- a/apps/roam/src/components/settings/LeftSidebarPersonalSettings.tsx
+++ b/apps/roam/src/components/settings/LeftSidebarPersonalSettings.tsx
@@ -41,7 +41,7 @@ import getPageTitleByPageUid from "roamjs-components/queries/getPageTitleByPageU
 import posthog from "posthog-js";
 import {
   commands,
-  sidebarCommandPopover,
+  SidebarCommandPopover,
 } from "~/components/LeftSidebarCommands";
 
 /* eslint-disable @typescript-eslint/naming-convention */
@@ -444,7 +444,7 @@ const SectionItem = memo(
                   onClick={() => void handleAddChild()}
                   title="Add child"
                 />
-                {sidebarCommandPopover(resetAutocomplete)}
+                <SidebarCommandPopover onSelect={resetAutocomplete} />
               </div>
 
               {(section.children || []).length > 0 && (

--- a/apps/roam/src/components/settings/LeftSidebarPersonalSettings.tsx
+++ b/apps/roam/src/components/settings/LeftSidebarPersonalSettings.tsx
@@ -39,7 +39,10 @@ import { refreshAndNotify } from "~/components/LeftSidebarView";
 import { memo, Dispatch, SetStateAction } from "react";
 import getPageTitleByPageUid from "roamjs-components/queries/getPageTitleByPageUid";
 import posthog from "posthog-js";
-import { commands } from "~/components/LeftSidebarCommands";
+import {
+  commands,
+  sidebarCommandPopover,
+} from "~/components/LeftSidebarCommands";
 
 /* eslint-disable @typescript-eslint/naming-convention */
 export const sectionsToBlockProps = (
@@ -339,6 +342,19 @@ const SectionItem = memo(
       }
     }, [childInput, section, addChildToSection]);
 
+    const setPageValue = useCallback(
+      (value: string) => {
+        const input = document.getElementById(
+          `sectionPageInput-${section.uid}`,
+        ) as HTMLInputElement;
+        if (input) {
+          input.value = value;
+          setChildInput(value);
+        }
+      },
+      [section],
+    );
+
     const sectionWithoutSettingsAndChildren =
       (!section.settings && section.children?.length === 0) ||
       !section.children;
@@ -416,6 +432,7 @@ const SectionItem = memo(
             <div className="ml-6 mt-3">
               <div className="mb-2 flex items-center gap-2">
                 <AutocompleteInput
+                  id={`sectionPageInput-${section.uid}`}
                   key={childInputKey}
                   value={childInput}
                   setValue={setChildInput}
@@ -433,6 +450,7 @@ const SectionItem = memo(
                   onClick={() => void handleAddChild()}
                   title="Add child"
                 />
+                {sidebarCommandPopover(setPageValue)}
               </div>
 
               {(section.children || []).length > 0 && (

--- a/apps/roam/src/styles/styles.css
+++ b/apps/roam/src/styles/styles.css
@@ -169,13 +169,11 @@
   width: 100%;
 }
 
-.roam-sidebar-container .bp3-dark .bp3-button:not([class*="bp3-intent-"]) {
+#dg-left-sidebar-root .bp3-dark .bp3-button:not([class*="bp3-intent-"]) {
   color: #8b97a5;
   background-color: #333f4c;
 }
 
-.roam-sidebar-container
-  .bp3-dark
-  .bp3-button:not([class*="bp3-intent-"]):hover {
+#dg-left-sidebar-root .bp3-dark .bp3-button:not([class*="bp3-intent-"]):hover {
   color: #f5f8fa;
 }

--- a/apps/roam/src/styles/styles.css
+++ b/apps/roam/src/styles/styles.css
@@ -179,6 +179,6 @@
   border-style: solid;
 }
 
-.roam-sidebar-container .bp3-button:not([class*="bp3-intent-"]) :hover {
+/*.roam-sidebar-container .bp3-button:not([class*="bp3-intent-"]):hover {
   color: #f5f8fa;
-}
+}*/

--- a/apps/roam/src/styles/styles.css
+++ b/apps/roam/src/styles/styles.css
@@ -169,16 +169,13 @@
   width: 100%;
 }
 
-.roam-sidebar-container .bp3-button:not([class*="bp3-intent-"]) {
-  color: rgba(75, 85, 99, var(--tw-text-opacity));
+.roam-sidebar-container .bp3-dark .bp3-button:not([class*="bp3-intent-"]) {
+  color: #8b97a5;
+  background-color: #333f4c;
 }
 
-.roam-sidebar-container .bp3-button.bp3-minimal:not([class*="bp3-intent-"]) {
-  border-color: rgba(75, 85, 99, var(--tw-text-opacity));
-  border-width: 1px;
-  border-style: solid;
-}
-
-/*.roam-sidebar-container .bp3-button:not([class*="bp3-intent-"]):hover {
+.roam-sidebar-container
+  .bp3-dark
+  .bp3-button:not([class*="bp3-intent-"]):hover {
   color: #f5f8fa;
-}*/
+}

--- a/apps/roam/src/styles/styles.css
+++ b/apps/roam/src/styles/styles.css
@@ -168,3 +168,17 @@
 .fuzzy-select-input-popover .bp3-popover-target {
   width: 100%;
 }
+
+.roam-sidebar-container .bp3-button:not([class*="bp3-intent-"]) {
+  color: rgba(75, 85, 99, var(--tw-text-opacity));
+}
+
+.roam-sidebar-container .bp3-button.bp3-minimal:not([class*="bp3-intent-"]) {
+  border-color: rgba(75, 85, 99, var(--tw-text-opacity));
+  border-width: 1px;
+  border-style: solid;
+}
+
+.roam-sidebar-container .bp3-button:not([class*="bp3-intent-"]) :hover {
+  color: #f5f8fa;
+}

--- a/apps/roam/src/utils/registerCommandPaletteCommands.ts
+++ b/apps/roam/src/utils/registerCommandPaletteCommands.ts
@@ -74,7 +74,7 @@ const getBlockSelection = (uid: string): BlockSelection => {
   };
 };
 
-const createDiscourseNodeFromCommand = (
+export const createDiscourseNodeFromCommand = (
   extensionAPI: OnloadArgs["extensionAPI"],
 ) => {
   posthog.capture("Discourse Node: Create Command Triggered");

--- a/apps/roam/src/utils/registerCommandPaletteCommands.ts
+++ b/apps/roam/src/utils/registerCommandPaletteCommands.ts
@@ -30,6 +30,97 @@ import { refreshAndNotify } from "~/components/LeftSidebarView";
 import { setPersonalSetting } from "~/components/settings/utils/accessors";
 import { sectionsToBlockProps } from "~/components/settings/LeftSidebarPersonalSettings";
 
+type BlockSelection = {
+  selectionStart: number;
+  selectionEnd: number;
+  selectedText: string;
+};
+
+const getBlockSelection = (uid: string): BlockSelection => {
+  const activeElement = document.activeElement;
+  const isFocusedTextarea =
+    activeElement instanceof HTMLTextAreaElement &&
+    activeElement.classList.contains("rm-block-input") &&
+    getUids(activeElement).blockUid === uid;
+  if (isFocusedTextarea) {
+    return {
+      selectionStart: activeElement.selectionStart,
+      selectionEnd: activeElement.selectionEnd,
+      selectedText: activeElement.value.substring(
+        activeElement.selectionStart,
+        activeElement.selectionEnd,
+      ),
+    };
+  }
+  const textareas = document.querySelectorAll("textarea.rm-block-input");
+  for (const el of textareas) {
+    const textarea = el as HTMLTextAreaElement;
+    if (getUids(textarea).blockUid === uid) {
+      return {
+        selectionStart: textarea.selectionStart,
+        selectionEnd: textarea.selectionEnd,
+        selectedText: textarea.value.substring(
+          textarea.selectionStart,
+          textarea.selectionEnd,
+        ),
+      };
+    }
+  }
+  const textLength = (getTextByBlockUid(uid) || "").length;
+  return {
+    selectionStart: textLength,
+    selectionEnd: textLength,
+    selectedText: "",
+  };
+};
+
+const createDiscourseNodeFromCommand = (
+  extensionAPI: OnloadArgs["extensionAPI"],
+) => {
+  posthog.capture("Discourse Node: Create Command Triggered");
+  const focusedBlock = window.roamAlphaAPI.ui.getFocusedBlock();
+  const uid = focusedBlock?.["block-uid"];
+  const windowId = focusedBlock?.["window-id"] || "main-window";
+
+  const { selectionStart, selectionEnd, selectedText } = uid
+    ? getBlockSelection(uid)
+    : { selectionStart: 0, selectionEnd: 0, selectedText: "" };
+
+  renderModifyNodeDialog({
+    mode: "create",
+    nodeType: "",
+    initialValue: { text: selectedText, uid: "" },
+    extensionAPI,
+    onSuccess: async (result) => {
+      if (!uid) {
+        renderToast({
+          id: "create-discourse-node-command-no-block",
+          content: "No block focused to insert a discourse node.",
+        });
+        return;
+      }
+      const originalText = getTextByBlockUid(uid) || "";
+      const pageRef = `[[${result.text}]]`;
+      const newText = `${originalText.substring(0, selectionStart)}${pageRef}${originalText.substring(selectionEnd)}`;
+      const newCursorPosition = selectionStart + pageRef.length;
+
+      await updateBlock({ uid, text: newText });
+
+      await window.roamAlphaAPI.ui.setBlockFocusAndSelection({
+        location: {
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          "block-uid": uid,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          "window-id": windowId,
+        },
+        selection: { start: newCursorPosition },
+      });
+      return;
+    },
+    onClose: () => {},
+  });
+};
+
 export const registerCommandPaletteCommands = (onloadArgs: OnloadArgs) => {
   const { extensionAPI } = onloadArgs;
 
@@ -166,95 +257,6 @@ export const registerCommandPaletteCommands = (onloadArgs: OnloadArgs) => {
     renderSettings({ onloadArgs });
   };
 
-  type BlockSelection = {
-    selectionStart: number;
-    selectionEnd: number;
-    selectedText: string;
-  };
-
-  const getBlockSelection = (uid: string): BlockSelection => {
-    const activeElement = document.activeElement;
-    const isFocusedTextarea =
-      activeElement instanceof HTMLTextAreaElement &&
-      activeElement.classList.contains("rm-block-input") &&
-      getUids(activeElement).blockUid === uid;
-    if (isFocusedTextarea) {
-      return {
-        selectionStart: activeElement.selectionStart,
-        selectionEnd: activeElement.selectionEnd,
-        selectedText: activeElement.value.substring(
-          activeElement.selectionStart,
-          activeElement.selectionEnd,
-        ),
-      };
-    }
-    const textareas = document.querySelectorAll("textarea.rm-block-input");
-    for (const el of textareas) {
-      const textarea = el as HTMLTextAreaElement;
-      if (getUids(textarea).blockUid === uid) {
-        return {
-          selectionStart: textarea.selectionStart,
-          selectionEnd: textarea.selectionEnd,
-          selectedText: textarea.value.substring(
-            textarea.selectionStart,
-            textarea.selectionEnd,
-          ),
-        };
-      }
-    }
-    const textLength = (getTextByBlockUid(uid) || "").length;
-    return {
-      selectionStart: textLength,
-      selectionEnd: textLength,
-      selectedText: "",
-    };
-  };
-
-  const createDiscourseNodeFromCommand = () => {
-    posthog.capture("Discourse Node: Create Command Triggered");
-    const focusedBlock = window.roamAlphaAPI.ui.getFocusedBlock();
-    const uid = focusedBlock?.["block-uid"];
-    const windowId = focusedBlock?.["window-id"] || "main-window";
-
-    const { selectionStart, selectionEnd, selectedText } = uid
-      ? getBlockSelection(uid)
-      : { selectionStart: 0, selectionEnd: 0, selectedText: "" };
-
-    renderModifyNodeDialog({
-      mode: "create",
-      nodeType: "",
-      initialValue: { text: selectedText, uid: "" },
-      extensionAPI,
-      onSuccess: async (result) => {
-        if (!uid) {
-          renderToast({
-            id: "create-discourse-node-command-no-block",
-            content: "No block focused to insert a discourse node.",
-          });
-          return;
-        }
-        const originalText = getTextByBlockUid(uid) || "";
-        const pageRef = `[[${result.text}]]`;
-        const newText = `${originalText.substring(0, selectionStart)}${pageRef}${originalText.substring(selectionEnd)}`;
-        const newCursorPosition = selectionStart + pageRef.length;
-
-        await updateBlock({ uid, text: newText });
-
-        await window.roamAlphaAPI.ui.setBlockFocusAndSelection({
-          location: {
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            "block-uid": uid,
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            "window-id": windowId,
-          },
-          selection: { start: newCursorPosition },
-        });
-        return;
-      },
-      onClose: () => {},
-    });
-  };
-
   const toggleDiscourseContextOverlay = async () => {
     const currentValue =
       (extensionAPI.settings.get("discourse-context-overlay") as boolean) ??
@@ -312,9 +314,8 @@ export const registerCommandPaletteCommands = (onloadArgs: OnloadArgs) => {
   };
 
   // Roam organizes commands alphabetically
-  void addCommand(
-    "DG: Create/Insert discourse node",
-    createDiscourseNodeFromCommand,
+  void addCommand("DG: Create/Insert discourse node", () =>
+    createDiscourseNodeFromCommand(extensionAPI),
   );
   void addCommand("DG: Export - Current page", exportCurrentPage);
   void addCommand("DG: Export - Discourse graph", exportDiscourseGraph);


### PR DESCRIPTION
https://linear.app/discourse-graphs/issue/ENG-1640/add-custom-sidebar-commands-starting-with-create-node

I responded to all comments; here is the updated loom.

https://www.loom.com/share/145b85a3792047fe9a7023eedd27e715

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/971" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
