### PR TITLE
ENG-1646: Auto-resize content input and 512 char limit in node creation dialog (Roam)

### DIFF
--- a/apps/roam/src/components/FuzzySelectInput.tsx
+++ b/apps/roam/src/components/FuzzySelectInput.tsx
@@ -8,7 +8,6 @@ import React, {
 import {
   Button,
   TextArea,
-  InputGroup,
   Menu,
   MenuItem,
   Popover,
@@ -18,6 +17,7 @@ import fuzzy from "fuzzy";
 import { Result } from "~/utils/types";
 
 const RESULTS_LIMIT = 50;
+const MAX_CONTENT_LENGTH = 512;
 
 type FuzzySelectInputProps<T extends Result = Result> = {
   value?: T;
@@ -44,7 +44,7 @@ const FuzzySelectInput = <T extends Result = Result>({
   const [isFocused, setIsFocused] = useState(false);
 
   const menuRef = useRef<HTMLUListElement>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
 
   const filteredItems = useMemo(() => {
     if (!query) return options;
@@ -86,7 +86,7 @@ const FuzzySelectInput = <T extends Result = Result>({
   );
 
   const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent<HTMLInputElement>) => {
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
       if (e.key === "ArrowDown") {
         e.preventDefault();
         setActiveIndex((prev) =>
@@ -227,23 +227,32 @@ const FuzzySelectInput = <T extends Result = Result>({
         </Menu>
       }
       target={
-        <InputGroup
-          fill
-          inputRef={inputRef}
-          className="w-full"
-          value={query}
-          onChange={(e) => handleInputChange(e.target.value)}
-          onKeyDown={handleKeyDown}
-          autoFocus={autoFocus}
-          placeholder={placeholder}
-          onFocus={() => {
-            setIsFocused(true);
-          }}
-          onBlur={() => {
-            setIsFocused(false);
-            setTimeout(() => setIsOpen(false), 200);
-          }}
-        />
+        <div className="w-full">
+          <TextArea
+            fill
+            inputRef={inputRef}
+            className="w-full"
+            value={query}
+            onChange={(e) => handleInputChange(e.target.value)}
+            onKeyDown={handleKeyDown}
+            autoFocus={autoFocus}
+            placeholder={placeholder}
+            growVertically
+            maxLength={MAX_CONTENT_LENGTH}
+            onFocus={() => {
+              setIsFocused(true);
+            }}
+            onBlur={() => {
+              setIsFocused(false);
+              setTimeout(() => setIsOpen(false), 200);
+            }}
+          />
+          {query.length >= MAX_CONTENT_LENGTH && (
+            <p className="mt-1 text-xs text-red-500">
+              Character limit reached ({MAX_CONTENT_LENGTH})
+            </p>
+          )}
+        </div>
       }
     />
   );

--- a/apps/roam/src/components/FuzzySelectInput.tsx
+++ b/apps/roam/src/components/FuzzySelectInput.tsx
@@ -158,17 +158,26 @@ const FuzzySelectInput = <T extends Result = Result>({
   }, [autoFocus, mode, isLocked]);
 
   if (mode === "edit") {
+    const editText = value?.text || "";
     return (
-      <TextArea
-        value={value?.text || ""}
-        onChange={(e) => {
-          setValue({ text: e.target.value, uid: value?.uid || "" } as T);
-        }}
-        fill
-        growVertically
-        placeholder={placeholder}
-        autoFocus={autoFocus}
-      />
+      <div className="w-full">
+        <TextArea
+          value={editText}
+          onChange={(e) => {
+            setValue({ text: e.target.value, uid: value?.uid || "" } as T);
+          }}
+          fill
+          growVertically
+          placeholder={placeholder}
+          autoFocus={autoFocus}
+          maxLength={MAX_CONTENT_LENGTH}
+        />
+        {editText.length >= MAX_CONTENT_LENGTH && (
+          <p className="mt-1 text-xs text-red-500">
+            Character limit reached ({MAX_CONTENT_LENGTH})
+          </p>
+        )}
+      </div>
     );
   }
 

--- a/apps/roam/src/styles/discourseGraphStyles.css
+++ b/apps/roam/src/styles/discourseGraphStyles.css
@@ -168,7 +168,7 @@ div.roamjs-discourse-drawer div.bp3-drawer {
 }
 
 .roamjs-canvas-dialog textarea {
-  min-height: 96px;
+  min-height: 2rem;
 }
 
 /* 


### PR DESCRIPTION
https://www.loom.com/share/f6f185b35c214125b5f792663dc16fa0


## Summary

- Replaces the single-line `InputGroup` with a `TextArea` (`growVertically`) in the create mode of `FuzzySelectInput`, so the content field auto-resizes vertically as the user types
- Adds a 512 character limit (`maxLength`) with an inline red warning message that appears when the limit is reached

Fixes [ENG-1646](https://linear.app/discourse-graphs/issue/ENG-1646)

## Test plan

<img width="984" height="595" alt="image" src="https://github.com/user-attachments/assets/72510b0d-6ee9-4711-9105-69b76d010289" />


- [x] Open the node creation dialog and type a short title — field renders at default height
- [x] Type a long title that wraps — field and dialog grow to accommodate
- [x] Type 512+ characters — "Character limit reached (512)" warning appears below the field; no additional characters accepted
- [x] Select an existing node from the fuzzy dropdown — locked state display unchanged
- [x] Open in edit mode — existing `growVertically` behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/985" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
