### PR TITLE
ENG-1742 Add max height and scroll for node type menu

### DIFF
--- a/apps/roam/src/components/DiscourseNodeMenu.tsx
+++ b/apps/roam/src/components/DiscourseNodeMenu.tsx
@@ -35,6 +35,7 @@ type Props = {
   extensionAPI: OnloadArgs["extensionAPI"];
   trigger?: JSX.Element;
   isShift?: boolean;
+  menuMaxHeight?: number;
 };
 
 const NodeMenu = ({
@@ -44,6 +45,7 @@ const NodeMenu = ({
   extensionAPI,
   trigger,
   isShift,
+  menuMaxHeight,
 }: { onClose: () => void } & Props) => {
   const isInitialTextSelected =
     !!textarea && textarea.selectionStart !== textarea.selectionEnd;
@@ -69,13 +71,13 @@ const NodeMenu = ({
   );
   const menuRef = useRef<HTMLUListElement>(null);
   const [activeIndex, setActiveIndex] = useState(0);
+  const [isOpen, setIsOpen] = useState(!trigger);
 
   useEffect(() => {
     menuRef.current?.children[activeIndex]?.scrollIntoView({
       block: "nearest",
     });
   }, [activeIndex]);
-  const [isOpen, setIsOpen] = useState(!trigger);
 
   const onSelect = useCallback(
     (index: number) => {
@@ -268,7 +270,7 @@ const NodeMenu = ({
         <Menu
           ulRef={menuRef}
           data-active-index={activeIndex}
-          className="max-h-[60vh] overflow-y-auto"
+          style={{ overflowY: "auto", maxHeight: menuMaxHeight }}
         >
           {discourseNodes.map((item, i) => {
             const nodeColor =
@@ -312,15 +314,22 @@ const NodeMenu = ({
 
 export const render = (props: Props) => {
   if (!props.textarea) return;
+  if (props.textarea.parentElement?.querySelector("[data-discourse-node-menu]"))
+    return;
   const parent = document.createElement("span");
+  parent.setAttribute("data-discourse-node-menu", "true");
   const coords = getCoordsFromTextarea(props.textarea);
   parent.style.position = "absolute";
   parent.style.left = `${coords.left}px`;
   parent.style.top = `${coords.top}px`;
   props.textarea.parentElement?.insertBefore(parent, props.textarea);
+  const parentTop =
+    props.textarea.parentElement?.getBoundingClientRect().top ?? 0;
+  const menuMaxHeight = window.innerHeight - (parentTop + coords.top) - 24;
   ReactDOM.render(
     <NodeMenu
       {...props}
+      menuMaxHeight={menuMaxHeight}
       onClose={() => {
         ReactDOM.unmountComponentAtNode(parent);
         parent.remove();
@@ -365,6 +374,11 @@ export const TextSelectionNodeMenu = ({
     />
   );
 
+  const menuMaxHeight = Math.max(
+    window.innerHeight - textarea.getBoundingClientRect().bottom - 8,
+    100,
+  );
+
   return (
     <NodeMenu
       textarea={textarea}
@@ -372,6 +386,7 @@ export const TextSelectionNodeMenu = ({
       trigger={trigger}
       onClose={onClose}
       isShift
+      menuMaxHeight={menuMaxHeight}
     />
   );
 };

--- a/apps/roam/src/components/DiscourseNodeMenu.tsx
+++ b/apps/roam/src/components/DiscourseNodeMenu.tsx
@@ -271,7 +271,7 @@ const NodeMenu = ({
       className="relative z-50"
       position={Position.BOTTOM_LEFT}
       modifiers={{
-        flip: { enabled: false },
+        flip: { enabled: true },
         preventOverflow: { enabled: false },
       }}
       autoFocus={false}
@@ -336,7 +336,10 @@ export const render = (props: Props) => {
   props.textarea.parentElement?.insertBefore(parent, props.textarea);
   const parentTop =
     props.textarea.parentElement?.getBoundingClientRect().top ?? 0;
-  const menuMaxHeight = window.innerHeight - (parentTop + coords.top) - 24;
+  const menuMaxHeight = Math.max(
+    window.innerHeight - (parentTop + coords.top) - 24,
+    100,
+  );
   ReactDOM.render(
     <NodeMenu
       {...props}

--- a/apps/roam/src/components/DiscourseNodeMenu.tsx
+++ b/apps/roam/src/components/DiscourseNodeMenu.tsx
@@ -74,9 +74,20 @@ const NodeMenu = ({
   const [isOpen, setIsOpen] = useState(!trigger);
 
   useEffect(() => {
-    menuRef.current?.children[activeIndex]?.scrollIntoView({
-      block: "nearest",
-    });
+    const container = menuRef.current;
+    if (!container) return;
+    const activeItem = container.children[activeIndex] as
+      | HTMLElement
+      | undefined;
+    if (!activeItem) return;
+    const containerRect = container.getBoundingClientRect();
+    const itemRect = activeItem.getBoundingClientRect();
+    if (
+      itemRect.bottom > containerRect.bottom ||
+      itemRect.top < containerRect.top
+    ) {
+      activeItem.scrollIntoView({ block: "nearest", behavior: "auto" });
+    }
   }, [activeIndex]);
 
   const onSelect = useCallback(

--- a/apps/roam/src/components/DiscourseNodeMenu.tsx
+++ b/apps/roam/src/components/DiscourseNodeMenu.tsx
@@ -69,6 +69,12 @@ const NodeMenu = ({
   );
   const menuRef = useRef<HTMLUListElement>(null);
   const [activeIndex, setActiveIndex] = useState(0);
+
+  useEffect(() => {
+    menuRef.current?.children[activeIndex]?.scrollIntoView({
+      block: "nearest",
+    });
+  }, [activeIndex]);
   const [isOpen, setIsOpen] = useState(!trigger);
 
   const onSelect = useCallback(
@@ -259,7 +265,11 @@ const NodeMenu = ({
       enforceFocus={false}
       onInteraction={trigger ? handlePopoverInteraction : undefined}
       content={
-        <Menu ulRef={menuRef} data-active-index={activeIndex}>
+        <Menu
+          ulRef={menuRef}
+          data-active-index={activeIndex}
+          className="max-h-[60vh] overflow-y-auto"
+        >
           {discourseNodes.map((item, i) => {
             const nodeColor =
               formatHexColor(item?.canvasSettings?.color) || "#000";


### PR DESCRIPTION
https://www.loom.com/share/2c6b19da26f345a488119a7fe028e4d8
## Summary

- Adds `max-h-[60vh] overflow-y-auto` to the node type menu so it doesn't overflow off-screen when there are many node types
- Scrolls the active item into view when navigating with arrow keys, so keyboard navigation works correctly in a scrollable menu

Fixes [ENG-1742](https://linear.app/discourse-graphs/issue/ENG-1742/add-max-height-and-scroll-for-node-type-menu)

## Test plan

- [x] Open the node menu (e.g. on a graph with many node types like discourse-graphs graph)
- [x] Verify the menu is capped in height and scrollable
- [x] Navigate with arrow keys and verify the active item scrolls into view
- [x] Verify mouse selection and keyboard shortcut selection still work as expected

Made with [Cursor](https://cursor.com)