### PR TITLE
ENG-949: Add query sections to the left sidebar

### DIFF
--- a/apps/roam/src/components/LeftSidebarView.tsx
+++ b/apps/roam/src/components/LeftSidebarView.tsx
@@ -30,9 +30,10 @@ import {
   notify,
   subscribe,
 } from "~/utils/discourseConfigRef";
-import type {
-  LeftSidebarConfig,
-  LeftSidebarPersonalSectionConfig,
+import {
+  isQuerySection,
+  type LeftSidebarConfig,
+  type LeftSidebarPersonalSectionConfig,
 } from "~/utils/getLeftSidebarSettings";
 import { createBlock } from "roamjs-components/writes";
 import deleteBlock from "roamjs-components/writes/deleteBlock";
@@ -48,6 +49,8 @@ import getPageTitleByPageUid from "roamjs-components/queries/getPageTitleByPageU
 import { migrateLeftSidebarSettings } from "~/utils/migrateLeftSidebarSettings";
 import posthog from "posthog-js";
 import { commands, cleanCommandName } from "~/components/LeftSidebarCommands";
+import fireQuery from "~/utils/fireQuery";
+import parseQuery from "~/utils/parseQuery";
 
 const parseReference = (text: string) => {
   const extracted = extractRef(text);
@@ -289,6 +292,151 @@ const PersonalSectionItem = ({
   );
 };
 
+const QuerySectionItem = ({
+  section,
+  dragHandle,
+  onloadArgs,
+}: {
+  section: LeftSidebarPersonalSectionConfig;
+  dragHandle: SortableHandle;
+  onloadArgs: OnloadArgs;
+}) => {
+  const queryUid = extractRef(section.text);
+  const alias = section.settings?.alias?.value;
+  const queryLabel = useMemo(() => getTextByBlockUid(queryUid), [queryUid]);
+  const displayName = alias || queryLabel || section.text;
+  const truncateAt = section.settings?.truncateResult.value;
+  const resultLimit = section.settings?.resultLimit?.value ?? 0;
+
+  const [isOpen, setIsOpen] = useState<boolean>(
+    !!section.settings?.folded.value || false,
+  );
+  const [results, setResults] = useState<ChildNode[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [hasLoaded, setHasLoaded] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+
+  const runQuery = useCallback(() => {
+    setIsLoading(true);
+    setError(null);
+    const args = parseQuery(queryUid);
+    fireQuery(args)
+      .then((queryResults) => {
+        const limited =
+          resultLimit > 0 ? queryResults.slice(0, resultLimit) : queryResults;
+        const children: ChildNode[] = limited.map((r) => {
+          const pageTitle = getPageTitleByPageUid(r.uid);
+          return {
+            uid: r.uid,
+            text: pageTitle ? r.uid : `((${r.uid}))`,
+          };
+        });
+        setResults(children);
+      })
+      .catch(() => setError("Query failed to run"))
+      .finally(() => {
+        setIsLoading(false);
+        setHasLoaded(true);
+      });
+  }, [queryUid, resultLimit]);
+
+  useEffect(() => {
+    if (isOpen && !hasLoaded) {
+      runQuery();
+    }
+  }, [isOpen, hasLoaded, runQuery]);
+
+  const handleChevronClick = () => {
+    if (!section.settings) return;
+    toggleFoldedState({
+      isOpen,
+      setIsOpen,
+      folded: section.settings.folded,
+      parentUid: section.settings.uid || "",
+    });
+  };
+
+  return (
+    <>
+      <div
+        {...dragHandle.attributes}
+        {...dragHandle.listeners}
+        className="sidebar-title-button flex w-full cursor-pointer items-center border-none bg-transparent pl-6 pr-2.5 font-semibold outline-none"
+      >
+        <div className="flex w-full items-center justify-between">
+          <div
+            className="flex flex-1 items-center"
+            onClick={handleChevronClick}
+          >
+            {displayName.toUpperCase()}
+          </div>
+          <Popover
+            interactionKind={PopoverInteractionKind.CLICK}
+            position={Position.BOTTOM_RIGHT}
+            autoFocus={false}
+            enforceFocus={false}
+            captureDismiss
+            hasBackdrop
+            isOpen={isMenuOpen}
+            onInteraction={(next) => setIsMenuOpen(next)}
+            onClose={() => setIsMenuOpen(false)}
+            popoverClassName="dg-leftsidebar-popover"
+            minimal
+            content={
+              <Menu>
+                <MenuItem
+                  icon="refresh"
+                  text="Refresh"
+                  onClick={() => {
+                    runQuery();
+                    setIsMenuOpen(false);
+                  }}
+                />
+                <MenuItem
+                  icon="document-open"
+                  text="Go to query block"
+                  onClick={() => {
+                    void window.roamAlphaAPI.ui.mainWindow.openBlock({
+                      block: { uid: queryUid },
+                    });
+                    setIsMenuOpen(false);
+                  }}
+                />
+              </Menu>
+            }
+          >
+            <span className="sidebar-title-button-add p-1">
+              <Icon icon="more" size={14} />
+            </span>
+          </Popover>
+          <span
+            className="sidebar-title-button-chevron p-1"
+            onClick={handleChevronClick}
+          >
+            <Icon icon={isOpen ? "chevron-down" : "chevron-right"} />
+          </span>
+        </div>
+      </div>
+      <Collapse isOpen={isOpen}>
+        {isLoading ? (
+          <div className="pl-8 pr-2.5 text-sm text-gray-500">Loading…</div>
+        ) : error ? (
+          <div className="pl-8 pr-2.5 text-sm text-red-500">{error}</div>
+        ) : results.length > 0 ? (
+          <SectionChildren
+            childrenNodes={results}
+            truncateAt={truncateAt}
+            onloadArgs={onloadArgs}
+          />
+        ) : hasLoaded ? (
+          <div className="pl-8 pr-2.5 text-sm text-gray-500">No results</div>
+        ) : null}
+      </Collapse>
+    </>
+  );
+};
+
 const PersonalSections = ({
   config,
   setConfig,
@@ -358,14 +506,22 @@ const PersonalSections = ({
       getId={(s) => s.uid}
       onReorder={reorderSections}
       className="personal-left-sidebar-sections"
-      renderItem={(section, handle) => (
-        <PersonalSectionItem
-          section={section}
-          dragHandle={handle}
-          onChildrenReorder={reorderChildren}
-          onloadArgs={onloadArgs}
-        />
-      )}
+      renderItem={(section, handle) =>
+        isQuerySection(section.text) ? (
+          <QuerySectionItem
+            section={section}
+            dragHandle={handle}
+            onloadArgs={onloadArgs}
+          />
+        ) : (
+          <PersonalSectionItem
+            section={section}
+            dragHandle={handle}
+            onChildrenReorder={reorderChildren}
+            onloadArgs={onloadArgs}
+          />
+        )
+      }
     />
   );
 };

--- a/apps/roam/src/components/LeftSidebarView.tsx
+++ b/apps/roam/src/components/LeftSidebarView.tsx
@@ -49,8 +49,7 @@ import getPageTitleByPageUid from "roamjs-components/queries/getPageTitleByPageU
 import { migrateLeftSidebarSettings } from "~/utils/migrateLeftSidebarSettings";
 import posthog from "posthog-js";
 import { commands, cleanCommandName } from "~/components/LeftSidebarCommands";
-import fireQuery from "~/utils/fireQuery";
-import parseQuery from "~/utils/parseQuery";
+import runQuery from "~/utils/runQuery";
 
 const parseReference = (text: string) => {
   const extracted = extractRef(text);
@@ -317,35 +316,33 @@ const QuerySectionItem = ({
   const [error, setError] = useState<string | null>(null);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
 
-  const runQuery = useCallback(() => {
+  const loadResults = useCallback(async () => {
     setIsLoading(true);
     setError(null);
-    const args = parseQuery(queryUid);
-    fireQuery(args)
-      .then((queryResults) => {
-        const limited =
-          resultLimit > 0 ? queryResults.slice(0, resultLimit) : queryResults;
-        const children: ChildNode[] = limited.map((r) => {
-          const pageTitle = getPageTitleByPageUid(r.uid);
-          return {
-            uid: r.uid,
-            text: pageTitle ? r.uid : `((${r.uid}))`,
-          };
-        });
-        setResults(children);
-      })
-      .catch(() => setError("Query failed to run"))
-      .finally(() => {
-        setIsLoading(false);
-        setHasLoaded(true);
+    try {
+      const { allProcessedResults } = await runQuery({
+        parentUid: queryUid,
+        extensionAPI: onloadArgs.extensionAPI,
       });
-  }, [queryUid, resultLimit]);
+      const children: ChildNode[] = allProcessedResults.map((r) => ({
+        uid: r.uid,
+        text: getPageTitleByPageUid(r.uid) ? r.uid : `((${r.uid}))`,
+      }));
+      setResults(children);
+    } catch (e) {
+      console.error(e);
+      setError("Query failed to run");
+    } finally {
+      setIsLoading(false);
+      setHasLoaded(true);
+    }
+  }, [queryUid, onloadArgs.extensionAPI]);
 
   useEffect(() => {
     if (isOpen && !hasLoaded) {
-      runQuery();
+      void loadResults();
     }
-  }, [isOpen, hasLoaded, runQuery]);
+  }, [isOpen, hasLoaded, loadResults]);
 
   const handleChevronClick = () => {
     if (!section.settings) return;
@@ -389,7 +386,7 @@ const QuerySectionItem = ({
                   icon="refresh"
                   text="Refresh"
                   onClick={() => {
-                    runQuery();
+                    void loadResults();
                     setIsMenuOpen(false);
                   }}
                 />
@@ -425,7 +422,9 @@ const QuerySectionItem = ({
           <div className="pl-8 pr-2.5 text-sm text-red-500">{error}</div>
         ) : results.length > 0 ? (
           <SectionChildren
-            childrenNodes={results}
+            childrenNodes={
+              resultLimit > 0 ? results.slice(0, resultLimit) : results
+            }
             truncateAt={truncateAt}
             onloadArgs={onloadArgs}
           />

--- a/apps/roam/src/components/settings/LeftSidebarPersonalSettings.tsx
+++ b/apps/roam/src/components/settings/LeftSidebarPersonalSettings.tsx
@@ -941,6 +941,7 @@ const LeftSidebarPersonalSectionsContent = ({
                 order={2}
                 uid={activeDialogSection.settings.resultLimit?.uid}
                 parentUid={activeDialogSection.settings.uid || ""}
+                // eslint-disable-next-line @typescript-eslint/naming-convention
                 setter={(_keys, value) => {
                   const updatedSections = sectionsRef.current.map((s) =>
                     s.uid === activeDialogSection.uid

--- a/apps/roam/src/components/settings/LeftSidebarPersonalSettings.tsx
+++ b/apps/roam/src/components/settings/LeftSidebarPersonalSettings.tsx
@@ -46,6 +46,7 @@ import {
   commands,
   SidebarCommandPopover,
 } from "~/components/LeftSidebarCommands";
+import { isQuerySection } from "~/utils/getLeftSidebarSettings";
 
 /* eslint-disable @typescript-eslint/naming-convention */
 export const sectionsToBlockProps = (
@@ -60,6 +61,8 @@ export const sectionsToBlockProps = (
     Settings: {
       "Truncate-result?": s.settings?.truncateResult?.value ?? 75,
       Folded: s.settings?.folded?.value ?? false,
+      Alias: s.settings?.alias?.value ?? "",
+      "Result-limit": s.settings?.resultLimit?.value ?? 0,
     },
   }));
 /* eslint-enable @typescript-eslint/naming-convention */
@@ -98,6 +101,11 @@ const SectionItem = memo(
       new Set(initiallyExpanded ? [section.uid] : []),
     );
     const isExpanded = expandedChildLists.has(section.uid);
+    const isQuery = isQuerySection(section.text);
+    const [aliasValue, setAliasValue] = useState(
+      section.settings?.alias?.value ?? "",
+    );
+    const aliasUpdateTimeoutRef = useRef<ReturnType<typeof setTimeout>>();
     const [childSettingsUid, setChildSettingsUid] = useState<string | null>(
       null,
     );
@@ -328,6 +336,54 @@ const SectionItem = memo(
       setChildInputKey((prev) => prev + 1);
     }, []);
 
+    const handleAliasChange = useCallback(
+      (newValue: string) => {
+        setAliasValue(newValue);
+
+        clearTimeout(aliasUpdateTimeoutRef.current);
+        aliasUpdateTimeoutRef.current = setTimeout(() => {
+          const currentSection = sectionsRef.current.find(
+            (s) => s.uid === section.uid,
+          );
+          const alias = currentSection?.settings?.alias;
+          if (!alias?.uid) return;
+          const aliasUid = alias.uid;
+
+          void (async () => {
+            if (alias.valueUid) {
+              await updateBlock({ uid: alias.valueUid, text: newValue });
+            } else {
+              const newUid = await createBlock({
+                parentUid: aliasUid,
+                order: 0,
+                node: { text: newValue },
+              });
+              setSections((prev) =>
+                prev.map((s) =>
+                  s.uid === section.uid && s.settings
+                    ? {
+                        ...s,
+                        settings: {
+                          ...s.settings,
+                          alias: {
+                            ...s.settings.alias,
+                            valueUid: newUid,
+                            value: newValue,
+                          },
+                        },
+                      }
+                    : s,
+                ),
+              );
+            }
+            syncAllSectionsToBlockProps(sectionsRef.current);
+            refreshAndNotify();
+          })();
+        }, 300);
+      },
+      [section.uid, sectionsRef, setSections],
+    );
+
     const handleAddChild = useCallback(async () => {
       if (childInput && section.childrenUid) {
         await addChildToSection(section, section.childrenUid, childInput);
@@ -339,6 +395,45 @@ const SectionItem = memo(
     const sectionWithoutSettingsAndChildren =
       (!section.settings && section.children?.length === 0) ||
       !section.children;
+
+    if (isQuery) {
+      return (
+        <div
+          className="personal-section rounded-md p-3 hover:bg-gray-50"
+          style={{ border: "1px solid rgba(51, 51, 51, 0.2)" }}
+        >
+          <div
+            {...dragHandle.attributes}
+            {...dragHandle.listeners}
+            className="group flex cursor-grab items-center gap-2 active:cursor-grabbing"
+          >
+            <InputGroup
+              value={aliasValue}
+              onChange={(e) => handleAliasChange(e.target.value)}
+              placeholder="Alias…"
+              small
+            />
+            <span className="flex-shrink-0 text-xs text-gray-400">
+              {section.text}
+            </span>
+            <div className="flex-1" />
+            <ButtonGroup minimal>
+              <Button
+                icon="settings"
+                onClick={() => setSettingsDialogSectionUid(section.uid)}
+                title="Edit section settings"
+              />
+              <Button
+                icon="trash"
+                intent="danger"
+                onClick={() => void removeSection(section)}
+                title="Remove section"
+              />
+            </ButtonGroup>
+          </div>
+        </div>
+      );
+    }
 
     return (
       <div
@@ -603,13 +698,58 @@ const LeftSidebarPersonalSectionsContent = ({
           node: { text: sectionName },
         });
 
-        const newSection = {
-          text: sectionName,
-          uid: newBlock,
-          settings: undefined,
-          children: undefined,
-          childrenUid: undefined,
-        } as LeftSidebarPersonalSectionConfig;
+        let newSection: LeftSidebarPersonalSectionConfig;
+
+        if (isQuerySection(sectionName)) {
+          const settingsUid = await createBlock({
+            parentUid: newBlock,
+            order: 0,
+            node: { text: "Settings" },
+          });
+          const aliasUid = await createBlock({
+            parentUid: settingsUid,
+            order: 0,
+            node: { text: "Alias" },
+          });
+          const foldedUid = await createBlock({
+            parentUid: settingsUid,
+            order: 1,
+            node: { text: "Folded" },
+          });
+          const truncateUid = await createBlock({
+            parentUid: settingsUid,
+            order: 2,
+            node: { text: "Truncate-result?", children: [{ text: "75" }] },
+          });
+          const resultLimitUid = await createBlock({
+            parentUid: settingsUid,
+            order: 3,
+            node: { text: "Result-limit", children: [{ text: "10" }] },
+          });
+
+          newSection = {
+            text: sectionName,
+            uid: newBlock,
+            settings: {
+              uid: settingsUid,
+              alias: { uid: aliasUid, value: "" },
+              folded: { uid: foldedUid, value: false },
+              truncateResult: { uid: truncateUid, value: 75 },
+              resultLimit: { uid: resultLimitUid, value: 10 },
+            },
+            children: undefined,
+            childrenUid: undefined,
+          };
+        } else {
+          newSection = {
+            text: sectionName,
+            uid: newBlock,
+            settings: undefined,
+            children: undefined,
+            childrenUid: undefined,
+          } as LeftSidebarPersonalSectionConfig;
+        }
+
         const updatedSections = [...sectionsRef.current, newSection];
         setSections(updatedSections);
         syncAllSectionsToBlockProps(updatedSections);
@@ -780,6 +920,37 @@ const LeftSidebarPersonalSectionsContent = ({
                                 ...s.settings,
                                 truncateResult: {
                                   ...s.settings.truncateResult,
+                                  value,
+                                },
+                              }
+                            : s.settings,
+                        }
+                      : s,
+                  );
+                  setSections(updatedSections);
+                  syncAllSectionsToBlockProps(updatedSections);
+                }}
+              />
+              <PersonalNumberPanel
+                title="Result-limit"
+                description="Maximum number of children to display"
+                settingKeys={["Left sidebar"]}
+                initialValue={
+                  activeDialogSection.settings.resultLimit?.value ?? 0
+                }
+                order={2}
+                uid={activeDialogSection.settings.resultLimit?.uid}
+                parentUid={activeDialogSection.settings.uid || ""}
+                setter={(_keys, value) => {
+                  const updatedSections = sectionsRef.current.map((s) =>
+                    s.uid === activeDialogSection.uid
+                      ? {
+                          ...s,
+                          settings: s.settings
+                            ? {
+                                ...s.settings,
+                                resultLimit: {
+                                  ...s.settings.resultLimit,
                                   value,
                                 },
                               }

--- a/apps/roam/src/components/settings/LeftSidebarPersonalSettings.tsx
+++ b/apps/roam/src/components/settings/LeftSidebarPersonalSettings.tsx
@@ -350,33 +350,33 @@ const SectionItem = memo(
           const aliasUid = alias.uid;
 
           void (async () => {
-            if (alias.valueUid) {
-              await updateBlock({ uid: alias.valueUid, text: newValue });
+            let valueUid = alias.valueUid;
+            if (valueUid) {
+              await updateBlock({ uid: valueUid, text: newValue });
             } else {
-              const newUid = await createBlock({
+              valueUid = await createBlock({
                 parentUid: aliasUid,
                 order: 0,
                 node: { text: newValue },
               });
-              setSections((prev) =>
-                prev.map((s) =>
-                  s.uid === section.uid && s.settings
-                    ? {
-                        ...s,
-                        settings: {
-                          ...s.settings,
-                          alias: {
-                            ...s.settings.alias,
-                            valueUid: newUid,
-                            value: newValue,
-                          },
-                        },
-                      }
-                    : s,
-                ),
-              );
             }
-            syncAllSectionsToBlockProps(sectionsRef.current);
+            const nextSections = sectionsRef.current.map((s) =>
+              s.uid === section.uid && s.settings
+                ? {
+                    ...s,
+                    settings: {
+                      ...s.settings,
+                      alias: {
+                        ...s.settings.alias,
+                        valueUid,
+                        value: newValue,
+                      },
+                    },
+                  }
+                : s,
+            );
+            setSections(nextSections);
+            syncAllSectionsToBlockProps(nextSections);
             refreshAndNotify();
           })();
         }, 300);

--- a/apps/roam/src/utils/getLeftSidebarSettings.ts
+++ b/apps/roam/src/utils/getLeftSidebarSettings.ts
@@ -19,8 +19,8 @@ type LeftSidebarPersonalSectionSettings = {
   resultLimit?: IntSetting;
 };
 
-export const isQuerySection = (text: string) =>
-  text.startsWith("((") && text.endsWith("))");
+const BLOCK_REF_PATTERN = /^\(\([\w-]{9,10}\)\)$/;
+export const isQuerySection = (text: string) => BLOCK_REF_PATTERN.test(text);
 
 export type PersonalSectionChild = RoamBasicNode & {
   alias: StringSetting;

--- a/apps/roam/src/utils/getLeftSidebarSettings.ts
+++ b/apps/roam/src/utils/getLeftSidebarSettings.ts
@@ -9,11 +9,18 @@ import {
 } from "./getExportSettings";
 import { getSubTree } from "roamjs-components/util";
 
+type AliasSetting = StringSetting & { valueUid?: string };
+
 type LeftSidebarPersonalSectionSettings = {
   uid: string;
   truncateResult: IntSetting;
   folded: BooleanSetting;
+  alias?: AliasSetting;
+  resultLimit?: IntSetting;
 };
+
+export const isQuerySection = (text: string) =>
+  text.startsWith("((") && text.endsWith("))");
 
 export type PersonalSectionChild = RoamBasicNode & {
   alias: StringSetting;
@@ -119,10 +126,24 @@ const getPersonalSectionSettings = (
     text: "Folded",
   });
 
+  const aliasNode = settingsTree.find((n) => n.text === "Alias");
+  const aliasSetting: AliasSetting = {
+    uid: aliasNode?.uid,
+    value: aliasNode?.children?.[0]?.text ?? "",
+    valueUid: aliasNode?.children?.[0]?.uid,
+  };
+
+  const resultLimitSetting = getUidAndIntSetting({
+    tree: settingsTree,
+    text: "Result-limit",
+  });
+
   return {
     uid: settingsNode.uid,
     truncateResult: truncateResultSetting,
     folded: foldedSetting,
+    alias: aliasSetting,
+    resultLimit: resultLimitSetting,
   };
 };
 


### PR DESCRIPTION
https://www.loom.com/share/4981b1b58cfc4db1b70b766029858903

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Query sections can now be added to the personal sidebar for executing saved queries on-demand.
  * Query results display as clickable items in the sidebar with customizable result limits.
  * Added refresh option and dedicated menu for managing query sections in the sidebar.
  * Query sections support alias names and configurable result limits via settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->