### PR TITLE
ENG-1664: Replace getBlockUidByTextOnPage scan with pull in settings writer

### DIFF
--- a/apps/roam/src/components/settings/utils/accessors.ts
+++ b/apps/roam/src/components/settings/utils/accessors.ts
@@ -4,7 +4,6 @@ import getBlockProps, {
 } from "~/utils/getBlockProps";
 import setBlockProps from "~/utils/setBlockProps";
 import getBasicTreeByParentUid from "roamjs-components/queries/getBasicTreeByParentUid";
-import getBlockUidByTextOnPage from "roamjs-components/queries/getBlockUidByTextOnPage";
 import getPageUidByPageTitle from "roamjs-components/queries/getPageUidByPageTitle";
 import { getSubTree } from "roamjs-components/util";
 import getSettingValueFromTree from "roamjs-components/util/getSettingValueFromTree";
@@ -669,10 +668,17 @@ const setBlockPropBasedSettings = ({
     return;
   }
 
-  const blockUid = getBlockUidByTextOnPage({
-    text: keys[0],
-    title: DG_BLOCK_PROP_SETTINGS_PAGE_TITLE,
-  });
+  const pageResult = window.roamAlphaAPI.pull(
+    "[{:block/children [:block/uid :block/string]}]",
+    [":node/title", DG_BLOCK_PROP_SETTINGS_PAGE_TITLE],
+  ) as Record<string, json> | null;
+  const children = (pageResult?.[":block/children"] ?? []) as Record<
+    string,
+    json
+  >[];
+  const match = children.find((child) => child[":block/string"] === keys[0]);
+  const matchedUid = match?.[":block/uid"];
+  const blockUid = typeof matchedUid === "string" ? matchedUid : "";
 
   if (!blockUid) {
     internalError({


### PR DESCRIPTION
https://www.loom.com/share/815280668e46486c92d970b1f29ddee4

| Step | Before | After |
| -- | -- | -- |
| top-level uid lookup | ~318 ms | ~0.5 ms |
| `setPersonalSetting` total | ~320 ms | ~1.2 ms |
| `BaseFlagPanel` total handleChange | ~420 ms | ~97 ms |


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/975" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
