### PR TITLE
[ENG-1686] Remove "Open node type" command

### DIFF
--- a/apps/obsidian/src/utils/registerCommands.ts
+++ b/apps/obsidian/src/utils/registerCommands.ts
@@ -62,35 +62,6 @@ export const createModifyNodeModalSubmitHandler = (
 
 export const registerCommands = (plugin: DiscourseGraphPlugin) => {
   plugin.addCommand({
-    id: "open-node-type-menu",
-    name: "Open node type menu",
-    editorCallback: (editor: Editor) => {
-      const hasSelection = !!editor.getSelection();
-
-      if (hasSelection) {
-        new NodeTypeModal(plugin, (nodeType: DiscourseNode) => {
-          void createDiscourseNode({
-            plugin,
-            editor,
-            nodeType,
-            text: editor.getSelection().trim() || "",
-          });
-        }).open();
-      } else {
-        const currentFile =
-          plugin.app.workspace.getActiveViewOfType(MarkdownView)?.file ||
-          undefined;
-        new ModifyNodeModal(plugin.app, {
-          nodeTypes: plugin.settings.nodeTypes,
-          plugin,
-          currentFile,
-          onSubmit: createModifyNodeModalSubmitHandler(plugin, editor),
-        }).open();
-      }
-    },
-  });
-
-  plugin.addCommand({
     id: "create-discourse-node",
     name: "Create discourse node",
     callback: () => {


### PR DESCRIPTION
Command removed

<img width="1329" height="487" alt="image" src="https://github.com/user-attachments/assets/f371917c-5b1a-44f1-8d0f-eb2e265838ad" />


Comprehensive doc update for create node flow will be addressed by [ENG-1698: Complete update of documentations on node creation flow](https://linear.app/discourse-graphs/issue/ENG-1698/complete-update-of-documentations-on-node-creation-flow)
