### PR TITLE
ENG-1708 - Make Roam page-ref observer idempotent

### DIFF
--- a/apps/roam/src/utils/pageRefObserverHandlers.ts
+++ b/apps/roam/src/utils/pageRefObserverHandlers.ts
@@ -122,15 +122,19 @@ export const previewPageRefHandler = (s: HTMLSpanElement) => {
   }
 };
 
-export const enablePageRefObserver = () =>
-  (pageRefObserverRef.current = createHTMLObserver({
+export const enablePageRefObserver = () => {
+  if (pageRefObserverRef.current) return pageRefObserverRef.current;
+
+  pageRefObserverRef.current = createHTMLObserver({
     useBody: true,
     tag: "SPAN",
     className: "rm-page-ref",
     callback: (s: HTMLSpanElement) => {
       pageRefObservers.forEach((f) => f(s));
     },
-  }));
+  });
+  return pageRefObserverRef.current;
+};
 
 const disablePageRefObserver = () => {
   pageRefObserverRef.current?.disconnect();


### PR DESCRIPTION
- Updated `enablePageRefObserver` to return the existing observer if already initialized, preventing unnecessary re-creation.
- Cleaned up the function structure for better readability and maintainability.

This change enhances the efficiency of the page reference observer setup in the application.