### PR TITLE
ENG-1692: Open ModifyNodeModal pre-populated on hotkey node creation

### DIFF
--- a/apps/obsidian/src/components/InlineNodeTypePicker.ts
+++ b/apps/obsidian/src/components/InlineNodeTypePicker.ts
@@ -1,7 +1,8 @@
-import { Editor } from "obsidian";
+import { Editor, MarkdownView } from "obsidian";
 import { DiscourseNode } from "~/types";
-import { createDiscourseNode } from "~/utils/createNode";
 import type DiscourseGraphPlugin from "~/index";
+import { createModifyNodeModalSubmitHandler } from "~/utils/registerCommands";
+import ModifyNodeModal from "./ModifyNodeModal";
 
 /**
  * A popover that shows all node types inline near the cursor/selection.
@@ -98,7 +99,7 @@ export class InlineNodeTypePicker {
       itemEl.addEventListener("mousedown", (e) => {
         e.preventDefault();
         e.stopPropagation();
-        void this.selectItem(item);
+        this.selectItem(item);
       });
 
       itemEl.addEventListener("mouseenter", () => {
@@ -138,14 +139,22 @@ export class InlineNodeTypePicker {
     }
   }
 
-  private async selectItem(item: DiscourseNode) {
+  private selectItem(item: DiscourseNode) {
     this.close();
-    await createDiscourseNode({
+    const currentFile =
+      this.options.plugin.app.workspace.getActiveViewOfType(MarkdownView)
+        ?.file || undefined;
+    new ModifyNodeModal(this.options.plugin.app, {
+      nodeTypes: this.options.plugin.settings.nodeTypes,
       plugin: this.options.plugin,
-      nodeType: item,
-      text: this.options.selectedText,
-      editor: this.options.editor,
-    });
+      initialTitle: this.options.selectedText,
+      initialNodeType: item,
+      currentFile,
+      onSubmit: createModifyNodeModalSubmitHandler(
+        this.options.plugin,
+        this.options.editor,
+      ),
+    }).open();
   }
 
   private setupEventHandlers() {
@@ -173,7 +182,7 @@ export class InlineNodeTypePicker {
         e.stopPropagation();
         const selectedItem = this.items[this.selectedIndex];
         if (selectedItem) {
-          void this.selectItem(selectedItem);
+          this.selectItem(selectedItem);
         }
       } else if (e.key === "Escape") {
         e.preventDefault();


### PR DESCRIPTION
https://www.loom.com/share/f5f4e01ba347431b89f50b0a4679d3fe

## Summary
- After selecting text and picking a node type from `InlineNodeTypePicker`, open `ModifyNodeModal` pre-filled with the selected text and the chosen node type — instead of immediately creating the node
- Consistent with right-click and tag-click creation flows that already route through `ModifyNodeModal`
- Reuses the existing `createModifyNodeModalSubmitHandler` from `registerCommands.ts` (already exported)

## Test plan
- [x] Select text in a note → hit the node tag hotkey (`\`) → `InlineNodeTypePicker` appears
- [x] Pick a node type → `ModifyNodeModal` opens with title pre-filled to the selected text and the chosen type pre-selected
- [x] Confirm in modal → selected text in editor replaced with `[[NodeTitle]]`
- [x] Hotkey with no selection → `NodeTagSuggestPopover` unchanged (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)