### PR TITLE
Remove (BETA) label from Left Sidebar feature

### DIFF
--- a/apps/roam/src/components/settings/GeneralSettings.tsx
+++ b/apps/roam/src/components/settings/GeneralSettings.tsx
@@ -41,7 +41,7 @@ const DiscourseGraphHome = () => {
         parentUid={settings.settingsUid}
       />
       <FeatureFlagPanel
-        title="(BETA) Left Sidebar"
+        title="Left Sidebar"
         description="Whether or not to enable the left sidebar."
         initialValue={settings.leftSidebarEnabled.value}
         featureKey="Enable left sidebar"

--- a/apps/roam/src/utils/discourseConfigRef.ts
+++ b/apps/roam/src/utils/discourseConfigRef.ts
@@ -73,9 +73,10 @@ export const getFormattedConfigTree = (): FormattedConfigTree => {
     }),
     suggestiveMode: getSuggestiveModeConfigAndUids(configTreeRef.tree),
     leftSidebar: getLeftSidebarSettings(configTreeRef.tree),
+    // BETA used as key, will be removed with settings migration
     leftSidebarEnabled: getUidAndBooleanSetting({
       tree: configTreeRef.tree,
-      text: "Left Sidebar",
+      text: "(BETA) Left Sidebar",
     }),
   };
 };

--- a/apps/roam/src/utils/discourseConfigRef.ts
+++ b/apps/roam/src/utils/discourseConfigRef.ts
@@ -75,7 +75,7 @@ export const getFormattedConfigTree = (): FormattedConfigTree => {
     leftSidebar: getLeftSidebarSettings(configTreeRef.tree),
     leftSidebarEnabled: getUidAndBooleanSetting({
       tree: configTreeRef.tree,
-      text: "(BETA) Left Sidebar",
+      text: "Left Sidebar",
     }),
   };
 };

--- a/apps/roam/src/utils/initializeObserversAndListeners.ts
+++ b/apps/roam/src/utils/initializeObserversAndListeners.ts
@@ -250,7 +250,7 @@ export const initObservers = async ({
       void (async () => {
         const isLeftSidebarEnabled = getUidAndBooleanSetting({
           tree: configTree,
-          text: "(BETA) Left Sidebar",
+          text: "Left Sidebar",
         }).value;
         const container = el as HTMLDivElement;
         if (isLeftSidebarEnabled) {

--- a/apps/roam/src/utils/initializeObserversAndListeners.ts
+++ b/apps/roam/src/utils/initializeObserversAndListeners.ts
@@ -248,9 +248,10 @@ export const initObservers = async ({
     className: "starred-pages-wrapper",
     callback: (el) => {
       void (async () => {
+        // BETA used as key, will be removed with settings migration
         const isLeftSidebarEnabled = getUidAndBooleanSetting({
           tree: configTree,
-          text: "Left Sidebar",
+          text: "(BETA) Left Sidebar",
         }).value;
         const container = el as HTMLDivElement;
         if (isLeftSidebarEnabled) {

--- a/apps/roam/src/utils/registerCommandPaletteCommands.ts
+++ b/apps/roam/src/utils/registerCommandPaletteCommands.ts
@@ -334,7 +334,7 @@ export const registerCommandPaletteCommands = (onloadArgs: OnloadArgs) => {
 
   const leftSidebarEnabled = getUidAndBooleanSetting({
     tree: discourseConfigRef.tree,
-    text: "(BETA) Left Sidebar",
+    text: "Left Sidebar",
   });
   if (leftSidebarEnabled.value) {
     const leftSidebarNode = discourseConfigRef.tree.find(

--- a/apps/roam/src/utils/registerCommandPaletteCommands.ts
+++ b/apps/roam/src/utils/registerCommandPaletteCommands.ts
@@ -332,9 +332,10 @@ export const registerCommandPaletteCommands = (onloadArgs: OnloadArgs) => {
   void addCommand("DG: Query block - Create", createQueryBlock);
   void addCommand("DG: Query block - Refresh", refreshCurrentQueryBuilder);
 
+  // BETA used as key, will be removed with settings migration
   const leftSidebarEnabled = getUidAndBooleanSetting({
     tree: discourseConfigRef.tree,
-    text: "Left Sidebar",
+    text: "(BETA) Left Sidebar",
   });
   if (leftSidebarEnabled.value) {
     const leftSidebarNode = discourseConfigRef.tree.find(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removed the "(BETA)" label from the Left Sidebar feature in the UI settings panel as requested in Linear issue ENG-1542. The Custom favorites in sidebar project is marked as complete, so the feature is no longer in beta from a user-facing perspective.

## Changes

Updated only the user-facing UI title in:
- `apps/roam/src/components/settings/GeneralSettings.tsx` - Changed title from "(BETA) Left Sidebar" to "Left Sidebar"

**Note:** The "(BETA) Left Sidebar" string is retained in the following files because it's used as a configuration key:
- `apps/roam/src/utils/discourseConfigRef.ts`
- `apps/roam/src/utils/initializeObserversAndListeners.ts`
- `apps/roam/src/utils/registerCommandPaletteCommands.ts`

Added comments in these files: `// BETA used as key, will be removed with settings migration`

Changing the key would break existing user configurations. A proper settings migration will be needed to update the key in the future.

## Testing

- ✅ Lint checks passed
- ✅ TypeScript type checking passed
- ✅ Build completed successfully with no errors

## Related Issues

Closes: ENG-1542
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-1542](https://linear.app/discourse-graphs/issue/ENG-1542/remove-beta-from-beta-left-sidebar)

<div><a href="https://cursor.com/agents/bc-caa0e7db-d514-48ef-a297-2660b3a0c407"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-caa0e7db-d514-48ef-a297-2660b3a0c407"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

