### PR TITLE
[ENG-1647] Auto-resize content input and add fileName character limit in node creation dialog

### DIFF
--- a/apps/obsidian/src/components/ModifyNodeModal.tsx
+++ b/apps/obsidian/src/components/ModifyNodeModal.tsx
@@ -15,11 +15,29 @@ import { isProvisionalSchema } from "~/utils/typeUtils";
 import { getNodeTypeIdForFile } from "~/utils/relationsStore";
 import { formatNodeName } from "~/utils/createNode";
 
-// macOS/APFS limit: full filename (including extension) must be ≤ 255 bytes.
-// The file is stored as `{formattedNodeName}.md`, so the formatted name itself
-// can be at most 252 chars (255 - 3 for ".md").
-const MAX_FILENAME_LENGTH = 255;
-const MD_EXTENSION_LENGTH = ".md".length;
+// APFS and ext4 both enforce a 255 UTF-8 byte limit per filename component.
+const MAX_FILENAME_BYTES = 255;
+const MD_EXTENSION_BYTES = 3; // ".md"
+
+const getByteLength = (str: string): number =>
+  new TextEncoder().encode(str).byteLength;
+
+// Remove characters from the end until the string fits within maxBytes.
+const trimToByteLimit = (str: string, maxBytes: number): string => {
+  if (getByteLength(str) <= maxBytes) return str;
+  let trimmed = str;
+  while (trimmed.length > 0 && getByteLength(trimmed) > maxBytes) {
+    trimmed = trimmed.slice(0, -1);
+  }
+  return trimmed;
+};
+
+const computeMaxTitleBytes = (nodeType: DiscourseNode | null): number => {
+  const formatOverhead = nodeType
+    ? getByteLength(formatNodeName("", nodeType) ?? "")
+    : 0;
+  return Math.max(1, MAX_FILENAME_BYTES - MD_EXTENSION_BYTES - formatOverhead);
+};
 
 type ModifyNodeFormProps = {
   nodeTypes: DiscourseNode[];
@@ -72,26 +90,10 @@ export const ModifyNodeForm = ({
   const debounceTimeoutRef = useRef<number | null>(null);
   const selectedFileRef = useRef<TFile | null>(null);
 
-  // The format prefix/suffix (e.g. "CLM - ") and ".md" extension all count
-  // toward the 255-byte filename limit. Compute how many chars the user can type.
-  const maxTitleLength = useMemo(() => {
-    const formatOverhead = selectedNodeType
-      ? (formatNodeName("", selectedNodeType)?.length ?? 0)
-      : 0;
-    return Math.max(
-      1,
-      MAX_FILENAME_LENGTH - MD_EXTENSION_LENGTH - formatOverhead,
-    );
-  }, [selectedNodeType]);
-
-  // Trim existing text if switching node type reduces the allowed length
-  useEffect(() => {
-    if (query.length > maxTitleLength) {
-      const trimmed = query.slice(0, maxTitleLength);
-      setQuery(trimmed);
-      setTitle(trimmed);
-    }
-  }, [maxTitleLength, query]);
+  const maxTitleBytes = useMemo(
+    () => computeMaxTitleBytes(selectedNodeType),
+    [selectedNodeType],
+  );
 
   // Search for nodes when query changes (only in create mode)
   useEffect(() => {
@@ -327,16 +329,25 @@ export const ModifyNodeForm = ({
     const newSelectedType =
       nodeTypes.find((nt) => nt.id === selectedId) || null;
     setSelectedNodeType(newSelectedType);
+
     if (selectedExistingNode) {
       setSelectedExistingNode(null);
       setQuery("");
       setTitle("");
+    } else {
+      const newMaxBytes = computeMaxTitleBytes(newSelectedType);
+      if (getByteLength(query) > newMaxBytes) {
+        const trimmed = trimToByteLimit(query, newMaxBytes);
+        setQuery(trimmed);
+        setTitle(trimmed);
+      }
     }
+
     setSelectedRelationshipKey(undefined);
   };
 
   const handleQueryChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    const newQuery = e.target.value;
+    const newQuery = trimToByteLimit(e.target.value, maxTitleBytes);
     setQuery(newQuery);
     setTitle(newQuery);
     if (selectedExistingNode) {
@@ -453,14 +464,13 @@ export const ModifyNodeForm = ({
                   setTimeout(() => setIsFocused(false), 200);
                 }}
                 disabled={isSubmitting}
-                maxLength={maxTitleLength}
                 rows={1}
                 className="font-inherit border-background-modifier-border bg-background-primary text-text-normal min-h-[2.5em] w-full resize-none overflow-hidden rounded-md border p-2"
                 autoComplete="off"
               />
-              {query.length >= maxTitleLength && (
+              {getByteLength(query) >= maxTitleBytes && (
                 <p className="text-error mt-1 text-xs">
-                  Character limit reached ({maxTitleLength})
+                  Character limit reached
                 </p>
               )}
               {isOpen && !isEditMode && (

--- a/apps/obsidian/src/components/ModifyNodeModal.tsx
+++ b/apps/obsidian/src/components/ModifyNodeModal.tsx
@@ -59,7 +59,7 @@ export const ModifyNodeForm = ({
     string | undefined
   >(undefined);
   const queryEngine = useRef(new QueryEngine(plugin.app));
-  const titleInputRef = useRef<HTMLInputElement>(null);
+  const titleInputRef = useRef<HTMLTextAreaElement>(null);
   const popoverRef = useRef<HTMLDivElement>(null);
   const menuRef = useRef<HTMLUListElement>(null);
   const debounceTimeoutRef = useRef<number | null>(null);
@@ -151,6 +151,13 @@ export const ModifyNodeForm = ({
   useEffect(() => {
     titleInputRef.current?.focus();
   }, []);
+
+  useEffect(() => {
+    const el = titleInputRef.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${el.scrollHeight}px`;
+  }, [query]);
 
   // Determine available relationships based on current file and selected node type
   const availableRelationships = useMemo(() => {
@@ -256,7 +263,7 @@ export const ModifyNodeForm = ({
     }, 50);
   }, []);
 
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (selectedExistingNode) {
       // If locked, only handle Escape
       if (e.key === "Escape") {
@@ -300,7 +307,7 @@ export const ModifyNodeForm = ({
     setSelectedRelationshipKey(undefined);
   };
 
-  const handleQueryChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleQueryChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const newQuery = e.target.value;
     setQuery(newQuery);
     setTitle(newQuery);
@@ -377,12 +384,12 @@ export const ModifyNodeForm = ({
           {selectedExistingNode ? (
             // Locked state: show selected node with clear button
             <div className="relative flex w-full items-start">
-              <input
-                type="text"
+              <textarea
                 value={selectedExistingNode.basename}
                 readOnly
                 disabled={isSubmitting}
-                className="resize-vertical font-inherit border-background-modifier-border bg-background-secondary text-text-normal max-h-[6em] min-h-[2.5em] w-full cursor-default overflow-y-auto rounded-md border p-2 pr-8"
+                rows={1}
+                className="font-inherit border-background-modifier-border bg-background-secondary text-text-normal min-h-[2.5em] w-full cursor-default resize-none overflow-hidden rounded-md border p-2 pr-8"
               />
               <button
                 onClick={handleClearSelection}
@@ -397,9 +404,8 @@ export const ModifyNodeForm = ({
           ) : (
             // Search input with popover (only in create mode)
             <div className="relative w-full">
-              <input
+              <textarea
                 ref={titleInputRef}
-                type="text"
                 placeholder={
                   isEditMode
                     ? "Enter new content"
@@ -419,9 +425,16 @@ export const ModifyNodeForm = ({
                   setTimeout(() => setIsFocused(false), 200);
                 }}
                 disabled={isSubmitting}
-                className="resize-vertical font-inherit border-background-modifier-border bg-background-primary text-text-normal max-h-[6em] min-h-[2.5em] w-full overflow-y-auto rounded-md border p-2"
+                maxLength={512}
+                rows={1}
+                className="font-inherit border-background-modifier-border bg-background-primary text-text-normal min-h-[2.5em] w-full resize-none overflow-hidden rounded-md border p-2"
                 autoComplete="off"
               />
+              {query.length >= 512 && (
+                <p className="text-error mt-1 text-xs">
+                  Character limit reached (512)
+                </p>
+              )}
               {isOpen && !isEditMode && (
                 <div
                   ref={popoverRef}

--- a/apps/obsidian/src/components/ModifyNodeModal.tsx
+++ b/apps/obsidian/src/components/ModifyNodeModal.tsx
@@ -84,6 +84,15 @@ export const ModifyNodeForm = ({
     );
   }, [selectedNodeType]);
 
+  // Trim existing text if switching node type reduces the allowed length
+  useEffect(() => {
+    if (query.length > maxTitleLength) {
+      const trimmed = query.slice(0, maxTitleLength);
+      setQuery(trimmed);
+      setTitle(trimmed);
+    }
+  }, [maxTitleLength]);
+
   // Search for nodes when query changes (only in create mode)
   useEffect(() => {
     if (isEditMode) {

--- a/apps/obsidian/src/components/ModifyNodeModal.tsx
+++ b/apps/obsidian/src/components/ModifyNodeModal.tsx
@@ -425,14 +425,14 @@ export const ModifyNodeForm = ({
                   setTimeout(() => setIsFocused(false), 200);
                 }}
                 disabled={isSubmitting}
-                maxLength={512}
+                maxLength={255}
                 rows={1}
                 className="font-inherit border-background-modifier-border bg-background-primary text-text-normal min-h-[2.5em] w-full resize-none overflow-hidden rounded-md border p-2"
                 autoComplete="off"
               />
               {query.length >= 512 && (
                 <p className="text-error mt-1 text-xs">
-                  Character limit reached (512)
+                  Character limit reached (255)
                 </p>
               )}
               {isOpen && !isEditMode && (

--- a/apps/obsidian/src/components/ModifyNodeModal.tsx
+++ b/apps/obsidian/src/components/ModifyNodeModal.tsx
@@ -12,9 +12,9 @@ import { DiscourseNode } from "~/types";
 import type DiscourseGraphPlugin from "~/index";
 import { QueryEngine } from "~/services/QueryEngine";
 import { isProvisionalSchema } from "~/utils/typeUtils";
+import { getNodeTypeIdForFile } from "~/utils/relationsStore";
 
 const MAX_NODE_TITLE_LENGTH = 255;
-import { getNodeTypeIdForFile } from "~/utils/relationsStore";
 
 type ModifyNodeFormProps = {
   nodeTypes: DiscourseNode[];

--- a/apps/obsidian/src/components/ModifyNodeModal.tsx
+++ b/apps/obsidian/src/components/ModifyNodeModal.tsx
@@ -91,7 +91,7 @@ export const ModifyNodeForm = ({
       setQuery(trimmed);
       setTitle(trimmed);
     }
-  }, [maxTitleLength]);
+  }, [maxTitleLength, query]);
 
   // Search for nodes when query changes (only in create mode)
   useEffect(() => {

--- a/apps/obsidian/src/components/ModifyNodeModal.tsx
+++ b/apps/obsidian/src/components/ModifyNodeModal.tsx
@@ -331,6 +331,7 @@ export const ModifyNodeForm = ({
     setSelectedNodeType(newSelectedType);
 
     if (selectedExistingNode) {
+      selectedFileRef.current = null;
       setSelectedExistingNode(null);
       setQuery("");
       setTitle("");

--- a/apps/obsidian/src/components/ModifyNodeModal.tsx
+++ b/apps/obsidian/src/components/ModifyNodeModal.tsx
@@ -13,8 +13,13 @@ import type DiscourseGraphPlugin from "~/index";
 import { QueryEngine } from "~/services/QueryEngine";
 import { isProvisionalSchema } from "~/utils/typeUtils";
 import { getNodeTypeIdForFile } from "~/utils/relationsStore";
+import { formatNodeName } from "~/utils/createNode";
 
-const MAX_NODE_TITLE_LENGTH = 255;
+// macOS/APFS limit: full filename (including extension) must be ≤ 255 bytes.
+// The file is stored as `{formattedNodeName}.md`, so the formatted name itself
+// can be at most 252 chars (255 - 3 for ".md").
+const MAX_FILENAME_LENGTH = 255;
+const MD_EXTENSION_LENGTH = ".md".length;
 
 type ModifyNodeFormProps = {
   nodeTypes: DiscourseNode[];
@@ -66,6 +71,18 @@ export const ModifyNodeForm = ({
   const menuRef = useRef<HTMLUListElement>(null);
   const debounceTimeoutRef = useRef<number | null>(null);
   const selectedFileRef = useRef<TFile | null>(null);
+
+  // The format prefix/suffix (e.g. "CLM - ") and ".md" extension all count
+  // toward the 255-byte filename limit. Compute how many chars the user can type.
+  const maxTitleLength = useMemo(() => {
+    const formatOverhead = selectedNodeType
+      ? (formatNodeName("", selectedNodeType)?.length ?? 0)
+      : 0;
+    return Math.max(
+      1,
+      MAX_FILENAME_LENGTH - MD_EXTENSION_LENGTH - formatOverhead,
+    );
+  }, [selectedNodeType]);
 
   // Search for nodes when query changes (only in create mode)
   useEffect(() => {
@@ -133,7 +150,7 @@ export const ModifyNodeForm = ({
       popover.style.left = `${inputRect.left}px`;
       popover.style.width = `${inputRect.width}px`;
     }
-  }, [isOpen]);
+  }, [isOpen, query]);
 
   useEffect(() => {
     if (menuRef.current && isOpen && activeIndex >= 0) {
@@ -391,7 +408,7 @@ export const ModifyNodeForm = ({
                 readOnly
                 disabled={isSubmitting}
                 rows={1}
-                className="font-inherit border-background-modifier-border bg-background-secondary text-text-normal min-h-[2.5em] w-full cursor-default resize-none overflow-hidden rounded-md border p-2 pr-8"
+                className="font-inherit border-background-modifier-border bg-background-secondary text-text-normal min-h-[2.5em] w-full cursor-default resize-none overflow-y-auto rounded-md border p-2 pr-8"
               />
               <button
                 onClick={handleClearSelection}
@@ -427,14 +444,14 @@ export const ModifyNodeForm = ({
                   setTimeout(() => setIsFocused(false), 200);
                 }}
                 disabled={isSubmitting}
-                maxLength={MAX_NODE_TITLE_LENGTH}
+                maxLength={maxTitleLength}
                 rows={1}
                 className="font-inherit border-background-modifier-border bg-background-primary text-text-normal min-h-[2.5em] w-full resize-none overflow-hidden rounded-md border p-2"
                 autoComplete="off"
               />
-              {query.length >= MAX_NODE_TITLE_LENGTH && (
+              {query.length >= maxTitleLength && (
                 <p className="text-error mt-1 text-xs">
-                  Character limit reached ({MAX_NODE_TITLE_LENGTH})
+                  Character limit reached ({maxTitleLength})
                 </p>
               )}
               {isOpen && !isEditMode && (

--- a/apps/obsidian/src/components/ModifyNodeModal.tsx
+++ b/apps/obsidian/src/components/ModifyNodeModal.tsx
@@ -12,6 +12,8 @@ import { DiscourseNode } from "~/types";
 import type DiscourseGraphPlugin from "~/index";
 import { QueryEngine } from "~/services/QueryEngine";
 import { isProvisionalSchema } from "~/utils/typeUtils";
+
+const MAX_NODE_TITLE_LENGTH = 255;
 import { getNodeTypeIdForFile } from "~/utils/relationsStore";
 
 type ModifyNodeFormProps = {
@@ -425,14 +427,14 @@ export const ModifyNodeForm = ({
                   setTimeout(() => setIsFocused(false), 200);
                 }}
                 disabled={isSubmitting}
-                maxLength={255}
+                maxLength={MAX_NODE_TITLE_LENGTH}
                 rows={1}
                 className="font-inherit border-background-modifier-border bg-background-primary text-text-normal min-h-[2.5em] w-full resize-none overflow-hidden rounded-md border p-2"
                 autoComplete="off"
               />
-              {query.length >= 512 && (
+              {query.length >= MAX_NODE_TITLE_LENGTH && (
                 <p className="text-error mt-1 text-xs">
-                  Character limit reached (255)
+                  Character limit reached ({MAX_NODE_TITLE_LENGTH})
                 </p>
               )}
               {isOpen && !isEditMode && (


### PR DESCRIPTION
https://www.loom.com/share/bed117935dff48c3afd0bd4e26c10264

https://www.loom.com/share/9a89838e6f224b15aa356ddc9a5f50e4

## Summary
- Converts the Content `<input>` to a `<textarea>` that auto-resizes vertically as the user types, allowing the dialog to grow to accommodate longer node titles
- Adds `maxLength={255}` matching Obsidian's filename character limit
- Shows an inline error message when the character limit is reached
- Converts the locked (read-only) state input to `<textarea>` for visual consistency

Closes [ENG-1647](https://linear.app/discourse-graphs/issue/ENG-1647)

## Test plan
- [x] Open node creation dialog and type a long title — textarea should grow vertically
- [x] Verify the dialog grows to accommodate the larger input
- [x] Type 255 characters — further input should be blocked and the error message "Character limit reached (255)" should appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/977" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
