### PR TITLE
Remove naming-convention eslint-disable comments from apps/website

### DIFF
--- a/apps/website/app/(docs)/docs/_components/DocsPageTemplate.tsx
+++ b/apps/website/app/(docs)/docs/_components/DocsPageTemplate.tsx
@@ -15,7 +15,6 @@ const DocsPageTemplate = ({
   ...wrapperProps
 }: DocsPageTemplateProps): React.ReactElement => {
   const { h1, wrapper } = useMDXComponents();
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   const Wrapper = wrapper as React.ComponentType<DocsPageTemplateProps>;
   const H1 = h1 as React.ComponentType<
     React.HTMLAttributes<HTMLHeadingElement> & {

--- a/apps/website/app/(docs)/docs/shared/docMap.ts
+++ b/apps/website/app/(docs)/docs/shared/docMap.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 // Shared paths
 export const SHARED_DOCS = "app/(docs)/docs/sharedPages";
 

--- a/apps/website/app/(extract)/extract-nodes/page.tsx
+++ b/apps/website/app/(extract)/extract-nodes/page.tsx
@@ -90,7 +90,6 @@ const ExtractNodesPage = (): React.ReactElement => {
       };
       const response = await fetch("/api/ai/extract", {
         method: "POST",
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(requestBody),
       });

--- a/apps/website/app/(home)/auth/token/route.ts
+++ b/apps/website/app/(home)/auth/token/route.ts
@@ -37,10 +37,8 @@ export const GET = async (request: NextRequest): Promise<NextResponse> => {
       );
     }
     const data = JSON.parse(result.data) as {
-      /* eslint-disable @typescript-eslint/naming-convention */
       access_token: string;
       refresh_token: string;
-      /* eslint-enable @typescript-eslint/naming-convention */
     };
     if (
       !data ||

--- a/apps/website/app/(home)/blog/blogSchema.ts
+++ b/apps/website/app/(home)/blog/blogSchema.ts
@@ -1,11 +1,9 @@
 import { z } from "zod";
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 const BlogTagsSchema = z
   .union([z.array(z.string()), z.string()])
   .transform((value) => (Array.isArray(value) ? value : [value]));
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export const BlogFrontmatterSchema = z.object({
   title: z.string(),
   published: z.boolean().default(false),

--- a/apps/website/app/(home)/page.tsx
+++ b/apps/website/app/(home)/page.tsx
@@ -11,7 +11,6 @@ import { getLatestBlogs } from "~/(home)/blog/readBlogs";
 import { TeamPerson } from "~/components/TeamPerson";
 import { TEAM_MEMBERS } from "~/data/constants";
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 const Home = async () => {
   const blogs = await getLatestBlogs();
   return (

--- a/apps/website/app/api/ai/extract/route.ts
+++ b/apps/website/app/api/ai/extract/route.ts
@@ -42,7 +42,7 @@ const buildExtractionMessages = ({
               type: "document",
               source: {
                 type: "base64",
-                media_type: "application/pdf", // eslint-disable-line @typescript-eslint/naming-convention
+                media_type: "application/pdf",
                 data: pdfBase64,
               },
             },
@@ -59,7 +59,7 @@ const buildExtractionMessages = ({
               type: "file",
               file: {
                 filename: "paper.pdf",
-                file_data: `data:application/pdf;base64,${pdfBase64}`, // eslint-disable-line @typescript-eslint/naming-convention
+                file_data: `data:application/pdf;base64,${pdfBase64}`,
               },
             },
             { type: "text", text: userPrompt },

--- a/apps/website/app/api/supabase/agent-identifier/route.ts
+++ b/apps/website/app/api/supabase/agent-identifier/route.ts
@@ -11,17 +11,14 @@ import {
 import { type TablesInsert, Constants } from "@repo/database/dbTypes";
 
 type AgentIdentifierDataInput = TablesInsert<"AgentIdentifier">;
-// eslint-disable-next-line @typescript-eslint/naming-convention
 const { AgentIdentifierType } = Constants.public.Enums;
 
 // ItemValidator<"AgentIdentifier">
 const agentIdentifierValidator = (
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   agent_identifier: AgentIdentifierDataInput,
 ): string | null => {
   if (!agent_identifier || typeof agent_identifier !== "object")
     return "Invalid request body: expected a JSON object.";
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   const { identifier_type, account_id, value, trusted } = agent_identifier;
 
   if (!AgentIdentifierType.includes(identifier_type))

--- a/apps/website/app/api/supabase/document/route.ts
+++ b/apps/website/app/api/supabase/document/route.ts
@@ -18,7 +18,6 @@ type DocumentRecord = Tables<"Document">;
 const validateDocument = (data: DocumentDataInput): string | null => {
   if (!data || typeof data !== "object")
     return "Invalid request body: expected a JSON object.";
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   const { space_id, author_id, source_local_id } = data;
 
   if (!author_id) return "Missing required author_id field.";

--- a/apps/website/app/api/supabase/env/route.ts
+++ b/apps/website/app/api/supabase/env/route.ts
@@ -11,7 +11,6 @@ export const GET = (request: NextRequest): NextResponse => {
     if (!SUPABASE_URL || !SUPABASE_PUBLISHABLE_KEY)
       return new NextResponse("Missing variables", { status: 500 });
     return NextResponse.json(
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       { SUPABASE_URL, SUPABASE_ANON_KEY, SUPABASE_PUBLISHABLE_KEY },
       { status: 200 },
     );

--- a/apps/website/app/api/supabase/platform-account/route.ts
+++ b/apps/website/app/api/supabase/platform-account/route.ts
@@ -10,7 +10,6 @@ import {
 } from "~/utils/supabase/apiUtils";
 import { type TablesInsert, Constants } from "@repo/database/dbTypes";
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 const { AgentType, Platform } = Constants.public.Enums;
 
 type PlatformAccountDataInput = TablesInsert<"PlatformAccount">;
@@ -19,7 +18,6 @@ type PlatformAccountDataInput = TablesInsert<"PlatformAccount">;
 const accountValidator = (account: PlatformAccountDataInput): string | null => {
   if (!account || typeof account !== "object")
     return "Invalid request body: expected a JSON object.";
-  /* eslint-disable @typescript-eslint/naming-convention */
   const {
     name,
     platform,
@@ -30,7 +28,6 @@ const accountValidator = (account: PlatformAccountDataInput): string | null => {
     metadata,
     dg_account,
   } = account;
-  /* eslint-enable @typescript-eslint/naming-convention */
 
   if (!name || typeof name !== "string" || name.trim() === "")
     return "Missing or invalid name";

--- a/apps/website/app/components/Logo.tsx
+++ b/apps/website/app/components/Logo.tsx
@@ -5,9 +5,7 @@ import { usePathname } from "next/navigation";
 import { PlatformBadge } from "./PlatformBadge";
 
 const DOCS_PLATFORMS = {
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   "/docs/obsidian": "obsidian",
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   "/docs/roam": "roam",
 } as const;
 
@@ -32,16 +30,12 @@ export const Logo = ({
         aria-hidden="true"
         className={`block h-12 w-12 shrink-0 bg-current ${textClassName}`}
         style={{
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           WebkitMaskImage: "url('/logo-light-48.svg')",
           maskImage: "url('/logo-light-48.svg')",
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           WebkitMaskPosition: "center",
           maskPosition: "center",
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           WebkitMaskRepeat: "no-repeat",
           maskRepeat: "no-repeat",
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           WebkitMaskSize: "contain",
           maskSize: "contain",
         }}

--- a/apps/website/app/types/extraction.ts
+++ b/apps/website/app/types/extraction.ts
@@ -4,7 +4,6 @@ export const PROVIDER_IDS = ["anthropic", "openai", "gemini"] as const;
 
 export type ProviderId = (typeof PROVIDER_IDS)[number];
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export const ExtractedNodeSchema = z.object({
   nodeType: z.string(),
   content: z.string(),
@@ -14,14 +13,12 @@ export const ExtractedNodeSchema = z.object({
 
 export type ExtractedNode = z.infer<typeof ExtractedNodeSchema>;
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export const ExtractionResultSchema = z.object({
   nodes: z.array(ExtractedNodeSchema),
 });
 
 export type ExtractionResult = z.infer<typeof ExtractionResultSchema>;
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export const ExtractionRequestSchema = z.object({
   pdfBase64: z.string().min(1).max(44_000_000),
   provider: z.enum(PROVIDER_IDS),

--- a/apps/website/app/utils/llm/providers.ts
+++ b/apps/website/app/utils/llm/providers.ts
@@ -18,10 +18,8 @@ export const openaiConfig: LLMProviderConfig = {
     temperature: settings.temperature,
     max_completion_tokens: settings.maxTokens,
     ...(settings.outputSchema && {
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       response_format: {
         type: "json_schema",
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         json_schema: {
           name: "extraction_result",
           strict: true,
@@ -81,7 +79,6 @@ export const anthropicConfig: LLMProviderConfig = {
     temperature: settings.temperature,
     ...(settings.systemPrompt && { system: settings.systemPrompt }),
     ...(settings.outputSchema && {
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       output_config: {
         format: {
           type: "json_schema",

--- a/apps/website/app/utils/supabase/account.ts
+++ b/apps/website/app/utils/supabase/account.ts
@@ -4,7 +4,6 @@ export const createGroup = async (
   client: DGSupabaseClient,
   name: string,
 ): Promise<string | null> => {
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   const result = await client.functions.invoke<{ group_id: string }>(
     "create-group",
     { body: { name } },

--- a/apps/website/app/utils/supabase/dbUtils.ts
+++ b/apps/website/app/utils/supabase/dbUtils.ts
@@ -17,7 +17,6 @@ export type PublicTableName = keyof Database["public"]["Tables"];
 export type RawTables<TN extends PublicTableName> =
   Database["public"]["Tables"][TN]["Row"];
 export type RawTablesInsert<TN extends PublicTableName> =
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   Database["public"]["Tables"][TN] extends { Insert: unknown }
     ? Database["public"]["Tables"][TN]["Insert"]
     : never;

--- a/apps/website/app/utils/supabase/validators.ts
+++ b/apps/website/app/utils/supabase/validators.ts
@@ -1,14 +1,12 @@
 import type { PublicTableName, RawTablesInsert, RawTables } from "./dbUtils";
 import type { Tables, TablesInsert } from "@repo/database/dbTypes";
 
-/* eslint-disable @typescript-eslint/naming-convention */
 export type InputTypes = {
   ContentEmbedding_openai_text_embedding_3_small_1536: ContentEmbeddingVecTablesInsert;
 };
 export type OutputTypes = {
   ContentEmbedding_openai_text_embedding_3_small_1536: ContentEmbeddingVecTables;
 };
-/* eslint-enable @typescript-eslint/naming-convention */
 
 export type InputTypeOf<T extends PublicTableName> = T extends keyof InputTypes
   ? InputTypes[T]
@@ -50,7 +48,6 @@ export const KNOWN_EMBEDDING_TABLES: {
     tableSize: number;
   };
 } = {
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   openai_text_embedding_3_small_1536: {
     tableName: "ContentEmbedding_openai_text_embedding_3_small_1536",
     tableSize: 1536,
@@ -77,7 +74,6 @@ export const embeddingInputValidation = <T extends ContentEmbeddingTableName>(
 ): string | null => {
   if (!data || typeof data !== "object")
     return "Invalid request body: expected a JSON object.";
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   const { target_id, model, vector } = data;
 
   if (
@@ -192,7 +188,6 @@ export const contentInputValidation = (
 ): string | null => {
   if (!data || typeof data !== "object")
     return "Invalid request body: expected a JSON object.";
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   const { author_id, created, last_modified, scale, space_id, text } = data;
 
   if (!text || typeof text !== "string") return "Invalid or missing text.";

--- a/apps/website/content/_meta.ts
+++ b/apps/website/content/_meta.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import type { MetaRecord } from "nextra";
 
 const meta: MetaRecord = {

--- a/apps/website/content/obsidian/_meta.ts
+++ b/apps/website/content/obsidian/_meta.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import type { MetaRecord } from "nextra";
 
 const meta: MetaRecord = {

--- a/apps/website/content/obsidian/advanced-features/_meta.ts
+++ b/apps/website/content/obsidian/advanced-features/_meta.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import type { MetaRecord } from "nextra";
 
 const meta: MetaRecord = {

--- a/apps/website/content/obsidian/configuration/_meta.ts
+++ b/apps/website/content/obsidian/configuration/_meta.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import type { MetaRecord } from "nextra";
 
 const meta: MetaRecord = {

--- a/apps/website/content/obsidian/core-features/_meta.ts
+++ b/apps/website/content/obsidian/core-features/_meta.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import type { MetaRecord } from "nextra";
 
 const meta: MetaRecord = {

--- a/apps/website/content/obsidian/fundamentals/_meta.ts
+++ b/apps/website/content/obsidian/fundamentals/_meta.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import type { MetaRecord } from "nextra";
 
 const meta: MetaRecord = {

--- a/apps/website/content/obsidian/use-cases/_meta.ts
+++ b/apps/website/content/obsidian/use-cases/_meta.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import type { MetaRecord } from "nextra";
 
 const meta: MetaRecord = {

--- a/apps/website/content/obsidian/welcome/_meta.ts
+++ b/apps/website/content/obsidian/welcome/_meta.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import type { MetaRecord } from "nextra";
 
 const meta: MetaRecord = {

--- a/apps/website/content/roam/_meta.ts
+++ b/apps/website/content/roam/_meta.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import type { MetaRecord } from "nextra";
 
 const meta: MetaRecord = {

--- a/apps/website/content/roam/fundamentals/_meta.ts
+++ b/apps/website/content/roam/fundamentals/_meta.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import type { MetaRecord } from "nextra";
 
 const meta: MetaRecord = {

--- a/apps/website/content/roam/fundamentals/grammar/_meta.ts
+++ b/apps/website/content/roam/fundamentals/grammar/_meta.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import type { MetaRecord } from "nextra";
 
 const meta: MetaRecord = {

--- a/apps/website/content/roam/guides/_meta.ts
+++ b/apps/website/content/roam/guides/_meta.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import type { MetaRecord } from "nextra";
 
 const meta: MetaRecord = {

--- a/apps/website/content/roam/guides/exploring-discourse-graph/_meta.ts
+++ b/apps/website/content/roam/guides/exploring-discourse-graph/_meta.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import type { MetaRecord } from "nextra";
 
 const meta: MetaRecord = {

--- a/apps/website/content/roam/use-cases/_meta.ts
+++ b/apps/website/content/roam/use-cases/_meta.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import type { MetaRecord } from "nextra";
 
 const meta: MetaRecord = {

--- a/apps/website/content/roam/welcome/_meta.ts
+++ b/apps/website/content/roam/welcome/_meta.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import type { MetaRecord } from "nextra";
 
 const meta: MetaRecord = {

--- a/apps/website/docsRouteMap.ts
+++ b/apps/website/docsRouteMap.ts
@@ -12,7 +12,6 @@ export const ROAM_DOC_SECTIONS = {
   ],
   fundamentals: ["what-is-a-discourse-graph", "grammar", "relations-patterns"],
 
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   "use-cases": [
     "literature-reviewing",
     "enhanced-zettelkasten",
@@ -30,7 +29,6 @@ export const OBSIDIAN_DOC_SECTIONS = {
     "relationship-types",
     "general-settings",
   ],
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   "core-features": [
     "creating-discourse-nodes",
     "creating-discourse-relationships",
@@ -38,9 +36,7 @@ export const OBSIDIAN_DOC_SECTIONS = {
     "canvas",
     "node-tags",
   ],
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   "advanced-features": ["command-palette", "sync-and-import"],
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   "use-cases": [
     "literature-reviewing",
     "research-roadmapping",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR removes all `@typescript-eslint/naming-convention` eslint-disable comments from `apps/website`, following the relaxed naming convention rules introduced in ENG-1777.

## Changes

- Removed 54+ eslint-disable comments that are no longer needed
- Updated files across:
  - API routes
  - Components
  - Content metadata files
  - Type definitions
  - Utility functions

## Testing

- ✅ Ran ESLint on apps/website
- ✅ No new lint warnings introduced
- ✅ All existing warnings are unrelated to the removed comments
- ✅ The relaxed naming convention rules are working as expected

## Related Issues

Closes ENG-1781
Related to ENG-1777
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-1781](https://linear.app/discourse-graphs/issue/ENG-1781/remove-naming-convention-comments-from-appswebsite)

<div><a href="https://cursor.com/agents/bc-155d1cb5-e42f-4106-9796-bb684866e8f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-155d1cb5-e42f-4106-9796-bb684866e8f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

