### PR TITLE
ENG-1687 Memory leak: Unmounting the DiscourseContext Overlay leaves it dangling in Roam components

### DIFF
--- a/apps/roam/src/components/DiscourseContextOverlay.tsx
+++ b/apps/roam/src/components/DiscourseContextOverlay.tsx
@@ -366,6 +366,26 @@ const Wrapper = ({ parent, tag }: { parent: HTMLElement; tag: string }) => {
   );
 };
 
+const trackedContainers = new Set<HTMLElement>();
+let cleanupObserver: MutationObserver | null = null;
+
+const ensureObserver = () => {
+  if (cleanupObserver) return;
+  cleanupObserver = new MutationObserver(() => {
+    for (const el of trackedContainers) {
+      if (!el.isConnected) {
+        ReactDOM.unmountComponentAtNode(el);
+        trackedContainers.delete(el);
+      }
+    }
+    if (trackedContainers.size === 0) {
+      cleanupObserver!.disconnect();
+      cleanupObserver = null;
+    }
+  });
+  cleanupObserver.observe(document.body, { childList: true, subtree: true });
+};
+
 export const render = ({
   tag,
   parent,
@@ -383,6 +403,8 @@ export const render = ({
     </ExtensionApiContextProvider>,
     parent,
   );
+  trackedContainers.add(parent);
+  ensureObserver();
 };
 
 export default DiscourseContextPopupOverlay;

--- a/apps/roam/src/components/DiscourseContextOverlay.tsx
+++ b/apps/roam/src/components/DiscourseContextOverlay.tsx
@@ -395,7 +395,7 @@ export const render = ({
   tag: string;
   parent: HTMLElement;
   onloadArgs: OnloadArgs;
-}) => {
+}): void => {
   parent.style.margin = "0 8px";
   parent.onmousedown = (e) => e.stopPropagation();
   ReactDOM.render(

--- a/apps/roam/src/components/DiscourseContextOverlay.tsx
+++ b/apps/roam/src/components/DiscourseContextOverlay.tsx
@@ -374,6 +374,7 @@ const ensureObserver = () => {
   cleanupObserver = new MutationObserver(() => {
     for (const el of trackedContainers) {
       if (!el.isConnected) {
+        // eslint-disable-next-line react/no-deprecated
         ReactDOM.unmountComponentAtNode(el);
         trackedContainers.delete(el);
       }

--- a/apps/roam/src/components/DiscourseContextOverlay.tsx
+++ b/apps/roam/src/components/DiscourseContextOverlay.tsx
@@ -8,6 +8,7 @@ import {
 } from "@blueprintjs/core";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import ReactDOM from "react-dom";
+import renderWithUnmount from "roamjs-components/util/renderWithUnmount";
 import { ContextContent } from "./DiscourseContext";
 import useInViewport from "react-in-viewport/dist/es/lib/useInViewport";
 import normalizePageTitle from "roamjs-components/queries/normalizePageTitle";
@@ -366,27 +367,6 @@ const Wrapper = ({ parent, tag }: { parent: HTMLElement; tag: string }) => {
   );
 };
 
-const trackedContainers = new Set<HTMLElement>();
-let cleanupObserver: MutationObserver | null = null;
-
-const ensureObserver = () => {
-  if (cleanupObserver) return;
-  cleanupObserver = new MutationObserver(() => {
-    for (const el of trackedContainers) {
-      if (!el.isConnected) {
-        // eslint-disable-next-line react/no-deprecated
-        ReactDOM.unmountComponentAtNode(el);
-        trackedContainers.delete(el);
-      }
-    }
-    if (trackedContainers.size === 0) {
-      cleanupObserver!.disconnect();
-      cleanupObserver = null;
-    }
-  });
-  cleanupObserver.observe(document.body, { childList: true, subtree: true });
-};
-
 export const render = ({
   tag,
   parent,
@@ -398,14 +378,7 @@ export const render = ({
 }): void => {
   parent.style.margin = "0 8px";
   parent.onmousedown = (e) => e.stopPropagation();
-  ReactDOM.render(
-    <ExtensionApiContextProvider {...onloadArgs}>
-      <Wrapper tag={tag} parent={parent} />
-    </ExtensionApiContextProvider>,
-    parent,
-  );
-  trackedContainers.add(parent);
-  ensureObserver();
+  renderWithUnmount(<Wrapper tag={tag} parent={parent} />, parent, onloadArgs);
 };
 
 export default DiscourseContextPopupOverlay;


### PR DESCRIPTION
https://linear.app/discourse-graphs/issue/ENG-1687/memory-leak-unmounting-the-discoursecontext-overlay-leaves-it-dangling

Problem: https://www.loom.com/share/b7207d93abd942839133327de691aa86

Demonstrating the solution: https://www.loom.com/share/5d6a22757ca24905b44f921b87faa9ce

Again the diagnosis is mine but the solution is Claude's.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory management for overlay components to ensure proper cleanup of disconnected DOM elements, enhancing stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->