### PR TITLE
FEE-791 Move Roam image controls away from resize handle

### DIFF
--- a/apps/roam/src/utils/renderImageToolsMenu.tsx
+++ b/apps/roam/src/utils/renderImageToolsMenu.tsx
@@ -93,7 +93,7 @@ const setupWrapperForMenu = (wrapper: HTMLElement): void => {
 
 const createMenuContainer = (): HTMLDivElement => {
   const menuContainer = document.createElement("div");
-  menuContainer.className = "absolute bottom-8 right-8 z-[100] hidden";
+  menuContainer.className = "absolute bottom-2 right-2 z-[100] hidden";
   return menuContainer;
 };
 

--- a/apps/roam/src/utils/renderImageToolsMenu.tsx
+++ b/apps/roam/src/utils/renderImageToolsMenu.tsx
@@ -93,7 +93,7 @@ const setupWrapperForMenu = (wrapper: HTMLElement): void => {
 
 const createMenuContainer = (): HTMLDivElement => {
   const menuContainer = document.createElement("div");
-  menuContainer.className = "absolute bottom-1 right-1 z-[100] hidden";
+  menuContainer.className = "absolute bottom-8 right-8 z-[100] hidden";
   return menuContainer;
 };
 


### PR DESCRIPTION
https://www.loom.com/share/74ae06c9734d4a5898389ecfcae3857e

## Summary
- Move the Roam image tools overlay farther up and left from the bottom-right image corner. -> leave space for resizing action