### PR TITLE
ENG-1725 Enhance Roam CI/CD workflows with Linear release integration

### DIFF
--- a/.github/workflows/roam-main.yaml
+++ b/.github/workflows/roam-main.yaml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -53,3 +55,15 @@ jobs:
 
       - name: Deploy
         run: npx turbo run deploy --filter=roam --ui stream -- --no-compile
+
+      - name: Get version
+        id: version
+        run: echo "version=$(node -p "require('./apps/roam/package.json').version")" >> $GITHUB_OUTPUT
+
+      - name: Sync Linear release
+        uses: linear/linear-release-action@v0
+        with:
+          access_key: ${{ secrets.LINEAR_RELEASES_ACCESS_KEY }}
+          name: Roam ${{ steps.version.outputs.version }}
+          version: ${{ steps.version.outputs.version }}
+          include_paths: "apps/roam/**,packages/tailwind-config/**,packages/utils/**,packages/database/**,packages/ui/**"

--- a/.github/workflows/roam-release-complete.yaml
+++ b/.github/workflows/roam-release-complete.yaml
@@ -1,0 +1,19 @@
+name: Complete Roam Linear Release
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Roam release version to complete in Linear, for example 0.18.1."
+        required: true
+        type: string
+
+jobs:
+  complete-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Complete Linear release
+        uses: linear/linear-release-action@v0
+        with:
+          access_key: ${{ secrets.LINEAR_RELEASES_ACCESS_KEY }}
+          command: complete
+          version: ${{ inputs.version }}

--- a/.github/workflows/roam-release.yaml
+++ b/.github/workflows/roam-release.yaml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -42,6 +44,14 @@ jobs:
         id: version
         run: echo "version=$(node -p "require('./apps/roam/package.json').version")" >> $GITHUB_OUTPUT
 
+      - name: Sync Linear release
+        uses: linear/linear-release-action@v0
+        with:
+          access_key: ${{ secrets.LINEAR_RELEASES_ACCESS_KEY }}
+          name: Roam ${{ steps.version.outputs.version }}
+          version: ${{ steps.version.outputs.version }}
+          include_paths: "apps/roam/**,packages/tailwind-config/**,packages/utils/**,packages/database/**,packages/ui/**"
+
       - name: Inject & upload source maps to PostHog
         uses: PostHog/upload-source-maps@v0.5.7.0
         with:
@@ -53,3 +63,11 @@ jobs:
 
       - name: Update Roam Depot Extension
         run: npx turbo run publish --filter=roam --ui stream -- --no-compile
+
+      - name: Mark Linear release sent to Roam review
+        uses: linear/linear-release-action@v0
+        with:
+          access_key: ${{ secrets.LINEAR_RELEASES_ACCESS_KEY }}
+          command: update
+          version: ${{ steps.version.outputs.version }}
+          stage: Sent to Roam for Review


### PR DESCRIPTION
https://linear.app/docs/releases
https://linear.app/discourse-graphs/settings/releases

- Updated roam-main.yaml and roam-release.yaml to include steps for syncing and marking Linear releases, utilizing the linear-release-action.
- Added a new workflow, roam-release-complete.yaml, to facilitate the completion of Linear releases via manual input of the version.
- Set fetch-depth to 0 in checkout steps to ensure full repository history is available for versioning.