### PR TITLE
ENG-1741 Prevent duplicate keyboard shortcuts for node types

### DIFF
--- a/apps/roam/src/components/settings/DiscourseNodeConfigPanel.tsx
+++ b/apps/roam/src/components/settings/DiscourseNodeConfigPanel.tsx
@@ -79,7 +79,15 @@ const DiscourseNodeConfigPanel: React.FC<DiscourseNodeConfigPanelProps> = ({
           className="select-none"
           disabled={!label}
           onClick={() => {
-            const shortcut = label.slice(0, 1).toUpperCase();
+            const candidateShortcut = label.slice(0, 1).toUpperCase();
+            const existingShortcuts = new Set(
+              getDiscourseNodes()
+                .map((n) => n.shortcut.toUpperCase())
+                .filter(Boolean),
+            );
+            const shortcut = existingShortcuts.has(candidateShortcut)
+              ? ""
+              : candidateShortcut;
             const format = `[[${label.slice(0, 3).toUpperCase()}]] - {content}`;
             posthog.capture("Discourse Node: Type Created", { label: label });
             void createPage({

--- a/apps/roam/src/components/settings/NodeConfig.tsx
+++ b/apps/roam/src/components/settings/NodeConfig.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useEffect } from "react";
-import { DiscourseNode } from "~/utils/getDiscourseNodes";
+import getDiscourseNodes, { DiscourseNode } from "~/utils/getDiscourseNodes";
 import DualWriteBlocksPanel from "./components/EphemeralBlocksPanel";
 import { getSubTree } from "roamjs-components/util";
 import Description from "roamjs-components/components/Description";
@@ -86,9 +86,11 @@ const NodeConfig = ({
   const [selectedTabId, setSelectedTabId] = useState<TabId>("general");
   const [tagError, setTagError] = useState("");
   const [formatError, setFormatError] = useState("");
+  const [shortcutError, setShortcutError] = useState("");
 
   const [tagValue, setTagValue] = useState(node.tag || "");
   const [formatValue, setFormatValue] = useState(node.format || "");
+  const [shortcutValue, setShortcutValue] = useState(node.shortcut || "");
   const validate = useCallback(
     ({
       tag,
@@ -148,6 +150,25 @@ const NodeConfig = ({
     validate({ tag: tagValue, format: formatValue });
   }, [tagValue, formatValue, validate]);
 
+  const validateShortcut = useCallback(
+    (value: string) => {
+      if (!value) return setShortcutError("");
+      const taken = getDiscourseNodes()
+        .filter((n) => n.type !== node.type && n.shortcut)
+        .map((n) => n.shortcut.toUpperCase());
+      setShortcutError(
+        taken.includes(value.toUpperCase())
+          ? `Shortcut "${value.toUpperCase()}" is already used by another node type.`
+          : "",
+      );
+    },
+    [node.type],
+  );
+
+  useEffect(() => {
+    validateShortcut(shortcutValue);
+  }, [shortcutValue, validateShortcut]);
+
   return (
     <>
       <Tabs
@@ -177,6 +198,8 @@ const NodeConfig = ({
                 description={`The trigger to quickly create a ${node.text} page from the node menu.`}
                 settingKeys={["shortcut"]}
                 initialValue={node.shortcut}
+                error={shortcutError}
+                onChange={setShortcutValue}
                 order={0}
                 parentUid={node.type}
                 uid={shortcutUid}

--- a/apps/roam/src/components/settings/NodeConfig.tsx
+++ b/apps/roam/src/components/settings/NodeConfig.tsx
@@ -151,23 +151,41 @@ const NodeConfig = ({
   }, [tagValue, formatValue, validate]);
 
   const validateShortcut = useCallback(
-    (value: string) => {
-      if (!value) return setShortcutError("");
+    (value: string): boolean => {
+      if (!value) {
+        setShortcutError("");
+        return true;
+      }
+      const normalizedValue = value.toUpperCase();
       const taken = getDiscourseNodes()
         .filter((n) => n.type !== node.type && n.shortcut)
-        .map((n) => n.shortcut.toUpperCase());
-      setShortcutError(
-        taken.includes(value.toUpperCase())
-          ? `Shortcut "${value.toUpperCase()}" is already used by another node type.`
-          : "",
-      );
+        .map((n) => ({
+          shortcut: n.shortcut.toUpperCase(),
+          label: n.text,
+        }));
+      const matchingNodes = taken.filter((n) => n.shortcut === normalizedValue);
+      if (matchingNodes.length) {
+        setShortcutError(
+          `Shortcut "${normalizedValue}" is already used by: ${matchingNodes
+            .map((n) => `"${n.label}"`)
+            .join(", ")}.`,
+        );
+        return false;
+      }
+      setShortcutError("");
+      return true;
     },
     [node.type],
   );
 
-  useEffect(() => {
-    validateShortcut(shortcutValue);
-  }, [shortcutValue, validateShortcut]);
+  const handleShortcutChange = useCallback(
+    (value: string) => {
+      if (validateShortcut(value)) {
+        setShortcutValue(value);
+      }
+    },
+    [validateShortcut],
+  );
 
   return (
     <>
@@ -199,7 +217,7 @@ const NodeConfig = ({
                 settingKeys={["shortcut"]}
                 initialValue={node.shortcut}
                 error={shortcutError}
-                onChange={setShortcutValue}
+                onChange={handleShortcutChange}
                 order={0}
                 parentUid={node.type}
                 uid={shortcutUid}


### PR DESCRIPTION
https://www.loom.com/share/10168beedb5548b38b716ba59b10138f

## Summary

- On node creation, skip auto-assigning the first-letter shortcut if it is already taken by any existing node type; leave empty instead so the user is prompted to set a unique one manually
- In node type settings, validate the shortcut field against all other node types and surface an inline error when a conflict is detected (same warning pattern as the existing tag/format validation)

Fixes: [ENG-1741](https://linear.app/discourse-graphs/issue/ENG-1741/modify-keyboard-shortcut-behavior-for-node-type-dropdown-menu)

## Changes

- `DiscourseNodeConfigPanel.tsx` — collision-aware shortcut auto-assignment on "Add node"
- `NodeConfig.tsx` — `validateShortcut` callback + `shortcutError` state wired to the Shortcut text panel

## Test plan

- [x] Create a new node type whose label starts with the same letter as an existing node (e.g. add "Concept" when "Claim" with shortcut `C` exists) — shortcut should be empty, not `C`
- [x] In node settings, manually set a shortcut that matches another node's shortcut — inline error should appear immediately
- [x] Setting a unique shortcut clears the error
- [x] Existing nodes with no conflicts are unaffected

Made with [Cursor](https://cursor.com)