### PR TITLE
Remove naming-convention eslint-disable comments from apps/obsidian

### DIFF
--- a/apps/obsidian/scripts/compile.ts
+++ b/apps/obsidian/scripts/compile.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import esbuild from "esbuild";
 import fs from "fs";
 import path from "path";

--- a/apps/obsidian/src/components/AdminPanelSettings.tsx
+++ b/apps/obsidian/src/components/AdminPanelSettings.tsx
@@ -54,13 +54,11 @@ export const AdminPanelSettings = () => {
       new Notice("Failed to connect to the database", 3000);
       return;
     }
-    /* eslint-disable @typescript-eslint/naming-convention */
     const { access_token, refresh_token } = sessionData.data.session;
     const { data, error } = await client.rpc("create_secret_token", {
       v_payload: JSON.stringify({ access_token, refresh_token }),
       expiry_interval: "45s",
     });
-    /* eslint-enable @typescript-eslint/naming-convention */
     if (error || typeof data !== "string") {
       new Notice("Failed to connect to the database", 3000);
       return;

--- a/apps/obsidian/src/components/canvas/TldrawViewComponent.tsx
+++ b/apps/obsidian/src/components/canvas/TldrawViewComponent.tsx
@@ -428,7 +428,6 @@ export const TldrawPreviewComponent = ({
               },
             }}
             components={{
-              /* eslint-disable @typescript-eslint/naming-convention */
               ContextMenu: (props) => (
                 <CustomContextMenu canvasFile={file} props={props} />
               ),

--- a/apps/obsidian/src/components/canvas/stores/assetStore.ts
+++ b/apps/obsidian/src/components/canvas/stores/assetStore.ts
@@ -341,7 +341,6 @@ export class ObsidianTLAssetStore implements Required<TLAssetStore> {
 
   resolve = async (
     asset: TLAsset,
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     _ctx: TLAssetContext,
   ): Promise<string | null> => {
     try {

--- a/apps/obsidian/src/components/canvas/utils/relationUtils.tsx
+++ b/apps/obsidian/src/components/canvas/utils/relationUtils.tsx
@@ -13,7 +13,6 @@ https://github.com/tldraw/tldraw/tree/main/packages/tldraw/src/lib/shapes/arrow
 /* eslint-disable max-params */
 /* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
 /* eslint-disable preferArrows/prefer-arrow-functions */
-/* eslint-disable @typescript-eslint/naming-convention */
 
 import React, { useRef, useEffect, useState } from "react";
 import {

--- a/apps/obsidian/src/components/canvas/utils/tldraw.ts
+++ b/apps/obsidian/src/components/canvas/utils/tldraw.ts
@@ -30,11 +30,9 @@ import { DiscourseRelationBindingUtil } from "~/components/canvas/shapes/Discour
 import { discourseNodeMigrations } from "~/components/canvas/shapes/discourseNodeMigrations";
 
 export type TldrawPluginMetaData = {
-  /* eslint-disable @typescript-eslint/naming-convention */
   "plugin-version": string;
   "tldraw-version": string;
   uuid: string;
-  /* eslint-disable @typescript-eslint/naming-convention */
 };
 
 export type TldrawRawData = {

--- a/apps/obsidian/src/services/QueryEngine.ts
+++ b/apps/obsidian/src/services/QueryEngine.ts
@@ -28,7 +28,6 @@ export class QueryEngine {
         query: (query: string) => DatacorePage[];
       }
     | undefined;
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   private readonly MIN_QUERY_LENGTH = 2;
 
   constructor(app: App) {

--- a/apps/obsidian/src/utils/conceptConversion.ts
+++ b/apps/obsidian/src/utils/conceptConversion.ts
@@ -16,7 +16,6 @@ import type { Json } from "@repo/database/dbTypes";
  */
 const getNodeExtraData = (
   file: TFile,
-  /* eslint-disable @typescript-eslint/naming-convention */
   author_id: number,
 ): {
   author_id: number;
@@ -28,7 +27,6 @@ const getNodeExtraData = (
     created: new Date(file.stat.ctime).toISOString(),
     last_modified: new Date(file.stat.mtime).toISOString(),
   };
-  /* eslint-enable @typescript-eslint/naming-convention */
 };
 
 export const discourseNodeSchemaToLocalConcept = ({
@@ -50,7 +48,6 @@ export const discourseNodeSchemaToLocalConcept = ({
     importedFromRid,
     ...otherData
   } = node;
-  /* eslint-disable @typescript-eslint/naming-convention */
   const literal_content: Record<string, Json> = {
     label: name,
     source_data: otherData,
@@ -68,7 +65,6 @@ export const discourseNodeSchemaToLocalConcept = ({
     last_modified: new Date(modified).toISOString(),
     description: description,
     literal_content,
-    /* eslint-enable @typescript-eslint/naming-convention */
   };
 };
 
@@ -89,18 +85,15 @@ export const discourseRelationTypeToLocalConcept = (
     status, //destructuring status to not upload it to the database
     ...otherData
   } = relationType;
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   const literal_content: Record<string, Json> = {
     roles: STANDARD_ROLES,
     label,
     complement,
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     source_data: otherData,
   };
   if (importedFromRid) literal_content.importedFromRid = importedFromRid;
 
   return {
-    /* eslint-disable @typescript-eslint/naming-convention */
     space_id: context.spaceId,
     name: label,
     source_local_id: id,
@@ -109,7 +102,6 @@ export const discourseRelationTypeToLocalConcept = (
     created: new Date(created).toISOString(),
     last_modified: new Date(modified).toISOString(),
     literal_content,
-    /* eslint-enable @typescript-eslint/naming-convention */
   };
 };
 
@@ -138,7 +130,6 @@ export const discourseRelationTripleSchemaToLocalConcept = ({
   const relationType = relationTypesById[relationshipTypeId];
   if (!relationType) return null;
   const { label, complement } = relationType;
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   const literal_content: Record<string, Json> = {
     roles: STANDARD_ROLES,
     label,
@@ -147,7 +138,6 @@ export const discourseRelationTripleSchemaToLocalConcept = ({
   if (importedFromRid) literal_content.importedFromRid = importedFromRid;
 
   return {
-    /* eslint-disable @typescript-eslint/naming-convention */
     space_id: context.spaceId,
     name: `${sourceName} -${label}-> ${destinationName}`,
     source_local_id: id,
@@ -161,7 +151,6 @@ export const discourseRelationTripleSchemaToLocalConcept = ({
       source: sourceId,
       destination: destinationId,
     },
-    /* eslint-enable @typescript-eslint/naming-convention */
   };
 };
 
@@ -175,23 +164,19 @@ export const discourseNodeInstanceToLocalConcept = (
   const extraData = getNodeExtraData(nodeData.file, context.userId);
   const { nodeInstanceId, nodeTypeId, importedFromRid, ...otherData } =
     nodeData.frontmatter;
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   const literal_content: Record<string, Json> = {
     label: nodeData.file.basename,
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     source_data: otherData as unknown as Json,
   };
   if (importedFromRid && typeof importedFromRid === "string")
     literal_content.importedFromRid = importedFromRid;
   return {
-    /* eslint-disable @typescript-eslint/naming-convention */
     space_id: context.spaceId,
     name: nodeData.file.path,
     source_local_id: nodeInstanceId as string,
     schema_represented_by_local_id: nodeTypeId as string,
     is_schema: false,
     literal_content,
-    /* eslint-enable @typescript-eslint/naming-convention */
     ...extraData,
   };
 };
@@ -222,7 +207,6 @@ export const relationInstanceToLocalConcept = ({
     return null;
   }
 
-  /* eslint-disable @typescript-eslint/naming-convention */
   const literal_content: Record<string, Json> = {};
   if (importedFromRid) literal_content.importedFromRid = importedFromRid;
   return {
@@ -243,7 +227,6 @@ export const relationInstanceToLocalConcept = ({
         (destinationNode.frontmatter.importedFromRid as string | undefined) ??
         destination,
     },
-    /* eslint-enable @typescript-eslint/naming-convention */
   };
 };
 

--- a/apps/obsidian/src/utils/importNodes.ts
+++ b/apps/obsidian/src/utils/importNodes.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import type { Json } from "@repo/database/dbTypes";
 import matter from "gray-matter";
 import { App, Notice, TFile } from "obsidian";

--- a/apps/obsidian/src/utils/importPreview.ts
+++ b/apps/obsidian/src/utils/importPreview.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import type DiscourseGraphPlugin from "~/index";
 import type { ImportableNode } from "~/types";
 import { getLoggedInClient, getSupabaseContext } from "./supabaseContext";

--- a/apps/obsidian/src/utils/importRelations.ts
+++ b/apps/obsidian/src/utils/importRelations.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import type { Json } from "@repo/database/dbTypes";
 import type { DGSupabaseClient } from "@repo/database/lib/client";
 import { uuidv7 } from "uuidv7";

--- a/apps/obsidian/src/utils/publishNode.ts
+++ b/apps/obsidian/src/utils/publishNode.ts
@@ -54,11 +54,9 @@ const publishSchema = async ({
   // Publish schema to group via ResourceAccess
   const publishResponse = await client.from("ResourceAccess").upsert(
     {
-      /* eslint-disable @typescript-eslint/naming-convention */
       account_uid: groupId,
       source_local_id: nodeTypeId,
       space_id: spaceId,
-      /* eslint-enable @typescript-eslint/naming-convention */
     },
     { ignoreDuplicates: true },
   );
@@ -151,11 +149,9 @@ export const publishNewRelation = async (
   for (const group of targetGroups) {
     for (const id of resourceIds) {
       entries.push({
-        /* eslint-disable @typescript-eslint/naming-convention */
         account_uid: group,
         source_local_id: id,
         space_id: context.spaceId,
-        /* eslint-enable @typescript-eslint/naming-convention */
       });
     }
   }
@@ -226,11 +222,9 @@ export const publishNodeRelations = async ({
   if (resourceIds.size === 0) return;
   const publishResponse = await client.from("ResourceAccess").upsert(
     [...resourceIds.values()].map((sourceLocalId: string) => ({
-      /* eslint-disable @typescript-eslint/naming-convention */
       account_uid: myGroup,
       source_local_id: sourceLocalId,
       space_id: spaceId,
-      /* eslint-enable @typescript-eslint/naming-convention */
     })),
     { ignoreDuplicates: true },
   );
@@ -364,13 +358,11 @@ export const ensurePublishedRelationsAccuracy = async ({
     );
     if (missingPublishableIds.size > 0) {
       missingPublishRecords.push(
-        /* eslint-disable @typescript-eslint/naming-convention */
         ...[...missingPublishableIds].map((source_local_id) => ({
           source_local_id,
           space_id: context.spaceId,
           account_uid: group,
         })),
-        /* eslint-enable @typescript-eslint/naming-convention */
       );
     }
     const extraPublishableIds = difference(
@@ -479,10 +471,8 @@ export const publishNodeToGroup = async ({
   if (!skipPublishAccess) {
     const publishSpaceResponse = await client.from("SpaceAccess").upsert(
       {
-        /* eslint-disable @typescript-eslint/naming-convention */
         account_uid: myGroup,
         space_id: spaceId,
-        /* eslint-enable @typescript-eslint/naming-convention */
         permissions: "partial",
       },
       { ignoreDuplicates: true },
@@ -495,11 +485,9 @@ export const publishNodeToGroup = async ({
 
     const publishResponse = await client.from("ResourceAccess").upsert(
       {
-        /* eslint-disable @typescript-eslint/naming-convention */
         account_uid: myGroup,
         source_local_id: nodeId,
         space_id: spaceId,
-        /* eslint-enable @typescript-eslint/naming-convention */
       },
       { ignoreDuplicates: true },
     );

--- a/apps/obsidian/src/utils/syncDgNodesToSupabase.ts
+++ b/apps/obsidian/src/utils/syncDgNodesToSupabase.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import { Notice, TFile } from "obsidian";
 import { addFile } from "@repo/database/lib/files";
 import mime from "mime-types";

--- a/apps/obsidian/src/utils/tagNodeHandler.ts
+++ b/apps/obsidian/src/utils/tagNodeHandler.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-/* eslint-disable @typescript-eslint/naming-convention */
 import { App, Editor, Notice, MarkdownView, TFile } from "obsidian";
 import { DiscourseNode } from "~/types";
 import type DiscourseGraphPlugin from "~/index";

--- a/apps/obsidian/src/utils/tldrawColors.ts
+++ b/apps/obsidian/src/utils/tldrawColors.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 /**
  * Tldraw color names that can be used for relation types.
  * These match the defaultColorNames from tldraw's TLColorStyle.

--- a/apps/obsidian/src/utils/upsertNodesAsContentWithEmbeddings.ts
+++ b/apps/obsidian/src/utils/upsertNodesAsContentWithEmbeddings.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import { nextApiRoot } from "@repo/utils/execContext";
 import { DGSupabaseClient } from "@repo/database/lib/client";
 import { Json, CompositeTypes } from "@repo/database/dbTypes";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

This PR removes all `@typescript-eslint/naming-convention` eslint-disable comments from the `apps/obsidian` codebase, following the relaxation of naming convention rules in the base ESLint config.

## Changes

- Removed all `/* eslint-disable @typescript-eslint/naming-convention */` comments from 16 files in `apps/obsidian`
- Verified no new lint warnings are introduced by running `npm run lint`

## Files Modified

- `scripts/compile.ts`
- `src/components/AdminPanelSettings.tsx`
- `src/components/canvas/TldrawViewComponent.tsx`
- `src/components/canvas/stores/assetStore.ts`
- `src/components/canvas/utils/relationUtils.tsx`
- `src/components/canvas/utils/tldraw.ts`
- `src/services/QueryEngine.ts`
- `src/utils/conceptConversion.ts`
- `src/utils/importNodes.ts`
- `src/utils/importPreview.ts`
- `src/utils/importRelations.ts`
- `src/utils/publishNode.ts`
- `src/utils/syncDgNodesToSupabase.ts`
- `src/utils/tagNodeHandler.ts`
- `src/utils/tldrawColors.ts`
- `src/utils/upsertNodesAsContentWithEmbeddings.ts`

## Testing

- Ran `npm run lint` in `apps/obsidian` to confirm no new warnings were introduced
- All lint checks passed successfully
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-1780](https://linear.app/discourse-graphs/issue/ENG-1780/remove-naming-convention-comments-from-appsobsidian)

<div><a href="https://cursor.com/agents/bc-58962781-5af7-4c13-8dd4-3a651bb8d629"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-58962781-5af7-4c13-8dd4-3a651bb8d629"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

