### PR TITLE
[ENG-1614] Switch positions of node type and node title fields (Obsidian)

### DIFF
--- a/apps/obsidian/src/components/ModifyNodeModal.tsx
+++ b/apps/obsidian/src/components/ModifyNodeModal.tsx
@@ -12,6 +12,7 @@ import { DiscourseNode } from "~/types";
 import type DiscourseGraphPlugin from "~/index";
 import { QueryEngine } from "~/services/QueryEngine";
 import { isProvisionalSchema } from "~/utils/typeUtils";
+import { getNodeTypeIdForFile } from "~/utils/relationsStore";
 
 type ModifyNodeFormProps = {
   nodeTypes: DiscourseNode[];
@@ -145,6 +146,11 @@ export const ModifyNodeForm = ({
     }
   }, [activeIndex, isOpen]);
 
+  // Focus the content input on mount so users can start typing immediately
+  useEffect(() => {
+    titleInputRef.current?.focus();
+  }, []);
+
   // Determine available relationships based on current file and selected node type
   const availableRelationships = useMemo(() => {
     if (!currentFile || !selectedNodeType || isEditMode) {
@@ -223,11 +229,20 @@ export const ModifyNodeForm = ({
 
   const isFormValid = title.trim() && selectedNodeType;
 
-  const handleSelect = useCallback((file: TFile) => {
-    setSelectedExistingNode(file);
-    setQuery(file.basename);
-    setTitle(file.basename);
-  }, []);
+  const handleSelect = useCallback(
+    async (file: TFile) => {
+      setSelectedExistingNode(file);
+      setQuery(file.basename);
+      setTitle(file.basename);
+      // Auto-detect node type from the selected file's frontmatter
+      const nodeTypeId = await getNodeTypeIdForFile(plugin, file);
+      if (nodeTypeId) {
+        const detected = nodeTypes.find((nt) => nt.id === nodeTypeId);
+        if (detected) setSelectedNodeType(detected);
+      }
+    },
+    [nodeTypes, plugin],
+  );
 
   const handleClearSelection = useCallback(() => {
     setSelectedExistingNode(null);
@@ -354,25 +369,6 @@ export const ModifyNodeForm = ({
     <div>
       <h2>{isEditMode ? "Modify discourse node" : "Create discourse node"}</h2>
       <div className="setting-item">
-        <div className="setting-item-name">Type</div>
-        <div className="setting-item-control">
-          <select
-            value={selectedNodeType?.id || ""}
-            onChange={handleNodeTypeChange}
-            disabled={isSubmitting || isEditMode}
-            className="w-full"
-          >
-            <option value="">Select node type</option>
-            {nodeTypes.map((nodeType) => (
-              <option key={nodeType.id} value={nodeType.id}>
-                {nodeType.name}
-              </option>
-            ))}
-          </select>
-        </div>
-      </div>
-
-      <div className="setting-item">
         <div className="setting-item-name">Content</div>
         <div className="setting-item-control">
           {selectedExistingNode ? (
@@ -433,18 +429,18 @@ export const ModifyNodeForm = ({
                     className="suggestion-list m-0 list-none py-1"
                   >
                     {isSearching ? (
-                      <li className="suggestion-item px-3 py-2 text-[var(--text-muted)]">
+                      <li className="suggestion-item py-2 text-[var(--text-muted)]">
                         Searching...
                       </li>
                     ) : searchResults.length === 0 ? (
-                      <li className="suggestion-item px-3 py-2 text-[var(--text-muted)]">
+                      <li className="suggestion-item py-2 text-[var(--text-muted)]">
                         No results found
                       </li>
                     ) : (
                       searchResults.map((file, index) => (
                         <li
                           key={file.path}
-                          className={`suggestion-item flex cursor-pointer items-center gap-2 px-3 py-2 ${
+                          className={`suggestion-item flex cursor-pointer items-center gap-2 py-2 ${
                             index === activeIndex
                               ? "is-selected bg-[var(--background-modifier-hover)]"
                               : "bg-transparent"
@@ -464,6 +460,25 @@ export const ModifyNodeForm = ({
               )}
             </div>
           )}
+        </div>
+      </div>
+
+      <div className="setting-item">
+        <div className="setting-item-name">Type</div>
+        <div className="setting-item-control">
+          <select
+            value={selectedNodeType?.id || ""}
+            onChange={handleNodeTypeChange}
+            disabled={isSubmitting || isEditMode}
+            className="w-full"
+          >
+            <option value="">Select node type</option>
+            {nodeTypes.map((nodeType) => (
+              <option key={nodeType.id} value={nodeType.id}>
+                {nodeType.name}
+              </option>
+            ))}
+          </select>
         </div>
       </div>
 

--- a/apps/obsidian/src/components/ModifyNodeModal.tsx
+++ b/apps/obsidian/src/components/ModifyNodeModal.tsx
@@ -63,6 +63,7 @@ export const ModifyNodeForm = ({
   const popoverRef = useRef<HTMLDivElement>(null);
   const menuRef = useRef<HTMLUListElement>(null);
   const debounceTimeoutRef = useRef<number | null>(null);
+  const selectedFileRef = useRef<TFile | null>(null);
 
   // Search for nodes when query changes (only in create mode)
   useEffect(() => {
@@ -231,12 +232,13 @@ export const ModifyNodeForm = ({
 
   const handleSelect = useCallback(
     async (file: TFile) => {
+      selectedFileRef.current = file;
       setSelectedExistingNode(file);
       setQuery(file.basename);
       setTitle(file.basename);
       // Auto-detect node type from the selected file's frontmatter
       const nodeTypeId = await getNodeTypeIdForFile(plugin, file);
-      if (nodeTypeId) {
+      if (nodeTypeId && selectedFileRef.current === file) {
         const detected = nodeTypes.find((nt) => nt.id === nodeTypeId);
         if (detected) setSelectedNodeType(detected);
       }
@@ -245,6 +247,7 @@ export const ModifyNodeForm = ({
   );
 
   const handleClearSelection = useCallback(() => {
+    selectedFileRef.current = null;
     setSelectedExistingNode(null);
     setQuery("");
     setTitle("");
@@ -274,7 +277,7 @@ export const ModifyNodeForm = ({
     } else if (e.key === "Enter") {
       e.preventDefault();
       if (isOpen && searchResults[activeIndex]) {
-        handleSelect(searchResults[activeIndex]);
+        void handleSelect(searchResults[activeIndex]);
       } else if (isFormValid && !isSubmitting) {
         void handleConfirm();
       }
@@ -447,7 +450,7 @@ export const ModifyNodeForm = ({
                           }`}
                           onMouseDown={(e) => {
                             e.preventDefault();
-                            handleSelect(file);
+                            void handleSelect(file);
                           }}
                           onMouseEnter={() => setActiveIndex(index)}
                         >


### PR DESCRIPTION
https://www.loom.com/share/e517ec71e9c14786b93ba987c7eaee92

Obsidian counterpart to the Roam change in #907 (ENG-1545).

## Changes

- **Field reorder**: Content input now appears before the node type selector, matching the keyboard-centric flow
- **Auto-focus**: Content field is focused on mount so users can start typing immediately without clicking
- **Auto-detect node type**: When selecting an existing node from the dropdown, the node type is auto-detected from the file's frontmatter via `getNodeTypeIdForFile`


## Test plan

- [x] Open the "Create discourse node" modal — cursor should be in the Content field immediately
- [x] Select an existing node from the dropdown — node type should auto-populate in the Type selector
- [x] Manually pick a node type first, then type — search filters to that type as before
- [x] Edit mode: Content field still shows existing title; Type selector is disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/976" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
