### PR TITLE
ENG-1757: Read fresh relation settings on edit to prevent duplicate data loss

### DIFF
--- a/apps/roam/src/components/settings/DiscourseRelationConfigPanel.tsx
+++ b/apps/roam/src/components/settings/DiscourseRelationConfigPanel.tsx
@@ -1037,12 +1037,15 @@ const DiscourseRelationConfigPanel = ({
   };
 
   const handleDelete = (rel: Relation) => {
-    deleteBlock(rel.uid);
-    setRelations(relations.filter((r) => r.uid !== rel.uid));
-
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/naming-convention
-    const { [rel.uid]: _, ...remaining } = getGlobalSettings().Relations;
-    setGlobalSetting([GLOBAL_KEYS.relations], remaining);
+    void deleteBlock(rel.uid).then(() => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/naming-convention
+      const { [rel.uid]: _, ...remaining } = getGlobalSettings().Relations;
+      setGlobalSetting([GLOBAL_KEYS.relations], remaining);
+      setTimeout(() => {
+        refreshConfigTree();
+        setRelations(refreshRelations());
+      }, 50);
+    });
   };
   const handleDuplicate = (rel: Relation) => {
     const text = rel.text;
@@ -1067,16 +1070,10 @@ const DiscourseRelationConfigPanel = ({
           label: text,
         });
       }
-
-      setRelations([
-        ...relations,
-        {
-          uid: newUid,
-          source: rel.source,
-          destination: rel.destination,
-          text,
-        },
-      ]);
+      setTimeout(() => {
+        refreshConfigTree();
+        setRelations(refreshRelations());
+      }, 50);
     });
   };
   const handleBack = () => {

--- a/apps/roam/src/components/settings/DiscourseRelationConfigPanel.tsx
+++ b/apps/roam/src/components/settings/DiscourseRelationConfigPanel.tsx
@@ -52,7 +52,6 @@ import { getStoredRelationsEnabled } from "~/utils/storedRelations";
 import {
   setGlobalSetting,
   getGlobalSettings,
-  type SettingsSnapshot,
 } from "~/components/settings/utils/accessors";
 import { GLOBAL_KEYS } from "~/components/settings/utils/settingKeys";
 import { RenderRoamBlock } from "~/utils/roamReactComponents";
@@ -77,14 +76,12 @@ export const RelationEditPanel = ({
   back,
   translatorKeys,
   previewUid,
-  globalSettings,
 }: {
   editingRelationInfo: TreeNode;
   back: () => void;
   nodes: Record<string, { label: string; format: string; color: string }>;
   translatorKeys: string[];
   previewUid: string;
-  globalSettings: SettingsSnapshot["globalSettings"];
 }) => {
   const nodeFormatsByLabel = useMemo(
     () =>
@@ -125,7 +122,7 @@ export const RelationEditPanel = ({
     DEFAULT_SELECTED_RELATION,
   );
   const [tab, setTab] = useState(0);
-  const relation = globalSettings.Relations[editingRelationInfo.uid];
+  const relation = getGlobalSettings().Relations[editingRelationInfo.uid];
   const initialSourceUid = relation?.source ?? "";
   const initialSource = useMemo(
     () => edgeDisplayByUid(initialSourceUid),
@@ -963,13 +960,11 @@ type Relation = {
 const DiscourseRelationConfigPanel = ({
   uid,
   parentUid,
-  globalSettings,
 }: {
   uid: string;
   parentUid: string;
   defaultValue: unknown;
   title: string;
-  globalSettings: SettingsSnapshot["globalSettings"];
 }) => {
   const refreshRelations = useCallback(
     (): Relation[] =>
@@ -1102,7 +1097,6 @@ const DiscourseRelationConfigPanel = ({
           back={handleBack}
           translatorKeys={translatorKeys}
           previewUid={previewUid}
-          globalSettings={globalSettings}
         />
       </div>
     );

--- a/apps/roam/src/components/settings/Settings.tsx
+++ b/apps/roam/src/components/settings/Settings.tsx
@@ -250,7 +250,6 @@ export const SettingsDialog = ({
                 title="Relations"
                 parentUid={grammarNode?.uid || ""}
                 uid={relationsNode?.uid || ""}
-                globalSettings={settings.globalSettings}
               />
             }
           />


### PR DESCRIPTION
https://www.loom.com/share/1d435b44a0ba45d88970d056887dc1bc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced relation configuration panel data handling to ensure the relations list refreshes properly when adding or removing items.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DiscourseGraphs/discourse-graph/pull/1035)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->