### PR TITLE
ENG-1732: Add sorting to advanced node search

### DIFF
--- a/apps/roam/src/components/AdvancedNodeSearchDialog/AdvancedSearchDialog.tsx
+++ b/apps/roam/src/components/AdvancedNodeSearchDialog/AdvancedSearchDialog.tsx
@@ -148,6 +148,7 @@ const AdvancedNodeSearchDialog = ({
   const [isIndexLoading, setIsIndexLoading] = useState(false);
   const [indexError, setIndexError] = useState(false);
   const [activeIndex, setActiveIndex] = useState(0);
+  const [results, setResults] = useState<SearchResult[]>([]);
   const [sort, setSort] = useState<SortConfig>(DEFAULT_SORT_CONFIG);
   const miniSearchRef = useRef<MiniSearch<
     SearchResult & { id: string }
@@ -164,26 +165,6 @@ const AdvancedNodeSearchDialog = ({
       discourseNodes.map((node) => [node.type, node]),
     ) as Record<string, DiscourseNode>;
   }, []);
-
-  const results = useMemo(() => {
-    if (
-      !isOpen ||
-      isIndexLoading ||
-      indexError ||
-      !debouncedSearchTerm ||
-      !miniSearchRef.current
-    ) {
-      return [];
-    }
-
-    const scoredHits = searchIndexedNodes({
-      miniSearch: miniSearchRef.current,
-      allResults: allResultsRef.current,
-      searchTerm: debouncedSearchTerm,
-    });
-
-    return sortSearchResults({ hits: scoredHits, sort });
-  }, [debouncedSearchTerm, indexError, isIndexLoading, isOpen, sort]);
 
   const activeResult = results[activeIndex] ?? null;
   const keywords = debouncedSearchTerm.split(/\s+/).filter(Boolean);
@@ -206,8 +187,30 @@ const AdvancedNodeSearchDialog = ({
   useEffect(() => {
     if (!isOpen) {
       setSort(DEFAULT_SORT_CONFIG);
+      setResults([]);
     }
   }, [isOpen]);
+
+  useEffect(() => {
+    if (
+      !isOpen ||
+      isIndexLoading ||
+      indexError ||
+      !debouncedSearchTerm ||
+      !miniSearchRef.current
+    ) {
+      setResults([]);
+      return;
+    }
+
+    const scoredHits = searchIndexedNodes({
+      miniSearch: miniSearchRef.current,
+      allResults: allResultsRef.current,
+      searchTerm: debouncedSearchTerm,
+    });
+
+    setResults(sortSearchResults({ hits: scoredHits, sort }));
+  }, [debouncedSearchTerm, indexError, isIndexLoading, isOpen, sort]);
 
   useEffect(() => {
     let cancelled = false;

--- a/apps/roam/src/components/AdvancedNodeSearchDialog/AdvancedSearchDialog.tsx
+++ b/apps/roam/src/components/AdvancedNodeSearchDialog/AdvancedSearchDialog.tsx
@@ -186,8 +186,12 @@ const AdvancedNodeSearchDialog = ({
 
   useEffect(() => {
     if (!isOpen) {
+      setSearchTerm("");
+      setDebouncedSearchTerm("");
+      setActiveIndex(0);
       setSort(DEFAULT_SORT_CONFIG);
       setResults([]);
+      setIndexError(false);
     }
   }, [isOpen]);
 

--- a/apps/roam/src/components/AdvancedNodeSearchDialog/AdvancedSearchDialog.tsx
+++ b/apps/roam/src/components/AdvancedNodeSearchDialog/AdvancedSearchDialog.tsx
@@ -20,16 +20,20 @@ import getPageTitleByPageUid from "roamjs-components/queries/getPageTitleByPageU
 import renderOverlay, {
   RoamOverlayProps,
 } from "roamjs-components/util/renderOverlay";
+import { DiscourseNodeSortControl } from "~/components/DiscourseNodeSortControl";
 import getDiscourseNodes, {
   type DiscourseNode,
 } from "~/utils/getDiscourseNodes";
 import { getNodeTagStyles } from "~/utils/getDiscourseNodeColors";
 import {
   DEBOUNCE_MS,
+  DEFAULT_SORT_CONFIG,
   type SearchResult,
+  type SortConfig,
   buildSearchIndex,
   formatMetadataDate,
   searchIndexedNodes,
+  sortSearchResults,
   splitWithHighlights,
   stripTypePrefix,
 } from "./utils";
@@ -144,6 +148,8 @@ const AdvancedNodeSearchDialog = ({
   const [isIndexLoading, setIsIndexLoading] = useState(false);
   const [indexError, setIndexError] = useState(false);
   const [activeIndex, setActiveIndex] = useState(0);
+  const [sort, setSort] = useState<SortConfig>(DEFAULT_SORT_CONFIG);
+  const [isSortPopoverOpen, setIsSortPopoverOpen] = useState(false);
   const miniSearchRef = useRef<MiniSearch<
     SearchResult & { id: string }
   > | null>(null);
@@ -160,18 +166,31 @@ const AdvancedNodeSearchDialog = ({
     ) as Record<string, DiscourseNode>;
   }, []);
 
-  const results =
-    isOpen &&
-    !isIndexLoading &&
-    !indexError &&
-    debouncedSearchTerm &&
-    miniSearchRef.current
-      ? searchIndexedNodes({
-          miniSearch: miniSearchRef.current,
-          allResults: allResultsRef.current,
-          searchTerm: debouncedSearchTerm,
-        })
-      : [];
+  const results = useMemo(() => {
+    if (
+      !isOpen ||
+      isIndexLoading ||
+      indexError ||
+      !debouncedSearchTerm ||
+      !miniSearchRef.current
+    ) {
+      return [];
+    }
+
+    const scoredHits = searchIndexedNodes({
+      miniSearch: miniSearchRef.current,
+      allResults: allResultsRef.current,
+      searchTerm: debouncedSearchTerm,
+    });
+
+    return sortSearchResults({ hits: scoredHits, sort });
+  }, [
+    debouncedSearchTerm,
+    indexError,
+    isIndexLoading,
+    isOpen,
+    sort,
+  ]);
 
   const activeResult = results[activeIndex] ?? null;
   const keywords = debouncedSearchTerm.split(/\s+/).filter(Boolean);
@@ -189,6 +208,13 @@ const AdvancedNodeSearchDialog = ({
       cancelAnimationFrame(rafId);
       window.clearTimeout(timeoutId);
     };
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setSort(DEFAULT_SORT_CONFIG);
+      setIsSortPopoverOpen(false);
+    }
   }, [isOpen]);
 
   useEffect(() => {
@@ -235,7 +261,7 @@ const AdvancedNodeSearchDialog = ({
 
   useEffect(() => {
     setActiveIndex(0);
-  }, [debouncedSearchTerm]);
+  }, [debouncedSearchTerm, sort]);
 
   useEffect(() => {
     const panel = resultsPanelRef.current;
@@ -244,6 +270,11 @@ const AdvancedNodeSearchDialog = ({
     const activeRow = panel.querySelector('[aria-selected="true"]');
     activeRow?.scrollIntoView({ block: "nearest" });
   }, [activeIndex, activeResult?.uid, debouncedSearchTerm]);
+
+  const handleSortChange = useCallback((nextSort: SortConfig): void => {
+    setSort(nextSort);
+    setActiveIndex(0);
+  }, []);
 
   const onKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLDivElement>) => {
@@ -255,10 +286,14 @@ const AdvancedNodeSearchDialog = ({
         setActiveIndex((index) => Math.max(index - 1, 0));
       } else if (event.key === "Escape") {
         event.preventDefault();
+        if (isSortPopoverOpen) {
+          setIsSortPopoverOpen(false);
+          return;
+        }
         onClose();
       }
     },
-    [onClose, results.length],
+    [isSortPopoverOpen, onClose, results.length],
   );
 
   const contentState = indexError
@@ -295,17 +330,33 @@ const AdvancedNodeSearchDialog = ({
         className="flex min-h-0 flex-1 flex-col overflow-hidden"
       >
         <div className="flex flex-none items-center gap-2 border-b border-gray-200 px-3 py-2">
-          <InputGroup
-            fill
-            inputRef={inputRef}
-            leftIcon="search"
-            onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
-              setSearchTerm(event.target.value)
-            }
-            placeholder="Search discourse nodes..."
-            value={searchTerm}
-          />
-          <Button icon="cross" minimal onClick={onClose} title="Close search" />
+          <div className="min-w-0 flex-1">
+            <InputGroup
+              fill
+              inputRef={inputRef}
+              leftIcon="search"
+              onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+                setSearchTerm(event.target.value)
+              }
+              placeholder="Search discourse nodes..."
+              value={searchTerm}
+            />
+          </div>
+          <div className="flex shrink-0 items-center gap-1">
+            <DiscourseNodeSortControl
+              disabled={isIndexLoading || indexError}
+              onPopoverOpenChange={setIsSortPopoverOpen}
+              onSortChange={handleSortChange}
+              sort={sort}
+            />
+            <Button
+              className="shrink-0"
+              icon="cross"
+              minimal
+              onClick={onClose}
+              title="Close search"
+            />
+          </div>
         </div>
         <div className="flex min-h-0 w-full flex-1 overflow-hidden">
           {showSplitView ? (

--- a/apps/roam/src/components/AdvancedNodeSearchDialog/AdvancedSearchDialog.tsx
+++ b/apps/roam/src/components/AdvancedNodeSearchDialog/AdvancedSearchDialog.tsx
@@ -330,33 +330,30 @@ const AdvancedNodeSearchDialog = ({
         className="flex min-h-0 flex-1 flex-col overflow-hidden"
       >
         <div className="flex flex-none items-center gap-2 border-b border-gray-200 px-3 py-2">
-          <div className="min-w-0 flex-1">
-            <InputGroup
-              fill
-              inputRef={inputRef}
-              leftIcon="search"
-              onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
-                setSearchTerm(event.target.value)
-              }
-              placeholder="Search discourse nodes..."
-              value={searchTerm}
-            />
-          </div>
-          <div className="flex shrink-0 items-center gap-1">
-            <DiscourseNodeSortControl
-              disabled={isIndexLoading || indexError}
-              onPopoverOpenChange={setIsSortPopoverOpen}
-              onSortChange={handleSortChange}
-              sort={sort}
-            />
-            <Button
-              className="shrink-0"
-              icon="cross"
-              minimal
-              onClick={onClose}
-              title="Close search"
-            />
-          </div>
+          <InputGroup
+            fill
+            inputRef={inputRef}
+            leftIcon="search"
+            onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+              setSearchTerm(event.target.value)
+            }
+            placeholder="Search discourse nodes..."
+            value={searchTerm}
+          />
+
+          <DiscourseNodeSortControl
+            disabled={isIndexLoading || indexError}
+            onPopoverOpenChange={setIsSortPopoverOpen}
+            onSortChange={handleSortChange}
+            sort={sort}
+          />
+          <Button
+            className="shrink-0"
+            icon="cross"
+            minimal
+            onClick={onClose}
+            title="Close search"
+          />
         </div>
         <div className="flex min-h-0 w-full flex-1 overflow-hidden">
           {showSplitView ? (

--- a/apps/roam/src/components/AdvancedNodeSearchDialog/AdvancedSearchDialog.tsx
+++ b/apps/roam/src/components/AdvancedNodeSearchDialog/AdvancedSearchDialog.tsx
@@ -149,7 +149,6 @@ const AdvancedNodeSearchDialog = ({
   const [indexError, setIndexError] = useState(false);
   const [activeIndex, setActiveIndex] = useState(0);
   const [sort, setSort] = useState<SortConfig>(DEFAULT_SORT_CONFIG);
-  const [isSortPopoverOpen, setIsSortPopoverOpen] = useState(false);
   const miniSearchRef = useRef<MiniSearch<
     SearchResult & { id: string }
   > | null>(null);
@@ -184,13 +183,7 @@ const AdvancedNodeSearchDialog = ({
     });
 
     return sortSearchResults({ hits: scoredHits, sort });
-  }, [
-    debouncedSearchTerm,
-    indexError,
-    isIndexLoading,
-    isOpen,
-    sort,
-  ]);
+  }, [debouncedSearchTerm, indexError, isIndexLoading, isOpen, sort]);
 
   const activeResult = results[activeIndex] ?? null;
   const keywords = debouncedSearchTerm.split(/\s+/).filter(Boolean);
@@ -213,7 +206,6 @@ const AdvancedNodeSearchDialog = ({
   useEffect(() => {
     if (!isOpen) {
       setSort(DEFAULT_SORT_CONFIG);
-      setIsSortPopoverOpen(false);
     }
   }, [isOpen]);
 
@@ -273,7 +265,6 @@ const AdvancedNodeSearchDialog = ({
 
   const handleSortChange = useCallback((nextSort: SortConfig): void => {
     setSort(nextSort);
-    setActiveIndex(0);
   }, []);
 
   const onKeyDown = useCallback(
@@ -286,14 +277,10 @@ const AdvancedNodeSearchDialog = ({
         setActiveIndex((index) => Math.max(index - 1, 0));
       } else if (event.key === "Escape") {
         event.preventDefault();
-        if (isSortPopoverOpen) {
-          setIsSortPopoverOpen(false);
-          return;
-        }
         onClose();
       }
     },
-    [isSortPopoverOpen, onClose, results.length],
+    [onClose, results.length],
   );
 
   const contentState = indexError
@@ -343,7 +330,6 @@ const AdvancedNodeSearchDialog = ({
 
           <DiscourseNodeSortControl
             disabled={isIndexLoading || indexError}
-            onPopoverOpenChange={setIsSortPopoverOpen}
             onSortChange={handleSortChange}
             sort={sort}
           />

--- a/apps/roam/src/components/AdvancedNodeSearchDialog/utils.ts
+++ b/apps/roam/src/components/AdvancedNodeSearchDialog/utils.ts
@@ -13,6 +13,26 @@ import {
 export const DEBOUNCE_MS = 250;
 export const MAX_RESULTS = 50;
 
+export type SortField = "relevance" | "alphabetical" | "dateCreated" | "author";
+export type SortDirection = "asc" | "desc";
+
+export type SortConfig = {
+  field: SortField;
+  direction: SortDirection;
+};
+
+export const DEFAULT_SORT_CONFIG: SortConfig = {
+  field: "relevance",
+  direction: "desc",
+};
+
+export const SORT_FIELD_LABELS: Record<SortField, string> = {
+  relevance: "Relevance",
+  alphabetical: "Alphabetical",
+  dateCreated: "Date created",
+  author: "Author",
+};
+
 export type SearchResult = {
   uid: string;
   title: string;
@@ -22,6 +42,11 @@ export type SearchResult = {
   createdAt: string;
   lastModified: string;
   authorName: string;
+};
+
+export type ScoredSearchHit = {
+  result: SearchResult;
+  score: number;
 };
 
 type MiniSearchDocument = SearchResult & {
@@ -148,6 +173,80 @@ export const buildSearchIndex = async (
   return { miniSearch, results };
 };
 
+const compareNumbers = (
+  a: number,
+  b: number,
+  direction: SortDirection,
+): number => (direction === "desc" ? b - a : a - b);
+
+const compareStrings = (
+  a: string,
+  b: string,
+  direction: SortDirection,
+): number => {
+  const comparison = a.localeCompare(b, undefined, { sensitivity: "base" });
+  return direction === "desc" ? -comparison : comparison;
+};
+
+const getSortableTitle = (result: SearchResult): string =>
+  stripTypePrefix(result.title);
+
+const getCreatedTime = (result: SearchResult): number =>
+  Number(result.createdAt) || 0;
+
+export const isNonDefaultSort = (sort: SortConfig): boolean =>
+  sort.field !== DEFAULT_SORT_CONFIG.field ||
+  sort.direction !== DEFAULT_SORT_CONFIG.direction;
+
+export const sortSearchResults = ({
+  hits,
+  sort,
+}: {
+  hits: ScoredSearchHit[];
+  sort: SortConfig;
+}): SearchResult[] => {
+  const sorted = [...hits];
+
+  sorted.sort((aHit, bHit) => {
+    const a = aHit.result;
+    const b = bHit.result;
+    let comparison = 0;
+
+    switch (sort.field) {
+      case "relevance":
+        comparison = compareNumbers(aHit.score, bHit.score, sort.direction);
+        break;
+      case "alphabetical":
+        comparison = compareStrings(
+          getSortableTitle(a),
+          getSortableTitle(b),
+          sort.direction,
+        );
+        break;
+      case "dateCreated":
+        comparison = compareNumbers(
+          getCreatedTime(a),
+          getCreatedTime(b),
+          sort.direction,
+        );
+        break;
+      case "author": {
+        const aAuthor = a.authorName.trim();
+        const bAuthor = b.authorName.trim();
+        if (!aAuthor && !bAuthor) comparison = 0;
+        else if (!aAuthor) comparison = 1;
+        else if (!bAuthor) comparison = -1;
+        else comparison = compareStrings(aAuthor, bAuthor, sort.direction);
+        break;
+      }
+    }
+
+    return comparison || a.uid.localeCompare(b.uid);
+  });
+
+  return sorted.map((hit) => hit.result);
+};
+
 export const searchIndexedNodes = ({
   miniSearch,
   allResults,
@@ -156,7 +255,7 @@ export const searchIndexedNodes = ({
   miniSearch: MiniSearch<MiniSearchDocument>;
   allResults: SearchResult[];
   searchTerm: string;
-}): SearchResult[] => {
+}): ScoredSearchHit[] => {
   const resultsByUid = new Map(
     allResults.map((result) => [result.uid, result]),
   );
@@ -168,6 +267,10 @@ export const searchIndexedNodes = ({
     })
     .filter((result) => result.score > DISCOURSE_NODE_MIN_SEARCH_SCORE)
     .slice(0, MAX_RESULTS)
-    .map((result) => resultsByUid.get(String(result.id)))
-    .filter((result): result is SearchResult => !!result);
+    .map((result) => {
+      const searchResult = resultsByUid.get(String(result.id));
+      if (!searchResult) return null;
+      return { result: searchResult, score: result.score };
+    })
+    .filter((hit): hit is ScoredSearchHit => !!hit);
 };

--- a/apps/roam/src/components/DiscourseNodeSortControl.tsx
+++ b/apps/roam/src/components/DiscourseNodeSortControl.tsx
@@ -11,7 +11,6 @@ import {
   type SortConfig,
   type SortDirection,
   type SortField,
-  isNonDefaultSort,
 } from "~/components/AdvancedNodeSearchDialog/utils";
 
 const SORT_FIELDS: SortField[] = [
@@ -20,9 +19,6 @@ const SORT_FIELDS: SortField[] = [
   "dateCreated",
   "author",
 ];
-
-const POPOVER_CONTENT_CLASS =
-  "[&_.bp3-popover-content]:overflow-hidden [&_.bp3-popover-content]:rounded-lg [&_.bp3-popover-content]:p-0";
 
 export type DiscourseNodeSortControlProps = {
   sort: SortConfig;
@@ -217,10 +213,7 @@ export const DiscourseNodeSortControl = ({
         }}
         onClose={closePopover}
         onInteraction={handlePopoverInteraction}
-        popoverClassName={POPOVER_CONTENT_CLASS}
-        popoverRef={(element) => {
-          popoverRef.current = element;
-        }}
+        popoverRef={popoverRef}
         position={Position.BOTTOM_RIGHT}
         target={sortButton}
         usePortal

--- a/apps/roam/src/components/DiscourseNodeSortControl.tsx
+++ b/apps/roam/src/components/DiscourseNodeSortControl.tsx
@@ -1,13 +1,8 @@
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import React, { useCallback, useRef, useState } from "react";
 import { Button, Icon, Popover, Position } from "@blueprintjs/core";
 import {
   SORT_FIELD_LABELS,
+  isNonDefaultSort,
   type SortConfig,
   type SortDirection,
   type SortField,
@@ -23,35 +18,7 @@ const SORT_FIELDS: SortField[] = [
 export type DiscourseNodeSortControlProps = {
   sort: SortConfig;
   onSortChange: (sort: SortConfig) => void;
-  onPopoverOpenChange?: (isOpen: boolean) => void;
   disabled?: boolean;
-};
-
-const useCloseOnClickOutside = ({
-  isOpen,
-  onClose,
-  popoverRef,
-  targetRef,
-}: {
-  isOpen: boolean;
-  onClose: () => void;
-  popoverRef: React.RefObject<HTMLElement | null>;
-  targetRef: React.RefObject<HTMLElement>;
-}): void => {
-  useEffect(() => {
-    if (!isOpen) return;
-
-    const handleMouseDown = (event: MouseEvent): void => {
-      const clickTarget = event.target as Node;
-      if (popoverRef.current?.contains(clickTarget)) return;
-      if (targetRef.current?.contains(clickTarget)) return;
-      onClose();
-    };
-
-    document.addEventListener("mousedown", handleMouseDown, true);
-    return () =>
-      document.removeEventListener("mousedown", handleMouseDown, true);
-  }, [isOpen, onClose, popoverRef, targetRef]);
 };
 
 const SortDirectionToggles = ({
@@ -103,7 +70,6 @@ const SortDirectionToggles = ({
 
 export const DiscourseNodeSortControl = ({
   disabled = false,
-  onPopoverOpenChange,
   onSortChange,
   sort,
 }: DiscourseNodeSortControlProps): React.ReactElement => {
@@ -111,26 +77,8 @@ export const DiscourseNodeSortControl = ({
   const triggerRef = useRef<HTMLButtonElement>(null);
   const popoverRef = useRef<HTMLElement | null>(null);
 
-  const sortLabel = useMemo(() => SORT_FIELD_LABELS[sort.field], [sort.field]);
-
-  const setOpen = useCallback(
-    (nextOpen: boolean): void => {
-      setIsOpen(nextOpen);
-      onPopoverOpenChange?.(nextOpen);
-    },
-    [onPopoverOpenChange],
-  );
-
-  const closePopover = useCallback((): void => {
-    setOpen(false);
-  }, [setOpen]);
-
-  useCloseOnClickOutside({
-    isOpen,
-    onClose: closePopover,
-    popoverRef,
-    targetRef: triggerRef,
-  });
+  const sortLabel = SORT_FIELD_LABELS[sort.field];
+  const isTriggerActive = isOpen || isNonDefaultSort(sort);
 
   const handlePopoverInteraction = useCallback(
     (nextOpen: boolean, event?: React.SyntheticEvent<HTMLElement>): void => {
@@ -138,9 +86,17 @@ export const DiscourseNodeSortControl = ({
       if (nextOpen) {
         event?.stopPropagation();
       }
-      setOpen(nextOpen);
+      setIsOpen(nextOpen);
     },
-    [disabled, setOpen],
+    [disabled],
+  );
+
+  const applySort = useCallback(
+    (nextSort: SortConfig): void => {
+      onSortChange(nextSort);
+      setIsOpen(false);
+    },
+    [onSortChange],
   );
 
   const sortButton = (
@@ -148,11 +104,15 @@ export const DiscourseNodeSortControl = ({
       aria-expanded={isOpen}
       aria-haspopup="listbox"
       aria-label={`Sort by ${sortLabel}`}
+      className={`${
+        isTriggerActive
+          ? "!bg-[rgba(95,87,192,0.1)] !text-[#5f57c0]"
+          : "!text-gray-600 hover:!bg-gray-100 hover:!text-gray-900"
+      }`}
       disabled={disabled}
       elementRef={triggerRef}
       icon="sort"
       minimal
-      onClick={() => setOpen(!isOpen)}
       onMouseDown={(event) => event.preventDefault()}
       title={`Sort: ${sortLabel}`}
     />
@@ -180,7 +140,7 @@ export const DiscourseNodeSortControl = ({
                     gridTemplateColumns: "22px 1fr auto",
                   }}
                   onClick={() =>
-                    onSortChange({ field, direction: sort.direction })
+                    applySort({ field, direction: sort.direction })
                   }
                   type="button"
                 >
@@ -195,7 +155,7 @@ export const DiscourseNodeSortControl = ({
                     field={field}
                     isSelected={isSelected}
                     onDirectionChange={(direction) =>
-                      onSortChange({ field, direction })
+                      applySort({ field, direction })
                     }
                   />
                 </button>
@@ -211,7 +171,7 @@ export const DiscourseNodeSortControl = ({
           flip: { enabled: true },
           preventOverflow: { enabled: true, boundariesElement: "viewport" },
         }}
-        onClose={closePopover}
+        onClose={() => setIsOpen(false)}
         onInteraction={handlePopoverInteraction}
         popoverRef={popoverRef}
         position={Position.BOTTOM_RIGHT}

--- a/apps/roam/src/components/DiscourseNodeSortControl.tsx
+++ b/apps/roam/src/components/DiscourseNodeSortControl.tsx
@@ -1,0 +1,232 @@
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { Button, Icon, Popover, Position } from "@blueprintjs/core";
+import {
+  SORT_FIELD_LABELS,
+  type SortConfig,
+  type SortDirection,
+  type SortField,
+  isNonDefaultSort,
+} from "~/components/AdvancedNodeSearchDialog/utils";
+
+const SORT_FIELDS: SortField[] = [
+  "relevance",
+  "alphabetical",
+  "dateCreated",
+  "author",
+];
+
+const POPOVER_CONTENT_CLASS =
+  "[&_.bp3-popover-content]:overflow-hidden [&_.bp3-popover-content]:rounded-lg [&_.bp3-popover-content]:p-0";
+
+export type DiscourseNodeSortControlProps = {
+  sort: SortConfig;
+  onSortChange: (sort: SortConfig) => void;
+  onPopoverOpenChange?: (isOpen: boolean) => void;
+  disabled?: boolean;
+};
+
+const useCloseOnClickOutside = ({
+  isOpen,
+  onClose,
+  popoverRef,
+  targetRef,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+  popoverRef: React.RefObject<HTMLElement | null>;
+  targetRef: React.RefObject<HTMLElement>;
+}): void => {
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleMouseDown = (event: MouseEvent): void => {
+      const clickTarget = event.target as Node;
+      if (popoverRef.current?.contains(clickTarget)) return;
+      if (targetRef.current?.contains(clickTarget)) return;
+      onClose();
+    };
+
+    document.addEventListener("mousedown", handleMouseDown, true);
+    return () =>
+      document.removeEventListener("mousedown", handleMouseDown, true);
+  }, [isOpen, onClose, popoverRef, targetRef]);
+};
+
+const SortDirectionToggles = ({
+  direction,
+  field,
+  isSelected,
+  onDirectionChange,
+}: {
+  direction: SortDirection;
+  field: SortField;
+  isSelected: boolean;
+  onDirectionChange: (direction: SortDirection) => void;
+}): React.ReactElement => (
+  <span
+    className="inline-flex gap-0.5"
+    onClick={(event) => event.stopPropagation()}
+    role="presentation"
+  >
+    <button
+      aria-label={`${SORT_FIELD_LABELS[field]} ascending`}
+      className={`inline-flex h-6 w-6 cursor-pointer items-center justify-center rounded border-0 bg-transparent p-0 text-gray-400 hover:bg-gray-100 hover:text-gray-900 ${
+        isSelected && direction === "asc" ? "bg-blue-700/10 text-blue-700" : ""
+      }`}
+      onClick={(event) => {
+        event.stopPropagation();
+        onDirectionChange("asc");
+      }}
+      onMouseDown={(event) => event.preventDefault()}
+      type="button"
+    >
+      <Icon icon="arrow-up" size={12} />
+    </button>
+    <button
+      aria-label={`${SORT_FIELD_LABELS[field]} descending`}
+      className={`inline-flex h-6 w-6 cursor-pointer items-center justify-center rounded border-0 bg-transparent p-0 text-gray-400 hover:bg-gray-100 hover:text-gray-900 ${
+        isSelected && direction === "desc" ? "bg-blue-700/10 text-blue-700" : ""
+      }`}
+      onClick={(event) => {
+        event.stopPropagation();
+        onDirectionChange("desc");
+      }}
+      onMouseDown={(event) => event.preventDefault()}
+      type="button"
+    >
+      <Icon icon="arrow-down" size={12} />
+    </button>
+  </span>
+);
+
+export const DiscourseNodeSortControl = ({
+  disabled = false,
+  onPopoverOpenChange,
+  onSortChange,
+  sort,
+}: DiscourseNodeSortControlProps): React.ReactElement => {
+  const [isOpen, setIsOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const popoverRef = useRef<HTMLElement | null>(null);
+
+  const sortLabel = useMemo(() => SORT_FIELD_LABELS[sort.field], [sort.field]);
+  const isSortActive = isNonDefaultSort(sort);
+  const isTriggerActive = isOpen || isSortActive;
+
+  const setOpen = useCallback(
+    (nextOpen: boolean): void => {
+      setIsOpen(nextOpen);
+      onPopoverOpenChange?.(nextOpen);
+    },
+    [onPopoverOpenChange],
+  );
+
+  const closePopover = useCallback((): void => {
+    setOpen(false);
+  }, [setOpen]);
+
+  useCloseOnClickOutside({
+    isOpen,
+    onClose: closePopover,
+    popoverRef,
+    targetRef: triggerRef,
+  });
+
+  const handlePopoverInteraction = useCallback(
+    (nextOpen: boolean, event?: React.SyntheticEvent<HTMLElement>): void => {
+      if (disabled) return;
+      if (nextOpen) {
+        event?.stopPropagation();
+      }
+      setOpen(nextOpen);
+    },
+    [disabled, setOpen],
+  );
+
+  const sortButton = (
+    <Button
+      aria-expanded={isOpen}
+      aria-haspopup="listbox"
+      aria-label={`Sort by ${sortLabel}`}
+      disabled={disabled}
+      elementRef={triggerRef}
+      icon="sort"
+      minimal
+      onClick={() => setOpen(!isOpen)}
+      onMouseDown={(event) => event.preventDefault()}
+      title={`Sort: ${sortLabel}`}
+    />
+  );
+
+  return (
+    <span className="inline-flex shrink-0 [&_.bp3-popover-wrapper]:shrink-0">
+      <Popover
+        autoFocus={false}
+        canEscapeKeyClose
+        content={
+          <div className="w-60 overflow-hidden">
+            <div className="px-3 pb-1 pt-2 text-xs font-medium text-gray-500">
+              Sort by
+            </div>
+            {SORT_FIELDS.map((field) => {
+              const isSelected = sort.field === field;
+              return (
+                <button
+                  key={field}
+                  className={`grid w-full cursor-pointer items-center gap-2 border-0 px-3 py-1.5 text-left text-sm text-gray-900 hover:bg-gray-50 ${
+                    isSelected ? "bg-blue-700/[0.07]" : "bg-transparent"
+                  }`}
+                  style={{
+                    gridTemplateColumns: "22px 1fr auto",
+                  }}
+                  onClick={() =>
+                    onSortChange({ field, direction: sort.direction })
+                  }
+                  type="button"
+                >
+                  <span className="inline-flex items-center justify-center text-blue-700">
+                    {isSelected && <Icon icon="tick" size={12} />}
+                  </span>
+                  <span className={isSelected ? "font-semibold" : ""}>
+                    {SORT_FIELD_LABELS[field]}
+                  </span>
+                  <SortDirectionToggles
+                    direction={sort.direction}
+                    field={field}
+                    isSelected={isSelected}
+                    onDirectionChange={(direction) =>
+                      onSortChange({ field, direction })
+                    }
+                  />
+                </button>
+              );
+            })}
+          </div>
+        }
+        disabled={disabled}
+        enforceFocus={false}
+        isOpen={isOpen}
+        minimal
+        modifiers={{
+          flip: { enabled: true },
+          preventOverflow: { enabled: true, boundariesElement: "viewport" },
+        }}
+        onClose={closePopover}
+        onInteraction={handlePopoverInteraction}
+        popoverClassName={POPOVER_CONTENT_CLASS}
+        popoverRef={(element) => {
+          popoverRef.current = element;
+        }}
+        position={Position.BOTTOM_RIGHT}
+        target={sortButton}
+        usePortal
+      />
+    </span>
+  );
+};

--- a/apps/roam/src/components/DiscourseNodeSortControl.tsx
+++ b/apps/roam/src/components/DiscourseNodeSortControl.tsx
@@ -1,5 +1,12 @@
 import React, { useCallback, useRef, useState } from "react";
-import { Button, Icon, Popover, Position } from "@blueprintjs/core";
+import {
+  Button,
+  ButtonGroup,
+  Menu,
+  MenuItem,
+  Popover,
+  Position,
+} from "@blueprintjs/core";
 import {
   SORT_FIELD_LABELS,
   isNonDefaultSort,
@@ -32,40 +39,71 @@ const SortDirectionToggles = ({
   isSelected: boolean;
   onDirectionChange: (direction: SortDirection) => void;
 }): React.ReactElement => (
-  <span
-    className="inline-flex gap-0.5"
+  <ButtonGroup
+    className="shrink-0"
+    minimal
     onClick={(event) => event.stopPropagation()}
-    role="presentation"
   >
-    <button
+    <Button
+      active={isSelected && direction === "asc"}
       aria-label={`${SORT_FIELD_LABELS[field]} ascending`}
-      className={`inline-flex h-6 w-6 cursor-pointer items-center justify-center rounded border-0 bg-transparent p-0 text-gray-400 hover:bg-gray-100 hover:text-gray-900 ${
-        isSelected && direction === "asc" ? "bg-blue-700/10 text-blue-700" : ""
-      }`}
+      icon="arrow-up"
+      minimal
       onClick={(event) => {
         event.stopPropagation();
         onDirectionChange("asc");
       }}
       onMouseDown={(event) => event.preventDefault()}
-      type="button"
-    >
-      <Icon icon="arrow-up" size={12} />
-    </button>
-    <button
+      small
+    />
+    <Button
+      active={isSelected && direction === "desc"}
       aria-label={`${SORT_FIELD_LABELS[field]} descending`}
-      className={`inline-flex h-6 w-6 cursor-pointer items-center justify-center rounded border-0 bg-transparent p-0 text-gray-400 hover:bg-gray-100 hover:text-gray-900 ${
-        isSelected && direction === "desc" ? "bg-blue-700/10 text-blue-700" : ""
-      }`}
+      icon="arrow-down"
+      minimal
       onClick={(event) => {
         event.stopPropagation();
         onDirectionChange("desc");
       }}
       onMouseDown={(event) => event.preventDefault()}
-      type="button"
-    >
-      <Icon icon="arrow-down" size={12} />
-    </button>
-  </span>
+      small
+    />
+  </ButtonGroup>
+);
+
+const SortPopoverMenu = ({
+  onSortChange,
+  sort,
+}: {
+  onSortChange: (sort: SortConfig) => void;
+  sort: SortConfig;
+}): React.ReactElement => (
+  <Menu className="w-60">
+    <MenuItem disabled shouldDismissPopover={false} text="Sort by" />
+    {SORT_FIELDS.map((field) => {
+      const isSelected = sort.field === field;
+      return (
+        <MenuItem
+          key={field}
+          active={isSelected}
+          icon={isSelected ? "tick" : "blank"}
+          labelElement={
+            <SortDirectionToggles
+              direction={sort.direction}
+              field={field}
+              isSelected={isSelected}
+              onDirectionChange={(direction) =>
+                onSortChange({ field, direction })
+              }
+            />
+          }
+          onClick={() => onSortChange({ field, direction: sort.direction })}
+          shouldDismissPopover={false}
+          text={SORT_FIELD_LABELS[field]}
+        />
+      );
+    })}
+  </Menu>
 );
 
 export const DiscourseNodeSortControl = ({
@@ -123,46 +161,7 @@ export const DiscourseNodeSortControl = ({
       <Popover
         autoFocus={false}
         canEscapeKeyClose
-        content={
-          <div className="w-60 overflow-hidden">
-            <div className="px-3 pb-1 pt-2 text-xs font-medium text-gray-500">
-              Sort by
-            </div>
-            {SORT_FIELDS.map((field) => {
-              const isSelected = sort.field === field;
-              return (
-                <button
-                  key={field}
-                  className={`grid w-full cursor-pointer items-center gap-2 border-0 px-3 py-1.5 text-left text-sm text-gray-900 hover:bg-gray-50 ${
-                    isSelected ? "bg-blue-700/[0.07]" : "bg-transparent"
-                  }`}
-                  style={{
-                    gridTemplateColumns: "22px 1fr auto",
-                  }}
-                  onClick={() =>
-                    applySort({ field, direction: sort.direction })
-                  }
-                  type="button"
-                >
-                  <span className="inline-flex items-center justify-center text-blue-700">
-                    {isSelected && <Icon icon="tick" size={12} />}
-                  </span>
-                  <span className={isSelected ? "font-semibold" : ""}>
-                    {SORT_FIELD_LABELS[field]}
-                  </span>
-                  <SortDirectionToggles
-                    direction={sort.direction}
-                    field={field}
-                    isSelected={isSelected}
-                    onDirectionChange={(direction) =>
-                      applySort({ field, direction })
-                    }
-                  />
-                </button>
-              );
-            })}
-          </div>
-        }
+        content={<SortPopoverMenu onSortChange={applySort} sort={sort} />}
         disabled={disabled}
         enforceFocus={false}
         isOpen={isOpen}

--- a/apps/roam/src/components/DiscourseNodeSortControl.tsx
+++ b/apps/roam/src/components/DiscourseNodeSortControl.tsx
@@ -1,12 +1,5 @@
 import React, { useCallback, useRef, useState } from "react";
-import {
-  Button,
-  ButtonGroup,
-  Menu,
-  MenuItem,
-  Popover,
-  Position,
-} from "@blueprintjs/core";
+import { Button, Menu, MenuItem, Popover, Position } from "@blueprintjs/core";
 import {
   SORT_FIELD_LABELS,
   isNonDefaultSort,
@@ -28,81 +21,25 @@ export type DiscourseNodeSortControlProps = {
   disabled?: boolean;
 };
 
-const SortDirectionToggles = ({
-  direction,
-  field,
-  isSelected,
-  onDirectionChange,
-}: {
-  direction: SortDirection;
-  field: SortField;
-  isSelected: boolean;
-  onDirectionChange: (direction: SortDirection) => void;
-}): React.ReactElement => (
-  <ButtonGroup
-    className="shrink-0"
-    minimal
-    onClick={(event) => event.stopPropagation()}
-  >
-    <Button
-      active={isSelected && direction === "asc"}
-      aria-label={`${SORT_FIELD_LABELS[field]} ascending`}
-      icon="arrow-up"
-      minimal
-      onClick={(event) => {
-        event.stopPropagation();
-        onDirectionChange("asc");
-      }}
-      onMouseDown={(event) => event.preventDefault()}
-      small
-    />
-    <Button
-      active={isSelected && direction === "desc"}
-      aria-label={`${SORT_FIELD_LABELS[field]} descending`}
-      icon="arrow-down"
-      minimal
-      onClick={(event) => {
-        event.stopPropagation();
-        onDirectionChange("desc");
-      }}
-      onMouseDown={(event) => event.preventDefault()}
-      small
-    />
-  </ButtonGroup>
-);
-
 const SortPopoverMenu = ({
-  onSortChange,
+  onFieldChange,
   sort,
 }: {
-  onSortChange: (sort: SortConfig) => void;
+  onFieldChange: (field: SortField) => void;
   sort: SortConfig;
 }): React.ReactElement => (
-  <Menu className="w-60">
+  <Menu className="w-52">
     <MenuItem disabled shouldDismissPopover={false} text="Sort by" />
-    {SORT_FIELDS.map((field) => {
-      const isSelected = sort.field === field;
-      return (
-        <MenuItem
-          key={field}
-          active={isSelected}
-          icon={isSelected ? "tick" : "blank"}
-          labelElement={
-            <SortDirectionToggles
-              direction={sort.direction}
-              field={field}
-              isSelected={isSelected}
-              onDirectionChange={(direction) =>
-                onSortChange({ field, direction })
-              }
-            />
-          }
-          onClick={() => onSortChange({ field, direction: sort.direction })}
-          shouldDismissPopover={false}
-          text={SORT_FIELD_LABELS[field]}
-        />
-      );
-    })}
+    {SORT_FIELDS.map((field) => (
+      <MenuItem
+        key={field}
+        active={sort.field === field}
+        icon={sort.field === field ? "tick" : "blank"}
+        onClick={() => onFieldChange(field)}
+        shouldDismissPopover={false}
+        text={SORT_FIELD_LABELS[field]}
+      />
+    ))}
   </Menu>
 );
 
@@ -117,6 +54,7 @@ export const DiscourseNodeSortControl = ({
 
   const sortLabel = SORT_FIELD_LABELS[sort.field];
   const isTriggerActive = isOpen || isNonDefaultSort(sort);
+  const directionIcon = sort.direction === "asc" ? "arrow-up" : "arrow-down";
 
   const handlePopoverInteraction = useCallback(
     (nextOpen: boolean, event?: React.SyntheticEvent<HTMLElement>): void => {
@@ -129,13 +67,19 @@ export const DiscourseNodeSortControl = ({
     [disabled],
   );
 
-  const applySort = useCallback(
-    (nextSort: SortConfig): void => {
-      onSortChange(nextSort);
+  const applyField = useCallback(
+    (field: SortField): void => {
+      onSortChange({ field, direction: sort.direction });
       setIsOpen(false);
     },
-    [onSortChange],
+    [onSortChange, sort.direction],
   );
+
+  const toggleDirection = useCallback((): void => {
+    const nextDirection: SortDirection =
+      sort.direction === "asc" ? "desc" : "asc";
+    onSortChange({ field: sort.field, direction: nextDirection });
+  }, [onSortChange, sort.direction, sort.field]);
 
   const sortButton = (
     <Button
@@ -157,11 +101,11 @@ export const DiscourseNodeSortControl = ({
   );
 
   return (
-    <span className="inline-flex shrink-0 [&_.bp3-popover-wrapper]:shrink-0">
+    <span className="inline-flex shrink-0 items-center gap-0.5 [&_.bp3-popover-wrapper]:shrink-0">
       <Popover
         autoFocus={false}
         canEscapeKeyClose
-        content={<SortPopoverMenu onSortChange={applySort} sort={sort} />}
+        content={<SortPopoverMenu onFieldChange={applyField} sort={sort} />}
         disabled={disabled}
         enforceFocus={false}
         isOpen={isOpen}
@@ -176,6 +120,17 @@ export const DiscourseNodeSortControl = ({
         position={Position.BOTTOM_RIGHT}
         target={sortButton}
         usePortal
+      />
+      <Button
+        aria-label={`${sortLabel} ${sort.direction === "asc" ? "ascending" : "descending"}`}
+        className="!text-gray-600 hover:!bg-gray-100 hover:!text-gray-900"
+        disabled={disabled}
+        icon={directionIcon}
+        minimal
+        onClick={toggleDirection}
+        onMouseDown={(event) => event.preventDefault()}
+        small
+        title={`${sort.direction === "asc" ? "Ascending" : "Descending"}`}
       />
     </span>
   );

--- a/apps/roam/src/components/DiscourseNodeSortControl.tsx
+++ b/apps/roam/src/components/DiscourseNodeSortControl.tsx
@@ -1,5 +1,13 @@
 import React, { useCallback, useRef, useState } from "react";
-import { Button, Menu, MenuItem, Popover, Position } from "@blueprintjs/core";
+import {
+  Button,
+  ButtonGroup,
+  Menu,
+  MenuDivider,
+  MenuItem,
+  Popover,
+  Position,
+} from "@blueprintjs/core";
 import {
   SORT_FIELD_LABELS,
   isNonDefaultSort,
@@ -21,25 +29,65 @@ export type DiscourseNodeSortControlProps = {
   disabled?: boolean;
 };
 
+const SortDirectionFooter = ({
+  direction,
+  onDirectionChange,
+}: {
+  direction: SortDirection;
+  onDirectionChange: (direction: SortDirection) => void;
+}): React.ReactElement => (
+  <div
+    className="px-2 py-2"
+    onClick={(event) => event.stopPropagation()}
+    onMouseDown={(event) => event.preventDefault()}
+  >
+    <ButtonGroup fill>
+      <Button
+        active={direction === "asc"}
+        aria-label="Ascending"
+        icon="sort-asc"
+        onClick={() => onDirectionChange("asc")}
+        small
+        text="Ascending"
+      />
+      <Button
+        active={direction === "desc"}
+        aria-label="Descending"
+        icon="sort-desc"
+        onClick={() => onDirectionChange("desc")}
+        small
+        text="Descending"
+      />
+    </ButtonGroup>
+  </div>
+);
+
 const SortPopoverMenu = ({
-  onFieldChange,
+  onSortChange,
   sort,
 }: {
-  onFieldChange: (field: SortField) => void;
+  onSortChange: (sort: SortConfig) => void;
   sort: SortConfig;
 }): React.ReactElement => (
-  <Menu className="w-52">
+  <Menu className="w-56">
     <MenuItem disabled shouldDismissPopover={false} text="Sort by" />
     {SORT_FIELDS.map((field) => (
       <MenuItem
         key={field}
         active={sort.field === field}
         icon={sort.field === field ? "tick" : "blank"}
-        onClick={() => onFieldChange(field)}
+        onClick={() => onSortChange({ field, direction: sort.direction })}
         shouldDismissPopover={false}
         text={SORT_FIELD_LABELS[field]}
       />
     ))}
+    <MenuDivider />
+    <SortDirectionFooter
+      direction={sort.direction}
+      onDirectionChange={(direction) =>
+        onSortChange({ field: sort.field, direction })
+      }
+    />
   </Menu>
 );
 
@@ -54,7 +102,6 @@ export const DiscourseNodeSortControl = ({
 
   const sortLabel = SORT_FIELD_LABELS[sort.field];
   const isTriggerActive = isOpen || isNonDefaultSort(sort);
-  const directionIcon = sort.direction === "asc" ? "arrow-up" : "arrow-down";
 
   const handlePopoverInteraction = useCallback(
     (nextOpen: boolean, event?: React.SyntheticEvent<HTMLElement>): void => {
@@ -66,20 +113,6 @@ export const DiscourseNodeSortControl = ({
     },
     [disabled],
   );
-
-  const applyField = useCallback(
-    (field: SortField): void => {
-      onSortChange({ field, direction: sort.direction });
-      setIsOpen(false);
-    },
-    [onSortChange, sort.direction],
-  );
-
-  const toggleDirection = useCallback((): void => {
-    const nextDirection: SortDirection =
-      sort.direction === "asc" ? "desc" : "asc";
-    onSortChange({ field: sort.field, direction: nextDirection });
-  }, [onSortChange, sort.direction, sort.field]);
 
   const sortButton = (
     <Button
@@ -101,11 +134,11 @@ export const DiscourseNodeSortControl = ({
   );
 
   return (
-    <span className="inline-flex shrink-0 items-center gap-0.5 [&_.bp3-popover-wrapper]:shrink-0">
+    <span className="inline-flex shrink-0 [&_.bp3-popover-wrapper]:shrink-0">
       <Popover
         autoFocus={false}
         canEscapeKeyClose
-        content={<SortPopoverMenu onFieldChange={applyField} sort={sort} />}
+        content={<SortPopoverMenu onSortChange={onSortChange} sort={sort} />}
         disabled={disabled}
         enforceFocus={false}
         isOpen={isOpen}
@@ -120,17 +153,6 @@ export const DiscourseNodeSortControl = ({
         position={Position.BOTTOM_RIGHT}
         target={sortButton}
         usePortal
-      />
-      <Button
-        aria-label={`${sortLabel} ${sort.direction === "asc" ? "ascending" : "descending"}`}
-        className="!text-gray-600 hover:!bg-gray-100 hover:!text-gray-900"
-        disabled={disabled}
-        icon={directionIcon}
-        minimal
-        onClick={toggleDirection}
-        onMouseDown={(event) => event.preventDefault()}
-        small
-        title={`${sort.direction === "asc" ? "Ascending" : "Descending"}`}
       />
     </span>
   );

--- a/apps/roam/src/components/DiscourseNodeSortControl.tsx
+++ b/apps/roam/src/components/DiscourseNodeSortControl.tsx
@@ -48,7 +48,7 @@ const SortDirectionFooter = ({
         icon="sort-asc"
         onClick={() => onDirectionChange("asc")}
         small
-        text="Ascending"
+        text="Asc"
       />
       <Button
         active={direction === "desc"}
@@ -56,7 +56,7 @@ const SortDirectionFooter = ({
         icon="sort-desc"
         onClick={() => onDirectionChange("desc")}
         small
-        text="Descending"
+        text="Desc"
       />
     </ButtonGroup>
   </div>

--- a/apps/roam/src/components/DiscourseNodeSortControl.tsx
+++ b/apps/roam/src/components/DiscourseNodeSortControl.tsx
@@ -116,8 +116,6 @@ export const DiscourseNodeSortControl = ({
   const popoverRef = useRef<HTMLElement | null>(null);
 
   const sortLabel = useMemo(() => SORT_FIELD_LABELS[sort.field], [sort.field]);
-  const isSortActive = isNonDefaultSort(sort);
-  const isTriggerActive = isOpen || isSortActive;
 
   const setOpen = useCallback(
     (nextOpen: boolean): void => {


### PR DESCRIPTION
https://www.loom.com/share/3962e60744dd4477a24c1e993d8b9def

## Summary

- Add a sort icon control to the advanced node search dialog toolbar with a popover for relevance, alphabetical, date created, and author (each with asc/desc).
- Preserve MiniSearch scores and apply client-side sorting over the top 50 results after search.
- Fix toolbar layout so the search input, sort button, and close button do not overlap.

## Test plan

- [x] Open **DG: Open Node Search Menu** in Roam and run a keyword search
- [x] Confirm sort icon appears next to close without overlapping the search field
- [x] Sort by **Relevance** (desc): highest-scoring matches first
- [x] Sort by **Alphabetical** (asc/desc): titles reorder by stripped display title
- [x] Sort by **Date created** (asc/desc): order follows node creation time
- [x] Sort by **Author** (asc/desc): order follows author display name; empty authors sort last
- [x] Change sort while results are shown: list reorders immediately and selection resets to first row


Made with [Cursor](https://cursor.com)