### PR TITLE
ENG-1628: Open ModifyNodeModal with pre-filled text on editor right-click

### DIFF
--- a/apps/obsidian/src/components/ModifyNodeModal.tsx
+++ b/apps/obsidian/src/components/ModifyNodeModal.tsx
@@ -177,9 +177,14 @@ export const ModifyNodeForm = ({
     }
   }, [activeIndex, isOpen]);
 
-  // Focus the content input on mount so users can start typing immediately
+  // Focus the content input on mount so users can start typing immediately,
+  // with cursor placed at the end of any pre-filled text
   useEffect(() => {
-    titleInputRef.current?.focus();
+    const el = titleInputRef.current;
+    if (!el) return;
+    el.focus();
+    const len = el.value.length;
+    el.setSelectionRange(len, len);
   }, []);
 
   useEffect(() => {

--- a/apps/obsidian/src/index.ts
+++ b/apps/obsidian/src/index.ts
@@ -217,6 +217,9 @@ export default class DiscourseGraphPlugin extends Plugin {
         if (!editor.getSelection()) return;
 
         const selection = editor.getSelection().trim();
+        const currentFile =
+          this.app.workspace.getActiveViewOfType(MarkdownView)?.file ||
+          undefined;
         addConvertSubmenu({
           menu,
           label: "Turn into discourse node",
@@ -227,6 +230,7 @@ export default class DiscourseGraphPlugin extends Plugin {
               plugin: this,
               initialTitle: selection,
               initialNodeType: nodeType,
+              currentFile,
               onSubmit: createModifyNodeModalSubmitHandler(this, editor),
             }).open();
           },

--- a/apps/obsidian/src/index.ts
+++ b/apps/obsidian/src/index.ts
@@ -18,13 +18,13 @@ import {
 } from "~/utils/editorMenuUtils";
 import { createImageEmbedHoverExtension } from "~/utils/imageEmbedHoverIcon";
 import { createWikilinkDragExtension } from "~/utils/wikilinkDragHandler";
-import { registerCommands } from "~/utils/registerCommands";
+import {
+  registerCommands,
+  createModifyNodeModalSubmitHandler,
+} from "~/utils/registerCommands";
 import { DiscourseContextView } from "~/components/DiscourseContextView";
 import { VIEW_TYPE_TLDRAW_DG_PREVIEW, FRONTMATTER_KEY } from "~/constants";
-import {
-  convertPageToDiscourseNode,
-  createDiscourseNode,
-} from "~/utils/createNode";
+import { convertPageToDiscourseNode } from "~/utils/createNode";
 import { DEFAULT_SETTINGS } from "~/constants";
 import ModifyNodeModal from "~/components/ModifyNodeModal";
 import { TagNodeHandler } from "~/utils/tagNodeHandler";
@@ -221,13 +221,14 @@ export default class DiscourseGraphPlugin extends Plugin {
           menu,
           label: "Turn into discourse node",
           nodeTypes: this.settings.nodeTypes,
-          onClick: async (nodeType) => {
-            await createDiscourseNode({
+          onClick: (nodeType) => {
+            new ModifyNodeModal(this.app, {
+              nodeTypes: this.settings.nodeTypes,
               plugin: this,
-              editor,
-              nodeType,
-              text: selection,
-            });
+              initialTitle: selection,
+              initialNodeType: nodeType,
+              onSubmit: createModifyNodeModalSubmitHandler(this, editor),
+            }).open();
           },
         });
       }),

--- a/apps/obsidian/src/utils/registerCommands.ts
+++ b/apps/obsidian/src/utils/registerCommands.ts
@@ -24,7 +24,7 @@ type ModifyNodeSubmitParams = {
   relationshipTargetFile?: TFile;
 };
 
-const createModifyNodeModalSubmitHandler = (
+export const createModifyNodeModalSubmitHandler = (
   plugin: DiscourseGraphPlugin,
   editor?: Editor,
 ): ((params: ModifyNodeSubmitParams) => Promise<void>) => {


### PR DESCRIPTION
https://www.loom.com/share/cb92f8fced6a4991a5843fd576fd4d5a

## Summary

- Right-clicking highlighted text and selecting a node type from "Turn into discourse node" now opens `ModifyNodeModal` pre-filled with the selected text and the chosen node type pre-selected, instead of creating the node directly
- Fixed cursor placement in the content input field to land at the end of pre-filled text rather than the beginning (applies to all modal entry points — right-click, command palette, file menu)

## Changes

- `apps/obsidian/src/index.ts` — updated `editor-menu` handler to open `ModifyNodeModal` instead of calling `createDiscourseNode` directly
- `apps/obsidian/src/utils/registerCommands.ts` — exported `createModifyNodeModalSubmitHandler` for reuse
- `apps/obsidian/src/components/ModifyNodeModal.tsx` — fixed focus effect to set cursor at end of value via `setSelectionRange`

## Test plan

- [x] Highlight text in an Obsidian note → right-click → hover "Turn into discourse node" → pick a node type
- [x] Verify `ModifyNodeModal` opens with the highlighted text pre-filled and the node type pre-selected
- [x] Verify cursor is at the end of the pre-filled text
- [x] Submit → node created correctly
- [x] Verify no regression in command palette "Create discourse node" (pre-fill and cursor still work)

Fixes ENG-1628

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/990" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
