### PR TITLE
Add checkout step to roam-release-complete workflow

### DIFF
--- a/.github/workflows/roam-release-complete.yaml
+++ b/.github/workflows/roam-release-complete.yaml
@@ -11,6 +11,11 @@ jobs:
   complete-release:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
       - name: Complete Linear release
         uses: linear/linear-release-action@v0
         with:


### PR DESCRIPTION
step is erroring
follow up on [ENG-1725: set up roam linear releases](https://linear.app/discourse-graphs/issue/ENG-1725/set-up-roam-linear-releases)