### PR TITLE
ENG-1550: Fix # fragment encoding in markdown links and wikilinks during import

### DIFF
--- a/apps/obsidian/src/utils/importNodes.ts
+++ b/apps/obsidian/src/utils/importNodes.ts
@@ -604,51 +604,59 @@ const updateMarkdownAssetLinks = ({
       return linkPath;
     }
 
-    // First, try to find if this link resolves to one of our imported assets
-    const importedAssetFile = findImportedAssetFile(linkPath);
-    if (importedAssetFile) {
-      return getRelativeLinkPath(importedAssetFile.path);
-    }
+    // Separate file path from heading/block fragment (e.g. "Note.md#section" → filePath="Note.md", fragment="#section")
+    // so that file resolution operates only on the file path portion.
+    const hashIndex = linkPath.indexOf("#");
+    const filePath = hashIndex !== -1 ? linkPath.slice(0, hashIndex) : linkPath;
+    const fragment = hashIndex !== -1 ? linkPath.slice(hashIndex) : "";
 
-    // Direct lookup from pathMapping (record built when we downloaded each asset)
-    const newPath = getNewPathForLink(linkPath);
-    if (newPath) {
-      const newFile = app.metadataCache.getFirstLinkpathDest(
-        newPath,
+    const resolveFilePath = (path: string): string => {
+      // First, try to find if this link resolves to one of our imported assets
+      const importedAssetFile = findImportedAssetFile(path);
+      if (importedAssetFile) {
+        return getRelativeLinkPath(importedAssetFile.path);
+      }
+
+      // Direct lookup from pathMapping (record built when we downloaded each asset)
+      const newPath = getNewPathForLink(path);
+      if (newPath) {
+        const newFile = app.metadataCache.getFirstLinkpathDest(
+          newPath,
+          targetFile.path,
+        );
+        if (newFile) {
+          return getRelativeLinkPath(newFile.path);
+        }
+      }
+
+      // Only resolve to files under import/{spaceName}/ so we don't point at the wrong vault's files
+      const resolvedFile = app.metadataCache.getFirstLinkpathDest(
+        path,
         targetFile.path,
       );
-      if (newFile) {
-        return getRelativeLinkPath(newFile.path);
+      const isInImportFolder =
+        importFolder &&
+        resolvedFile &&
+        resolvedFile.path.startsWith(importFolder + "/");
+      if (isInImportFolder && resolvedFile) {
+        return getRelativeLinkPath(resolvedFile.path);
       }
-    }
 
-    // Only resolve to files under import/{spaceName}/ so we don't point at the wrong vault's files
-    const resolvedFile = app.metadataCache.getFirstLinkpathDest(
-      linkPath,
-      targetFile.path,
-    );
-    const isInImportFolder =
-      importFolder &&
-      resolvedFile &&
-      resolvedFile.path.startsWith(importFolder + "/");
-    if (isInImportFolder && resolvedFile) {
-      return getRelativeLinkPath(resolvedFile.path);
-    }
+      // Unresolved (dead) link from another vault: rewrite so that when the user creates the file from this link, it is created under import/{vaultName}/ in the same relative position as in the source vault
+      if (importFolder && originalNodePath && !resolvedFile) {
+        // Vault-relative link (e.g. "Discourse Nodes/EVD - no relation testing") -> use as-is. Path-from-current-file (e.g. "EVD - no relation testing") -> resolve relative to source note dir
+        const canonicalSourcePath =
+          path.includes("/") && !path.startsWith(".") && !path.startsWith("/")
+            ? normalizePathForLookup(path)
+            : (getCanonicalFromOriginalNote(path) ??
+              normalizePathForLookup(path));
+        return `${importFolder}/${canonicalSourcePath}`;
+      }
 
-    // Unresolved (dead) link from another vault: rewrite so that when the user creates the file from this link, it is created under import/{vaultName}/ in the same relative position as in the source vault
-    if (importFolder && originalNodePath && !resolvedFile) {
-      // Vault-relative link (e.g. "Discourse Nodes/EVD - no relation testing") -> use as-is. Path-from-current-file (e.g. "EVD - no relation testing") -> resolve relative to source note dir
-      const canonicalSourcePath =
-        linkPath.includes("/") &&
-        !linkPath.startsWith(".") &&
-        !linkPath.startsWith("/")
-          ? normalizePathForLookup(linkPath)
-          : (getCanonicalFromOriginalNote(linkPath) ??
-            normalizePathForLookup(linkPath));
-      return `${importFolder}/${canonicalSourcePath}`;
-    }
+      return path;
+    };
 
-    return linkPath;
+    return resolveFilePath(filePath) + fragment;
   };
 
   // Match wiki links: [[path]] or [[path|alias]]
@@ -662,8 +670,13 @@ const updateMarkdownAssetLinks = ({
         .map((s: string) => s.trim());
       if (!linkPath) return match;
       let processedPath = processLink(linkPath);
-      if (processedPath.endsWith(".md") && !linkPath.endsWith(".md"))
-        processedPath = processedPath.substring(0, processedPath.length - 3);
+      const hashIdx = processedPath.indexOf("#");
+      const pathBeforeHash =
+        hashIdx !== -1 ? processedPath.slice(0, hashIdx) : processedPath;
+      const pathAfterHash = hashIdx !== -1 ? processedPath.slice(hashIdx) : "";
+      if (pathBeforeHash.endsWith(".md") && !linkPath.endsWith(".md")) {
+        processedPath = pathBeforeHash.slice(0, -3) + pathAfterHash;
+      }
       if (alias) {
         return `[[${processedPath}|${alias}]]`;
       }
@@ -1545,9 +1558,20 @@ export const refreshAllImportedFiles = async (
 };
 
 const encodePathForMarkdownLink = (linkPath: string): string => {
-  // Input is already decoded; encode each segment (spaces → %20) but keep / as separator
-  return linkPath
+  // Input is already decoded; encode each segment (spaces → %20) but keep / as separator.
+  // Split on the first # to preserve heading/block fragments (e.g. "Note.md#section" → "Note.md#section", not "Note.md%23section").
+  const hashIndex = linkPath.indexOf("#");
+  if (hashIndex === -1) {
+    return linkPath
+      .split("/")
+      .map((segment) => encodeURIComponent(segment))
+      .join("/");
+  }
+  const pathPart = linkPath.slice(0, hashIndex);
+  const fragment = linkPath.slice(hashIndex); // includes the leading #
+  const encodedPath = pathPart
     .split("/")
     .map((segment) => encodeURIComponent(segment))
     .join("/");
+  return encodedPath + fragment;
 };


### PR DESCRIPTION
https://www.loom.com/share/a00c76ac173b44be803a0917fc1d02c9


## Summary

- **`encodePathForMarkdownLink`**: Split on the first `#` before percent-encoding path segments, so heading/block fragments (e.g. `#section`, `#^block-id`) are preserved as `#section` instead of being encoded as `%23section`
- **`processLink`**: Strip the `#fragment` before all file-resolution logic, then re-append it to the returned path — previously, successfully resolved wikilinks (e.g. `[[Note#Section]]`) would silently drop the heading reference
- **Wikilink `.md` stripping**: The `.endsWith(".md")` check now operates only on the path portion before `#`, so paths like `import/space/Note.md#Section` correctly strip the `.md` extension

## Root cause

`encodeURIComponent("#") === "%23"`, so the old `encodePathForMarkdownLink` turned `[text](Note.md#section)` into `[text](Note.md%23section)`. Obsidian interprets the latter as pointing to a file literally named `Note.md#section` rather than the `Section` heading inside `Note.md`.

The secondary bug in `processLink` passed the full `Note.md#section` string to `app.metadataCache.getFirstLinkpathDest`, which can't resolve a fragment-appended path, and returned a bare file path — discarding the fragment entirely.

## Test plan

- [x] Import a note with `[text](Note.md#section)` — verify the link renders as `[text](Note.md#section)` (relative equivalent), not `[text](Note.md%23section)`
- [x] Import a note with `[text](Note.md#^block-id)` — verify block reference is preserved
- [x] Import a note with `[[Note#Section]]` — verify section reference is preserved in the output wikilink
- [x] Normal links without `#` still work: `[text](Note.md)`, `[text](folder/Note.md)`
- [x] Spaces still encoded: `[text](Note With Spaces.md)` → `[text](Note%20With%20Spaces.md)`
- [x] External URLs pass through unchanged: `[text](https://example.com)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)