### PR TITLE
ENG-1699 - Implement batch upsert for concepts in Supabase

### DIFF
--- a/apps/roam/src/utils/syncDgNodesToSupabase.ts
+++ b/apps/roam/src/utils/syncDgNodesToSupabase.ts
@@ -34,12 +34,68 @@ const SYNC_INTERVAL = "130s";
 const BASE_SYNC_INTERVAL = 5 * 60 * 1000; // 5 minutes
 const SYNC_TIMEOUT = "60s"; // must be less than half the SYNC_INTERVAL.
 const BATCH_SIZE = 200;
+const CONCEPT_BATCH_SIZE = 200;
 const DEFAULT_TIME = new Date("1970-01-01");
 
 type SyncTaskInfo = {
   lastUpdateTime?: Date;
   nextUpdateTime?: Date;
   shouldProceed: boolean;
+};
+
+type LocalConceptDataInput = Partial<CompositeTypes<"concept_local_input">>;
+
+const chunk = <T>(array: T[], size: number): T[][] => {
+  const chunks: T[][] = [];
+  for (let i = 0; i < array.length; i += size) {
+    chunks.push(array.slice(i, i + size));
+  }
+  return chunks;
+};
+
+const summarizeFailedConceptUpsertIds = (failedIds: number[]): string => {
+  const counts = failedIds.reduce<Record<string, number>>((acc, id) => {
+    acc[id] = (acc[id] ?? 0) + 1;
+    return acc;
+  }, {});
+
+  return Object.entries(counts)
+    .map(([id, count]) => `${id}: ${count}`)
+    .join(", ");
+};
+
+const upsertConceptBatches = async ({
+  concepts,
+  supabaseClient,
+  spaceId,
+}: {
+  concepts: LocalConceptDataInput[];
+  supabaseClient: DGSupabaseClient;
+  spaceId: number;
+}): Promise<void> => {
+  const batches = chunk(concepts, CONCEPT_BATCH_SIZE);
+
+  for (let idx = 0; idx < batches.length; idx++) {
+    const batch = batches[idx];
+
+    const { data, error } = await supabaseClient.rpc("upsert_concepts", {
+      data: batch as Json,
+      v_space_id: spaceId,
+    });
+
+    if (error) {
+      throw new Error(
+        `upsert_concepts failed for batch ${idx + 1}/${batches.length}: ${JSON.stringify(error, null, 2)}`,
+      );
+    }
+
+    const failedIds = (data || []).filter((id) => id < 0);
+    if (failedIds.length > 0) {
+      throw new Error(
+        `upsert_concepts returned row failures for batch ${idx + 1}/${batches.length}: ${summarizeFailedConceptUpsertIds(failedIds)}`,
+      );
+    }
+  }
 };
 
 const notifyEndSyncFailure = ({
@@ -261,16 +317,20 @@ export const convertDgToSupabaseConcepts = async ({
     ...nodesTypesToLocalConcepts,
     ...nodeBlockToLocalConcepts,
   ];
-  const { ordered } = orderConceptsByDependency(conceptsToUpsert);
-  const { error } = await supabaseClient.rpc("upsert_concepts", {
-    data: ordered,
-    v_space_id: context.spaceId,
-  });
-  if (error) {
-    throw new Error(
-      `upsert_concepts failed: ${JSON.stringify(error, null, 2)}`,
+  const { ordered, missing } = orderConceptsByDependency(conceptsToUpsert);
+
+  if (missing.length > 0) {
+    console.warn(
+      "Some concept dependencies were not in the current sync batch:",
+      missing,
     );
   }
+
+  await upsertConceptBatches({
+    concepts: ordered,
+    supabaseClient,
+    spaceId: context.spaceId,
+  });
 };
 
 export const upsertNodesToSupabaseAsContentWithEmbeddings = async (
@@ -308,14 +368,6 @@ export const upsertNodesToSupabaseAsContentWithEmbeddings = async (
       "upsertNodesToSupabaseAsContentWithEmbeddings: Mismatch between node and embedding counts.",
     );
   }
-
-  const chunk = <T>(array: T[], size: number): T[][] => {
-    const chunks: T[][] = [];
-    for (let i = 0; i < array.length; i += size) {
-      chunks.push(array.slice(i, i + size));
-    }
-    return chunks;
-  };
 
   const uploadBatches = async (batches: LocalContentDataInput[][]) => {
     for (let idx = 0; idx < batches.length; idx++) {


### PR DESCRIPTION
*Written by codex 5.5 xhigh after long debugging session.

## Summary

  Fixes large first-sync failures by batching `upsert_concepts` calls during Roam Supabase sync.

  Previously, concept sync sent the entire concept payload in one `upsert_concepts` RPC. On larger graphs, this can exceed Supabase/Postgres statement
  timeout, causing the whole concept transaction to roll back and leaving the graph with synced `Content`/embeddings but zero `Concept` rows.

  ## Changes

  - Added sequential batching for `upsert_concepts` with a batch size of `200`.
  - Reused a shared `chunk` helper for sync batching.
  - Preserved dependency ordering by ordering concepts before batching.
  - Added explicit handling for negative `upsert_concepts` sentinel return values (`-1`, `-2`) so row-level failures fail the sync with batch context.
  - Added warning output for concept dependencies missing from the current sync batch.

  ## Why

  A customer graph had ~6,700 synced content rows and embeddings, but `upsert_concepts` failed with:

  ```txt
  canceling statement due to statement timeout

  Because Concept upsert was one large RPC, timeout rolled back the entire concept sync, leaving Concept empty. Batching makes the work fit within
  normal statement timeout limits and allows retries to continue idempotently.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Optimized data synchronization with batch processing for concept and content operations to improve efficiency.

* **Bug Fixes**
  * Enhanced error handling with detailed per-batch failure reporting for improved visibility into sync issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->