### PR TITLE
ENG-1377: Sync templates when syncing a node schema

### DIFF
--- a/apps/obsidian/src/utils/conceptConversion.ts
+++ b/apps/obsidian/src/utils/conceptConversion.ts
@@ -35,10 +35,12 @@ export const discourseNodeSchemaToLocalConcept = ({
   context,
   node,
   accountLocalId,
+  templateContent,
 }: {
   context: SupabaseContext;
   node: DiscourseNode;
   accountLocalId: string;
+  templateContent?: string;
 }): LocalConceptDataInput => {
   const {
     description,
@@ -56,6 +58,7 @@ export const discourseNodeSchemaToLocalConcept = ({
     source_data: otherData,
   };
   if (template) literal_content.template = template;
+  if (templateContent) literal_content.template_content = templateContent;
   if (importedFromRid) literal_content.importedFromRid = importedFromRid;
   return {
     space_id: context.spaceId,

--- a/apps/obsidian/src/utils/conceptConversion.ts
+++ b/apps/obsidian/src/utils/conceptConversion.ts
@@ -34,12 +34,10 @@ const getNodeExtraData = (
 export const discourseNodeSchemaToLocalConcept = ({
   context,
   node,
-  accountLocalId,
   templateContent,
 }: {
   context: SupabaseContext;
   node: DiscourseNode;
-  accountLocalId: string;
   templateContent?: string;
 }): LocalConceptDataInput => {
   const {

--- a/apps/obsidian/src/utils/conceptConversion.ts
+++ b/apps/obsidian/src/utils/conceptConversion.ts
@@ -35,10 +35,12 @@ export const discourseNodeSchemaToLocalConcept = ({
   context,
   node,
   templateContent,
+  existingMetadataVersion,
 }: {
   context: SupabaseContext;
   node: DiscourseNode;
   templateContent?: string;
+  existingMetadataVersion?: number;
 }): LocalConceptDataInput => {
   const {
     description,
@@ -54,10 +56,10 @@ export const discourseNodeSchemaToLocalConcept = ({
   const literal_content: Record<string, Json> = {
     label: name,
     source_data: otherData,
+    metadata_version: (existingMetadataVersion ?? 0) + 1,
   };
   if (template) literal_content.template = template;
   if (templateContent) {
-    literal_content.metadata_version = 1;
     literal_content.template_content = templateContent;
   }
   if (importedFromRid) literal_content.importedFromRid = importedFromRid;

--- a/apps/obsidian/src/utils/conceptConversion.ts
+++ b/apps/obsidian/src/utils/conceptConversion.ts
@@ -56,7 +56,10 @@ export const discourseNodeSchemaToLocalConcept = ({
     source_data: otherData,
   };
   if (template) literal_content.template = template;
-  if (templateContent) literal_content.template_content = templateContent;
+  if (templateContent) {
+    literal_content.metadata_version = 1;
+    literal_content.template_content = templateContent;
+  }
   if (importedFromRid) literal_content.importedFromRid = importedFromRid;
   return {
     space_id: context.spaceId,

--- a/apps/obsidian/src/utils/conceptConversion.ts
+++ b/apps/obsidian/src/utils/conceptConversion.ts
@@ -12,7 +12,7 @@ import type { ObsidianDiscourseNodeData } from "./syncDgNodesToSupabase";
 import type { Json } from "@repo/database/dbTypes";
 
 /**
- * Get extra data (author, timestamps) from file metadata
+ * Get extra data (author, timestamps) from file
  */
 const getNodeExtraData = (
   file: TFile,
@@ -35,12 +35,10 @@ export const discourseNodeSchemaToLocalConcept = ({
   context,
   node,
   templateContent,
-  existingMetadataVersion,
 }: {
   context: SupabaseContext;
   node: DiscourseNode;
   templateContent?: string;
-  existingMetadataVersion?: number;
 }): LocalConceptDataInput => {
   const {
     description,
@@ -56,7 +54,6 @@ export const discourseNodeSchemaToLocalConcept = ({
   const literal_content: Record<string, Json> = {
     label: name,
     source_data: otherData,
-    metadata_version: (existingMetadataVersion ?? 0) + 1,
   };
   if (template) literal_content.template = template;
   literal_content.template_content = templateContent || null;

--- a/apps/obsidian/src/utils/conceptConversion.ts
+++ b/apps/obsidian/src/utils/conceptConversion.ts
@@ -12,7 +12,7 @@ import type { ObsidianDiscourseNodeData } from "./syncDgNodesToSupabase";
 import type { Json } from "@repo/database/dbTypes";
 
 /**
- * Get extra data (author, timestamps) from file
+ * Get extra data (author, timestamps) from file metadata
  */
 const getNodeExtraData = (
   file: TFile,

--- a/apps/obsidian/src/utils/conceptConversion.ts
+++ b/apps/obsidian/src/utils/conceptConversion.ts
@@ -59,9 +59,7 @@ export const discourseNodeSchemaToLocalConcept = ({
     metadata_version: (existingMetadataVersion ?? 0) + 1,
   };
   if (template) literal_content.template = template;
-  if (templateContent) {
-    literal_content.template_content = templateContent;
-  }
+  literal_content.template_content = templateContent || null;
   if (importedFromRid) literal_content.importedFromRid = importedFromRid;
   return {
     space_id: context.spaceId,

--- a/apps/obsidian/src/utils/importNodes.ts
+++ b/apps/obsidian/src/utils/importNodes.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import type { Json } from "@repo/database/dbTypes";
 import matter from "gray-matter";
-import { App, TFile } from "obsidian";
+import { App, Notice, TFile } from "obsidian";
 import type { DGSupabaseClient } from "@repo/database/lib/client";
 import type DiscourseGraphPlugin from "~/index";
 import { getLoggedInClient, getSupabaseContext } from "./supabaseContext";
@@ -19,6 +19,7 @@ import {
   importRelationsForImportedNodes,
   type RemoteRelationInstance,
 } from "./importRelations";
+import { createTemplateFile } from "./templates";
 
 export const getAvailableGroupIds = async (
   client: DGSupabaseClient,
@@ -999,7 +1000,7 @@ const parseSchemaLiteralContent = (
 ): Pick<
   DiscourseNode,
   "name" | "format" | "color" | "tag" | "template" | "keyImage"
-> => {
+> & { templateContent?: string } => {
   const obj =
     typeof literalContent === "string"
       ? (JSON.parse(literalContent) as Record<string, unknown>)
@@ -1016,6 +1017,7 @@ const parseSchemaLiteralContent = (
     color: (src.color as string) || (obj.color as string) || undefined,
     tag: (src.tag as string) || (obj.tag as string) || undefined,
     template: (obj.template as string) || undefined,
+    templateContent: (obj.template_content as string) || undefined,
     keyImage:
       (src.keyImage as boolean) ?? (obj.keyImage as boolean) ?? undefined,
   };
@@ -1090,6 +1092,32 @@ export const mapNodeTypeIdToLocal = async ({
     modified: now,
     importedFromRid,
   };
+
+  if (parsed.templateContent && parsed.template) {
+    const result = await createTemplateFile({
+      app: plugin.app,
+      templateName: parsed.template,
+      content: parsed.templateContent,
+    });
+    if (result.created) {
+      new Notice(
+        `Template "${parsed.template}" created for imported node type "${parsed.name}".`,
+        4000,
+      );
+    } else if (
+      result.reason === "Templates plugin is not enabled" ||
+      result.reason === "Templates folder path is not configured"
+    ) {
+      // Don't store a template filename that can never resolve
+      newNodeType.template = undefined;
+      new Notice(
+        `Node type "${parsed.name}" imported without template: ${result.reason}. Configure the Templates plugin to use templates.`,
+        6000,
+      );
+    }
+    // If reason is "template already exists", keep newNodeType.template — local file takes precedence
+  }
+
   plugin.settings.nodeTypes = [...plugin.settings.nodeTypes, newNodeType];
   await plugin.saveSettings();
   return newNodeType.id;

--- a/apps/obsidian/src/utils/syncDgNodesToSupabase.ts
+++ b/apps/obsidian/src/utils/syncDgNodesToSupabase.ts
@@ -28,6 +28,7 @@ import {
   collectDiscourseNodesFromVault,
 } from "./getDiscourseNodes";
 import { isAcceptedSchema } from "./typeUtils";
+import { getTemplatePluginInfo } from "./templates";
 
 const DEFAULT_TIME = "1970-01-01";
 export type ChangeType = "title" | "content";
@@ -472,15 +473,30 @@ const convertDgToSupabaseConcepts = async ({
     nodeTypes.map((nodeType) => [nodeType.id, nodeType]),
   );
 
-  const nodesTypesToLocalConcepts = nodeTypes
-    .filter((nodeType) => nodeType.modified > lastNodeSchemaSync)
-    .map((nodeType) =>
-      discourseNodeSchemaToLocalConcept({
-        context,
-        node: nodeType,
-        accountLocalId,
+  const { isEnabled: templatesEnabled, folderPath: templatesFolderPath } =
+    getTemplatePluginInfo(plugin.app);
+
+  const nodesTypesToLocalConcepts = await Promise.all(
+    nodeTypes
+      .filter((nodeType) => nodeType.modified > lastNodeSchemaSync)
+      .map(async (nodeType) => {
+        let templateContent: string | undefined;
+        if (nodeType.template && templatesEnabled && templatesFolderPath) {
+          const templateFilePath = `${templatesFolderPath}/${nodeType.template}.md`;
+          const templateFile =
+            plugin.app.vault.getAbstractFileByPath(templateFilePath);
+          if (templateFile instanceof TFile) {
+            templateContent = await plugin.app.vault.read(templateFile);
+          }
+        }
+        return discourseNodeSchemaToLocalConcept({
+          context,
+          node: nodeType,
+          accountLocalId,
+          templateContent,
+        });
       }),
-    );
+  );
 
   const relationTypesById = Object.fromEntries(
     relationTypes.map((relationType) => [relationType.id, relationType]),

--- a/apps/obsidian/src/utils/syncDgNodesToSupabase.ts
+++ b/apps/obsidian/src/utils/syncDgNodesToSupabase.ts
@@ -492,7 +492,6 @@ const convertDgToSupabaseConcepts = async ({
         return discourseNodeSchemaToLocalConcept({
           context,
           node: nodeType,
-          accountLocalId,
           templateContent,
         });
       }),

--- a/apps/obsidian/src/utils/syncDgNodesToSupabase.ts
+++ b/apps/obsidian/src/utils/syncDgNodesToSupabase.ts
@@ -180,7 +180,7 @@ const getLastNodeSchemaSyncTime = async (
 ): Promise<Date> => {
   const { data } = await supabaseClient
     .from("my_concepts")
-    .select("last_modified, literal_content")
+    .select("last_modified")
     .eq("space_id", spaceId)
     .eq("is_schema", true)
     .eq("arity", 0)

--- a/apps/obsidian/src/utils/syncDgNodesToSupabase.ts
+++ b/apps/obsidian/src/utils/syncDgNodesToSupabase.ts
@@ -206,6 +206,48 @@ const getLastRelationSchemaSyncTime = async (
   return new Date((data?.last_modified || DEFAULT_TIME) + "Z");
 };
 
+const getExistingNodeTypeMetadataVersions = async (
+  supabaseClient: DGSupabaseClient,
+  spaceId: number,
+  sourceLocalIds: string[],
+): Promise<Map<string, number>> => {
+  if (sourceLocalIds.length === 0) return new Map();
+
+  const { data, error } = await supabaseClient
+    .from("my_concepts")
+    .select("source_local_id, literal_content")
+    .eq("space_id", spaceId)
+    .eq("is_schema", true)
+    .eq("arity", 0)
+    .in("source_local_id", sourceLocalIds);
+
+  if (error) {
+    console.error(
+      "Failed to fetch existing node type metadata versions:",
+      error,
+    );
+    return new Map();
+  }
+
+  const versionMap = new Map<string, number>();
+  for (const concept of data ?? []) {
+    if (!concept.source_local_id) continue;
+    const literalContent = concept.literal_content as Record<
+      string,
+      Json
+    > | null;
+    const version =
+      typeof literalContent?.metadata_version === "number"
+        ? literalContent.metadata_version
+        : undefined;
+    if (version !== undefined) {
+      versionMap.set(concept.source_local_id, version);
+    }
+  }
+
+  return versionMap;
+};
+
 const getLastRelationSyncTime = async (
   supabaseClient: DGSupabaseClient,
   spaceId: number,
@@ -476,25 +518,34 @@ const convertDgToSupabaseConcepts = async ({
   const { isEnabled: templatesEnabled, folderPath: templatesFolderPath } =
     getTemplatePluginInfo(plugin.app);
 
+  const filteredNodeTypes = nodeTypes.filter(
+    (nodeType) => nodeType.modified > lastNodeSchemaSync,
+  );
+
+  const existingMetadataVersions = await getExistingNodeTypeMetadataVersions(
+    supabaseClient,
+    context.spaceId,
+    filteredNodeTypes.map((n) => n.id),
+  );
+
   const nodesTypesToLocalConcepts = await Promise.all(
-    nodeTypes
-      .filter((nodeType) => nodeType.modified > lastNodeSchemaSync)
-      .map(async (nodeType) => {
-        let templateContent: string | undefined;
-        if (nodeType.template && templatesEnabled && templatesFolderPath) {
-          const templateFilePath = `${templatesFolderPath}/${nodeType.template}.md`;
-          const templateFile =
-            plugin.app.vault.getAbstractFileByPath(templateFilePath);
-          if (templateFile instanceof TFile) {
-            templateContent = await plugin.app.vault.read(templateFile);
-          }
+    filteredNodeTypes.map(async (nodeType) => {
+      let templateContent: string | undefined;
+      if (nodeType.template && templatesEnabled && templatesFolderPath) {
+        const templateFilePath = `${templatesFolderPath}/${nodeType.template}.md`;
+        const templateFile =
+          plugin.app.vault.getAbstractFileByPath(templateFilePath);
+        if (templateFile instanceof TFile) {
+          templateContent = await plugin.app.vault.read(templateFile);
         }
-        return discourseNodeSchemaToLocalConcept({
-          context,
-          node: nodeType,
-          templateContent,
-        });
-      }),
+      }
+      return discourseNodeSchemaToLocalConcept({
+        context,
+        node: nodeType,
+        templateContent,
+        existingMetadataVersion: existingMetadataVersions.get(nodeType.id),
+      });
+    }),
   );
 
   const relationTypesById = Object.fromEntries(

--- a/apps/obsidian/src/utils/syncDgNodesToSupabase.ts
+++ b/apps/obsidian/src/utils/syncDgNodesToSupabase.ts
@@ -174,10 +174,10 @@ const getLastContentSyncTime = async (
   return new Date((data?.last_modified || DEFAULT_TIME) + "Z");
 };
 
-const getLastNodeSchemaInfo = async (
+const getLastNodeSchemaSyncTime = async (
   supabaseClient: DGSupabaseClient,
   spaceId: number,
-): Promise<{ last_modified: Date; metadata_version: number | undefined }> => {
+): Promise<Date> => {
   const { data } = await supabaseClient
     .from("my_concepts")
     .select("last_modified, literal_content")
@@ -187,11 +187,7 @@ const getLastNodeSchemaInfo = async (
     .order("last_modified", { ascending: false })
     .limit(1)
     .maybeSingle();
-  return {
-    last_modified: new Date((data?.last_modified || DEFAULT_TIME) + "Z"),
-    metadata_version: (data?.literal_content as Record<string, unknown>)
-      ?.metadata_version as number | undefined,
-  };
+  return new Date((data?.last_modified || DEFAULT_TIME) + "Z");
 };
 
 const getLastRelationSchemaSyncTime = async (
@@ -452,11 +448,9 @@ const convertDgToSupabaseConcepts = async ({
   allNodes?: DiscourseNodeInVault[];
   fullSync?: boolean;
 }): Promise<void> => {
-  const lastNodeSchemaInfo = await getLastNodeSchemaInfo(
-    supabaseClient,
-    context.spaceId,
-  );
-  const lastNodeSchemaSync = lastNodeSchemaInfo.last_modified.getTime();
+  const lastNodeSchemaSync = (
+    await getLastNodeSchemaSyncTime(supabaseClient, context.spaceId)
+  ).getTime();
   const lastRelationSchemaSync = (
     await getLastRelationSchemaSyncTime(supabaseClient, context.spaceId)
   ).getTime();
@@ -499,7 +493,6 @@ const convertDgToSupabaseConcepts = async ({
           context,
           node: nodeType,
           templateContent,
-          existingMetadataVersion: lastNodeSchemaInfo.metadata_version,
         });
       }),
   );

--- a/apps/obsidian/src/utils/syncDgNodesToSupabase.ts
+++ b/apps/obsidian/src/utils/syncDgNodesToSupabase.ts
@@ -174,20 +174,24 @@ const getLastContentSyncTime = async (
   return new Date((data?.last_modified || DEFAULT_TIME) + "Z");
 };
 
-const getLastNodeSchemaSyncTime = async (
+const getLastNodeSchemaInfo = async (
   supabaseClient: DGSupabaseClient,
   spaceId: number,
-): Promise<Date> => {
+): Promise<{ last_modified: Date; metadata_version: number | undefined }> => {
   const { data } = await supabaseClient
     .from("my_concepts")
-    .select("last_modified")
+    .select("last_modified, literal_content")
     .eq("space_id", spaceId)
     .eq("is_schema", true)
     .eq("arity", 0)
     .order("last_modified", { ascending: false })
     .limit(1)
     .maybeSingle();
-  return new Date((data?.last_modified || DEFAULT_TIME) + "Z");
+  return {
+    last_modified: new Date((data?.last_modified || DEFAULT_TIME) + "Z"),
+    metadata_version: (data?.literal_content as Record<string, unknown>)
+      ?.metadata_version as number | undefined,
+  };
 };
 
 const getLastRelationSchemaSyncTime = async (
@@ -204,48 +208,6 @@ const getLastRelationSchemaSyncTime = async (
     .limit(1)
     .maybeSingle();
   return new Date((data?.last_modified || DEFAULT_TIME) + "Z");
-};
-
-const getExistingNodeTypeMetadataVersions = async (
-  supabaseClient: DGSupabaseClient,
-  spaceId: number,
-  sourceLocalIds: string[],
-): Promise<Map<string, number>> => {
-  if (sourceLocalIds.length === 0) return new Map();
-
-  const { data, error } = await supabaseClient
-    .from("my_concepts")
-    .select("source_local_id, literal_content")
-    .eq("space_id", spaceId)
-    .eq("is_schema", true)
-    .eq("arity", 0)
-    .in("source_local_id", sourceLocalIds);
-
-  if (error) {
-    console.error(
-      "Failed to fetch existing node type metadata versions:",
-      error,
-    );
-    return new Map();
-  }
-
-  const versionMap = new Map<string, number>();
-  for (const concept of data ?? []) {
-    if (!concept.source_local_id) continue;
-    const literalContent = concept.literal_content as Record<
-      string,
-      Json
-    > | null;
-    const version =
-      typeof literalContent?.metadata_version === "number"
-        ? literalContent.metadata_version
-        : undefined;
-    if (version !== undefined) {
-      versionMap.set(concept.source_local_id, version);
-    }
-  }
-
-  return versionMap;
 };
 
 const getLastRelationSyncTime = async (
@@ -490,9 +452,11 @@ const convertDgToSupabaseConcepts = async ({
   allNodes?: DiscourseNodeInVault[];
   fullSync?: boolean;
 }): Promise<void> => {
-  const lastNodeSchemaSync = (
-    await getLastNodeSchemaSyncTime(supabaseClient, context.spaceId)
-  ).getTime();
+  const lastNodeSchemaInfo = await getLastNodeSchemaInfo(
+    supabaseClient,
+    context.spaceId,
+  );
+  const lastNodeSchemaSync = lastNodeSchemaInfo.last_modified.getTime();
   const lastRelationSchemaSync = (
     await getLastRelationSchemaSyncTime(supabaseClient, context.spaceId)
   ).getTime();
@@ -518,34 +482,26 @@ const convertDgToSupabaseConcepts = async ({
   const { isEnabled: templatesEnabled, folderPath: templatesFolderPath } =
     getTemplatePluginInfo(plugin.app);
 
-  const filteredNodeTypes = nodeTypes.filter(
-    (nodeType) => nodeType.modified > lastNodeSchemaSync,
-  );
-
-  const existingMetadataVersions = await getExistingNodeTypeMetadataVersions(
-    supabaseClient,
-    context.spaceId,
-    filteredNodeTypes.map((n) => n.id),
-  );
-
   const nodesTypesToLocalConcepts = await Promise.all(
-    filteredNodeTypes.map(async (nodeType) => {
-      let templateContent: string | undefined;
-      if (nodeType.template && templatesEnabled && templatesFolderPath) {
-        const templateFilePath = `${templatesFolderPath}/${nodeType.template}.md`;
-        const templateFile =
-          plugin.app.vault.getAbstractFileByPath(templateFilePath);
-        if (templateFile instanceof TFile) {
-          templateContent = await plugin.app.vault.read(templateFile);
+    nodeTypes
+      .filter((nodeType) => nodeType.modified > lastNodeSchemaSync)
+      .map(async (nodeType) => {
+        let templateContent: string | undefined;
+        if (nodeType.template && templatesEnabled && templatesFolderPath) {
+          const templateFilePath = `${templatesFolderPath}/${nodeType.template}.md`;
+          const templateFile =
+            plugin.app.vault.getAbstractFileByPath(templateFilePath);
+          if (templateFile instanceof TFile) {
+            templateContent = await plugin.app.vault.read(templateFile);
+          }
         }
-      }
-      return discourseNodeSchemaToLocalConcept({
-        context,
-        node: nodeType,
-        templateContent,
-        existingMetadataVersion: existingMetadataVersions.get(nodeType.id),
-      });
-    }),
+        return discourseNodeSchemaToLocalConcept({
+          context,
+          node: nodeType,
+          templateContent,
+          existingMetadataVersion: lastNodeSchemaInfo.metadata_version,
+        });
+      }),
   );
 
   const relationTypesById = Object.fromEntries(

--- a/apps/obsidian/src/utils/templates.ts
+++ b/apps/obsidian/src/utils/templates.ts
@@ -130,7 +130,9 @@ export const createTemplateFile = async ({
     }
   }
 
-  const templateFilePath = `${folderPath}/${templateName}.md`;
+  // Sanitize to prevent path traversal (e.g. "../../sensitive" from a malicious sync)
+  const sanitizedName = templateName.replace(/[/\\]/g, "-");
+  const templateFilePath = `${folderPath}/${sanitizedName}.md`;
 
   // Don't overwrite an existing template — the local file takes precedence
   const existingFile = app.vault.getAbstractFileByPath(templateFilePath);

--- a/apps/obsidian/src/utils/templates.ts
+++ b/apps/obsidian/src/utils/templates.ts
@@ -93,6 +93,55 @@ export const getTemplateFiles = (app: App): string[] => {
   }
 };
 
+type CreateTemplateFileResult =
+  | { created: true }
+  | { created: false; reason: string };
+
+export const createTemplateFile = async ({
+  app,
+  templateName,
+  content,
+}: {
+  app: App;
+  templateName: string;
+  content: string;
+}): Promise<CreateTemplateFileResult> => {
+  const { isEnabled, folderPath } = getTemplatePluginInfo(app);
+
+  if (!isEnabled) {
+    return { created: false, reason: "Templates plugin is not enabled" };
+  }
+
+  if (!folderPath) {
+    return {
+      created: false,
+      reason: "Templates folder path is not configured",
+    };
+  }
+
+  // Ensure every segment of the folder path exists, creating missing ones
+  const segments = folderPath.split("/").filter(Boolean);
+  let currentPath = "";
+  for (const segment of segments) {
+    currentPath = currentPath ? `${currentPath}/${segment}` : segment;
+    const existing = app.vault.getAbstractFileByPath(currentPath);
+    if (!existing) {
+      await app.vault.createFolder(currentPath);
+    }
+  }
+
+  const templateFilePath = `${folderPath}/${templateName}.md`;
+
+  // Don't overwrite an existing template — the local file takes precedence
+  const existingFile = app.vault.getAbstractFileByPath(templateFilePath);
+  if (existingFile instanceof TFile) {
+    return { created: false, reason: "template already exists" };
+  }
+
+  await app.vault.create(templateFilePath, content);
+  return { created: true };
+};
+
 export const applyTemplate = async ({
   app,
   targetFile,


### PR DESCRIPTION
https://www.loom.com/share/4415ec83680545b180fa2c1e8dc7cabc

## Summary

- When syncing node schemas to Supabase, include the template file content (`template_content`) so it can be shared across vaults
- When importing a node schema that carries `template_content`, automatically create the template file in the local Templates plugin folder
- Respects Templates plugin state: skips template creation (and clears the `template` reference) if the plugin is disabled or the folder path is not configured
- Does not overwrite existing local templates — the local file takes precedence

## Test plan

- [x] Sync a node type that has a template → verify `template_content` is sent to Supabase
- [x] Import a node schema from another vault with `template_content` → verify the template file is created locally
- [x] Import with Templates plugin disabled → verify notice is shown and `template` field is not set
- [x] Import with Templates plugin enabled but folder not configured → same behavior as above
- [x] Import when template file already exists → verify local file is kept, no overwrite

🤖 Generated with [Claude Code](https://claude.com/claude-code)