### PR TITLE
ENG-1659: Use typed canvasSettings.color keys on color picker writes

### DIFF
--- a/apps/roam/src/components/settings/NodeConfig.tsx
+++ b/apps/roam/src/components/settings/NodeConfig.tsx
@@ -27,6 +27,7 @@ import {
   setDiscourseNodeSetting,
 } from "~/components/settings/utils/accessors";
 import {
+  CANVAS_KEYS,
   DISCOURSE_NODE_KEYS,
   SPECIFICATION_KEYS,
   TEMPLATE_SETTING_KEYS,
@@ -231,7 +232,10 @@ const NodeConfig = ({
                         });
                         setDiscourseNodeSetting(
                           node.type,
-                          ["canvasSettings", "color"],
+                          [
+                            DISCOURSE_NODE_KEYS.canvasSettings,
+                            CANVAS_KEYS.color,
+                          ],
                           colorValue,
                         );
                       }}
@@ -249,7 +253,10 @@ const NodeConfig = ({
                           });
                           setDiscourseNodeSetting(
                             node.type,
-                            ["canvasSettings", "color"],
+                            [
+                              DISCOURSE_NODE_KEYS.canvasSettings,
+                              CANVAS_KEYS.color,
+                            ],
                             "",
                           );
                         }}


### PR DESCRIPTION
https://www.loom.com/share/7390f1715e7c49eba3c5b714f052af63

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/980" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
