### PR TITLE
ENG-1690 Disable search dropdown in file explorer "Convert into" flow

### DIFF
--- a/apps/obsidian/src/components/ModifyNodeModal.tsx
+++ b/apps/obsidian/src/components/ModifyNodeModal.tsx
@@ -53,8 +53,13 @@ type ModifyNodeFormProps = {
   onCancel: () => void;
   initialTitle?: string;
   initialNodeType?: DiscourseNode;
-  initialFile?: TFile; // for edit mode
-  currentFile?: TFile; // the file where the node is being created from
+  /** Present in edit mode — the file being modified. Also drives `isEditMode`. */
+  initialFile?: TFile;
+  /** Context file for the "Relationship with …" block (editor "Turn into" flow). */
+  currentFile?: TFile;
+  /** Hides the search-existing-nodes dropdown. Used when intent is always to create
+   *  (e.g. file explorer "Convert into"), not to reuse an existing node. */
+  disableExistingNodeSearch?: boolean;
   plugin: DiscourseGraphPlugin;
 };
 
@@ -66,6 +71,7 @@ export const ModifyNodeForm = ({
   initialNodeType,
   initialFile,
   currentFile,
+  disableExistingNodeSearch = false,
   plugin,
 }: ModifyNodeFormProps) => {
   const isEditMode = !!initialFile;
@@ -95,9 +101,9 @@ export const ModifyNodeForm = ({
     [selectedNodeType],
   );
 
-  // Search for nodes when query changes (only in create mode)
+  // Search for nodes when query changes (only in create mode, and only when search is enabled)
   useEffect(() => {
-    if (isEditMode) {
+    if (isEditMode || disableExistingNodeSearch) {
       setSearchResults([]);
       return;
     }
@@ -137,16 +143,23 @@ export const ModifyNodeForm = ({
         clearTimeout(debounceTimeoutRef.current);
       }
     };
-  }, [query, selectedNodeType, isEditMode]);
+  }, [query, selectedNodeType, isEditMode, disableExistingNodeSearch]);
 
   const isOpen = useMemo(() => {
     return (
+      !disableExistingNodeSearch &&
       !selectedExistingNode &&
       isFocused &&
       searchResults.length > 0 &&
       query.trim().length >= 2
     );
-  }, [selectedExistingNode, isFocused, searchResults.length, query]);
+  }, [
+    disableExistingNodeSearch,
+    selectedExistingNode,
+    isFocused,
+    searchResults.length,
+    query,
+  ]);
 
   useEffect(() => {
     setActiveIndex(0);
@@ -454,15 +467,19 @@ export const ModifyNodeForm = ({
                 placeholder={
                   isEditMode
                     ? "Enter new content"
-                    : selectedNodeType
-                      ? `Search for existing ${selectedNodeType.name.toLowerCase()} or enter new content`
-                      : "Search for existing nodes or enter new content"
+                    : disableExistingNodeSearch
+                      ? selectedNodeType
+                        ? `Enter ${selectedNodeType.name.toLowerCase()} content`
+                        : "Enter content"
+                      : selectedNodeType
+                        ? `Search for existing ${selectedNodeType.name.toLowerCase()} or enter new content`
+                        : "Search for existing nodes or enter new content"
                 }
                 value={query}
                 onChange={handleQueryChange}
                 onKeyDown={handleKeyDown}
                 onFocus={() => {
-                  if (!isEditMode) {
+                  if (!isEditMode && !disableExistingNodeSearch) {
                     setIsFocused(true);
                   }
                 }}
@@ -609,8 +626,12 @@ type ModifyNodeModalProps = {
   }) => Promise<void>;
   initialTitle?: string;
   initialNodeType?: DiscourseNode;
+  /** Present in edit mode — the file being modified. */
   initialFile?: TFile;
+  /** Context file for the "Relationship with …" block (editor "Turn into" flow). */
   currentFile?: TFile;
+  /** See `ModifyNodeFormProps.disableExistingNodeSearch`. */
+  disableExistingNodeSearch?: boolean;
 };
 
 class ModifyNodeModal extends Modal {
@@ -628,6 +649,7 @@ class ModifyNodeModal extends Modal {
   private initialNodeType?: DiscourseNode;
   private initialFile?: TFile;
   private currentFile?: TFile;
+  private disableExistingNodeSearch: boolean;
   private plugin: DiscourseGraphPlugin;
 
   constructor(app: App, props: ModifyNodeModalProps) {
@@ -638,6 +660,7 @@ class ModifyNodeModal extends Modal {
     this.initialNodeType = props.initialNodeType;
     this.initialFile = props.initialFile;
     this.currentFile = props.currentFile;
+    this.disableExistingNodeSearch = props.disableExistingNodeSearch ?? false;
     this.plugin = props.plugin;
   }
 
@@ -656,6 +679,7 @@ class ModifyNodeModal extends Modal {
           initialNodeType={this.initialNodeType}
           initialFile={this.initialFile}
           currentFile={this.currentFile}
+          disableExistingNodeSearch={this.disableExistingNodeSearch}
           plugin={this.plugin}
         />
       </StrictMode>,

--- a/apps/obsidian/src/index.ts
+++ b/apps/obsidian/src/index.ts
@@ -177,6 +177,8 @@ export default class DiscourseGraphPlugin extends Plugin {
                 plugin: this,
                 imageFile: file,
                 initialNodeType: nodeType,
+                // File explorer always intends to create a new node
+                disableExistingNodeSearch: true,
               });
             },
           });
@@ -202,6 +204,8 @@ export default class DiscourseGraphPlugin extends Plugin {
                 plugin: this,
                 initialTitle: file.basename,
                 initialNodeType: nodeType,
+                // File explorer always intends to create a new node
+                disableExistingNodeSearch: true,
                 onSubmit: async ({ nodeType, title }) => {
                   await convertPageToDiscourseNode({
                     plugin: this,

--- a/apps/obsidian/src/utils/editorMenuUtils.ts
+++ b/apps/obsidian/src/utils/editorMenuUtils.ts
@@ -78,21 +78,27 @@ export const isImageFile = (file: TFile): boolean =>
 /**
  * Open ModifyNodeModal to convert an image file into a discourse node.
  * Shared by file-menu "Convert into" and the hover icon on embedded images.
+ *
+ * Pass `disableExistingNodeSearch: true` from the file-explorer path because
+ * the intent there is always to create a new node, not reuse an existing one.
  */
 export const openConvertImageToNodeModal = ({
   plugin,
   imageFile,
   initialNodeType,
+  disableExistingNodeSearch = false,
 }: {
   plugin: DiscourseGraphPlugin;
   imageFile: TFile;
   initialNodeType?: DiscourseNode;
+  disableExistingNodeSearch?: boolean;
 }): void => {
   new ModifyNodeModal(plugin.app, {
     nodeTypes: plugin.settings.nodeTypes,
     plugin,
     initialTitle: "",
     initialNodeType,
+    disableExistingNodeSearch,
     onSubmit: async ({
       nodeType: selectedType,
       title,


### PR DESCRIPTION
https://www.loom.com/share/45627180e19b47e78e2fef7d055f88df

## Summary

- Adds a `disableExistingNodeSearch` prop to `ModifyNodeModal` / `ModifyNodeForm` that suppresses the search-as-you-type dropdown for existing nodes
- Passes `disableExistingNodeSearch: true` from both file-explorer "Convert into" call sites (markdown files and image files) in `index.ts` and `editorMenuUtils.ts`
- Updates the textarea placeholder to remove "Search for existing…" language when search is disabled

## Why

When converting a file from the file explorer context menu, the intent is unambiguously to **create** a new discourse node (not reuse an existing one). Showing the search dropdown adds noise and could confuse users into selecting an existing node when they meant to convert their file.

## What is not affected

- Editor "Turn into discourse node" flow (`currentFile` passed) — search remains enabled
- Canvas double-click edit flow (`initialFile` passed, `isEditMode = true`) — already search-free
- Hover-icon image conversion — `openConvertImageToNodeModal` is called without the flag, so search stays enabled there
- All other create-mode form semantics: heading "Create discourse node", editable node type selector, "Creating…" button label, relationship block

## Test plan

- [x] Right-click a non-discourse-node file in the file explorer → "Convert into" → pick a node type → confirm the title input does **not** show a search dropdown when typing
- [x] Right-click an image file in the file explorer → "Convert into" → same check
- [x] Use editor context menu "Turn into discourse node" → confirm search dropdown **still works**
- [x] Use hover icon on an embedded image → confirm search dropdown **still works**
- [x] Confirm file conversion still completes successfully (node is created, file is updated)

Made with [Cursor](https://cursor.com)