### PR TITLE
Reorganize talks on website so newest is first

### DIFF
--- a/apps/website/app/(home)/page.tsx
+++ b/apps/website/app/(home)/page.tsx
@@ -557,6 +557,44 @@ const Home = async () => {
             <CardContent>
               <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
                 <div className="space-y-4">
+                  <div className="flex aspect-video items-center justify-center rounded-lg bg-neutral-100 p-6 text-center">
+                    <div className="space-y-3">
+                      <p className="text-sm text-neutral-dark">
+                        Hosted on Atmosphere Conf VODs
+                      </p>
+                      <Link
+                        href="https://atmosphereconf-vods.wisp.place/videos/keynote-towards-modular-open-science"
+                        className="inline-block rounded-md bg-primary px-4 py-2 text-sm font-semibold text-white transition hover:text-white"
+                      >
+                        Watch talk →
+                      </Link>
+                    </div>
+                  </div>
+                  <h3 className="text-xl font-semibold text-neutral-dark">
+                    Keynote: Towards Modular Open Science
+                  </h3>
+                  <p className="text-neutral-dark">
+                    Rowan Cockett, Matt Akamatsu
+                  </p>
+                </div>
+
+                <div className="space-y-4">
+                  <div className="relative aspect-video">
+                    <iframe
+                      className="absolute inset-0 h-full w-full rounded-lg"
+                      src="https://www.youtube-nocookie.com/embed/JOn_dJ-g3vY"
+                      title="HCIL Brown Bag Speaker Series: Matt Akamatsu (February 2026)"
+                      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                      allowFullScreen
+                    />
+                  </div>
+                  <h3 className="text-xl font-semibold text-neutral-dark">
+                    HCIL Brown Bag Speaker Series: Matt Akamatsu
+                  </h3>
+                  <p className="text-neutral-dark">Matt Akamatsu</p>
+                </div>
+
+                <div className="space-y-4">
                   <div className="relative aspect-video">
                     <iframe
                       className="absolute inset-0 h-full w-full rounded-lg"
@@ -625,44 +663,6 @@ const Home = async () => {
                   </h3>
                   <p className="text-neutral-dark">
                     Karola Kirsanow, NYC Protocol Labs Research Seminar
-                  </p>
-                </div>
-
-                <div className="space-y-4">
-                  <div className="relative aspect-video">
-                    <iframe
-                      className="absolute inset-0 h-full w-full rounded-lg"
-                      src="https://www.youtube-nocookie.com/embed/JOn_dJ-g3vY"
-                      title="HCIL Brown Bag Speaker Series: Matt Akamatsu (February 2026)"
-                      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                      allowFullScreen
-                    />
-                  </div>
-                  <h3 className="text-xl font-semibold text-neutral-dark">
-                    HCIL Brown Bag Speaker Series: Matt Akamatsu
-                  </h3>
-                  <p className="text-neutral-dark">Matt Akamatsu</p>
-                </div>
-
-                <div className="space-y-4">
-                  <div className="flex aspect-video items-center justify-center rounded-lg bg-neutral-100 p-6 text-center">
-                    <div className="space-y-3">
-                      <p className="text-sm text-neutral-dark">
-                        Hosted on Atmosphere Conf VODs
-                      </p>
-                      <Link
-                        href="https://atmosphereconf-vods.wisp.place/videos/keynote-towards-modular-open-science"
-                        className="inline-block rounded-md bg-primary px-4 py-2 text-sm font-semibold text-white transition hover:text-white"
-                      >
-                        Watch talk →
-                      </Link>
-                    </div>
-                  </div>
-                  <h3 className="text-xl font-semibold text-neutral-dark">
-                    Keynote: Towards Modular Open Science
-                  </h3>
-                  <p className="text-neutral-dark">
-                    Rowan Cockett, Matt Akamatsu
                   </p>
                 </div>
               </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Changes

Reorganized the talks section on the home page to display talks in chronological order from newest to oldest, with the flow going left to right in the grid layout.

## New Order

| Position | Date | Talk |
|----------|------|------|
| 1 (top left) | **March 27, 2026** | Keynote: Towards Modular Open Science |
| 2 | **February 2026** | HCIL Brown Bag Speaker Series: Matt Akamatsu |
| 3 | **December 5, 2024** | Discourse Graphs: A New Model for Scientific Communication |
| 4 | **March 2, 2024** | Open Sourcing Scientific Research with Lab Discourse Graphs |
| 5 | **July 19, 2022** | Accelerating Scientific Discovery with Discourse Graphs |
| 6 | **June 25, 2022** | Research roadmapping with Discourse Graphs |

## Testing

Verified the changes by running the development server and confirming the talks are displayed in the correct order:

[talks_section_walkthrough.mp4](https://cursor.com/agents/bc-9b5ccde5-5934-4937-a841-3b5a9ce10abc/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftalks_section_walkthrough.mp4)

[Talks section showing all 6 talks in correct order](https://cursor.com/agents/bc-9b5ccde5-5934-4937-a841-3b5a9ce10abc/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftalks_section_final.webp)

## Resolves

Fixes ENG-1743

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-1743](https://linear.app/discourse-graphs/issue/ENG-1743/reorganize-talks-on-the-website-so-newest-is-first)

<div><a href="https://cursor.com/agents/bc-9b5ccde5-5934-4937-a841-3b5a9ce10abc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b5ccde5-5934-4937-a841-3b5a9ce10abc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

