### PR TITLE
ENG-1777 Relax naming-convention lint exceptions for external fields

### DIFF
--- a/packages/eslint-config/base.js
+++ b/packages/eslint-config/base.js
@@ -27,12 +27,52 @@ export const config = [
       "@typescript-eslint/naming-convention": [
         "error",
         // Keep default
-        { selector: "default", format: ["camelCase"] },
+        {
+          selector: "default",
+          format: ["camelCase"],
+          leadingUnderscore: "allowSingleOrDouble",
+        },
+        // External APIs, generated database types, route maps, and host app
+        // integration points often require exact property names.
+        {
+          selector: [
+            "objectLiteralProperty",
+            "objectLiteralMethod",
+            "typeProperty",
+          ],
+          format: null,
+        },
+        // Allow exact external field names when destructuring API/database data.
+        {
+          selector: "variable",
+          modifiers: ["destructured"],
+          format: null,
+        },
+        // Allow local names that intentionally mirror database identifiers.
+        {
+          selector: ["variable", "parameter"],
+          filter: {
+            regex:
+              "^(?:[a-z][a-z0-9]*_)*(?:id|ids|uid|uids|t)$|^(?:last_modified|literal_content)$",
+            match: true,
+          },
+          format: null,
+        },
+        // Allow compact geometry helper names used by tldraw relation logic.
+        {
+          selector: "variable",
+          filter: {
+            regex: "^(?:[A-Z]\\d+|handle_[A-Za-z0-9]+)$",
+            match: true,
+          },
+          format: null,
+        },
         // Keep default for const
         {
           selector: "variable",
           modifiers: ["const"],
-          format: ["camelCase", "UPPER_CASE"],
+          format: ["camelCase", "PascalCase", "UPPER_CASE"],
+          leadingUnderscore: "allowSingleOrDouble",
         },
         // Keep default for types
         { selector: "typeLike", format: ["PascalCase"] },
@@ -41,6 +81,35 @@ export const config = [
           selector: "variable",
           types: ["function"],
           format: ["camelCase", "PascalCase"],
+          leadingUnderscore: "allowSingleOrDouble",
+        },
+        // Allow PascalCase for function declarations used as React components
+        // or tldraw SVG helper components.
+        {
+          selector: "function",
+          format: ["camelCase", "PascalCase"],
+          leadingUnderscore: "allowSingleOrDouble",
+        },
+        // Allow conventional ignored callback parameters.
+        {
+          selector: "parameter",
+          modifiers: ["unused"],
+          format: null,
+        },
+        // Allow constants and state names required by class-based libraries.
+        {
+          selector: "classProperty",
+          format: ["camelCase", "PascalCase", "UPPER_CASE"],
+          leadingUnderscore: "allowSingleOrDouble",
+        },
+        // Support common enum member conventions.
+        {
+          selector: "enumMember",
+          format: ["PascalCase", "UPPER_CASE"],
+        },
+        {
+          selector: "enum",
+          format: ["PascalCase", "UPPER_CASE"],
         },
         // Allow PascalCase for React imports
         {


### PR DESCRIPTION
- Added new rules to allow leading underscores for various selectors.
- Introduced flexibility for naming conventions in object properties, destructured variables, and class properties.
- Allowed PascalCase for function declarations used as React components.
- Updated existing rules to accommodate additional formats for constants and enum members.