### PR TITLE
ENG-1681: Advanced Search dialog with split-view preview (Roam)

### DIFF
--- a/apps/roam/src/components/AdvancedSearchDialog/ChipsSearchInput.tsx
+++ b/apps/roam/src/components/AdvancedSearchDialog/ChipsSearchInput.tsx
@@ -5,7 +5,7 @@ import React, {
   useMemo,
   type RefObject,
 } from "react";
-import { type NodeTypeConfig } from "./types";
+import { type NodeTypeConfig, hexToRgba } from "./types";
 
 type Props = {
   chips: string[];
@@ -43,6 +43,12 @@ const ChipsSearchInput = ({
 }: Props) => {
   const [focusedChip, setFocusedChip] = useState(-1);
   const chipRefs = useRef<(HTMLSpanElement | null)[]>([]);
+
+  // Build lookup map once per types change — avoids repeated find() in render
+  const typesById = useMemo(
+    () => Object.fromEntries(types.map((t) => [t.id, t])),
+    [types],
+  );
 
   // Focus chip element when focusedChip changes
   useEffect(() => {
@@ -229,35 +235,32 @@ const ChipsSearchInput = ({
   return (
     <div className="dg-as-chips-input">
       {chips.map((id, idx) => {
-        const t = types.find((x) => x.id === id);
+        const t = typesById[id];
         if (!t) return null;
+        const isFocused = focusedChip === idx;
+        const chipStyle: React.CSSProperties = {
+          background: hexToRgba(t.color, isFocused ? 0.18 : 0.08),
+          borderColor: hexToRgba(t.color, isFocused ? 1 : 0.3),
+          color: t.color,
+          boxShadow: isFocused
+            ? `0 0 0 2px ${hexToRgba(t.color, 0.2)}`
+            : undefined,
+        };
         return (
           <span
             key={id}
             ref={(el) => {
               chipRefs.current[idx] = el;
             }}
-            className={`dg-as-chip${focusedChip === idx ? "focused" : ""}`}
+            className="dg-as-chip"
+            style={chipStyle}
             tabIndex={-1}
             role="button"
             aria-label={`${t.label} filter — press Backspace or Delete to remove`}
             onKeyDown={(e) => onChipKeyDown(e, idx)}
             onClick={() => setFocusedChip(idx)}
           >
-            {t.kind === "node" ? (
-              <span
-                className="dg-as-chip-dot"
-                style={{ background: t.color }}
-              />
-            ) : (
-              <span
-                className="dg-as-chip-dot"
-                style={{
-                  border: `1.5px solid ${t.kind === "page" ? "#1F1F1F" : "#8E8E8E"}`,
-                  background: "transparent",
-                }}
-              />
-            )}
+            <span className="dg-as-chip-dot" style={{ background: t.color }} />
             <span>{t.label}</span>
             <span
               className="dg-as-chip-x"
@@ -302,7 +305,7 @@ const ChipsSearchInput = ({
           value={value}
           onChange={(e) => setValue(e.target.value)}
           onKeyDown={onInputKeyDown}
-          placeholder={chips.length === 0 ? "Search nodes, pages, blocks…" : ""}
+          placeholder={chips.length === 0 ? "Search nodes" : ""}
           autoFocus
           spellCheck={false}
           autoComplete="off"

--- a/apps/roam/src/components/AdvancedSearchDialog/ChipsSearchInput.tsx
+++ b/apps/roam/src/components/AdvancedSearchDialog/ChipsSearchInput.tsx
@@ -1,0 +1,315 @@
+import React, {
+  useState,
+  useRef,
+  useEffect,
+  useMemo,
+  type RefObject,
+} from "react";
+import { type NodeTypeConfig } from "./types";
+
+type Props = {
+  chips: string[];
+  setChips: (chips: string[]) => void;
+  value: string;
+  setValue: (v: string) => void;
+  types: NodeTypeConfig[];
+  inputRef: RefObject<HTMLInputElement>;
+  onArrowDown: () => void;
+  onArrowUp: () => void;
+  onEnter: () => void;
+  onShiftEnter: () => void;
+  onCmdEnter: () => void;
+  onEscape: () => void;
+};
+
+type Ghost = {
+  typeId: string;
+  full: string; // full alias string
+};
+
+const ChipsSearchInput = ({
+  chips,
+  setChips,
+  value,
+  setValue,
+  types,
+  inputRef,
+  onArrowDown,
+  onArrowUp,
+  onEnter,
+  onShiftEnter,
+  onCmdEnter,
+  onEscape,
+}: Props) => {
+  const [focusedChip, setFocusedChip] = useState(-1);
+  const chipRefs = useRef<(HTMLSpanElement | null)[]>([]);
+
+  // Focus chip element when focusedChip changes
+  useEffect(() => {
+    if (focusedChip >= 0 && chipRefs.current[focusedChip]) {
+      chipRefs.current[focusedChip]?.focus();
+    }
+  }, [focusedChip]);
+
+  // Clamp focusedChip when chip list shrinks
+  useEffect(() => {
+    if (focusedChip >= chips.length) setFocusedChip(-1);
+  }, [chips.length, focusedChip]);
+
+  const focusInput = () => {
+    setFocusedChip(-1);
+    setTimeout(() => inputRef.current?.focus(), 0);
+  };
+
+  // Ghost autocomplete: value prefix matches exactly one unselected alias
+  const ghost = useMemo((): Ghost | null => {
+    const v = value.trim().toLowerCase();
+    if (!v) return null;
+
+    const candidates: Ghost[] = [];
+    for (const t of types) {
+      if (chips.includes(t.id)) continue;
+      for (const alias of t.aliases) {
+        if (alias.toLowerCase().startsWith(v) && alias.toLowerCase() !== v) {
+          candidates.push({ typeId: t.id, full: alias });
+          break;
+        }
+      }
+    }
+    return candidates.length === 1 ? candidates[0] : null;
+  }, [value, types, chips]);
+
+  const tryConsumeAsTrigger = (word: string): boolean => {
+    const lower = word.toLowerCase();
+    const match = types.find(
+      (t) =>
+        !chips.includes(t.id) &&
+        t.aliases.some((a) => a.toLowerCase() === lower),
+    );
+    if (match) {
+      setChips([...chips, match.id]);
+      return true;
+    }
+    return false;
+  };
+
+  const removeChip = (idx: number) => chips.filter((_, i) => i !== idx);
+
+  const onChipKeyDown = (e: React.KeyboardEvent, idx: number) => {
+    if (e.key === "ArrowLeft") {
+      e.preventDefault();
+      if (idx > 0) setFocusedChip(idx - 1);
+      return;
+    }
+    if (e.key === "ArrowRight") {
+      e.preventDefault();
+      if (idx < chips.length - 1) setFocusedChip(idx + 1);
+      else focusInput();
+      return;
+    }
+    if (e.key === "Backspace" || e.key === "Delete") {
+      e.preventDefault();
+      const next = removeChip(idx);
+      setChips(next);
+      if (next.length === 0) {
+        focusInput();
+        return;
+      }
+      if (e.key === "Backspace") {
+        setFocusedChip(idx > 0 ? idx - 1 : 0);
+      } else {
+        if (idx >= next.length) focusInput();
+        else setFocusedChip(idx);
+      }
+      return;
+    }
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      const next = removeChip(idx);
+      setChips(next);
+      if (idx > 0 && next.length > 0)
+        setFocusedChip(Math.min(idx, next.length - 1));
+      else focusInput();
+      return;
+    }
+    if (e.key === "Escape") {
+      focusInput();
+      return;
+    }
+    if (e.key === "ArrowUp") {
+      e.preventDefault();
+      onArrowUp();
+      return;
+    }
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      onArrowDown();
+      return;
+    }
+    // Printable char → return focus to input and let the keystroke land
+    if (e.key.length === 1 && !e.metaKey && !e.ctrlKey && !e.altKey) {
+      focusInput();
+    }
+  };
+
+  const onInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Tab") {
+      if (ghost) {
+        e.preventDefault();
+        setChips([...chips, ghost.typeId]);
+        setValue("");
+      }
+      return;
+    }
+
+    if (e.key === " ") {
+      // If input is a single token (no embedded spaces), try to convert to chip
+      if (!/\s/.test(value) && value.length > 0) {
+        if (tryConsumeAsTrigger(value)) {
+          e.preventDefault();
+          setValue("");
+          return;
+        }
+      }
+    }
+
+    if (e.key === "Backspace") {
+      const el = inputRef.current;
+      if (
+        el &&
+        el.selectionStart === 0 &&
+        el.selectionEnd === 0 &&
+        value.length === 0 &&
+        chips.length > 0
+      ) {
+        e.preventDefault();
+        setFocusedChip(chips.length - 1);
+        return;
+      }
+    }
+
+    if (e.key === "ArrowLeft") {
+      const el = inputRef.current;
+      if (
+        el &&
+        el.selectionStart === 0 &&
+        el.selectionEnd === 0 &&
+        chips.length > 0
+      ) {
+        e.preventDefault();
+        setFocusedChip(chips.length - 1);
+        return;
+      }
+    }
+
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      onArrowDown();
+      return;
+    }
+    if (e.key === "ArrowUp") {
+      e.preventDefault();
+      onArrowUp();
+      return;
+    }
+
+    if (e.key === "Enter") {
+      e.preventDefault();
+      if (e.metaKey || e.ctrlKey) onCmdEnter();
+      else if (e.shiftKey) onShiftEnter();
+      else onEnter();
+      return;
+    }
+
+    if (e.key === "Escape") {
+      onEscape();
+    }
+  };
+
+  return (
+    <div className="dg-as-chips-input">
+      {chips.map((id, idx) => {
+        const t = types.find((x) => x.id === id);
+        if (!t) return null;
+        return (
+          <span
+            key={id}
+            ref={(el) => {
+              chipRefs.current[idx] = el;
+            }}
+            className={`dg-as-chip${focusedChip === idx ? "focused" : ""}`}
+            tabIndex={-1}
+            role="button"
+            aria-label={`${t.label} filter — press Backspace or Delete to remove`}
+            onKeyDown={(e) => onChipKeyDown(e, idx)}
+            onClick={() => setFocusedChip(idx)}
+          >
+            {t.kind === "node" ? (
+              <span
+                className="dg-as-chip-dot"
+                style={{ background: t.color }}
+              />
+            ) : (
+              <span
+                className="dg-as-chip-dot"
+                style={{
+                  border: `1.5px solid ${t.kind === "page" ? "#1F1F1F" : "#8E8E8E"}`,
+                  background: "transparent",
+                }}
+              />
+            )}
+            <span>{t.label}</span>
+            <span
+              className="dg-as-chip-x"
+              role="button"
+              aria-label={`Remove ${t.label} filter`}
+              onClick={(e) => {
+                e.stopPropagation();
+                setChips(chips.filter((x) => x !== id));
+                focusInput();
+              }}
+            >
+              <svg
+                width="10"
+                height="10"
+                viewBox="0 0 10 10"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.6"
+                strokeLinecap="round"
+              >
+                <line x1="2" y1="2" x2="8" y2="8" />
+                <line x1="8" y1="2" x2="2" y2="8" />
+              </svg>
+            </span>
+          </span>
+        );
+      })}
+
+      <span className="dg-as-input-wrap">
+        {ghost && (
+          <span className="dg-as-ghost" aria-hidden="true">
+            <span className="dg-as-ghost-typed">{value}</span>
+            <span className="dg-as-ghost-completion">
+              {ghost.full.slice(value.length)}
+            </span>
+            <span className="dg-as-ghost-tabkey">tab</span>
+          </span>
+        )}
+        <input
+          ref={inputRef}
+          className="dg-as-search-input"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          onKeyDown={onInputKeyDown}
+          placeholder={chips.length === 0 ? "Search nodes, pages, blocks…" : ""}
+          autoFocus
+          spellCheck={false}
+          autoComplete="off"
+        />
+      </span>
+    </div>
+  );
+};
+
+export default ChipsSearchInput;

--- a/apps/roam/src/components/AdvancedSearchDialog/FilterPopover.tsx
+++ b/apps/roam/src/components/AdvancedSearchDialog/FilterPopover.tsx
@@ -1,0 +1,520 @@
+import React, {
+  useState,
+  useEffect,
+  useRef,
+  useLayoutEffect,
+  type RefObject,
+} from "react";
+import ReactDOM from "react-dom";
+import {
+  type NodeTypeConfig,
+  type Sort,
+  type SortKey,
+  type SortDir,
+} from "./types";
+
+/* ── Helpers ─────────────────────────────────────────────────── */
+
+type PopoverPosition = { top: number; left: number };
+
+const computePosition = (
+  triggerRef: RefObject<HTMLElement>,
+  width: number,
+): PopoverPosition => {
+  if (!triggerRef.current) return { top: 0, left: 0 };
+  const rect = triggerRef.current.getBoundingClientRect();
+  const left = Math.max(
+    8,
+    Math.min(rect.right - width, window.innerWidth - width - 8),
+  );
+  const top = rect.bottom + 8;
+  return { top, left };
+};
+
+/* ── Checkbox ────────────────────────────────────────────────── */
+
+type CheckState = "off" | "indeterminate" | "on";
+
+const Checkbox = ({ state }: { state: CheckState }) => (
+  <span className={`dg-as-cb ${state === "off" ? "" : state}`}>
+    {state === "on" && (
+      <svg
+        width="10"
+        height="10"
+        viewBox="0 0 10 10"
+        fill="none"
+        stroke="white"
+        strokeWidth="1.8"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <polyline points="2,5 4.5,7.5 8,3" />
+      </svg>
+    )}
+  </span>
+);
+
+/* ── Filter Popover ──────────────────────────────────────────── */
+
+type FilterPopoverProps = {
+  types: NodeTypeConfig[];
+  chips: string[];
+  setChips: (chips: string[]) => void;
+  triggerRef: RefObject<HTMLElement>;
+  onClose: () => void;
+};
+
+export const FilterPopover = ({
+  types,
+  chips,
+  setChips,
+  triggerRef,
+  onClose,
+}: FilterPopoverProps) => {
+  const [query, setQuery] = useState("");
+  const [pos, setPos] = useState<PopoverPosition>({ top: 0, left: 0 });
+  const popRef = useRef<HTMLDivElement>(null);
+  const searchRef = useRef<HTMLInputElement>(null);
+
+  const nodeTypes = types.filter((t) => t.kind === "node");
+  const otherTypes = types.filter((t) => t.kind !== "node");
+
+  const filtered = query.trim()
+    ? types.filter((t) => t.label.toLowerCase().includes(query.toLowerCase()))
+    : null; // null = show all sections
+
+  const displayTypes = filtered ?? types;
+  const displayNodeTypes = filtered ? filtered : nodeTypes;
+  const displayOtherTypes = filtered ? [] : otherTypes;
+
+  // Select-all state
+  const selectedCount = chips.length;
+  const totalCount = types.length;
+  const selectAllState: CheckState =
+    selectedCount === 0
+      ? "off"
+      : selectedCount === totalCount
+        ? "on"
+        : "indeterminate";
+
+  const handleSelectAll = () => {
+    if (selectAllState === "off") setChips(types.map((t) => t.id));
+    else setChips([]);
+  };
+
+  const toggleType = (id: string) => {
+    setChips(
+      chips.includes(id) ? chips.filter((c) => c !== id) : [...chips, id],
+    );
+  };
+
+  const handleOnly = (id: string) => {
+    setChips([id]);
+  };
+
+  // Position
+  useLayoutEffect(() => {
+    setPos(computePosition(triggerRef, 280));
+  }, [triggerRef]);
+
+  // Reposition on resize/scroll
+  useEffect(() => {
+    const reposition = () => setPos(computePosition(triggerRef, 280));
+    window.addEventListener("resize", reposition);
+    window.addEventListener("scroll", reposition, true);
+    return () => {
+      window.removeEventListener("resize", reposition);
+      window.removeEventListener("scroll", reposition, true);
+    };
+  }, [triggerRef]);
+
+  // Outside click to close
+  useEffect(() => {
+    const onMouseDown = (e: MouseEvent) => {
+      if (popRef.current?.contains(e.target as Node)) return;
+      if (triggerRef.current?.contains(e.target as Node)) return;
+      onClose();
+    };
+    document.addEventListener("mousedown", onMouseDown);
+    return () => document.removeEventListener("mousedown", onMouseDown);
+  }, [onClose, triggerRef]);
+
+  // Escape to close
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  // Auto-focus search field
+  useEffect(() => {
+    searchRef.current?.focus();
+  }, []);
+
+  const renderRow = (t: NodeTypeConfig) => {
+    const checked = chips.includes(t.id);
+    return (
+      <div
+        key={t.id}
+        className="dg-as-pop-row"
+        onClick={() => toggleType(t.id)}
+      >
+        <Checkbox state={checked ? "on" : "off"} />
+        {t.kind === "node" ? (
+          <span className="dg-as-pop-dot" style={{ background: t.color }} />
+        ) : (
+          <span className="dg-as-pop-ring" />
+        )}
+        <span>{t.label}</span>
+        <button
+          className="dg-as-only-btn"
+          onClick={(e) => {
+            e.stopPropagation();
+            handleOnly(t.id);
+          }}
+          onMouseDown={(e) => e.preventDefault()}
+        >
+          Only
+        </button>
+      </div>
+    );
+  };
+
+  const popover = (
+    <div
+      ref={popRef}
+      className="dg-as-filter-pop"
+      style={{ position: "fixed", top: pos.top, left: pos.left, zIndex: 9999 }}
+    >
+      <div className="dg-as-pop-search">
+        <input
+          ref={searchRef}
+          className="dg-as-pop-search-input"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Filter types…"
+        />
+      </div>
+      <div className="dg-as-pop-list">
+        {displayTypes.length === 0 ? (
+          <div className="dg-as-pop-empty">No matches</div>
+        ) : (
+          <>
+            {/* Select all — hidden when searching */}
+            {!filtered && (
+              <div className="dg-as-pop-section">
+                <div
+                  className="dg-as-pop-row dg-as-pop-select-all"
+                  onClick={handleSelectAll}
+                >
+                  <Checkbox state={selectAllState} />
+                  <span />
+                  <span className="dg-as-pop-select-all-label">Select all</span>
+                  <span />
+                </div>
+              </div>
+            )}
+
+            {/* Node types */}
+            {displayNodeTypes.length > 0 && (
+              <div className="dg-as-pop-section">
+                {displayNodeTypes.map(renderRow)}
+              </div>
+            )}
+
+            {/* Page / Block */}
+            {displayOtherTypes.length > 0 && (
+              <div className="dg-as-pop-section">
+                {displayOtherTypes.map(renderRow)}
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+
+  return ReactDOM.createPortal(popover, document.body);
+};
+
+/* ── Sort Dropdown ───────────────────────────────────────────── */
+
+const SORT_OPTIONS: { key: SortKey; label: string; directional: boolean }[] = [
+  { key: "relevance", label: "Relevance", directional: false },
+  { key: "date_modified", label: "Date modified", directional: true },
+  { key: "date_created", label: "Date created", directional: true },
+  { key: "alphabetical", label: "Alphabetical", directional: true },
+  { key: "most_connected", label: "Most connected", directional: false },
+];
+
+type SortDropdownProps = {
+  sort: Sort;
+  setSort: (s: Sort) => void;
+  triggerRef: RefObject<HTMLElement>;
+  onClose: () => void;
+};
+
+export const SortDropdown = ({
+  sort,
+  setSort,
+  triggerRef,
+  onClose,
+}: SortDropdownProps) => {
+  const [pos, setPos] = useState<PopoverPosition>({ top: 0, left: 0 });
+  const dropRef = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    setPos(computePosition(triggerRef, 240));
+  }, [triggerRef]);
+
+  useEffect(() => {
+    const reposition = () => setPos(computePosition(triggerRef, 240));
+    window.addEventListener("resize", reposition);
+    window.addEventListener("scroll", reposition, true);
+    return () => {
+      window.removeEventListener("resize", reposition);
+      window.removeEventListener("scroll", reposition, true);
+    };
+  }, [triggerRef]);
+
+  useEffect(() => {
+    const onMouseDown = (e: MouseEvent) => {
+      if (dropRef.current?.contains(e.target as Node)) return;
+      if (triggerRef.current?.contains(e.target as Node)) return;
+      onClose();
+    };
+    document.addEventListener("mousedown", onMouseDown);
+    return () => document.removeEventListener("mousedown", onMouseDown);
+  }, [onClose, triggerRef]);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  const ArrowUp = () => (
+    <svg
+      width="10"
+      height="12"
+      viewBox="0 0 10 12"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M5 10 L5 2 M2 5 L5 2 L8 5" />
+    </svg>
+  );
+
+  const ArrowDown = () => (
+    <svg
+      width="10"
+      height="12"
+      viewBox="0 0 10 12"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M5 2 L5 10 M2 7 L5 10 L8 7" />
+    </svg>
+  );
+
+  const dropdown = (
+    <div
+      ref={dropRef}
+      className="dg-as-dropdown"
+      style={{ position: "fixed", top: pos.top, left: pos.left, zIndex: 9999 }}
+    >
+      <div className="dg-as-dropdown-label">Sort by</div>
+      {SORT_OPTIONS.map((opt) => {
+        const isSelected = sort.key === opt.key;
+        return (
+          <button
+            key={opt.key}
+            className={`dg-as-dropdown-item${isSelected ? "selected" : ""}`}
+            onClick={() => {
+              setSort({ key: opt.key, dir: sort.dir });
+              onClose();
+            }}
+          >
+            <span className="dg-as-dropdown-check">
+              {isSelected && (
+                <svg
+                  width="12"
+                  height="12"
+                  viewBox="0 0 12 12"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <polyline points="2,6 5,9 10,3" />
+                </svg>
+              )}
+            </span>
+            <span className="dg-as-dropdown-item-label">{opt.label}</span>
+            {opt.directional && (
+              <span
+                className="dg-as-dir-toggles"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <button
+                  className={`dg-as-dir-btn${isSelected && sort.dir === "asc" ? "active" : ""}`}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setSort({ key: opt.key, dir: "asc" });
+                  }}
+                  title="Ascending"
+                >
+                  <ArrowUp />
+                </button>
+                <button
+                  className={`dg-as-dir-btn${isSelected && sort.dir === "desc" ? "active" : ""}`}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setSort({ key: opt.key, dir: "desc" });
+                  }}
+                  title="Descending"
+                >
+                  <ArrowDown />
+                </button>
+              </span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+
+  return ReactDOM.createPortal(dropdown, document.body);
+};
+
+/* ── Help Popover ────────────────────────────────────────────── */
+
+type HelpPopoverProps = {
+  types: NodeTypeConfig[];
+  triggerRef: RefObject<HTMLElement>;
+  onClose: () => void;
+};
+
+export const HelpPopover = ({
+  types,
+  triggerRef,
+  onClose,
+}: HelpPopoverProps) => {
+  const [pos, setPos] = useState<PopoverPosition>({ top: 0, left: 0 });
+  const popRef = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    setPos(computePosition(triggerRef, 320));
+  }, [triggerRef]);
+
+  useEffect(() => {
+    const onMouseDown = (e: MouseEvent) => {
+      if (popRef.current?.contains(e.target as Node)) return;
+      if (triggerRef.current?.contains(e.target as Node)) return;
+      onClose();
+    };
+    document.addEventListener("mousedown", onMouseDown);
+    return () => document.removeEventListener("mousedown", onMouseDown);
+  }, [onClose, triggerRef]);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  const nodeTypes = types.filter((t) => t.kind === "node");
+
+  const popover = (
+    <div
+      ref={popRef}
+      className="dg-as-help-pop"
+      style={{ position: "fixed", top: pos.top, left: pos.left, zIndex: 9999 }}
+      role="dialog"
+      aria-label="Keyboard shortcuts"
+    >
+      <h4>Filter by type</h4>
+      <div className="dg-as-help-row">
+        <span>Add filter chip</span>
+        <span className="dg-as-help-keys">
+          <kbd>evd</kbd>
+          <kbd>space</kbd>
+        </span>
+      </div>
+      <div className="dg-as-help-row">
+        <span>Autocomplete prefix</span>
+        <span className="dg-as-help-keys">
+          <kbd>ev</kbd>
+          <kbd>tab</kbd>
+        </span>
+      </div>
+      <div className="dg-as-help-row">
+        <span>Remove last chip</span>
+        <span className="dg-as-help-keys">
+          <kbd>⌫</kbd>
+        </span>
+      </div>
+
+      {nodeTypes.length > 0 && (
+        <>
+          <h4>Triggers</h4>
+          <div className="dg-as-triggers-grid">
+            {nodeTypes.map((t) => (
+              <span key={t.id}>
+                <kbd>{t.trigger}</kbd> {t.label}
+              </span>
+            ))}
+          </div>
+        </>
+      )}
+
+      <h4>Navigate</h4>
+      <div className="dg-as-help-row">
+        <span>Move selection</span>
+        <span className="dg-as-help-keys">
+          <kbd>↑</kbd>
+          <kbd>↓</kbd>
+        </span>
+      </div>
+      <div className="dg-as-help-row">
+        <span>Open in sidebar</span>
+        <span className="dg-as-help-keys">
+          <kbd>↵</kbd>
+        </span>
+      </div>
+      <div className="dg-as-help-row">
+        <span>Open in main</span>
+        <span className="dg-as-help-keys">
+          <kbd>⇧↵</kbd>
+        </span>
+      </div>
+      <div className="dg-as-help-row">
+        <span>Open all results</span>
+        <span className="dg-as-help-keys">
+          <kbd>⌘↵</kbd>
+        </span>
+      </div>
+      <div className="dg-as-help-row">
+        <span>Close</span>
+        <span className="dg-as-help-keys">
+          <kbd>esc</kbd>
+        </span>
+      </div>
+    </div>
+  );
+
+  return ReactDOM.createPortal(popover, document.body);
+};

--- a/apps/roam/src/components/AdvancedSearchDialog/FilterPopover.tsx
+++ b/apps/roam/src/components/AdvancedSearchDialog/FilterPopover.tsx
@@ -6,6 +6,7 @@ import React, {
   type RefObject,
 } from "react";
 import ReactDOM from "react-dom";
+import { Icon } from "@blueprintjs/core";
 import {
   type NodeTypeConfig,
   type Sort,
@@ -297,36 +298,6 @@ export const SortDropdown = ({
     return () => document.removeEventListener("keydown", onKey);
   }, [onClose]);
 
-  const ArrowUp = () => (
-    <svg
-      width="10"
-      height="12"
-      viewBox="0 0 10 12"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.6"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <path d="M5 10 L5 2 M2 5 L5 2 L8 5" />
-    </svg>
-  );
-
-  const ArrowDown = () => (
-    <svg
-      width="10"
-      height="12"
-      viewBox="0 0 10 12"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.6"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <path d="M5 2 L5 10 M2 7 L5 10 L8 7" />
-    </svg>
-  );
-
   const dropdown = (
     <div
       ref={dropRef}
@@ -339,27 +310,14 @@ export const SortDropdown = ({
         return (
           <button
             key={opt.key}
-            className={`dg-as-dropdown-item${isSelected ? "selected" : ""}`}
+            className={`dg-as-dropdown-item ${isSelected ? "selected" : ""}`}
             onClick={() => {
               setSort({ key: opt.key, dir: sort.dir });
               onClose();
             }}
           >
             <span className="dg-as-dropdown-check">
-              {isSelected && (
-                <svg
-                  width="12"
-                  height="12"
-                  viewBox="0 0 12 12"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                >
-                  <polyline points="2,6 5,9 10,3" />
-                </svg>
-              )}
+              {isSelected && <Icon icon="tick" size={12} />}
             </span>
             <span className="dg-as-dropdown-item-label">{opt.label}</span>
             {opt.directional && (
@@ -368,24 +326,24 @@ export const SortDropdown = ({
                 onClick={(e) => e.stopPropagation()}
               >
                 <button
-                  className={`dg-as-dir-btn${isSelected && sort.dir === "asc" ? "active" : ""}`}
+                  className={`dg-as-dir-btn ${isSelected && sort.dir === "asc" ? "active" : ""}`}
                   onClick={(e) => {
                     e.stopPropagation();
                     setSort({ key: opt.key, dir: "asc" });
                   }}
                   title="Ascending"
                 >
-                  <ArrowUp />
+                  <Icon icon="arrow-up" size={12} />
                 </button>
                 <button
-                  className={`dg-as-dir-btn${isSelected && sort.dir === "desc" ? "active" : ""}`}
+                  className={`dg-as-dir-btn ${isSelected && sort.dir === "desc" ? "active" : ""}`}
                   onClick={(e) => {
                     e.stopPropagation();
                     setSort({ key: opt.key, dir: "desc" });
                   }}
                   title="Descending"
                 >
-                  <ArrowDown />
+                  <Icon icon="arrow-down" size={12} />
                 </button>
               </span>
             )}

--- a/apps/roam/src/components/AdvancedSearchDialog/PreviewPane.tsx
+++ b/apps/roam/src/components/AdvancedSearchDialog/PreviewPane.tsx
@@ -1,0 +1,146 @@
+import React, { useState, useEffect, useRef } from "react";
+import {
+  type SearchResult,
+  type NodeTypeConfig,
+  splitWithHighlights,
+} from "./types";
+
+type PulledBlock = {
+  ":block/string"?: string;
+  ":block/order"?: number;
+  ":block/children"?: PulledBlock[];
+};
+
+type PulledPage = {
+  ":node/title"?: string;
+  ":block/children"?: PulledBlock[];
+};
+
+const fetchCurrentGraphContent = (uid: string): string[] => {
+  try {
+    const pulled = window.roamAlphaAPI.pull(
+      "[:node/title {:block/children [:block/string :block/order]}]",
+      [":block/uid", uid],
+    ) as PulledPage | null;
+
+    if (!pulled) return [];
+
+    return (pulled[":block/children"] ?? [])
+      .sort((a, b) => (a[":block/order"] ?? 0) - (b[":block/order"] ?? 0))
+      .slice(0, 8)
+      .map((b) => b[":block/string"] ?? "")
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+};
+
+type Props = {
+  result: SearchResult | null;
+  typeConfig: NodeTypeConfig | null;
+  keywords: string[];
+};
+
+const PreviewPane = ({ result, typeConfig, keywords }: Props) => {
+  const [richContent, setRichContent] = useState<string[] | null>(null);
+  const contentCache = useRef<Map<string, string[]>>(new Map());
+
+  useEffect(() => {
+    setRichContent(null);
+    if (!result?.fromCurrentGraph) return;
+
+    if (contentCache.current.has(result.uid)) {
+      setRichContent(contentCache.current.get(result.uid)!);
+      return;
+    }
+
+    // Debounce 80ms — avoids firing on fast arrow-key navigation
+    const timer = setTimeout(() => {
+      const content = fetchCurrentGraphContent(result.uid);
+      contentCache.current.set(result.uid, content);
+      setRichContent(content);
+    }, 80);
+
+    return () => clearTimeout(timer);
+  }, [result?.uid, result?.fromCurrentGraph]);
+
+  if (!result || !typeConfig) {
+    return (
+      <div className="dg-as-preview-panel dg-as-preview-empty">
+        <span>Select a result to preview</span>
+      </div>
+    );
+  }
+
+  const displayContent = richContent ?? [];
+  const titleSegments = splitWithHighlights(result.title, keywords);
+
+  const formattedDate = (() => {
+    try {
+      return new Date(result.lastModified).toLocaleDateString(undefined, {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+      });
+    } catch {
+      return result.lastModified;
+    }
+  })();
+
+  return (
+    <div className="dg-as-preview-panel">
+      <span
+        className="dg-as-type-badge dg-as-preview-badge"
+        style={{ background: typeConfig.color }}
+      >
+        {typeConfig.abbrev}
+      </span>
+
+      <h2 className="dg-as-preview-title">
+        {titleSegments.map((seg, i) =>
+          seg.hit ? (
+            <mark key={i}>{seg.text}</mark>
+          ) : (
+            <span key={i}>{seg.text}</span>
+          ),
+        )}
+        {result.refs > 0 && (
+          <sup className="dg-as-ref-count"> {result.refs}</sup>
+        )}
+      </h2>
+
+      <div className="dg-as-preview-body">
+        {displayContent.length > 0 ? (
+          displayContent.map((line, i) => (
+            <p key={i}>
+              {splitWithHighlights(line, keywords).map((seg, j) =>
+                seg.hit ? (
+                  <mark key={j}>{seg.text}</mark>
+                ) : (
+                  <span key={j}>{seg.text}</span>
+                ),
+              )}
+            </p>
+          ))
+        ) : (
+          <span className="dg-as-preview-body-empty">
+            {result.fromCurrentGraph
+              ? "No content"
+              : "Open this node to view its content"}
+          </span>
+        )}
+      </div>
+
+      <div className="dg-as-preview-meta">
+        Last edited: {formattedDate} · {result.authorName}
+        {!result.fromCurrentGraph && (
+          <div className="dg-as-preview-cross-graph">
+            From another graph — open to view full content
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default PreviewPane;

--- a/apps/roam/src/components/AdvancedSearchDialog/PreviewPane.tsx
+++ b/apps/roam/src/components/AdvancedSearchDialog/PreviewPane.tsx
@@ -91,9 +91,9 @@ const PreviewPane = ({ result, typeConfig, keywords }: Props) => {
     <div className="dg-as-preview-panel">
       <span
         className="dg-as-type-badge dg-as-preview-badge"
-        style={{ background: typeConfig.color }}
+        style={typeConfig.badgeStyle}
       >
-        {typeConfig.abbrev}
+        {typeConfig.label}
       </span>
 
       <h2 className="dg-as-preview-title">
@@ -108,6 +108,14 @@ const PreviewPane = ({ result, typeConfig, keywords }: Props) => {
           <sup className="dg-as-ref-count"> {result.refs}</sup>
         )}
       </h2>
+      <div className="dg-as-preview-meta">
+        Last edited: {formattedDate} · {result.authorName}
+        {!result.fromCurrentGraph && (
+          <div className="dg-as-preview-cross-graph">
+            From another graph — open to view full content
+          </div>
+        )}
+      </div>
 
       <div className="dg-as-preview-body">
         {displayContent.length > 0 ? (
@@ -128,15 +136,6 @@ const PreviewPane = ({ result, typeConfig, keywords }: Props) => {
               ? "No content"
               : "Open this node to view its content"}
           </span>
-        )}
-      </div>
-
-      <div className="dg-as-preview-meta">
-        Last edited: {formattedDate} · {result.authorName}
-        {!result.fromCurrentGraph && (
-          <div className="dg-as-preview-cross-graph">
-            From another graph — open to view full content
-          </div>
         )}
       </div>
     </div>

--- a/apps/roam/src/components/AdvancedSearchDialog/ResultRow.tsx
+++ b/apps/roam/src/components/AdvancedSearchDialog/ResultRow.tsx
@@ -3,6 +3,7 @@ import {
   type SearchResult,
   type NodeTypeConfig,
   splitWithHighlights,
+  stripTypePrefix,
 } from "./types";
 
 type Props = {
@@ -22,17 +23,22 @@ const ResultRow = ({
   onMouseEnter,
   onClick,
 }: Props) => {
-  const titleSegments = useMemo(
-    () => splitWithHighlights(result.title, keywords),
-    [result.title, keywords],
+  const displayTitle = useMemo(
+    () => stripTypePrefix(result.title),
+    [result.title],
   );
 
-  const badgeColor = typeConfig?.color ?? "#8E8E8E";
+  const titleSegments = useMemo(
+    () => splitWithHighlights(displayTitle, keywords),
+    [displayTitle, keywords],
+  );
+
   const abbrev = typeConfig?.abbrev ?? result.type.slice(0, 3).toUpperCase();
+  const badgeStyle = typeConfig?.badgeStyle ?? {};
 
   return (
     <div
-      className={`dg-as-result${active ? "active" : ""}`}
+      className={`dg-as-result ${active ? "active" : ""}`}
       role="option"
       aria-selected={active}
       onMouseEnter={onMouseEnter}
@@ -40,8 +46,12 @@ const ResultRow = ({
     >
       <span
         className="dg-as-type-badge"
-        style={{ background: badgeColor }}
-        title={typeConfig?.label}
+        style={{
+          color: badgeStyle?.color,
+          backgroundColor: badgeStyle?.backgroundColor,
+          border: badgeStyle?.border,
+          borderRadius: badgeStyle?.borderRadius,
+        }}
       >
         {abbrev}
       </span>

--- a/apps/roam/src/components/AdvancedSearchDialog/ResultRow.tsx
+++ b/apps/roam/src/components/AdvancedSearchDialog/ResultRow.tsx
@@ -1,0 +1,62 @@
+import React, { useMemo } from "react";
+import {
+  type SearchResult,
+  type NodeTypeConfig,
+  splitWithHighlights,
+} from "./types";
+
+type Props = {
+  result: SearchResult;
+  typeConfig: NodeTypeConfig | undefined;
+  active: boolean;
+  keywords: string[];
+  onMouseEnter: () => void;
+  onClick: () => void;
+};
+
+const ResultRow = ({
+  result,
+  typeConfig,
+  active,
+  keywords,
+  onMouseEnter,
+  onClick,
+}: Props) => {
+  const titleSegments = useMemo(
+    () => splitWithHighlights(result.title, keywords),
+    [result.title, keywords],
+  );
+
+  const badgeColor = typeConfig?.color ?? "#8E8E8E";
+  const abbrev = typeConfig?.abbrev ?? result.type.slice(0, 3).toUpperCase();
+
+  return (
+    <div
+      className={`dg-as-result${active ? "active" : ""}`}
+      role="option"
+      aria-selected={active}
+      onMouseEnter={onMouseEnter}
+      onClick={onClick}
+    >
+      <span
+        className="dg-as-type-badge"
+        style={{ background: badgeColor }}
+        title={typeConfig?.label}
+      >
+        {abbrev}
+      </span>
+      <span className="dg-as-result-title">
+        {titleSegments.map((seg, i) =>
+          seg.hit ? (
+            <mark key={i}>{seg.text}</mark>
+          ) : (
+            <span key={i}>{seg.text}</span>
+          ),
+        )}
+      </span>
+      {result.refs > 0 && <sup className="dg-as-ref-count">{result.refs}</sup>}
+    </div>
+  );
+};
+
+export default ResultRow;

--- a/apps/roam/src/components/AdvancedSearchDialog/index.tsx
+++ b/apps/roam/src/components/AdvancedSearchDialog/index.tsx
@@ -10,6 +10,7 @@ import MiniSearch from "minisearch";
 import renderOverlay from "roamjs-components/util/renderOverlay";
 import getDiscourseNodes from "~/utils/getDiscourseNodes";
 import { getAllDiscourseNodesSince } from "~/utils/getAllDiscourseNodesSince";
+import { getNodeTagStyles } from "~/utils/getDiscourseNodeColors";
 import {
   type SearchResult,
   type Sort,
@@ -176,7 +177,12 @@ const AdvancedSearchDialog = ({ isOpen, onClose }: Props) => {
       setIsLoading(true);
       try {
         const discourseNodes = getDiscourseNodes();
-        const configs = buildNodeTypeConfigs(discourseNodes);
+        const configs = buildNodeTypeConfigs(discourseNodes)
+          .filter((c) => c.kind === "node")
+          .map((c) => ({
+            ...c,
+            badgeStyle: getNodeTagStyles(c.color) ?? {},
+          }));
         const rawData = await getAllDiscourseNodesSince(
           undefined,
           discourseNodes,
@@ -184,16 +190,19 @@ const AdvancedSearchDialog = ({ isOpen, onClose }: Props) => {
         if (cancelled) return;
 
         const currentGraphUids = buildCurrentGraphUidSet();
+        const nodeTypeIds = new Set(configs.map((c) => c.id));
 
-        const results: SearchResult[] = rawData.map((r) => ({
-          uid: r.source_local_id,
-          title: r.text,
-          type: r.type,
-          refs: 0,
-          lastModified: r.last_modified,
-          authorName: r.author_name,
-          fromCurrentGraph: currentGraphUids.has(r.source_local_id),
-        }));
+        const results: SearchResult[] = rawData
+          .filter((r) => nodeTypeIds.has(r.type))
+          .map((r) => ({
+            uid: r.source_local_id,
+            title: r.text,
+            type: r.type,
+            refs: 0,
+            lastModified: r.last_modified,
+            authorName: r.author_name,
+            fromCurrentGraph: currentGraphUids.has(r.source_local_id),
+          }));
 
         const ms = new MiniSearch<MiniSearchDoc>({
           fields: ["title"],
@@ -313,6 +322,7 @@ const AdvancedSearchDialog = ({ isOpen, onClose }: Props) => {
       onClose={onClose}
       canOutsideClickClose
       canEscapeKeyClose={false} // handled manually to close popovers first
+      enforceFocus={false} // allow focus in portaled popovers (FilterPopover, SortDropdown, HelpPopover)
       className="dg-adv-search-dialog"
       portalClassName="dg-adv-search-portal"
     >
@@ -353,6 +363,7 @@ const AdvancedSearchDialog = ({ isOpen, onClose }: Props) => {
           <div className="dg-as-actions">
             <button
               ref={filterTriggerRef}
+              style={{ position: "relative" }}
               className={`dg-as-icon-btn${showFilterPop || chips.length > 0 ? "active" : ""}`}
               onClick={() => {
                 setShowFilterPop((s) => !s);

--- a/apps/roam/src/components/AdvancedSearchDialog/index.tsx
+++ b/apps/roam/src/components/AdvancedSearchDialog/index.tsx
@@ -5,7 +5,7 @@ import React, {
   useMemo,
   useCallback,
 } from "react";
-import { Dialog } from "@blueprintjs/core";
+import { Dialog, Icon } from "@blueprintjs/core";
 import MiniSearch from "minisearch";
 import renderOverlay from "roamjs-components/util/renderOverlay";
 import getDiscourseNodes from "~/utils/getDiscourseNodes";
@@ -23,86 +23,6 @@ import PreviewPane from "./PreviewPane";
 import { FilterPopover, SortDropdown, HelpPopover } from "./FilterPopover";
 
 const MIN_SEARCH_SCORE = 0.1;
-
-/* ── Icons ───────────────────────────────────────────────────── */
-
-const SearchIcon = () => (
-  <svg
-    className="dg-as-search-icon"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-  >
-    <circle cx="11" cy="11" r="7" />
-    <line x1="21" y1="21" x2="16.65" y2="16.65" />
-  </svg>
-);
-
-const FilterIcon = () => (
-  <svg
-    width="16"
-    height="16"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-  >
-    <polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3" />
-  </svg>
-);
-
-const SortIcon = () => (
-  <svg
-    width="12"
-    height="14"
-    viewBox="0 0 12 14"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="1.6"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-  >
-    <path d="M3.5 2.5 L3.5 11.5 M1.5 4.5 L3.5 2.5 L5.5 4.5" />
-    <path d="M8.5 11.5 L8.5 2.5 M6.5 9.5 L8.5 11.5 L10.5 9.5" />
-  </svg>
-);
-
-const ChevronDownIcon = () => (
-  <svg
-    width="10"
-    height="10"
-    viewBox="0 0 12 12"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="1.6"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-  >
-    <path d="M3 4.5 L6 7.5 L9 4.5" />
-  </svg>
-);
-
-const HelpIcon = () => (
-  <svg
-    width="16"
-    height="16"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-  >
-    <circle cx="12" cy="12" r="10" />
-    <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" />
-    <line x1="12" y1="17" x2="12.01" y2="17" />
-  </svg>
-);
 
 /* ── Detect current-graph UIDs ───────────────────────────────── */
 
@@ -337,7 +257,7 @@ const AdvancedSearchDialog = ({ isOpen, onClose }: Props) => {
       >
         {/* Search row */}
         <div className="dg-as-search-row">
-          <SearchIcon />
+          <Icon icon="search" size={18} className="dg-as-search-icon" />
           <ChipsSearchInput
             chips={chips}
             setChips={setChips}
@@ -373,7 +293,7 @@ const AdvancedSearchDialog = ({ isOpen, onClose }: Props) => {
               aria-label="Filter by type"
               aria-expanded={showFilterPop}
             >
-              <FilterIcon />
+              <Icon icon="filter" size={16} />
               {chips.length > 0 && (
                 <span className="dg-as-count-pill">{chips.length}</span>
               )}
@@ -390,9 +310,9 @@ const AdvancedSearchDialog = ({ isOpen, onClose }: Props) => {
               aria-label="Sort"
               aria-expanded={showSort}
             >
-              <SortIcon />
+              <Icon icon="double-caret-vertical" size={14} />
               <span>{currentSortLabel}</span>
-              <ChevronDownIcon />
+              <Icon icon="chevron-down" size={10} />
             </button>
 
             <button
@@ -405,7 +325,7 @@ const AdvancedSearchDialog = ({ isOpen, onClose }: Props) => {
               }}
               aria-label="Keyboard shortcuts"
             >
-              <HelpIcon />
+              <Icon icon="help" size={16} />
             </button>
           </div>
 

--- a/apps/roam/src/components/AdvancedSearchDialog/index.tsx
+++ b/apps/roam/src/components/AdvancedSearchDialog/index.tsx
@@ -1,0 +1,491 @@
+import React, {
+  useState,
+  useRef,
+  useEffect,
+  useMemo,
+  useCallback,
+} from "react";
+import { Dialog } from "@blueprintjs/core";
+import MiniSearch from "minisearch";
+import renderOverlay from "roamjs-components/util/renderOverlay";
+import getDiscourseNodes from "~/utils/getDiscourseNodes";
+import { getAllDiscourseNodesSince } from "~/utils/getAllDiscourseNodesSince";
+import {
+  type SearchResult,
+  type Sort,
+  type NodeTypeConfig,
+  buildNodeTypeConfigs,
+} from "./types";
+import ChipsSearchInput from "./ChipsSearchInput";
+import ResultRow from "./ResultRow";
+import PreviewPane from "./PreviewPane";
+import { FilterPopover, SortDropdown, HelpPopover } from "./FilterPopover";
+
+const MIN_SEARCH_SCORE = 0.1;
+
+/* ── Icons ───────────────────────────────────────────────────── */
+
+const SearchIcon = () => (
+  <svg
+    className="dg-as-search-icon"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <circle cx="11" cy="11" r="7" />
+    <line x1="21" y1="21" x2="16.65" y2="16.65" />
+  </svg>
+);
+
+const FilterIcon = () => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3" />
+  </svg>
+);
+
+const SortIcon = () => (
+  <svg
+    width="12"
+    height="14"
+    viewBox="0 0 12 14"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.6"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M3.5 2.5 L3.5 11.5 M1.5 4.5 L3.5 2.5 L5.5 4.5" />
+    <path d="M8.5 11.5 L8.5 2.5 M6.5 9.5 L8.5 11.5 L10.5 9.5" />
+  </svg>
+);
+
+const ChevronDownIcon = () => (
+  <svg
+    width="10"
+    height="10"
+    viewBox="0 0 12 12"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.6"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M3 4.5 L6 7.5 L9 4.5" />
+  </svg>
+);
+
+const HelpIcon = () => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <circle cx="12" cy="12" r="10" />
+    <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" />
+    <line x1="12" y1="17" x2="12.01" y2="17" />
+  </svg>
+);
+
+/* ── Detect current-graph UIDs ───────────────────────────────── */
+
+const buildCurrentGraphUidSet = (): Set<string> => {
+  try {
+    const results = window.roamAlphaAPI.q(
+      "[:find ?uid :where [?e :block/uid ?uid] [?e :node/title _]]",
+    ) as [string][];
+    return new Set(results.map(([uid]) => uid));
+  } catch {
+    return new Set();
+  }
+};
+
+/* ── Sort results ────────────────────────────────────────────── */
+
+const sortResults = (results: SearchResult[], sort: Sort): SearchResult[] => {
+  const sorted = [...results];
+  if (sort.key === "alphabetical") {
+    sorted.sort((a, b) => a.title.localeCompare(b.title));
+    if (sort.dir === "desc") sorted.reverse();
+  } else if (sort.key === "most_connected") {
+    sorted.sort((a, b) => b.refs - a.refs);
+  } else if (sort.key === "date_modified" || sort.key === "date_created") {
+    sorted.sort((a, b) => {
+      const ta = new Date(a.lastModified).getTime();
+      const tb = new Date(b.lastModified).getTime();
+      return sort.dir === "desc" ? tb - ta : ta - tb;
+    });
+  }
+  return sorted;
+};
+
+/* ── Main Dialog ─────────────────────────────────────────────── */
+
+type Props = {
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+type MiniSearchDoc = {
+  uid: string;
+  title: string;
+  type: string;
+};
+
+const AdvancedSearchDialog = ({ isOpen, onClose }: Props) => {
+  const [chips, setChips] = useState<string[]>([]);
+  const [value, setValue] = useState("");
+  const [activeIdx, setActiveIdx] = useState(0);
+  const [showFilterPop, setShowFilterPop] = useState(false);
+  const [showSort, setShowSort] = useState(false);
+  const [showHelp, setShowHelp] = useState(false);
+  const [sort, setSort] = useState<Sort>({ key: "relevance", dir: "desc" });
+  const [allResults, setAllResults] = useState<SearchResult[]>([]);
+  const [typeConfigs, setTypeConfigs] = useState<NodeTypeConfig[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const miniSearch = useRef<MiniSearch<MiniSearchDoc> | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const resultsRef = useRef<HTMLDivElement>(null);
+  const filterTriggerRef = useRef<HTMLButtonElement>(null);
+  const sortTriggerRef = useRef<HTMLButtonElement>(null);
+  const helpTriggerRef = useRef<HTMLButtonElement>(null);
+
+  // Load all nodes on mount
+  useEffect(() => {
+    if (!isOpen) return;
+    let cancelled = false;
+
+    const load = async () => {
+      setIsLoading(true);
+      try {
+        const discourseNodes = getDiscourseNodes();
+        const configs = buildNodeTypeConfigs(discourseNodes);
+        const rawData = await getAllDiscourseNodesSince(
+          undefined,
+          discourseNodes,
+        );
+        if (cancelled) return;
+
+        const currentGraphUids = buildCurrentGraphUidSet();
+
+        const results: SearchResult[] = rawData.map((r) => ({
+          uid: r.source_local_id,
+          title: r.text,
+          type: r.type,
+          refs: 0,
+          lastModified: r.last_modified,
+          authorName: r.author_name,
+          fromCurrentGraph: currentGraphUids.has(r.source_local_id),
+        }));
+
+        const ms = new MiniSearch<MiniSearchDoc>({
+          fields: ["title"],
+          storeFields: ["uid", "title", "type"],
+          idField: "uid",
+        });
+        ms.addAll(
+          results.map(({ uid, title, type }) => ({ uid, title, type })),
+        );
+        miniSearch.current = ms;
+
+        setTypeConfigs(configs);
+        setAllResults(results);
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    };
+
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen]);
+
+  // Parse keywords from input
+  const keywords = useMemo(
+    () => value.trim().split(/\s+/).filter(Boolean),
+    [value],
+  );
+
+  // Filtered + sorted results
+  const results = useMemo((): SearchResult[] => {
+    const ms = miniSearch.current;
+    let filtered: SearchResult[];
+
+    if (!ms) return [];
+
+    if (keywords.length > 0) {
+      const hits = ms.search(keywords.join(" "), {
+        prefix: true,
+        fuzzy: 0.2,
+        combineWith: "AND",
+        filter:
+          chips.length > 0
+            ? (result) =>
+                chips.includes((result as unknown as MiniSearchDoc).type)
+            : undefined,
+      });
+      const hitUids = new Set(
+        hits.filter((h) => h.score >= MIN_SEARCH_SCORE).map((h) => h.id),
+      );
+      filtered = allResults.filter((r) => hitUids.has(r.uid));
+    } else if (chips.length > 0) {
+      filtered = allResults.filter((r) => chips.includes(r.type));
+    } else {
+      filtered = allResults;
+    }
+
+    return sortResults(filtered, sort);
+  }, [allResults, chips, keywords, sort]);
+
+  // Clamp activeIdx when results change
+  useEffect(() => {
+    setActiveIdx((prev) =>
+      results.length === 0 ? 0 : Math.min(prev, results.length - 1),
+    );
+  }, [results.length]);
+
+  // Scroll active row into view
+  useEffect(() => {
+    const panel = resultsRef.current;
+    if (!panel) return;
+    const active = panel.querySelector(
+      ".dg-as-result.active",
+    ) as HTMLElement | null;
+    if (!active) return;
+    const pr = panel.getBoundingClientRect();
+    const er = active.getBoundingClientRect();
+    if (er.top < pr.top) panel.scrollTop -= pr.top - er.top + 4;
+    else if (er.bottom > pr.bottom)
+      panel.scrollTop += er.bottom - pr.bottom + 4;
+  }, [activeIdx]);
+
+  const typeConfigsById = useMemo(
+    () => Object.fromEntries(typeConfigs.map((t) => [t.id, t])),
+    [typeConfigs],
+  );
+
+  const currentSortLabel = useMemo(() => {
+    const labels: Record<string, string> = {
+      relevance: "Relevance",
+      date_modified: "Date modified",
+      date_created: "Date created",
+      alphabetical: "Alphabetical",
+      most_connected: "Most connected",
+    };
+    return labels[sort.key] ?? "Relevance";
+  }, [sort.key]);
+
+  const closePopovers = useCallback(() => {
+    setShowFilterPop(false);
+    setShowSort(false);
+    setShowHelp(false);
+  }, []);
+
+  const handleEscape = useCallback(() => {
+    if (showFilterPop || showSort || showHelp) {
+      closePopovers();
+    } else {
+      onClose();
+    }
+  }, [showFilterPop, showSort, showHelp, closePopovers, onClose]);
+
+  return (
+    <Dialog
+      isOpen={isOpen}
+      onClose={onClose}
+      canOutsideClickClose
+      canEscapeKeyClose={false} // handled manually to close popovers first
+      className="dg-adv-search-dialog"
+      portalClassName="dg-adv-search-portal"
+    >
+      <div
+        className="dg-as-modal"
+        onKeyDown={(e) => {
+          if (e.key === "Escape") {
+            e.stopPropagation();
+            handleEscape();
+          }
+        }}
+      >
+        {/* Search row */}
+        <div className="dg-as-search-row">
+          <SearchIcon />
+          <ChipsSearchInput
+            chips={chips}
+            setChips={setChips}
+            value={value}
+            setValue={setValue}
+            types={typeConfigs}
+            inputRef={inputRef}
+            onArrowDown={() =>
+              setActiveIdx((i) => Math.min(i + 1, results.length - 1))
+            }
+            onArrowUp={() => setActiveIdx((i) => Math.max(i - 1, 0))}
+            onEnter={() => {
+              /* TODO ENG-1682 */
+            }}
+            onShiftEnter={() => {
+              /* TODO ENG-1682 */
+            }}
+            onCmdEnter={() => {
+              /* TODO ENG-1682 */
+            }}
+            onEscape={handleEscape}
+          />
+          <div className="dg-as-actions">
+            <button
+              ref={filterTriggerRef}
+              className={`dg-as-icon-btn${showFilterPop || chips.length > 0 ? "active" : ""}`}
+              onClick={() => {
+                setShowFilterPop((s) => !s);
+                setShowSort(false);
+                setShowHelp(false);
+              }}
+              aria-label="Filter by type"
+              aria-expanded={showFilterPop}
+            >
+              <FilterIcon />
+              {chips.length > 0 && (
+                <span className="dg-as-count-pill">{chips.length}</span>
+              )}
+            </button>
+
+            <button
+              ref={sortTriggerRef}
+              className={`dg-as-sort-pill${showSort ? "active" : ""}`}
+              onClick={() => {
+                setShowSort((s) => !s);
+                setShowFilterPop(false);
+                setShowHelp(false);
+              }}
+              aria-label="Sort"
+              aria-expanded={showSort}
+            >
+              <SortIcon />
+              <span>{currentSortLabel}</span>
+              <ChevronDownIcon />
+            </button>
+
+            <button
+              ref={helpTriggerRef}
+              className={`dg-as-icon-btn${showHelp ? "active" : ""}`}
+              onClick={() => {
+                setShowHelp((s) => !s);
+                setShowFilterPop(false);
+                setShowSort(false);
+              }}
+              aria-label="Keyboard shortcuts"
+            >
+              <HelpIcon />
+            </button>
+          </div>
+
+          {showFilterPop && (
+            <FilterPopover
+              types={typeConfigs}
+              chips={chips}
+              setChips={setChips}
+              triggerRef={filterTriggerRef}
+              onClose={() => setShowFilterPop(false)}
+            />
+          )}
+          {showSort && (
+            <SortDropdown
+              sort={sort}
+              setSort={setSort}
+              triggerRef={sortTriggerRef}
+              onClose={() => setShowSort(false)}
+            />
+          )}
+          {showHelp && (
+            <HelpPopover
+              types={typeConfigs}
+              triggerRef={helpTriggerRef}
+              onClose={() => setShowHelp(false)}
+            />
+          )}
+        </div>
+
+        {/* Split body */}
+        <div className="dg-as-body">
+          {/* Left: results list */}
+          <div className="dg-as-results-panel" ref={resultsRef} role="listbox">
+            {isLoading ? (
+              <div className="dg-as-results-loading">Loading nodes…</div>
+            ) : results.length === 0 ? (
+              <div className="dg-as-results-empty">
+                No matches. Try removing a filter or keyword.
+              </div>
+            ) : (
+              results.map((r, i) => (
+                <ResultRow
+                  key={r.uid}
+                  result={r}
+                  typeConfig={typeConfigsById[r.type]}
+                  active={i === activeIdx}
+                  keywords={keywords}
+                  onMouseEnter={() => setActiveIdx(i)}
+                  onClick={() => setActiveIdx(i)}
+                />
+              ))
+            )}
+          </div>
+
+          {/* Right: preview */}
+          <PreviewPane
+            result={results[activeIdx] ?? null}
+            typeConfig={
+              results[activeIdx]
+                ? (typeConfigsById[results[activeIdx].type] ?? null)
+                : null
+            }
+            keywords={keywords}
+          />
+        </div>
+
+        {/* Footer */}
+        <div className="dg-as-footer">
+          <span className="dg-as-footer-keys">
+            <span className="dg-as-key-group">
+              <kbd>↑</kbd>
+              <kbd>↓</kbd> navigate
+            </span>
+            <span className="dg-as-key-group">
+              <kbd>↵</kbd> sidebar
+            </span>
+            <span className="dg-as-key-group">
+              <kbd>⇧↵</kbd> main
+            </span>
+            <span className="dg-as-key-group">
+              <kbd>⌘↵</kbd> open all
+            </span>
+          </span>
+          <span className="dg-as-key-group">
+            <kbd>esc</kbd> close
+          </span>
+        </div>
+      </div>
+    </Dialog>
+  );
+};
+
+export const renderAdvancedSearchDialog = () =>
+  renderOverlay({ Overlay: AdvancedSearchDialog, props: {} });

--- a/apps/roam/src/components/AdvancedSearchDialog/index.tsx
+++ b/apps/roam/src/components/AdvancedSearchDialog/index.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 import React, {
   useState,
   useRef,
@@ -172,7 +173,9 @@ const AdvancedSearchDialog = ({ isOpen, onClose }: Props) => {
             : undefined,
       });
       const hitUids = new Set(
-        hits.filter((h) => h.score >= MIN_SEARCH_SCORE).map((h) => h.id),
+        hits
+          .filter((h) => h.score >= MIN_SEARCH_SCORE)
+          .map((h) => h.id as string),
       );
       filtered = allResults.filter((r) => hitUids.has(r.uid));
     } else if (chips.length > 0) {
@@ -195,9 +198,7 @@ const AdvancedSearchDialog = ({ isOpen, onClose }: Props) => {
   useEffect(() => {
     const panel = resultsRef.current;
     if (!panel) return;
-    const active = panel.querySelector(
-      ".dg-as-result.active",
-    ) as HTMLElement | null;
+    const active = panel.querySelector(".dg-as-result.active");
     if (!active) return;
     const pr = panel.getBoundingClientRect();
     const er = active.getBoundingClientRect();
@@ -301,7 +302,7 @@ const AdvancedSearchDialog = ({ isOpen, onClose }: Props) => {
 
             <button
               ref={sortTriggerRef}
-              className={`dg-as-sort-pill${showSort ? "active" : ""}`}
+              className={`dg-as-sort-pill ${showSort ? "active" : ""}`}
               onClick={() => {
                 setShowSort((s) => !s);
                 setShowFilterPop(false);

--- a/apps/roam/src/components/AdvancedSearchDialog/types.ts
+++ b/apps/roam/src/components/AdvancedSearchDialog/types.ts
@@ -1,3 +1,4 @@
+import { type CSSProperties } from "react";
 import { type DiscourseNode } from "~/utils/getDiscourseNodes";
 
 export type SearchResult = {
@@ -29,6 +30,7 @@ export type NodeTypeConfig = {
   label: string;
   abbrev: string; // 3-letter display, e.g. "EVD"
   color: string;
+  badgeStyle: CSSProperties; // computed once via getNodeTagStyles in index.tsx
   trigger: string; // abbrev lowercased, e.g. "evd"
   aliases: string[]; // all recognized aliases for chip trigger
   kind: "node" | "page" | "block";
@@ -37,6 +39,22 @@ export type NodeTypeConfig = {
 export type TextSegment = {
   text: string;
   hit: boolean;
+};
+
+/** Strip [[TypeName]] - prefix from a discourse node title. */
+export const stripTypePrefix = (title: string): string => {
+  const match = title.match(/^\[\[.*?\]\]\s*-\s*(.*)/s);
+  return match ? match[1] : title;
+};
+
+/** Convert a 6-digit hex color to rgba for dynamic chip/dot tinting. */
+export const hexToRgba = (hex: string, alpha: number): string => {
+  const clean = hex.replace("#", "");
+  if (clean.length !== 6) return hex;
+  const r = parseInt(clean.slice(0, 2), 16);
+  const g = parseInt(clean.slice(2, 4), 16);
+  const b = parseInt(clean.slice(4, 6), 16);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
 };
 
 /** Split text into highlighted/plain segments for keyword matching. */

--- a/apps/roam/src/components/AdvancedSearchDialog/types.ts
+++ b/apps/roam/src/components/AdvancedSearchDialog/types.ts
@@ -1,0 +1,100 @@
+import { type DiscourseNode } from "~/utils/getDiscourseNodes";
+
+export type SearchResult = {
+  uid: string;
+  title: string;
+  type: string; // matches NodeTypeConfig.id
+  refs: number;
+  lastModified: string;
+  authorName: string;
+  fromCurrentGraph: boolean;
+};
+
+export type SortKey =
+  | "relevance"
+  | "date_modified"
+  | "date_created"
+  | "alphabetical"
+  | "most_connected";
+
+export type SortDir = "asc" | "desc";
+
+export type Sort = {
+  key: SortKey;
+  dir: SortDir;
+};
+
+export type NodeTypeConfig = {
+  id: string;
+  label: string;
+  abbrev: string; // 3-letter display, e.g. "EVD"
+  color: string;
+  trigger: string; // abbrev lowercased, e.g. "evd"
+  aliases: string[]; // all recognized aliases for chip trigger
+  kind: "node" | "page" | "block";
+};
+
+export type TextSegment = {
+  text: string;
+  hit: boolean;
+};
+
+/** Split text into highlighted/plain segments for keyword matching. */
+export const splitWithHighlights = (
+  text: string,
+  keywords: string[],
+): TextSegment[] => {
+  if (!keywords.length) return [{ text, hit: false }];
+
+  const escaped = keywords.map((k) => k.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+  const regex = new RegExp(`(${escaped.join("|")})`, "gi");
+  const parts = text.split(regex);
+
+  return parts
+    .filter((p) => p.length > 0)
+    .map((part) => ({
+      text: part,
+      hit: regex.test(part),
+    }));
+};
+
+/** Build NodeTypeConfig array from DiscourseNode list. */
+export const buildNodeTypeConfigs = (
+  nodes: DiscourseNode[],
+): NodeTypeConfig[] => {
+  return nodes.map((node): NodeTypeConfig => {
+    const kind =
+      node.type === "page-node"
+        ? "page"
+        : node.type === "blck-node"
+          ? "block"
+          : "node";
+
+    // Derive abbreviation: prefer node.tag (first 3 chars), fallback to node.text
+    const abbrevSource = node.tag?.trim() ? node.tag.trim() : node.text.trim();
+    const abbrev = abbrevSource.slice(0, 3).toUpperCase();
+    const trigger = abbrev.toLowerCase();
+
+    // Build aliases: trigger, full label, tag if different
+    const aliases = Array.from(
+      new Set(
+        [
+          trigger,
+          node.text.toLowerCase(),
+          node.tag?.toLowerCase().slice(0, 3),
+          node.tag?.toLowerCase(),
+        ].filter(Boolean) as string[],
+      ),
+    );
+
+    return {
+      id: node.type,
+      label: node.text,
+      abbrev,
+      color: node.canvasSettings?.color ?? "#8E8E8E",
+      trigger,
+      aliases,
+      kind,
+    };
+  });
+};

--- a/apps/roam/src/index.ts
+++ b/apps/roam/src/index.ts
@@ -19,6 +19,7 @@ import styles from "./styles/styles.css";
 import discourseFloatingMenuStyles from "./styles/discourseFloatingMenuStyles.css";
 import settingsStyles from "./styles/settingsStyles.css";
 import discourseGraphStyles from "./styles/discourseGraphStyles.css";
+import advancedSearchStyles from "./styles/advancedSearch.css";
 import streamlineStyling from "./styles/streamlineStyling";
 import getDiscourseNodes from "./utils/getDiscourseNodes";
 import { initFeedbackWidget } from "./components/BirdEatsBugs";
@@ -86,6 +87,7 @@ export default runExtension(async (onloadArgs) => {
   const discourseGraphStyle = addStyle(discourseGraphStyles);
   const settingsStyle = addStyle(settingsStyles);
   const discourseFloatingMenuStyle = addStyle(discourseFloatingMenuStyles);
+  const advancedSearchStyle = addStyle(advancedSearchStyles);
 
   // Add streamline styling only if enabled
   const isStreamlineStylingEnabled = getSetting(STREAMLINE_STYLING_KEY, false);
@@ -152,6 +154,7 @@ export default runExtension(async (onloadArgs) => {
       settingsStyle,
       discourseGraphStyle,
       discourseFloatingMenuStyle,
+      advancedSearchStyle,
       ...(streamlineStyleElement ? [streamlineStyleElement] : []),
     ],
     observers: observers,

--- a/apps/roam/src/styles/advancedSearch.css
+++ b/apps/roam/src/styles/advancedSearch.css
@@ -28,7 +28,11 @@
   flex: 1;
   overflow: hidden;
   min-height: 0;
-  font-family: "Inter", system-ui, -apple-system, sans-serif;
+  font-family:
+    "Inter",
+    system-ui,
+    -apple-system,
+    sans-serif;
   color: #1f1f1f;
 }
 
@@ -45,10 +49,8 @@
 }
 
 .dg-as-search-icon {
-  width: 18px;
-  height: 18px;
-  color: rgba(31, 31, 31, 0.6);
   flex-shrink: 0;
+  color: rgba(31, 31, 31, 0.5) !important;
 }
 
 /* ── Chips + input ─────────────────────────────────────────────── */
@@ -82,8 +84,14 @@
 /* focused state handled via inline styles with per-type color */
 
 @keyframes dg-as-chip-in {
-  from { transform: scale(0.86); opacity: 0; }
-  to   { transform: scale(1); opacity: 1; }
+  from {
+    transform: scale(0.86);
+    opacity: 0;
+  }
+  to {
+    transform: scale(1);
+    opacity: 1;
+  }
 }
 
 .dg-as-chip-dot {
@@ -143,8 +151,12 @@
   white-space: pre;
 }
 
-.dg-as-ghost-typed { color: transparent; }
-.dg-as-ghost-completion { color: rgba(31, 31, 31, 0.35); }
+.dg-as-ghost-typed {
+  color: transparent;
+}
+.dg-as-ghost-completion {
+  color: rgba(31, 31, 31, 0.35);
+}
 
 .dg-as-ghost-tabkey {
   display: inline-flex;
@@ -230,8 +242,12 @@
   white-space: nowrap;
 }
 
-.dg-as-sort-pill:hover { background: rgba(27, 110, 194, 0.06); }
-.dg-as-sort-pill.active { background: rgba(27, 110, 194, 0.1); }
+.dg-as-sort-pill:hover {
+  background: rgba(27, 110, 194, 0.06);
+}
+.dg-as-sort-pill.active {
+  background: rgba(27, 110, 194, 0.1);
+}
 
 /* ── Split body ────────────────────────────────────────────────── */
 
@@ -271,7 +287,6 @@
   background: rgba(95, 87, 192, 0.08);
   box-shadow: inset 3px 0 0 #5f57c0;
 }
-
 
 .dg-as-type-badge {
   display: inline-flex;
@@ -452,8 +467,14 @@
 }
 
 @keyframes dg-as-pop-in {
-  from { transform: translateY(-4px); opacity: 0; }
-  to   { transform: translateY(0); opacity: 1; }
+  from {
+    transform: translateY(-4px);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
 }
 
 .dg-as-pop-search {
@@ -562,7 +583,9 @@
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
-  transition: background 100ms ease, border-color 100ms ease;
+  transition:
+    background 100ms ease,
+    border-color 100ms ease;
 }
 
 .dg-as-cb.on,

--- a/apps/roam/src/styles/advancedSearch.css
+++ b/apps/roam/src/styles/advancedSearch.css
@@ -3,7 +3,7 @@
 /* Override Blueprint Dialog defaults */
 .bp3-dialog.dg-adv-search-dialog {
   width: min(900px, 94vw);
-  max-height: 80vh;
+  height: 72vh;
   padding: 0;
   border-radius: 12px;
   box-shadow:
@@ -21,12 +21,13 @@
   padding-top: 12vh;
 }
 
-.dg-adv-search-modal {
+/* matches className="dg-as-modal" in index.tsx */
+.dg-as-modal {
   display: flex;
   flex-direction: column;
   flex: 1;
   overflow: hidden;
-  max-height: 80vh;
+  min-height: 0;
   font-family: "Inter", system-ui, -apple-system, sans-serif;
   color: #1f1f1f;
 }
@@ -67,9 +68,8 @@
   gap: 6px;
   height: 24px;
   padding: 0 8px 0 6px;
-  background: rgba(95, 87, 192, 0.08);
-  border: 1px solid rgba(95, 87, 192, 0.22);
-  color: #5f57c0;
+  /* background, border, color set via inline styles per node type color */
+  border: 1px solid transparent;
   border-radius: 6px;
   font-size: 13px;
   font-weight: 500;
@@ -79,11 +79,7 @@
   animation: dg-as-chip-in 140ms cubic-bezier(0.2, 0.7, 0.2, 1);
 }
 
-.dg-as-chip.focused {
-  background: rgba(95, 87, 192, 0.18);
-  border-color: #5f57c0;
-  box-shadow: 0 0 0 2px rgba(95, 87, 192, 0.2);
-}
+/* focused state handled via inline styles with per-type color */
 
 @keyframes dg-as-chip-in {
   from { transform: scale(0.86); opacity: 0; }
@@ -105,13 +101,14 @@
   height: 14px;
   border-radius: 3px;
   cursor: pointer;
-  color: rgba(95, 87, 192, 0.6);
+  color: currentColor;
+  opacity: 0.6;
   flex-shrink: 0;
 }
 
 .dg-as-chip-x:hover {
-  background: rgba(95, 87, 192, 0.15);
-  color: #5f57c0;
+  opacity: 1;
+  background: rgba(0, 0, 0, 0.08);
 }
 
 .dg-as-input-wrap {
@@ -242,6 +239,7 @@
   display: flex;
   flex: 1;
   overflow: hidden;
+  min-height: 0;
 }
 
 /* ── Results panel (left) ──────────────────────────────────────── */
@@ -252,16 +250,16 @@
   overflow-y: auto;
   padding: 6px 0;
   flex-shrink: 0;
+  min-height: 0;
 }
 
 .dg-as-result {
   display: grid;
-  grid-template-columns: 40px 1fr auto;
-  gap: 8px;
-  align-items: center;
+  grid-template-columns: auto 1fr;
+  gap: 10px;
+  align-items: start;
   padding: 10px 12px;
   cursor: pointer;
-  border-left: 2px solid transparent;
   user-select: none;
 }
 
@@ -271,30 +269,31 @@
 
 .dg-as-result.active {
   background: rgba(95, 87, 192, 0.08);
-  border-left-color: #5f57c0;
+  box-shadow: inset 3px 0 0 #5f57c0;
 }
+
 
 .dg-as-type-badge {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  height: 20px;
-  min-width: 34px;
-  padding: 0 5px;
-  border-radius: 4px;
+  height: 18px;
+  min-width: 30px;
+  padding: 0 4px;
+  border-radius: 3px;
   font-size: 10px;
   font-weight: 700;
-  color: #fff;
+  /* backgroundColor and color set via inline styles using getContrastColor() */
   letter-spacing: 0.05em;
   flex-shrink: 0;
+  white-space: nowrap;
 }
 
 .dg-as-result-title {
   font-size: 14px;
   color: #1f1f1f;
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
+  line-height: 1.4;
+  word-break: break-word;
 }
 
 .dg-as-ref-count {
@@ -333,6 +332,7 @@
 .dg-as-preview-panel {
   flex: 1;
   overflow-y: auto;
+  min-height: 0;
   padding: 20px 24px;
   background: #fff;
 }
@@ -565,7 +565,7 @@
   transition: background 100ms ease, border-color 100ms ease;
 }
 
-.dg-as-cb.checked,
+.dg-as-cb.on,
 .dg-as-cb.indeterminate {
   background: #1b6ec2;
   border-color: #1b6ec2;
@@ -619,6 +619,10 @@
 
 .dg-as-dropdown-item:hover {
   background: rgba(31, 31, 31, 0.04);
+}
+
+.dg-as-dropdown-item.selected {
+  background: rgba(27, 110, 194, 0.07);
 }
 
 .dg-as-dropdown-check {

--- a/apps/roam/src/styles/advancedSearch.css
+++ b/apps/roam/src/styles/advancedSearch.css
@@ -1,0 +1,710 @@
+/* ── Advanced Search Dialog ────────────────────────────────────── */
+
+/* Override Blueprint Dialog defaults */
+.bp3-dialog.dg-adv-search-dialog {
+  width: min(900px, 94vw);
+  max-height: 80vh;
+  padding: 0;
+  border-radius: 12px;
+  box-shadow:
+    0 24px 60px -12px rgba(0, 0, 0, 0.3),
+    0 8px 20px -8px rgba(0, 0, 0, 0.2),
+    0 0 0 1px rgba(31, 31, 31, 0.06);
+  overflow: hidden;
+  background: #fff;
+  display: flex;
+  flex-direction: column;
+}
+
+.bp3-dialog-container.dg-adv-search-container {
+  align-items: flex-start;
+  padding-top: 12vh;
+}
+
+.dg-adv-search-modal {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  overflow: hidden;
+  max-height: 80vh;
+  font-family: "Inter", system-ui, -apple-system, sans-serif;
+  color: #1f1f1f;
+}
+
+/* ── Search row ────────────────────────────────────────────────── */
+
+.dg-as-search-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 16px;
+  border-bottom: 1px solid rgba(31, 31, 31, 0.12);
+  position: relative;
+  flex-shrink: 0;
+}
+
+.dg-as-search-icon {
+  width: 18px;
+  height: 18px;
+  color: rgba(31, 31, 31, 0.6);
+  flex-shrink: 0;
+}
+
+/* ── Chips + input ─────────────────────────────────────────────── */
+
+.dg-as-chips-input {
+  flex: 1;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  min-height: 28px;
+}
+
+.dg-as-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 24px;
+  padding: 0 8px 0 6px;
+  background: rgba(95, 87, 192, 0.08);
+  border: 1px solid rgba(95, 87, 192, 0.22);
+  color: #5f57c0;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 500;
+  white-space: nowrap;
+  outline: none;
+  cursor: default;
+  animation: dg-as-chip-in 140ms cubic-bezier(0.2, 0.7, 0.2, 1);
+}
+
+.dg-as-chip.focused {
+  background: rgba(95, 87, 192, 0.18);
+  border-color: #5f57c0;
+  box-shadow: 0 0 0 2px rgba(95, 87, 192, 0.2);
+}
+
+@keyframes dg-as-chip-in {
+  from { transform: scale(0.86); opacity: 0; }
+  to   { transform: scale(1); opacity: 1; }
+}
+
+.dg-as-chip-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.dg-as-chip-x {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  border-radius: 3px;
+  cursor: pointer;
+  color: rgba(95, 87, 192, 0.6);
+  flex-shrink: 0;
+}
+
+.dg-as-chip-x:hover {
+  background: rgba(95, 87, 192, 0.15);
+  color: #5f57c0;
+}
+
+.dg-as-input-wrap {
+  position: relative;
+  flex: 1;
+  min-width: 80px;
+  display: inline-flex;
+}
+
+.dg-as-search-input {
+  flex: 1;
+  border: none;
+  outline: none;
+  background: transparent;
+  font: inherit;
+  font-size: 16px;
+  color: #1f1f1f;
+  padding: 2px 0;
+  caret-color: #5f57c0;
+}
+
+.dg-as-search-input::placeholder {
+  color: rgba(31, 31, 31, 0.5);
+}
+
+.dg-as-ghost {
+  position: absolute;
+  left: 0;
+  top: 2px;
+  font-size: 16px;
+  pointer-events: none;
+  white-space: pre;
+}
+
+.dg-as-ghost-typed { color: transparent; }
+.dg-as-ghost-completion { color: rgba(31, 31, 31, 0.35); }
+
+.dg-as-ghost-tabkey {
+  display: inline-flex;
+  align-items: center;
+  margin-left: 8px;
+  height: 18px;
+  padding: 0 5px;
+  border: 1px solid rgba(31, 31, 31, 0.12);
+  border-bottom-width: 2px;
+  border-radius: 4px;
+  font-family: ui-monospace, "Geist Mono", monospace;
+  font-size: 11px;
+  color: rgba(31, 31, 31, 0.6);
+  background: #fff;
+  vertical-align: 1px;
+}
+
+/* ── Actions cluster ───────────────────────────────────────────── */
+
+.dg-as-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.dg-as-icon-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: rgba(31, 31, 31, 0.6);
+  border-radius: 6px;
+  position: relative;
+  padding: 0;
+}
+
+.dg-as-icon-btn:hover {
+  background: rgba(31, 31, 31, 0.06);
+  color: #1f1f1f;
+}
+
+.dg-as-icon-btn.active {
+  background: rgba(95, 87, 192, 0.1);
+  color: #5f57c0;
+}
+
+.dg-as-count-pill {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  min-width: 14px;
+  height: 14px;
+  padding: 0 3px;
+  border-radius: 7px;
+  background: #5f57c0;
+  color: #fff;
+  font-size: 9px;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.dg-as-sort-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 30px;
+  padding: 0 8px 0 10px;
+  border: 1px solid rgba(31, 131, 221, 0.5);
+  border-radius: 6px;
+  background: #fff;
+  color: #1b6ec2;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.dg-as-sort-pill:hover { background: rgba(27, 110, 194, 0.06); }
+.dg-as-sort-pill.active { background: rgba(27, 110, 194, 0.1); }
+
+/* ── Split body ────────────────────────────────────────────────── */
+
+.dg-as-body {
+  display: flex;
+  flex: 1;
+  overflow: hidden;
+}
+
+/* ── Results panel (left) ──────────────────────────────────────── */
+
+.dg-as-results-panel {
+  width: 38%;
+  border-right: 1px solid rgba(31, 31, 31, 0.12);
+  overflow-y: auto;
+  padding: 6px 0;
+  flex-shrink: 0;
+}
+
+.dg-as-result {
+  display: grid;
+  grid-template-columns: 40px 1fr auto;
+  gap: 8px;
+  align-items: center;
+  padding: 10px 12px;
+  cursor: pointer;
+  border-left: 2px solid transparent;
+  user-select: none;
+}
+
+.dg-as-result:hover {
+  background: rgba(31, 31, 31, 0.03);
+}
+
+.dg-as-result.active {
+  background: rgba(95, 87, 192, 0.08);
+  border-left-color: #5f57c0;
+}
+
+.dg-as-type-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 20px;
+  min-width: 34px;
+  padding: 0 5px;
+  border-radius: 4px;
+  font-size: 10px;
+  font-weight: 700;
+  color: #fff;
+  letter-spacing: 0.05em;
+  flex-shrink: 0;
+}
+
+.dg-as-result-title {
+  font-size: 14px;
+  color: #1f1f1f;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.dg-as-ref-count {
+  font-size: 10px;
+  color: rgba(31, 31, 31, 0.5);
+  vertical-align: super;
+  flex-shrink: 0;
+}
+
+.dg-as-results-empty {
+  padding: 48px 16px;
+  text-align: center;
+  color: rgba(31, 31, 31, 0.5);
+  font-size: 14px;
+}
+
+.dg-as-results-loading {
+  padding: 32px 16px;
+  text-align: center;
+  color: rgba(31, 31, 31, 0.5);
+  font-size: 13px;
+}
+
+/* Keyword highlights */
+.dg-as-result mark,
+.dg-as-preview-title mark,
+.dg-as-preview-body mark {
+  background: rgba(255, 200, 60, 0.45);
+  color: inherit;
+  border-radius: 2px;
+  padding: 0 1px;
+}
+
+/* ── Preview panel (right) ─────────────────────────────────────── */
+
+.dg-as-preview-panel {
+  flex: 1;
+  overflow-y: auto;
+  padding: 20px 24px;
+  background: #fff;
+}
+
+.dg-as-preview-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: rgba(31, 31, 31, 0.4);
+  font-size: 13px;
+}
+
+.dg-as-preview-badge {
+  height: 24px;
+  min-width: 44px;
+  font-size: 12px;
+  border-radius: 5px;
+}
+
+.dg-as-preview-title {
+  font-size: 21px;
+  font-weight: 700;
+  color: #1f1f1f;
+  margin: 12px 0 16px;
+  line-height: 1.3;
+}
+
+.dg-as-preview-body {
+  font-size: 15px;
+  line-height: 1.7;
+  color: rgba(31, 31, 31, 0.8);
+}
+
+.dg-as-preview-body p {
+  margin: 0 0 6px;
+}
+
+.dg-as-preview-body-empty {
+  color: rgba(31, 31, 31, 0.35);
+  font-style: italic;
+  font-size: 14px;
+}
+
+.dg-as-preview-meta {
+  margin-top: 20px;
+  font-size: 11px;
+  font-family: ui-monospace, monospace;
+  color: rgba(31, 31, 31, 0.5);
+  border-top: 1px solid rgba(31, 31, 31, 0.08);
+  padding-top: 12px;
+}
+
+.dg-as-preview-cross-graph {
+  margin-top: 6px;
+  font-size: 11px;
+  color: rgba(31, 31, 31, 0.4);
+  font-style: italic;
+}
+
+/* ── Footer ────────────────────────────────────────────────────── */
+
+.dg-as-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 16px;
+  border-top: 1px solid rgba(31, 31, 31, 0.12);
+  background: #fafafa;
+  font-size: 11px;
+  color: rgba(31, 31, 31, 0.6);
+  flex-shrink: 0;
+}
+
+.dg-as-footer-keys {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+
+.dg-as-key-group {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.dg-as-modal kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 18px;
+  padding: 0 5px;
+  border: 1px solid rgba(31, 31, 31, 0.2);
+  border-bottom-width: 2px;
+  border-radius: 4px;
+  font-family: ui-monospace, monospace;
+  font-size: 11px;
+  background: #fff;
+  color: rgba(31, 31, 31, 0.8);
+  line-height: 1;
+}
+
+/* ── Filter popover ────────────────────────────────────────────── */
+
+.dg-as-filter-pop {
+  width: 280px;
+  background: #fff;
+  border: 1px solid rgba(31, 31, 31, 0.1);
+  border-radius: 8px;
+  box-shadow:
+    0 12px 32px -8px rgba(0, 0, 0, 0.18),
+    0 4px 12px -4px rgba(0, 0, 0, 0.1),
+    0 0 0 1px rgba(31, 31, 31, 0.04);
+  overflow: hidden;
+  animation: dg-as-pop-in 120ms cubic-bezier(0.2, 0.7, 0.2, 1);
+}
+
+@keyframes dg-as-pop-in {
+  from { transform: translateY(-4px); opacity: 0; }
+  to   { transform: translateY(0); opacity: 1; }
+}
+
+.dg-as-pop-search {
+  padding: 10px 12px;
+  border-bottom: 1px solid rgba(31, 31, 31, 0.12);
+}
+
+.dg-as-pop-search-input {
+  width: 100%;
+  border: none;
+  outline: none;
+  background: transparent;
+  font: inherit;
+  font-size: 14px;
+  color: #1f1f1f;
+}
+
+.dg-as-pop-search-input::placeholder {
+  color: rgba(31, 31, 31, 0.5);
+}
+
+.dg-as-pop-list {
+  padding: 4px 0;
+  max-height: 360px;
+  overflow-y: auto;
+}
+
+.dg-as-pop-section + .dg-as-pop-section {
+  border-top: 1px solid rgba(31, 31, 31, 0.12);
+  margin-top: 4px;
+  padding-top: 4px;
+}
+
+.dg-as-pop-row {
+  display: grid;
+  grid-template-columns: 22px 14px 1fr auto;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  cursor: pointer;
+  font-size: 14px;
+  color: #1f1f1f;
+  position: relative;
+}
+
+.dg-as-pop-row:hover {
+  background: rgba(31, 31, 31, 0.04);
+}
+
+.dg-as-pop-row .dg-as-only-btn {
+  font-size: 12px;
+  color: #5f57c0;
+  opacity: 0;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-weight: 500;
+  font-family: inherit;
+}
+
+.dg-as-pop-row:hover .dg-as-only-btn {
+  opacity: 1;
+}
+
+.dg-as-only-btn:hover {
+  background: rgba(95, 87, 192, 0.12);
+}
+
+.dg-as-pop-dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.dg-as-pop-ring {
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+  border: 1.5px solid rgba(31, 31, 31, 0.5);
+  background: transparent;
+  flex-shrink: 0;
+}
+
+.dg-as-pop-select-all-label {
+  font-weight: 600;
+}
+
+.dg-as-pop-empty {
+  padding: 12px;
+  text-align: center;
+  font-size: 13px;
+  color: rgba(31, 31, 31, 0.5);
+}
+
+/* Checkbox */
+.dg-as-cb {
+  width: 16px;
+  height: 16px;
+  border: 1.5px solid rgba(31, 31, 31, 0.3);
+  border-radius: 3px;
+  background: #fff;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: background 100ms ease, border-color 100ms ease;
+}
+
+.dg-as-cb.checked,
+.dg-as-cb.indeterminate {
+  background: #1b6ec2;
+  border-color: #1b6ec2;
+}
+
+.dg-as-cb.indeterminate::after {
+  content: "";
+  width: 8px;
+  height: 2px;
+  background: #fff;
+  border-radius: 1px;
+}
+
+/* ── Sort dropdown ─────────────────────────────────────────────── */
+
+.dg-as-dropdown {
+  width: 240px;
+  background: #fff;
+  border: 1px solid rgba(31, 31, 31, 0.1);
+  border-radius: 8px;
+  box-shadow:
+    0 12px 32px -8px rgba(0, 0, 0, 0.18),
+    0 4px 12px -4px rgba(0, 0, 0, 0.1),
+    0 0 0 1px rgba(31, 31, 31, 0.04);
+  padding: 4px 0;
+  animation: dg-as-pop-in 120ms cubic-bezier(0.2, 0.7, 0.2, 1);
+}
+
+.dg-as-dropdown-label {
+  padding: 8px 12px 4px;
+  font-size: 12px;
+  color: rgba(31, 31, 31, 0.6);
+  font-weight: 500;
+}
+
+.dg-as-dropdown-item {
+  display: grid;
+  grid-template-columns: 22px 1fr auto;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 7px 12px;
+  background: transparent;
+  border: none;
+  font: inherit;
+  font-size: 14px;
+  color: #1f1f1f;
+  text-align: left;
+  cursor: pointer;
+}
+
+.dg-as-dropdown-item:hover {
+  background: rgba(31, 31, 31, 0.04);
+}
+
+.dg-as-dropdown-check {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: #1b6ec2;
+}
+
+.dg-as-dropdown-item.selected .dg-as-dropdown-item-label {
+  font-weight: 600;
+}
+
+.dg-as-dir-toggles {
+  display: inline-flex;
+  gap: 2px;
+}
+
+.dg-as-dir-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  border-radius: 3px;
+  color: rgba(31, 31, 31, 0.3);
+  padding: 0;
+}
+
+.dg-as-dir-btn.active {
+  color: #1b6ec2;
+  background: rgba(27, 110, 194, 0.1);
+}
+
+.dg-as-dir-btn:hover:not(.active) {
+  color: rgba(31, 31, 31, 0.6);
+  background: rgba(31, 31, 31, 0.06);
+}
+
+/* ── Help popover ──────────────────────────────────────────────── */
+
+.dg-as-help-pop {
+  width: 320px;
+  background: #fff;
+  border: 1px solid rgba(31, 31, 31, 0.12);
+  border-radius: 10px;
+  box-shadow:
+    0 10px 15px -3px rgba(0, 0, 0, 0.1),
+    0 4px 6px -4px rgba(0, 0, 0, 0.05);
+  padding: 14px 14px 12px;
+  font-size: 13px;
+  animation: dg-as-pop-in 120ms cubic-bezier(0.2, 0.7, 0.2, 1);
+}
+
+.dg-as-help-pop h4 {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: rgba(31, 31, 31, 0.6);
+  margin: 12px 0 6px;
+  font-weight: 600;
+}
+
+.dg-as-help-pop h4:first-child {
+  margin-top: 0;
+}
+
+.dg-as-help-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 3px 0;
+  color: rgba(31, 31, 31, 0.8);
+}
+
+.dg-as-help-keys {
+  display: inline-flex;
+  gap: 3px;
+}
+
+.dg-as-triggers-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2px 16px;
+  color: rgba(31, 31, 31, 0.8);
+}

--- a/apps/roam/src/utils/registerCommandPaletteCommands.ts
+++ b/apps/roam/src/utils/registerCommandPaletteCommands.ts
@@ -29,6 +29,7 @@ import refreshConfigTree from "~/utils/refreshConfigTree";
 import { refreshAndNotify } from "~/components/LeftSidebarView";
 import { setPersonalSetting } from "~/components/settings/utils/accessors";
 import { sectionsToBlockProps } from "~/components/settings/LeftSidebarPersonalSettings";
+import { renderAdvancedSearchDialog } from "~/components/AdvancedSearchDialog";
 
 type BlockSelection = {
   selectionStart: number;
@@ -314,6 +315,9 @@ export const registerCommandPaletteCommands = (onloadArgs: OnloadArgs) => {
   };
 
   // Roam organizes commands alphabetically
+  void addCommand("DG: Open Node Search Menu", () =>
+    renderAdvancedSearchDialog(),
+  );
   void addCommand("DG: Create/Insert discourse node", () =>
     createDiscourseNodeFromCommand(extensionAPI),
   );


### PR DESCRIPTION
## Summary

Implements the Advanced Search dialog for Roam, triggered from the command palette via **"DG: Open Node Search Menu"**.

- **Chip-based type filters**: type a 3-letter trigger + space (e.g. `evd `) to add a filter chip; Tab autocompletes ghost text; Backspace focuses then removes the last chip; ←/→ navigates between chips; triggers derived from `node.tag`
- **Filter popover**: tri-state select-all, per-row "Only" button, type-search field — portaled to `document.body` so it escapes the modal's `overflow: hidden`
- **Sort dropdown**: Relevance, Date modified, Date created, Alphabetical, Most connected — with per-sort directional toggles for applicable sorts
- **Help popover**: keyboard shortcuts + all type triggers dynamically listed from the user's discourse graph config
- **Split-view layout**: left panel shows results list with type badge + highlighted title + ref count; right panel shows a live content preview of the active node
- **MiniSearch**: fuzzy/prefix client-side search across all signed-in graphs (via `getAllDiscourseNodesSince`)
- **Preview pane**: debounced `pull()` for current-graph nodes (80ms, cached); cross-graph nodes show metadata + "open to view" note

Enter/open actions (`↵`, `⇧↵`, `⌘↵`) are no-op stubs — covered in ENG-1682.

## Test plan

- [ ] Open command palette → type "DG: Open Node Search Menu" → dialog opens
- [ ] Type a search term → results appear with keyword highlights
- [ ] Type `evd ` (or other node tag prefix + space) → chip is added, results filter to that type
- [ ] Type partial prefix (e.g. `ev`) → ghost autocomplete appears → Tab adds chip
- [ ] Arrow keys navigate results → right panel updates to show preview
- [ ] Backspace at empty input → focuses last chip; second Backspace removes it
- [ ] ←/→ navigate between focused chips
- [ ] Filter button → popover opens with all node types; "Only" button filters to single type; "Select all" tri-states correctly
- [x] Sort pill → dropdown opens; selecting a sort changes result order; directional toggles work
- [x] Help button → popover shows all type triggers and keyboard shortcuts
- [ ] Esc closes popover if one is open; second Esc closes the dialog
- [ ] Current-graph node selected → preview shows live block content
- [ ] Cross-graph node selected → preview shows "open to view full content" note

🤖 Generated with [Claude Code](https://claude.com/claude-code)