### PR TITLE
Remove naming-convention comments from packages/database

### DIFF
--- a/packages/database/features/step-definitions/stepdefs.ts
+++ b/packages/database/features/step-definitions/stepdefs.ts
@@ -129,7 +129,7 @@ const substituteLocalReferencesRow = (
     }
     if (k.charAt(0) === "_") {
       k = k.substring(1);
-      v = substituteLocalReferences(v, localRefs);
+      v = substituteLocalReferences(v, localRefs); // eslint-disable-line @typescript-eslint/no-unsafe-assignment
     }
     return [k, v];
   };

--- a/packages/database/features/step-definitions/stepdefs.ts
+++ b/packages/database/features/step-definitions/stepdefs.ts
@@ -67,14 +67,17 @@ Given("the database is blank", async () => {
   assert.equal(r.error, null);
   const r3 = await client.from("group_membership").select("group_id");
   assert.equal(r3.error, null);
-  const groupIds = new Set((r3.data || []).map(({group_id})=>group_id));
+  const groupIds = new Set((r3.data || []).map(({ group_id }) => group_id));
   for (const id of groupIds) {
     const ur = await client.auth.admin.deleteUser(id);
     assert.equal(ur.error, null);
   }
-  const r2 = await client.from("PlatformAccount").select("dg_account").not('dg_account', 'is', null);
+  const r2 = await client
+    .from("PlatformAccount")
+    .select("dg_account")
+    .not("dg_account", "is", null);
   assert.equal(r2.error, null);
-  for (const {dg_account} of r2.data || []) {
+  for (const { dg_account } of r2.data || []) {
     const r = await client.auth.admin.deleteUser(dg_account!);
     assert.equal(r.error, null);
   }
@@ -126,7 +129,7 @@ const substituteLocalReferencesRow = (
     }
     if (k.charAt(0) === "_") {
       k = k.substring(1);
-      v = substituteLocalReferences(v, localRefs); // eslint-disable-line @typescript-eslint/no-unsafe-assignment
+      v = substituteLocalReferences(v, localRefs);
     }
     return [k, v];
   };
@@ -296,7 +299,7 @@ Given(
     if (typeof spaceId !== "number") assert.fail("spaceId not a number");
     const client = await getLoggedinDatabase(spaceId);
     const response = await client.rpc("upsert_accounts_in_space", {
-      space_id_: spaceId, // eslint-disable-line @typescript-eslint/naming-convention
+      space_id_: spaceId,
       accounts,
     });
     assert.equal(response.error, null);
@@ -313,7 +316,7 @@ Given(
     if (typeof spaceId !== "number") assert.fail("spaceId not a number");
     const client = await getLoggedinDatabase(spaceId);
     const response = await client.rpc("upsert_documents", {
-      v_space_id: spaceId, // eslint-disable-line @typescript-eslint/naming-convention
+      v_space_id: spaceId,
       data,
     });
     assert.equal(response.error, null);
@@ -332,10 +335,10 @@ Given(
     if (typeof userId !== "number") assert.fail("userId not a number");
     const client = await getLoggedinDatabase(spaceId);
     const response = await client.rpc("upsert_content", {
-      v_space_id: spaceId, // eslint-disable-line @typescript-eslint/naming-convention
+      v_space_id: spaceId,
       data,
-      v_creator_id: userId, // eslint-disable-line @typescript-eslint/naming-convention
-      content_as_document: false, // eslint-disable-line @typescript-eslint/naming-convention
+      v_creator_id: userId,
+      content_as_document: false,
     });
     assert.equal(response.error, null);
   },
@@ -351,7 +354,7 @@ Given(
     if (typeof spaceId !== "number") assert.fail("spaceId not a number");
     const client = await getLoggedinDatabase(spaceId);
     const response = await client.rpc("upsert_concepts", {
-      v_space_id: spaceId, // eslint-disable-line @typescript-eslint/naming-convention
+      v_space_id: spaceId,
       data,
     });
     assert.equal(response.error, null);
@@ -404,47 +407,60 @@ Then("query results should look like this", (table: DataTable) => {
   }
 });
 
-When("user of space {word} creates group {word}", async (spaceName: string, name: string) => {
-  const localRefs = (world.localRefs || {}) as LocalRefsType;
-  const spaceId = localRefs[spaceName];
-  if (typeof spaceId !== "number") assert.fail("spaceId not a number");
-  const client = await getLoggedinDatabase(spaceId);
-  try{
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    const response = await client.functions.invoke<{group_id: string}>("create-group", {body:{name}});
-    assert.equal(response.error, null);
-    assert.ok(response.data?.group_id, "create-group response missing group_id");
-    localRefs[name] = response.data.group_id;
-    world.localRefs = localRefs;
-  } catch (error) {
-    console.error((error as Record<string, any>).actual);
-    throw error;
-  }
-})
+When(
+  "user of space {word} creates group {word}",
+  async (spaceName: string, name: string) => {
+    const localRefs = (world.localRefs || {}) as LocalRefsType;
+    const spaceId = localRefs[spaceName];
+    if (typeof spaceId !== "number") assert.fail("spaceId not a number");
+    const client = await getLoggedinDatabase(spaceId);
+    try {
+      const response = await client.functions.invoke<{ group_id: string }>(
+        "create-group",
+        { body: { name } },
+      );
+      assert.equal(response.error, null);
+      assert.ok(
+        response.data?.group_id,
+        "create-group response missing group_id",
+      );
+      localRefs[name] = response.data.group_id;
+      world.localRefs = localRefs;
+    } catch (error) {
+      console.error((error as Record<string, any>).actual);
+      throw error;
+    }
+  },
+);
 
-When("user of space {word} adds space {word} to group {word}",
-    async (space1Name: string, space2Name:string, groupName: string): Promise<void> =>{
-  const localRefs = (world.localRefs || {}) as LocalRefsType;
-  const space1Id = localRefs[space1Name];
-  const space2Id = localRefs[space2Name];
-  const groupId = localRefs[groupName];
-  if (typeof space1Id !== 'number') assert.fail("space1Id not a number");
-  if (typeof space2Id !== 'number') assert.fail("space2Id not a number");
-  if (typeof groupId !== 'string') assert.fail("groupId not a string");
-  const client2 = await getLoggedinDatabase(space2Id);
-  const r1 = await client2.from("PlatformAccount")
+When(
+  "user of space {word} adds space {word} to group {word}",
+  async (
+    space1Name: string,
+    space2Name: string,
+    groupName: string,
+  ): Promise<void> => {
+    const localRefs = (world.localRefs || {}) as LocalRefsType;
+    const space1Id = localRefs[space1Name];
+    const space2Id = localRefs[space2Name];
+    const groupId = localRefs[groupName];
+    if (typeof space1Id !== "number") assert.fail("space1Id not a number");
+    if (typeof space2Id !== "number") assert.fail("space2Id not a number");
+    if (typeof groupId !== "string") assert.fail("groupId not a string");
+    const client2 = await getLoggedinDatabase(space2Id);
+    const r1 = await client2
+      .from("PlatformAccount")
       .select("dg_account")
       .eq("account_local_id", spaceAnonUserEmail("Roam", space2Id))
       .maybeSingle();
-  assert.equal(r1.error, null);
-  const memberId = r1.data?.dg_account;
-  assert.ok(memberId, "memberId not found for space2");
-  const client1 = await getLoggedinDatabase(space1Id);
-  const r2 = await client1.from("group_membership").insert({
-    /* eslint-disable @typescript-eslint/naming-convention */
-    group_id: groupId,
-    member_id: memberId
-    /* eslint-enable @typescript-eslint/naming-convention */
-  });
-  assert.equal(r2.error, null);
-})
+    assert.equal(r1.error, null);
+    const memberId = r1.data?.dg_account;
+    assert.ok(memberId, "memberId not found for space2");
+    const client1 = await getLoggedinDatabase(space1Id);
+    const r2 = await client1.from("group_membership").insert({
+      group_id: groupId,
+      member_id: memberId,
+    });
+    assert.equal(r2.error, null);
+  },
+);

--- a/packages/database/scripts/createEnv.mts
+++ b/packages/database/scripts/createEnv.mts
@@ -5,7 +5,6 @@ import { fileURLToPath } from "node:url";
 import dotenv from "dotenv";
 import { Vercel } from "@vercel/sdk";
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const projectRoot = join(__dirname, "..");
 const baseParams: Record<string, string> = {};

--- a/packages/database/src/dbDotEnv.mjs
+++ b/packages/database/src/dbDotEnv.mjs
@@ -78,13 +78,10 @@ export const envFilePath = () => {
 export const envContents = () => {
   const path = envFilePath();
   if (!path) {
-    // Fallback to process.env when running in production environments
     const raw = {
-      /* eslint-disable @typescript-eslint/naming-convention */
       SUPABASE_URL: process.env.SUPABASE_URL,
       SUPABASE_PUBLISHABLE_KEY: process.env.SUPABASE_PUBLISHABLE_KEY,
       NEXT_API_ROOT: process.env.NEXT_API_ROOT,
-      /* eslint-enable @typescript-eslint/naming-convention */
     };
     return Object.fromEntries(Object.entries(raw).filter(([, v]) => !!v));
   }

--- a/packages/database/src/dbDotEnv.mjs
+++ b/packages/database/src/dbDotEnv.mjs
@@ -78,6 +78,7 @@ export const envFilePath = () => {
 export const envContents = () => {
   const path = envFilePath();
   if (!path) {
+    // Fallback to process.env when running in production environments
     const raw = {
       SUPABASE_URL: process.env.SUPABASE_URL,
       SUPABASE_PUBLISHABLE_KEY: process.env.SUPABASE_PUBLISHABLE_KEY,

--- a/packages/database/src/lib/contextFunctions.ts
+++ b/packages/database/src/lib/contextFunctions.ts
@@ -71,7 +71,6 @@ export const fetchOrCreateSpaceIndirect = async (
   const response = await fetch(baseUrl + "/space", {
     method: "POST",
     headers: {
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       "Content-Type": "application/json",
     },
     body: JSON.stringify(input),
@@ -160,12 +159,9 @@ export const fetchOrCreateSpaceDirect = async (
     });
 
   if (result2.data === null) {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     let error: string = (result2.error?.message as string | undefined) || "";
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     if (result2.error?.context?.body)
       try {
-        // eslint-disable-next-line
         error += await new Response(result2.error.context.body).text();
       } catch (err) {
         // could not parse, not important

--- a/packages/database/src/lib/contextFunctions.ts
+++ b/packages/database/src/lib/contextFunctions.ts
@@ -159,9 +159,12 @@ export const fetchOrCreateSpaceDirect = async (
     });
 
   if (result2.data === null) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     let error: string = (result2.error?.message as string | undefined) || "";
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     if (result2.error?.context?.body)
       try {
+        // eslint-disable-next-line
         error += await new Response(result2.error.context.body).text();
       } catch (err) {
         // could not parse, not important

--- a/packages/database/src/lib/files.ts
+++ b/packages/database/src/lib/files.ts
@@ -3,55 +3,66 @@ import type { DGSupabaseClient } from "./client";
 const ASSETS_BUCKET_NAME = "assets";
 
 export const addFile = async ({
-  client, spaceId, sourceLocalId, fname, mimetype, created, lastModified, content
-}:{
-  client: DGSupabaseClient,
-  spaceId: number,
-  sourceLocalId: string,
-  fname: string,
-  mimetype: string,
-  created: Date,
-  lastModified: Date,
-  content: ArrayBuffer
+  client,
+  spaceId,
+  sourceLocalId,
+  fname,
+  mimetype,
+  created,
+  lastModified,
+  content,
+}: {
+  client: DGSupabaseClient;
+  spaceId: number;
+  sourceLocalId: string;
+  fname: string;
+  mimetype: string;
+  created: Date;
+  lastModified: Date;
+  content: ArrayBuffer;
 }): Promise<void> => {
   // This assumes the content fits in memory.
   const uint8Array = new Uint8Array(content);
-  const hashBuffer = await crypto.subtle.digest('SHA-256', uint8Array);
+  const hashBuffer = await crypto.subtle.digest("SHA-256", uint8Array);
   const hashArray = Array.from(new Uint8Array(hashBuffer));
-  const hashvalue = hashArray.map((h) => h.toString(16).padStart(2, '0')).join('');
-  const lookForDup = await client.rpc("file_exists",{hashvalue})
+  const hashvalue = hashArray
+    .map((h) => h.toString(16).padStart(2, "0"))
+    .join("");
+  const lookForDup = await client.rpc("file_exists", { hashvalue });
   if (lookForDup.error) throw lookForDup.error;
   const exists = lookForDup.data;
   if (!exists) {
-    // we should use upsert here for sync issues, but we get obscure rls errors.
-    const uploadResult = await client.storage.from(ASSETS_BUCKET_NAME).upload(hashvalue, content, {contentType: mimetype});
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    if (uploadResult.error && String((uploadResult.error as Record<string, any>).statusCode) !== "409")
+    const uploadResult = await client.storage
+      .from(ASSETS_BUCKET_NAME)
+      .upload(hashvalue, content, { contentType: mimetype });
+    if (
+      uploadResult.error &&
+      String((uploadResult.error as Record<string, any>).statusCode) !== "409"
+    )
       throw uploadResult.error;
   }
-  // not doing an upsert because it does not update on conflict
   const frefResult = await client.from("FileReference").insert({
-    /* eslint-disable @typescript-eslint/naming-convention */
     space_id: spaceId,
     source_local_id: sourceLocalId,
     last_modified: lastModified.toISOString(),
-    /* eslint-enable @typescript-eslint/naming-convention */
     filepath: fname,
     filehash: hashvalue,
-    created: created.toISOString()
+    created: created.toISOString(),
   });
 
   if (frefResult.error) {
     if (frefResult.error.code === "23505") {
-      // 23505 is duplicate key, which means the file is already there, not an error
-      const updateResult = await client.from("FileReference").update({
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        last_modified: lastModified.toISOString(),
-        filehash: hashvalue,
-        created: created.toISOString()
-      }).eq("source_local_id", sourceLocalId).eq("space_id", spaceId).eq("filepath", fname);
+      const updateResult = await client
+        .from("FileReference")
+        .update({
+          last_modified: lastModified.toISOString(),
+          filehash: hashvalue,
+          created: created.toISOString(),
+        })
+        .eq("source_local_id", sourceLocalId)
+        .eq("space_id", spaceId)
+        .eq("filepath", fname);
       if (updateResult.error) throw updateResult.error;
-    } else
-      throw frefResult.error;
+    } else throw frefResult.error;
   }
-}
+};

--- a/packages/database/src/lib/files.ts
+++ b/packages/database/src/lib/files.ts
@@ -35,6 +35,7 @@ export const addFile = async ({
     const uploadResult = await client.storage
       .from(ASSETS_BUCKET_NAME)
       .upload(hashvalue, content, { contentType: mimetype });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     if (
       uploadResult.error &&
       String((uploadResult.error as Record<string, any>).statusCode) !== "409"

--- a/packages/database/src/lib/files.ts
+++ b/packages/database/src/lib/files.ts
@@ -32,6 +32,7 @@ export const addFile = async ({
   if (lookForDup.error) throw lookForDup.error;
   const exists = lookForDup.data;
   if (!exists) {
+    // we should use upsert here for sync issues, but we get obscure rls errors.
     const uploadResult = await client.storage
       .from(ASSETS_BUCKET_NAME)
       .upload(hashvalue, content, { contentType: mimetype });
@@ -42,6 +43,7 @@ export const addFile = async ({
     )
       throw uploadResult.error;
   }
+  // not doing an upsert because it does not update on conflict
   const frefResult = await client.from("FileReference").insert({
     space_id: spaceId,
     source_local_id: sourceLocalId,
@@ -53,6 +55,7 @@ export const addFile = async ({
 
   if (frefResult.error) {
     if (frefResult.error.code === "23505") {
+      // 23505 is duplicate key, which means the file is already there, not an error
       const updateResult = await client
         .from("FileReference")
         .update({

--- a/packages/database/src/lib/files.ts
+++ b/packages/database/src/lib/files.ts
@@ -36,9 +36,9 @@ export const addFile = async ({
     const uploadResult = await client.storage
       .from(ASSETS_BUCKET_NAME)
       .upload(hashvalue, content, { contentType: mimetype });
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     if (
       uploadResult.error &&
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       String((uploadResult.error as Record<string, any>).statusCode) !== "409"
     )
       throw uploadResult.error;

--- a/packages/database/src/lib/queries.ts
+++ b/packages/database/src/lib/queries.ts
@@ -70,7 +70,6 @@ export const initNodeSchemaCache = () => {
   });
 };
 
-/* eslint-disable @typescript-eslint/naming-convention */
 export type PDocument = Partial<Tables<"Document">>;
 export type PContent = Partial<Tables<"Content">> & {
   Document?: PDocument | null;
@@ -97,7 +96,6 @@ type DefaultQueryShape = {
   name: string;
   Content: { source_local_id: string };
 };
-/* eslint-enable @typescript-eslint/naming-convention */
 
 /**
  * Defines what type of concepts to query and any specific constraints.
@@ -137,8 +135,7 @@ export type NodeFilters = {
   author?: string;
 };
 
-type NodeFiltersDb = Omit<NodeFilters, "ofTypes"> & { ofTypes?: number[]};
-
+type NodeFiltersDb = Omit<NodeFilters, "ofTypes"> & { ofTypes?: number[] };
 
 /**
  * Filters for querying concepts based on their relationships.
@@ -171,7 +168,10 @@ export type RelationFilters = {
   author?: string;
 };
 
-export type RelationFiltersDb = Omit<RelationFilters, "ofTypes"|"toNodeTypes">&{ofTypes?: number[], toNodeTypes?: number[]};
+export type RelationFiltersDb = Omit<
+  RelationFilters,
+  "ofTypes" | "toNodeTypes"
+> & { ofTypes?: number[]; toNodeTypes?: number[] };
 
 /**
  * Controls which fields are returned in the response.
@@ -254,7 +254,10 @@ export type GetConceptsParams = {
   pagination?: PaginationOptions;
 };
 
-type GetConceptsParamsDb = Omit<GetConceptsParams, "scope"|"relations">&{scope?: NodeFiltersDb, relations?: RelationFiltersDb};
+type GetConceptsParamsDb = Omit<GetConceptsParams, "scope" | "relations"> & {
+  scope?: NodeFiltersDb;
+  relations?: RelationFiltersDb;
+};
 
 // Utility function to compose a generic query to fetch concepts, content and document.
 // Arguments are as in getConcepts, except we use numeric db ids of concepts for schemas instead
@@ -262,15 +265,15 @@ type GetConceptsParamsDb = Omit<GetConceptsParams, "scope"|"relations">&{scope?:
 const composeConceptQuery = ({
   supabase,
   spaceId,
-  scope= {
+  scope = {
     type: "nodes",
   },
-  relations= {},
-  fields= {
+  relations = {},
+  fields = {
     concepts: ["id", "name", "space_id"],
     content: ["source_local_id"],
   },
-  pagination= {
+  pagination = {
     offset: 0,
     limit: 100,
   },
@@ -290,7 +293,9 @@ const composeConceptQuery = ({
   if (ctArgs.length > 0) {
     const documentFields = fields.documents || [];
     if (documentFields.length > 0) {
-      ctArgs.push(`Document:my_documents!document_id${innerContent ? "!inner" : ""} (\n ${documentFields.join(",\n")} )`);
+      ctArgs.push(
+        `Document:my_documents!document_id${innerContent ? "!inner" : ""} (\n ${documentFields.join(",\n")} )`,
+      );
     }
     q += `,\nContent:content_of_concept${innerContent ? "!inner" : ""} (\n${ctArgs.join(",\n")})`;
   }
@@ -327,7 +332,7 @@ const composeConceptQuery = ({
   let query = supabase.from("my_concepts").select(q);
   if (scope.type === "nodes") {
     query = query.eq("arity", 0);
-  } else if (scope.type === 'relations') {
+  } else if (scope.type === "relations") {
     query = query.gt("arity", 0);
   }
   // else fetch both
@@ -344,28 +349,24 @@ const composeConceptQuery = ({
     if (schemaDbIds.length > 0) {
       if (schemaDbIds.length === 1)
         query = query.eq("schema_id", schemaDbIds[0]!);
-      else
-        query = query.in("schema_id", schemaDbIds);
+      else query = query.in("schema_id", schemaDbIds);
     }
     // else we'll get all nodes
   }
   if (baseNodeLocalIds.length > 0) {
     if (baseNodeLocalIds.length === 1)
       query = query.eq("Content.source_local_id", baseNodeLocalIds[0]!);
-    else
-      query = query.in("Content.source_local_id", baseNodeLocalIds);
+    else query = query.in("Content.source_local_id", baseNodeLocalIds);
   }
   if (inRelsOfType !== undefined && inRelsOfType.length > 0) {
     if (inRelsOfType.length === 1)
       query = query.eq("relations.schema_id", inRelsOfType[0]!);
-    else
-      query = query.in("relations.schema_id", inRelsOfType);
+    else query = query.in("relations.schema_id", inRelsOfType);
   }
   if (inRelsToNodesOfType !== undefined && inRelsToNodesOfType.length > 0) {
     if (inRelsToNodesOfType.length === 1)
       query = query.eq("relations.subnodes.schema_id", inRelsToNodesOfType[0]!);
-    else
-      query = query.in("relations.subnodes.schema_id", inRelsToNodesOfType);
+    else query = query.in("relations.subnodes.schema_id", inRelsToNodesOfType);
   }
   if (inRelsToNodesOfAuthor !== undefined) {
     query = query.eq(
@@ -410,7 +411,11 @@ export const getSchemaConcepts = async (
     .filter((x) => typeof x === "object")
     .filter((x) => x.spaceId === spaceId || x.spaceId === 0);
   if (forceCacheReload || result.length === 1) {
-    const q = composeConceptQuery({ supabase, spaceId, scope: {type:"all", schemas: true} });
+    const q = composeConceptQuery({
+      supabase,
+      spaceId,
+      scope: { type: "all", schemas: true },
+    });
     const res = (await q) as PostgrestResponse<DefaultQueryShape>;
     if (res.error) {
       console.error("getSchemaConcepts failed", res.error);
@@ -467,7 +472,11 @@ const getLocalToDbIdMapping = async (
       console.warn("Cannot populate cache without spaceId");
       return dbIds;
     }
-    let q = composeConceptQuery({ supabase, spaceId, scope: {type:"all", schemas: true} });
+    let q = composeConceptQuery({
+      supabase,
+      spaceId,
+      scope: { type: "all", schemas: true },
+    });
     if (Object.keys(NODE_SCHEMA_CACHE).length > 1) {
       // Non-empty cache, query selectively
       q = q
@@ -768,7 +777,7 @@ export const getNodesOfTypeWithRelations = async ({
   return getConcepts({
     supabase,
     spaceId,
-    scope: { type:"nodes", ofTypes, }, // we still start from the node
+    scope: { type: "nodes", ofTypes }, // we still start from the node
     relations: {
       ofTypes: relationTypes,
       author: nodeAuthoredBy,
@@ -832,7 +841,6 @@ export const getDiscourseContext = async ({
   });
 };
 
-
 // instrumentation for benchmarking
 export const LAST_QUERY_DATA = { duration: 0 };
 
@@ -879,25 +887,23 @@ export const LAST_QUERY_DATA = { duration: 0 };
  * });
  * ```
  */
-export const getConcepts = async (
-  {
-    supabase,
-    spaceId,
-    scope= {
-      type: "nodes",
-    },
-    relations= {},
-    fields= {
-      concepts: CONCEPT_FIELDS,
-      content: CONTENT_FIELDS,
-      documents: DOCUMENT_FIELDS
-    },
-    pagination= {
-      offset: 0,
-      limit: 100,
-    },
-  }: GetConceptsParams
-): Promise<PConceptFull[]> => {
+export const getConcepts = async ({
+  supabase,
+  spaceId,
+  scope = {
+    type: "nodes",
+  },
+  relations = {},
+  fields = {
+    concepts: CONCEPT_FIELDS,
+    content: CONTENT_FIELDS,
+    documents: DOCUMENT_FIELDS,
+  },
+  pagination = {
+    offset: 0,
+    limit: 100,
+  },
+}: GetConceptsParams): Promise<PConceptFull[]> => {
   // translate schema local content Ids to concept database Ids.
   const localSchemaIds = new Set<string>();
   (scope.ofTypes || []).map((k) => localSchemaIds.add(k));
@@ -926,15 +932,15 @@ export const getConcepts = async (
     spaceId,
     scope: {
       ...scope,
-      ofTypes: localToDbArray(scope.ofTypes)
+      ofTypes: localToDbArray(scope.ofTypes),
     },
     relations: {
       ...relations,
       ofTypes: localToDbArray(relations.ofTypes),
-      toNodeTypes: localToDbArray(relations.toNodeTypes)
+      toNodeTypes: localToDbArray(relations.toNodeTypes),
     },
     fields,
-    pagination
+    pagination,
   });
   const before = Date.now();
   const { error, data } = (await q) as PostgrestResponse<PConceptFull>;

--- a/packages/database/supabase/functions/create-group/index.ts
+++ b/packages/database/supabase/functions/create-group/index.ts
@@ -3,12 +3,16 @@
 // This enables autocomplete, go to definition, etc.
 
 import "@supabase/functions-js/edge-runtime";
-import { corsHeaders } from '@supabase/supabase-js/cors'
+import { corsHeaders } from "@supabase/supabase-js/cors";
 import { createClient, type UserResponse } from "@supabase/supabase-js";
 import type { DGSupabaseClient } from "@repo/database/lib/client";
 
 // The following lines are duplicated from apps/website/app/utils/llm/cors.ts
-const allowedOrigins = ["https://roamresearch.com", "http://localhost:3000", "app://obsidian.md"];
+const allowedOrigins = [
+  "https://roamresearch.com",
+  "http://localhost:3000",
+  "app://obsidian.md",
+];
 
 const isVercelPreviewUrl = (origin: string): boolean =>
   /^https:\/\/.*-discourse-graph-[a-z0-9]+\.vercel\.app$/.test(origin);
@@ -21,7 +25,10 @@ const isAllowedOrigin = (origin: string): boolean =>
 Deno.serve(async (req) => {
   const origin = req.headers.get("origin");
   const originIsAllowed = origin && isAllowedOrigin(origin);
-  const myCorsHeaders = {...corsHeaders, "Access-Control-Allow-Origin": originIsAllowed? origin:''};
+  const myCorsHeaders = {
+    ...corsHeaders,
+    "Access-Control-Allow-Origin": originIsAllowed ? origin : "",
+  };
   if (req.method === "OPTIONS") {
     return new Response(null, {
       status: 204,
@@ -30,22 +37,24 @@ Deno.serve(async (req) => {
   }
   if (req.method !== "POST") {
     return Response.json(
-      { msg: 'Method not allowed' },
-      { status: 405,
-        headers: myCorsHeaders,
-      }
+      { msg: "Method not allowed" },
+      { status: 405, headers: myCorsHeaders },
     );
   }
-  let input: {name?: string} = {}
+  let input: { name?: string } = {};
   try {
     input = await req.json();
   } catch (error) {
-    return Response.json({
-      msg: 'Invalid JSON in request body', error: String(error?.message ?? error)
-    }, {
-      status: 400,
-      headers: myCorsHeaders,
-    });
+    return Response.json(
+      {
+        msg: "Invalid JSON in request body",
+        error: String(error?.message ?? error),
+      },
+      {
+        status: 400,
+        headers: myCorsHeaders,
+      },
+    );
   }
   const groupName = input.name;
   if (groupName === undefined) {
@@ -62,34 +71,37 @@ Deno.serve(async (req) => {
   const anon_key = Deno.env.get("SB_PUBLISHABLE_KEY");
 
   if (!url || !anon_key || !service_key) {
-    return new Response("Missing SUPABASE_URL or SB_SECRET_KEY or SB_PUBLISHABLE_KEY", {
-      status: 500,
-      headers: myCorsHeaders,
-    });
+    return new Response(
+      "Missing SUPABASE_URL or SB_SECRET_KEY or SB_PUBLISHABLE_KEY",
+      {
+        status: 500,
+        headers: myCorsHeaders,
+      },
+    );
   }
-  const supabase = createClient(url, anon_key)
-  const authHeader = req.headers.get('Authorization');
+  const supabase = createClient(url, anon_key);
+  const authHeader = req.headers.get("Authorization");
   if (!authHeader) {
     return Response.json(
-      { msg: 'Missing authorization headers' },
+      { msg: "Missing authorization headers" },
       {
         status: 401,
         headers: myCorsHeaders,
-      }
-    )
+      },
+    );
   }
-  const token = authHeader.replace('Bearer ', '')
-  const { data, error } = await supabase.auth.getClaims(token)
+  const token = authHeader.replace("Bearer ", "");
+  const { data, error } = await supabase.auth.getClaims(token);
 
-  const userEmail = data?.claims?.email
+  const userEmail = data?.claims?.email;
   if (!userEmail || error || data?.claims?.is_anonymous === true) {
     return Response.json(
-      { msg: 'Invalid JWT' },
+      { msg: "Invalid JWT" },
       {
         status: 401,
         headers: myCorsHeaders,
-      }
-    )
+      },
+    );
   }
   // This password is discarded; nobody is expected to ever login as a group.
   const password = crypto.randomUUID();
@@ -100,35 +112,39 @@ Deno.serve(async (req) => {
     userResponse = await supabaseAdmin.auth.admin.createUser({
       email,
       password,
-      role:'anon',
-      user_metadata: {group: true},
-      email_confirm: false, // eslint-disable-line @typescript-eslint/naming-convention
+      role: "anon",
+      user_metadata: { group: true },
+      email_confirm: false,
     });
-    if (userResponse.error)
-      throw userResponse.error;
-    if (!userResponse.data.user)
-      throw new Error("Did not create user");
+    if (userResponse.error) throw userResponse.error;
+    if (!userResponse.data.user) throw new Error("Did not create user");
   } catch (error) {
-    if (error.code === 'email_exists') {
+    if (error.code === "email_exists") {
       return Response.json(
-        { msg: 'A group by this name exists' },
+        { msg: "A group by this name exists" },
         {
           status: 400,
           headers: myCorsHeaders,
-        });
+        },
+      );
     }
-    return Response.json({ msg: 'Failed to create group user', error: error.message }, { status: 500,  headers: myCorsHeaders });
+    return Response.json(
+      { msg: "Failed to create group user", error: error.message },
+      { status: 500, headers: myCorsHeaders },
+    );
   }
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   const group_id = userResponse.data.user.id;
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  const membershipResponse = await supabaseAdmin.from("group_membership").insert({group_id, member_id:data.claims.sub, admin:true});
+  const membershipResponse = await supabaseAdmin
+    .from("group_membership")
+    .insert({ group_id, member_id: data.claims.sub, admin: true });
   if (membershipResponse.error)
-    return Response.json({
-      msg: `Failed to create membership for group ${group_id}`,
-      error: membershipResponse.error.message
-    },
-    { status: 500, headers: myCorsHeaders, });
+    return Response.json(
+      {
+        msg: `Failed to create membership for group ${group_id}`,
+        error: membershipResponse.error.message,
+      },
+      { status: 500, headers: myCorsHeaders },
+    );
 
-  return Response.json({group_id}, {headers: myCorsHeaders });
+  return Response.json({ group_id }, { headers: myCorsHeaders });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Removes all `/* eslint-disable @typescript-eslint/naming-convention */` comments from `packages/database`.

This is a follow-up to the relaxed base ESLint naming-convention rules, which now allow:
- Leading underscores for various selectors
- Flexibility for naming conventions in object properties, destructured variables, and class properties
- PascalCase for function declarations used as React components
- Additional formats for constants and enum members

## Changes

Removed eslint-disable comments from the following files:
- `packages/database/scripts/createEnv.mts`
- `packages/database/features/step-definitions/stepdefs.ts`
- `packages/database/src/dbDotEnv.mjs`
- `packages/database/src/lib/contextFunctions.ts`
- `packages/database/src/lib/queries.ts`
- `packages/database/src/lib/files.ts`
- `packages/database/supabase/functions/create-group/index.ts`

## Testing

✅ Ran `pnpm run lint` in `packages/database` - no new warnings introduced
✅ All previously suppressed code now passes with the relaxed rules

## Impact

- No functional changes to the code
- Cleaner codebase with fewer lint suppressions
- Confirms the relaxed naming-convention rules are working as intended
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-1782](https://linear.app/discourse-graphs/issue/ENG-1782/remove-naming-convention-comments-from-packagesdatabase)

<div><a href="https://cursor.com/agents/bc-29eb603a-d0b6-4593-aa1e-22a56bf3d186"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-29eb603a-d0b6-4593-aa1e-22a56bf3d186"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

