### PR TITLE
[ENG-1622] Remove guard that only allows node creation commands when an md file is open

### DIFF
--- a/apps/obsidian/src/utils/registerCommands.ts
+++ b/apps/obsidian/src/utils/registerCommands.ts
@@ -26,7 +26,7 @@ type ModifyNodeSubmitParams = {
 
 const createModifyNodeModalSubmitHandler = (
   plugin: DiscourseGraphPlugin,
-  editor: Editor,
+  editor?: Editor,
 ): ((params: ModifyNodeSubmitParams) => Promise<void>) => {
   return async ({
     nodeType,
@@ -36,7 +36,9 @@ const createModifyNodeModalSubmitHandler = (
     relationshipTargetFile,
   }: ModifyNodeSubmitParams) => {
     if (selectedExistingNode) {
-      editor.replaceSelection(`[[${selectedExistingNode.basename}]]`);
+      if (editor) {
+        editor.replaceSelection(`[[${selectedExistingNode.basename}]]`);
+      }
       await addRelationIfRequested(plugin, selectedExistingNode, {
         relationshipId,
         relationshipTargetFile,
@@ -66,7 +68,7 @@ export const registerCommands = (plugin: DiscourseGraphPlugin) => {
       const hasSelection = !!editor.getSelection();
 
       if (hasSelection) {
-        new NodeTypeModal(plugin, (nodeType) => {
+        new NodeTypeModal(plugin, (nodeType: DiscourseNode) => {
           void createDiscourseNode({
             plugin,
             editor,
@@ -91,10 +93,12 @@ export const registerCommands = (plugin: DiscourseGraphPlugin) => {
   plugin.addCommand({
     id: "create-discourse-node",
     name: "Create discourse node",
-    editorCallback: (editor: Editor) => {
+    callback: () => {
       const currentFile =
         plugin.app.workspace.getActiveViewOfType(MarkdownView)?.file ||
         undefined;
+      const editor =
+        plugin.app.workspace.getActiveViewOfType(MarkdownView)?.editor;
       new ModifyNodeModal(plugin.app, {
         nodeTypes: plugin.settings.nodeTypes,
         plugin,


### PR DESCRIPTION
https://www.loom.com/share/fa2e9c27991941c2bbc6850122aff3cd?live_rewind=1

## Summary
- Removes the `editorCallback` guard on the "create discourse node" command so it shows in the command palette even without an active markdown file
- Editor is now retrieved from the active `MarkdownView` at call time (optional), so insertion still works when a file is open
- Adds a null check before calling `editor.replaceSelection` to safely handle the no-editor case

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/979" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
