### PR TITLE
ENG-1626 Pre-fill Create node dialog with selected text

### DIFF
--- a/apps/obsidian/src/utils/registerCommands.ts
+++ b/apps/obsidian/src/utils/registerCommands.ts
@@ -94,15 +94,15 @@ export const registerCommands = (plugin: DiscourseGraphPlugin) => {
     id: "create-discourse-node",
     name: "Create discourse node",
     callback: () => {
-      const currentFile =
-        plugin.app.workspace.getActiveViewOfType(MarkdownView)?.file ||
-        undefined;
-      const editor =
-        plugin.app.workspace.getActiveViewOfType(MarkdownView)?.editor;
+      const activeView = plugin.app.workspace.getActiveViewOfType(MarkdownView);
+      const currentFile = activeView?.file || undefined;
+      const editor = activeView?.editor;
+      const selectedText = editor?.getSelection()?.trim() || undefined;
       new ModifyNodeModal(plugin.app, {
         nodeTypes: plugin.settings.nodeTypes,
         plugin,
         currentFile,
+        initialTitle: selectedText,
         onSubmit: createModifyNodeModalSubmitHandler(plugin, editor),
       }).open();
     },


### PR DESCRIPTION
https://www.loom.com/share/47e8af6482514084a413b1660abf27d6

## Summary
- When the "Create discourse node" command is triggered with text selected in the editor, the selected text is now passed as `initialTitle` to `ModifyNodeModal`, pre-filling the title field
- When no text is selected, the modal opens with an empty title as before
- Mirrors the existing behaviour of the right-click context menu ("Turn into discourse node")

## Changes
Single change in `apps/obsidian/src/utils/registerCommands.ts`:
- Dedupe `getActiveViewOfType` into one `activeView` call
- Capture `editor?.getSelection()?.trim()` and pass it as `initialTitle` to `ModifyNodeModal`

## Test plan
- [x] Select text in an Obsidian note → run "Create discourse node" command → confirm title field is pre-filled with selected text, cursor at end
- [x] Run command with no text selected → confirm modal opens with empty title field

Fixes [ENG-1626](https://linear.app/discourse-graphs/issue/ENG-1626)

🤖 Generated with [Claude Code](https://claude.com/claude-code)