### PR TITLE
Remove version retrieval step from roam-main.yaml and update Linear r…

### DIFF
--- a/.github/workflows/roam-main.yaml
+++ b/.github/workflows/roam-main.yaml
@@ -56,14 +56,8 @@ jobs:
       - name: Deploy
         run: npx turbo run deploy --filter=roam --ui stream -- --no-compile
 
-      - name: Get version
-        id: version
-        run: echo "version=$(node -p "require('./apps/roam/package.json').version")" >> $GITHUB_OUTPUT
-
       - name: Sync Linear release
         uses: linear/linear-release-action@v0
         with:
           access_key: ${{ secrets.LINEAR_RELEASES_ACCESS_KEY }}
-          name: Roam ${{ steps.version.outputs.version }}
-          version: ${{ steps.version.outputs.version }}
           include_paths: "apps/roam/**,packages/tailwind-config/**,packages/utils/**,packages/database/**,packages/ui/**"


### PR DESCRIPTION
…elease action to use a static name instead of dynamic versioning.

This should sync commits to linear's current started/planned roam release instead of targeting and old version 