### PR TITLE
Remove naming-convention eslint-disable comments from apps/roam

### DIFF
--- a/apps/roam/src/components/CreateRelationDialog.tsx
+++ b/apps/roam/src/components/CreateRelationDialog.tsx
@@ -373,7 +373,6 @@ export const renderCreateRelationDialog = (
     });
   } else {
     renderOverlay({
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       Overlay: CreateRelationDialog,
       props: props as ExtendedCreateRelationDialogProps,
     });

--- a/apps/roam/src/components/DiscourseNodeSearchMenu.tsx
+++ b/apps/roam/src/components/DiscourseNodeSearchMenu.tsx
@@ -297,9 +297,7 @@ const NodeSearchMenu = ({
   const { ["block-uid"]: blockUid, ["window-id"]: windowId } = useMemo(
     () =>
       window.roamAlphaAPI.ui.getFocusedBlock() || {
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         "block-uid": "",
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         "window-id": "",
       },
     [],
@@ -352,9 +350,7 @@ const NodeSearchMenu = ({
               if (window.roamAlphaAPI.ui.setBlockFocusAndSelection) {
                 void window.roamAlphaAPI.ui.setBlockFocusAndSelection({
                   location: {
-                    // eslint-disable-next-line @typescript-eslint/naming-convention
                     "block-uid": blockUid,
-                    // eslint-disable-next-line @typescript-eslint/naming-convention
                     "window-id": windowId,
                   },
                   selection: { start: newCursorPosition },

--- a/apps/roam/src/components/Export.tsx
+++ b/apps/roam/src/components/Export.tsx
@@ -250,7 +250,6 @@ const ExportDialog: ExportDialogComponent = ({
     setSelectedPageUid(getPageUidByPageTitle(title));
   };
 
-  /* eslint-disable @typescript-eslint/naming-convention */
   const addToSelectedCanvas = async (pageUid: string) => {
     if (typeof results !== "object") return false;
 
@@ -283,7 +282,6 @@ const ExportDialog: ExportDialogComponent = ({
               if (event.shiftKey) {
                 void window.roamAlphaAPI.ui.rightSidebar.addWindow({
                   // @ts-expect-error - todo test
-                  // eslint-disable-next-line @typescript-eslint/naming-convention
                   window: { "block-uid": pageUid, type: "outline" },
                 });
               } else {
@@ -420,7 +418,6 @@ const ExportDialog: ExportDialogComponent = ({
       tldraw.schema = tlStore.schema.serialize();
       tempTlStoreSnapshot = tlStore.getStoreSnapshot();
     }
-    /* eslint-disable @typescript-eslint/naming-convention */
 
     const tlStoreSnapshot = isTLStore
       ? (tldraw as TLStoreSnapshot) // isTlStore type checked above
@@ -677,7 +674,6 @@ const ExportDialog: ExportDialogComponent = ({
                 if (event.shiftKey) {
                   void window.roamAlphaAPI.ui.rightSidebar.addWindow({
                     // @ts-expect-error - todo test
-                    // eslint-disable-next-line @typescript-eslint/naming-convention
                     window: { "block-uid": uid, type: "outline" },
                   });
                 } else {

--- a/apps/roam/src/components/LeftSidebarCommands.tsx
+++ b/apps/roam/src/components/LeftSidebarCommands.tsx
@@ -17,7 +17,6 @@ export const commands: Record<
   (onloadArgs: OnloadArgs) => Promise<void>
 > = {
   /* eslint-disable @typescript-eslint/require-await */
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   "{create node}": async (onloadArgs: OnloadArgs) => {
     createDiscourseNodeFromCommand(onloadArgs.extensionAPI);
     // typescript-eslint/naming-convention

--- a/apps/roam/src/components/LeftSidebarView.tsx
+++ b/apps/roam/src/components/LeftSidebarView.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import React, {
   useCallback,
   useEffect,
@@ -119,7 +118,6 @@ const openTarget = async (
   if (e.shiftKey) {
     await window.roamAlphaAPI.ui.rightSidebar.addWindow({
       // @ts-expect-error - todo test
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       window: { type: "outline", "block-uid": targetUid },
     });
   } else {

--- a/apps/roam/src/components/ModifyNodeDialog.tsx
+++ b/apps/roam/src/components/ModifyNodeDialog.tsx
@@ -322,7 +322,6 @@ const ModifyNodeDialog = ({
           extensionAPI,
           parentUid,
           // due to query format
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           inputs: { NODETEXT: content.text, NODEUID: pageUid },
         });
         const imagePlaceholderUid = results.allProcessedResults[0]?.uid;
@@ -398,7 +397,6 @@ const ModifyNodeDialog = ({
           formattedTitle = nodeFormat.replace(
             /{([\w\d-]*)}/g,
             // unused variable will take _ as name
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             (_, val: string) => {
               if (/content/i.test(val)) return content.text.trim();
               if (new RegExp(referencedNode.name, "i").test(val))
@@ -460,7 +458,6 @@ const ModifyNodeDialog = ({
                       await window.roamAlphaAPI.ui.rightSidebar.addWindow({
                         window: {
                           // @ts-expect-error TODO: fix this
-                          // eslint-disable-next-line @typescript-eslint/naming-convention
                           "block-uid": newPageUid,
                           type: "outline",
                         },
@@ -492,7 +489,6 @@ const ModifyNodeDialog = ({
         if (referencedNode && referencedNodeValue.text) {
           updatedContent = nodeFormat
             // unused variable will take _ as name
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             .replace(/{([\w\d-]*)}/g, (_, val: string) => {
               if (/content/i.test(val)) return content.text.trim();
               if (new RegExp(referencedNode.name, "i").test(val))
@@ -643,7 +639,6 @@ const ModifyNodeDialog = ({
 
 export const renderModifyNodeDialog = (props: ModifyNodeDialogProps) =>
   renderOverlay({
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     Overlay: ModifyNodeDialog,
     props,
   });

--- a/apps/roam/src/components/VectorDuplicateMatches.tsx
+++ b/apps/roam/src/components/VectorDuplicateMatches.tsx
@@ -92,7 +92,6 @@ export const VectorDuplicateMatches = ({
       window: {
         type: "outline",
         // @ts-expect-error - type definition mismatch
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         "block-uid": node.uid,
       },
     });

--- a/apps/roam/src/components/canvas/Clipboard.tsx
+++ b/apps/roam/src/components/canvas/Clipboard.tsx
@@ -84,7 +84,6 @@ type ClipboardContextValue = {
   setShowNodesOnCanvas: (show: boolean) => void;
 };
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 const ClipboardContext = createContext<ClipboardContextValue | null>(null);
 
 const CLIPBOARD_PROP_KEY = "pages";
@@ -109,9 +108,7 @@ const getOrCreateClipboardBlock = async (
     childBlocksData?.[":block/children"] &&
     Array.isArray(childBlocksData[":block/children"])
       ? (childBlocksData[":block/children"] as Array<{
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           ":block/uid": string;
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           ":block/string": string;
         }>)
       : [];

--- a/apps/roam/src/components/canvas/CustomDefaultToolbar.tsx
+++ b/apps/roam/src/components/canvas/CustomDefaultToolbar.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unsafe-enum-comparison */
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
-/* eslint-disable @typescript-eslint/naming-convention */
 /* eslint-disable preferArrows/prefer-arrow-functions */
 
 // from /packages/tldraw/src/lib/ui/components/Toolbar/DefaultToolbar.tsx

--- a/apps/roam/src/components/canvas/DiscourseNodeUtil.tsx
+++ b/apps/roam/src/components/canvas/DiscourseNodeUtil.tsx
@@ -76,7 +76,6 @@ export const DEFAULT_STYLE_PROPS = {
 };
 export const COLOR_ARRAY = Array.from(DefaultColorStyle.values).reverse();
 // from @tldraw/editor/editor.css
-/* eslint-disable @typescript-eslint/naming-convention */
 export const COLOR_PALETTE: Record<string, string> = {
   black: "#1d1d1d",
   blue: "#4263eb",
@@ -92,7 +91,6 @@ export const COLOR_PALETTE: Record<string, string> = {
   white: "#ffffff",
   yellow: "#ffc078",
 };
-/* eslint-disable @typescript-eslint/naming-convention */
 
 const getRelationIds = () =>
   new Set(

--- a/apps/roam/src/components/canvas/DiscourseRelationShape/DiscourseRelationTool.tsx
+++ b/apps/roam/src/components/canvas/DiscourseRelationShape/DiscourseRelationTool.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import {
   StateNode,
   TLEventHandlers,

--- a/apps/roam/src/components/canvas/DiscourseRelationShape/DiscourseRelationUtil.tsx
+++ b/apps/roam/src/components/canvas/DiscourseRelationShape/DiscourseRelationUtil.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 /* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
 import React from "react";
 import {

--- a/apps/roam/src/components/canvas/DiscourseRelationShape/discourseRelationMigrations.ts
+++ b/apps/roam/src/components/canvas/DiscourseRelationShape/discourseRelationMigrations.ts
@@ -3,7 +3,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/naming-convention */
 import {
   createMigrationSequence,
   createBindingId,

--- a/apps/roam/src/components/canvas/DiscourseRelationShape/helpers.tsx
+++ b/apps/roam/src/components/canvas/DiscourseRelationShape/helpers.tsx
@@ -10,7 +10,6 @@
 /* eslint-disable max-params */
 /* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
 /* eslint-disable preferArrows/prefer-arrow-functions */
-/* eslint-disable @typescript-eslint/naming-convention */
 
 import React, { useRef, useEffect, useState } from "react";
 import {

--- a/apps/roam/src/components/canvas/Tldraw.tsx
+++ b/apps/roam/src/components/canvas/Tldraw.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import React, {
   useState,
   useRef,

--- a/apps/roam/src/components/canvas/TldrawCanvasCloudflareSync.tsx
+++ b/apps/roam/src/components/canvas/TldrawCanvasCloudflareSync.tsx
@@ -42,7 +42,6 @@ const parseRoamUploadResponse = (value: string): string => {
 
 const createRoamAssetStore = (): TLAssetStore => {
   return {
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     upload: async (_asset, file) => {
       const response = await window.roamAlphaAPI.file.upload({ file });
       return parseRoamUploadResponse(response);

--- a/apps/roam/src/components/canvas/uiOverrides.tsx
+++ b/apps/roam/src/components/canvas/uiOverrides.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import React, { ReactElement } from "react";
 import {
   TLImageShape,

--- a/apps/roam/src/components/canvas/useRoamStore.ts
+++ b/apps/roam/src/components/canvas/useRoamStore.ts
@@ -256,7 +256,6 @@ export const useRoamStore = ({
       });
     };
 
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     let _store: TLStore;
 
     try {

--- a/apps/roam/src/components/settings/AdminPanel.tsx
+++ b/apps/roam/src/components/settings/AdminPanel.tsx
@@ -311,7 +311,6 @@ const FeatureFlagsTab = (): React.ReactElement => {
       });
       return;
     }
-    /* eslint-disable @typescript-eslint/naming-convention */
     const { access_token, refresh_token } = sessionData.data.session;
     const { data, error } = await client.rpc("create_secret_token", {
       v_payload: JSON.stringify({ access_token, refresh_token }),

--- a/apps/roam/src/components/settings/DiscourseRelationConfigPanel.tsx
+++ b/apps/roam/src/components/settings/DiscourseRelationConfigPanel.tsx
@@ -1038,7 +1038,6 @@ const DiscourseRelationConfigPanel = ({
 
   const handleDelete = (rel: Relation) => {
     void deleteBlock(rel.uid).then(() => {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/naming-convention
       const { [rel.uid]: _, ...remaining } = getGlobalSettings().Relations;
       setGlobalSetting([GLOBAL_KEYS.relations], remaining);
       setTimeout(() => {

--- a/apps/roam/src/components/settings/LeftSidebarPersonalSettings.tsx
+++ b/apps/roam/src/components/settings/LeftSidebarPersonalSettings.tsx
@@ -58,7 +58,6 @@ const isSmartBlockButtonRef = (text: string): boolean => {
   return isSmartBlockUid(extractRef(text));
 };
 
-/* eslint-disable @typescript-eslint/naming-convention */
 export const sectionsToBlockProps = (
   sections: LeftSidebarPersonalSectionConfig[],
 ) =>

--- a/apps/roam/src/components/settings/SuggestiveModeSettings.tsx
+++ b/apps/roam/src/components/settings/SuggestiveModeSettings.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import React, { useEffect, useState } from "react";
 import { Button, Intent, Tabs, Tab, TabId } from "@blueprintjs/core";
 import discourseConfigRef from "~/utils/discourseConfigRef";

--- a/apps/roam/src/components/settings/components/BlockPropSettingPanels.tsx
+++ b/apps/roam/src/components/settings/components/BlockPropSettingPanels.tsx
@@ -208,10 +208,8 @@ const BaseFlagPanel = ({
       if (checked) {
         if (blockUidRef.current) return;
         const newUid = window.roamAlphaAPI.util.generateUID();
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         await window.roamAlphaAPI.data.block.create({
           block: { string: title, uid: newUid },
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           location: { order, "parent-uid": parentUid },
         });
         blockUidRef.current = newUid;
@@ -398,7 +396,6 @@ const BaseMultiTextPanel = ({
     const newUid = window.roamAlphaAPI.util.generateUID();
     await window.roamAlphaAPI.createBlock({
       block: { string: title, uid: newUid },
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       location: { order, "parent-uid": parentUid },
     });
     blockUidRef.current = newUid;
@@ -421,7 +418,6 @@ const BaseMultiTextPanel = ({
           block: { string: trimmed, uid: valueUid },
           location: {
             order: childUidsRef.current.length,
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             "parent-uid": parent,
           },
         });
@@ -432,7 +428,6 @@ const BaseMultiTextPanel = ({
   };
 
   const handleRemove = (index: number) => {
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     const newValues = values.filter((_, i) => i !== index);
     setValues(newValues);
     onChange?.(newValues);
@@ -442,10 +437,7 @@ const BaseMultiTextPanel = ({
       if (removedUid) {
         void window.roamAlphaAPI.deleteBlock({ block: { uid: removedUid } });
       }
-      childUidsRef.current = childUidsRef.current.filter(
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        (_, i) => i !== index,
-      );
+      childUidsRef.current = childUidsRef.current.filter((_, i) => i !== index);
       refreshConfigTree();
     }
     setter(settingKeys, newValues);

--- a/apps/roam/src/components/settings/data/defaultRelationsBlockProps.ts
+++ b/apps/roam/src/components/settings/data/defaultRelationsBlockProps.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */ // This is for nodePosition keys
 import type { DiscourseRelationSettings } from "~/components/settings/utils/zodSchema";
 
 // TODO: Delete the original default relations in data/defaultRelations.ts when fully migrated.

--- a/apps/roam/src/components/settings/utils/accessors.ts
+++ b/apps/roam/src/components/settings/utils/accessors.ts
@@ -244,7 +244,6 @@ const PERSONAL_SCHEMA_PATH_TO_LEGACY_KEY = new Map<string, string>([
 const getLegacyPersonalLeftSidebarSetting = (): unknown[] => {
   const settings = getLeftSidebarSettings(discourseConfigRef.tree);
 
-  /* eslint-disable @typescript-eslint/naming-convention */
   return settings.personal.sections.map((section) => ({
     name: section.text,
     Children: (section.children || []).map((child) => ({
@@ -519,7 +518,6 @@ const getLegacyDiscourseNodeSetting = (
       c.children[0]?.text || "",
     ]),
   );
-  /* eslint-disable @typescript-eslint/naming-convention */
   const canvasSettings = {
     color: rawCanvas["color"] || "",
     alias: rawCanvas["alias"] || "",
@@ -701,7 +699,6 @@ export const LEGACY_SOURCED_FEATURE_FLAG_KEYS = [
   "Enable left sidebar",
 ] as const satisfies ReadonlyArray<keyof FeatureFlags>;
 
-/* eslint-disable @typescript-eslint/naming-convention */
 const FEATURE_FLAG_LEGACY_MAP: Record<
   (typeof LEGACY_SOURCED_FEATURE_FLAG_KEYS)[number],
   () => boolean

--- a/apps/roam/src/components/settings/utils/init.ts
+++ b/apps/roam/src/components/settings/utils/init.ts
@@ -261,7 +261,6 @@ const reconcileRelationKeys = (
   }
 
   if (changed) {
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     setBlockProps(globalBlockUid, { Relations: reconciledRelations }, false);
   }
 };
@@ -329,7 +328,6 @@ const logDualReadComparison = (): void => {
   // are aligned.
   const SKIP_NODE_KEYS = new Set(["template", "specification", "index"]);
 
-  /* eslint-disable @typescript-eslint/naming-convention */
   for (const g of groups) {
     const keys = new Set([...Object.keys(g.legacy), ...Object.keys(g.block)]);
     const mismatchedKeys: string[] = [];

--- a/apps/roam/src/components/settings/utils/pullWatchers.ts
+++ b/apps/roam/src/components/settings/utils/pullWatchers.ts
@@ -91,7 +91,6 @@ export const featureFlagHandlers: Partial<
     (newValue: boolean, oldValue: boolean, allFlags: FeatureFlags) => void
   >
 > = {
-  /* eslint-disable @typescript-eslint/naming-convention */
   "Enable left sidebar": (newValue, oldValue) => {
     emitSettingChange(settingKeys.leftSidebarFlag, newValue, oldValue);
   },
@@ -107,7 +106,6 @@ type GlobalSettingsHandlers = {
 };
 
 export const globalSettingsHandlers: GlobalSettingsHandlers = {
-  /* eslint-disable @typescript-eslint/naming-convention */
   "Left sidebar": (newValue, oldValue) => {
     emitSettingChange(settingKeys.globalLeftSidebar, newValue, oldValue);
   },
@@ -126,7 +124,6 @@ type PersonalSettingsHandlers = {
 };
 
 export const personalSettingsHandlers: PersonalSettingsHandlers = {
-  /* eslint-disable @typescript-eslint/naming-convention */
   "Left sidebar": (newValue, oldValue) => {
     emitSettingChange(settingKeys.personalLeftSidebar, newValue, oldValue);
   },
@@ -136,7 +133,6 @@ export const personalSettingsHandlers: PersonalSettingsHandlers = {
   "Node search menu trigger": (newValue, oldValue) => {
     emitSettingChange(settingKeys.nodeSearchMenuTrigger, newValue, oldValue);
   },
-  /* eslint-enable @typescript-eslint/naming-convention */
 };
 
 export const discourseNodeHandlers: Array<

--- a/apps/roam/src/components/settings/utils/zodSchema.example.ts
+++ b/apps/roam/src/components/settings/utils/zodSchema.example.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import type {
   CanvasSettings,

--- a/apps/roam/src/components/settings/utils/zodSchema.ts
+++ b/apps/roam/src/components/settings/utils/zodSchema.ts
@@ -1,8 +1,6 @@
 import { z } from "zod";
 import DEFAULT_RELATIONS_BLOCK_PROPS from "~/components/settings/data/defaultRelationsBlockProps";
 
-/* eslint-disable @typescript-eslint/naming-convention */
-
 export const CanvasSettingsSchema = z.object({
   color: z.string().default(""),
   alias: z.string().default(""),

--- a/apps/roam/src/data/legacyTldrawSchema.ts
+++ b/apps/roam/src/data/legacyTldrawSchema.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 export const LEGACY_SCHEMA = {
   schemaVersion: 1 as const,
   storeVersion: 1,

--- a/apps/roam/src/utils/calcCanvasNodeSizeAndImg.ts
+++ b/apps/roam/src/utils/calcCanvasNodeSizeAndImg.ts
@@ -24,14 +24,12 @@ const EMBED_REGEX =
 
 const getBlockReferences = (
   uid: string,
-  // eslint-disable-next-line @typescript-eslint/naming-convention
 ): { ":block/uid"?: string; ":block/string"?: string }[] => {
   const result =
     (window.roamAlphaAPI?.pull?.(
       "[:block/uid {:block/refs [:block/uid :block/string]}]",
       [":block/uid", uid],
     ) as {
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       [":block/refs"]?: { ":block/uid"?: string; ":block/string"?: string }[];
     } | null) || {};
   return result[":block/refs"] || [];
@@ -111,7 +109,6 @@ const calcCanvasNodeSizeAndImg = async ({
     const results = await runQuery({
       extensionAPI,
       parentUid,
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       inputs: { NODETEXT: nodeText, NODEUID: uid },
     });
     const resultUid = results.allProcessedResults[0]?.uid || "";

--- a/apps/roam/src/utils/conceptConversion.ts
+++ b/apps/roam/src/utils/conceptConversion.ts
@@ -11,7 +11,6 @@ import type { Json } from "@repo/database/dbTypes";
 import getPageTitleByPageUid from "roamjs-components/queries/getPageTitleByPageUid";
 
 const getNodeExtraData = (
-  /* eslint-disable @typescript-eslint/naming-convention */
   node_uid: string,
 ): {
   author_uid: string;
@@ -42,7 +41,6 @@ const getNodeExtraData = (
   if (result.length !== 1 || result[0].length !== 4)
     throw new Error("Invalid result from Roam query");
 
-  /* eslint-disable @typescript-eslint/naming-convention */
   const [author_uid, page_uid, created_t, last_modified_t] = result[0] as [
     string,
     string,
@@ -81,7 +79,6 @@ export const discourseNodeSchemaToLocalConcept = (
 ): LocalConceptDataInput => {
   const titleParts = node.text.split("/");
   const result: LocalConceptDataInput = {
-    /* eslint-disable @typescript-eslint/naming-convention */
     space_id: context.spaceId,
     name: node.text,
     source_local_id: node.type,
@@ -110,7 +107,6 @@ export const discourseNodeBlockToLocalConcept = (
   },
 ): LocalConceptDataInput => {
   return {
-    /* eslint-disable @typescript-eslint/naming-convention */
     space_id: context.spaceId,
     name: text,
     source_local_id: nodeUid,
@@ -129,7 +125,6 @@ export const discourseRelationSchemaToLocalConcept = (
 ): LocalConceptDataInput => {
   const { id, label, complement, source, destination, ...otherData } = relation;
   return {
-    /* eslint-disable @typescript-eslint/naming-convention */
     space_id: context.spaceId,
     source_local_id: id,
     name: getPageTitleByPageUid(id),
@@ -190,7 +185,6 @@ export const discourseRelationDataToLocalConcept = (
   // TODO: Also get the nodes from the representation, using QueryBuilder. That will likely give me the relation object
   const nodeData = Object.values(casting).map((v) => getNodeExtraData(v));
   // roundabout way to do a max from stringified dates
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   const last_modified = new Date(
     Math.max(...nodeData.map((nd) => new Date(nd.last_modified).getTime())),
   ).toISOString();
@@ -199,7 +193,6 @@ export const discourseRelationDataToLocalConcept = (
   const created = new Date(
     Math.max(...nodeData.map((nd) => new Date(nd.created).getTime())),
   ).toISOString();
-  /* eslint-disable @typescript-eslint/naming-convention */
   const author_local_id: string = nodeData[0].author_uid; // take any one; again until I get the relation object
   return {
     space_id: context.spaceId,

--- a/apps/roam/src/utils/conditionToDatalog.ts
+++ b/apps/roam/src/utils/conditionToDatalog.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import parseNlpDate from "roamjs-components/date/parseNlpDate";
 import getAllPageNames from "roamjs-components/queries/getAllPageNames";
 import normalizePageTitle from "roamjs-components/queries/normalizePageTitle";

--- a/apps/roam/src/utils/createDiscourseNode.ts
+++ b/apps/roam/src/utils/createDiscourseNode.ts
@@ -88,7 +88,6 @@ const handleImageCreation = async ({
       const results = await runQuery({
         extensionAPI,
         parentUid,
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         inputs: { NODETEXT: text, NODEUID: pageUid },
       });
       const imagePlaceholderUid = results.allProcessedResults[0]?.uid;

--- a/apps/roam/src/utils/createReifiedBlock.ts
+++ b/apps/roam/src/utils/createReifiedBlock.ts
@@ -63,7 +63,6 @@ const createReifiedBlock = async ({
       text: newUid,
       uid: newUid,
       props: {
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         [DISCOURSE_GRAPH_PROP_NAME]: data,
       },
     },

--- a/apps/roam/src/utils/getAllDiscourseNodesSince.ts
+++ b/apps/roam/src/utils/getAllDiscourseNodesSince.ts
@@ -4,7 +4,6 @@ import extractRef from "roamjs-components/util/extractRef";
 
 type ISODateString = string;
 
-/* eslint-disable @typescript-eslint/naming-convention */
 export type RoamDiscourseNodeData = {
   author_local_id: string;
   author_name: string;

--- a/apps/roam/src/utils/getExportTypes.ts
+++ b/apps/roam/src/utils/getExportTypes.ts
@@ -38,7 +38,6 @@ type getExportTypesProps = {
   isExportDiscourseGraph: boolean;
 };
 
-/* eslint-disable @typescript-eslint/naming-convention */
 type RoamImportUser = {
   ":user/uid": string;
 };

--- a/apps/roam/src/utils/hyde.ts
+++ b/apps/roam/src/utils/hyde.ts
@@ -19,13 +19,11 @@ type ApiEmbeddingResponse = {
   }>;
 };
 
-/* eslint-disable @typescript-eslint/naming-convention */
 type ApiSupabaseResultItem = {
   roam_uid: string;
   text_content: string;
   similarity: number;
 };
-/* eslint-disable @typescript-eslint/naming-convention */
 
 export type EmbeddingVectorType = number[];
 

--- a/apps/roam/src/utils/jsonld.ts
+++ b/apps/roam/src/utils/jsonld.ts
@@ -63,8 +63,8 @@ export const getJsonLdSchema = async ({
       numTreatedPages += 1;
       await updateExportProgress(numTreatedPages);
       return {
-        "@id": `pages:${node.type}`, // eslint-disable-line @typescript-eslint/naming-convention
-        "@type": "nodeSchema", // eslint-disable-line @typescript-eslint/naming-convention
+        "@id": `pages:${node.type}`,
+        "@type": "nodeSchema",
         label: node.text,
         content: r.content,
         modified: modified?.toJSON(),
@@ -74,15 +74,15 @@ export const getJsonLdSchema = async ({
     }),
   );
   const relSchemaData = allRelations.map((r: DiscourseRelation) => ({
-    "@id": `pages:${r.id}`, // eslint-disable-line @typescript-eslint/naming-convention
-    "@type": "relationDef", // eslint-disable-line @typescript-eslint/naming-convention
+    "@id": `pages:${r.id}`,
+    "@type": "relationDef",
     domain: `pages:${r.source}`,
     range: `pages:${r.destination}`,
     label: r.label,
   }));
   const inverseRelSchemaData = allRelations.map((r: DiscourseRelation) => ({
-    "@id": `pages:${r.id}-inverse`, // eslint-disable-line @typescript-eslint/naming-convention
-    "@type": "relationDef", // eslint-disable-line @typescript-eslint/naming-convention
+    "@id": `pages:${r.id}-inverse`,
+    "@type": "relationDef",
     domain: `pages:${r.destination}`,
     range: `pages:${r.source}`,
     label: r.complement,
@@ -154,8 +154,8 @@ export const getJsonLdData = async ({
       });
     }
     const r = {
-      "@id": `pages:${uid}`, // eslint-disable-line @typescript-eslint/naming-convention
-      "@type": nodeType ?? "nodeSchema", // eslint-disable-line @typescript-eslint/naming-convention
+      "@id": `pages:${uid}`,
+      "@type": nodeType ?? "nodeSchema",
       title: text,
       content: content as string,
       modified: modified?.toJSON(),
@@ -172,13 +172,12 @@ export const getJsonLdData = async ({
   );
   const relData = relations.map(({ relUid, source, target }) => ({
     // no id yet, just a blank node
-    "@type": "relationInstance", // eslint-disable-line @typescript-eslint/naming-convention
+    "@type": "relationInstance",
     predicate: `pages:${relUid}`,
     source: `pages:${source}`,
     destination: `pages:${target}`,
   }));
   return {
-    /* eslint-disable @typescript-eslint/naming-convention */
     "@context": jsonLdContext(roamUrl),
     "@id": roamUrl,
     "prov:generatedAtTime": new Date().toISOString(),

--- a/apps/roam/src/utils/moveRoamBlock.ts
+++ b/apps/roam/src/utils/moveRoamBlock.ts
@@ -11,7 +11,6 @@ export const moveRoamBlockToIndex = ({
 }) => {
   const finalIndex = destIndex > sourceIndex ? destIndex + 1 : destIndex;
   return window.roamAlphaAPI.moveBlock({
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     location: { "parent-uid": parentUid, order: finalIndex },
     block: { uid: blockUid },
   });

--- a/apps/roam/src/utils/posthog.ts
+++ b/apps/roam/src/utils/posthog.ts
@@ -20,7 +20,6 @@ export const initPostHog = (): void => {
     "$referrer",
     "$referring_domain",
   ]);
-  /* eslint-disable @typescript-eslint/naming-convention  */
   posthog.init("phc_SNMmBqwNfcEpNduQ41dBUjtGNEUEKAy6jTn63Fzsrax", {
     autocapture: false,
     disable_session_recording: true,

--- a/apps/roam/src/utils/registerCommandPaletteCommands.ts
+++ b/apps/roam/src/utils/registerCommandPaletteCommands.ts
@@ -125,9 +125,7 @@ export const createDiscourseNodeFromCommand = (
 
       await window.roamAlphaAPI.ui.setBlockFocusAndSelection({
         location: {
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           "block-uid": uid,
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           "window-id": windowId,
         },
         selection: { start: newCursorPosition },
@@ -446,7 +444,6 @@ export const registerCommandPaletteCommands = (onloadArgs: OnloadArgs) => {
 
       window.roamAlphaAPI.ui.blockContextMenu.addCommand({
         label: `DG: Favorites - Add to "${sectionName}" section`,
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         callback: (props: { "block-uid": string }) => {
           void addBlockToPersonalSection({
             blockUid: props["block-uid"],
@@ -463,7 +460,6 @@ export const registerCommandPaletteCommands = (onloadArgs: OnloadArgs) => {
     if (globalSection.childrenUid) {
       window.roamAlphaAPI.ui.blockContextMenu.addCommand({
         label: "DG: Favorites - Add to Global section",
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         callback: (props: { "block-uid": string }) => {
           void addBlockToGlobalSection({
             blockUid: props["block-uid"],

--- a/apps/roam/src/utils/renderImageToolsMenu.tsx
+++ b/apps/roam/src/utils/renderImageToolsMenu.tsx
@@ -19,9 +19,7 @@ const ImageToolsMenu = ({
 
   const handleEditBlock = useCallback((): void => {
     posthog.capture("Image Tools Menu: Edit Block Clicked");
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     void window.roamAlphaAPI.ui.setBlockFocusAndSelection({
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       location: { "block-uid": blockUid, "window-id": "main-window" },
     });
   }, [blockUid]);
@@ -98,7 +96,6 @@ const createMenuContainer = (): HTMLDivElement => {
 };
 
 type WrapperWithCleanup = HTMLElement & {
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   __imageMenuCleanup?: () => void;
 };
 

--- a/apps/roam/src/utils/sendErrorEmail.ts
+++ b/apps/roam/src/utils/sendErrorEmail.ts
@@ -35,7 +35,6 @@ const sendErrorEmail = async ({
     const response = await fetch(url, {
       method: "POST",
       headers: {
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         "Content-Type": "application/json",
       },
       body: JSON.stringify(payload),

--- a/apps/roam/src/utils/storedRelations.ts
+++ b/apps/roam/src/utils/storedRelations.ts
@@ -16,11 +16,10 @@ const setResolvedDefault = (value: boolean): void => {
 // page create date as the install cutoff because it reflects when DG was first
 // initialized in the graph.
 const getInstallDefault = (): boolean => {
-  const page = window.roamAlphaAPI.pull(
-    "[:create/time]",
-    [":node/title", DISCOURSE_CONFIG_PAGE_TITLE],
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-  ) as { ":create/time"?: number } | null;
+  const page = window.roamAlphaAPI.pull("[:create/time]", [
+    ":node/title",
+    DISCOURSE_CONFIG_PAGE_TITLE,
+  ]) as { ":create/time"?: number } | null;
   if (!page) return true; // handle case where config page doesn't exist yet, assume new install
 
   const createdAt = page[":create/time"];

--- a/apps/roam/src/utils/syncCanvasNodeTitlesOnLoad.ts
+++ b/apps/roam/src/utils/syncCanvasNodeTitlesOnLoad.ts
@@ -15,7 +15,6 @@ const queryTitlesByUids = async (
       :in $ [?uid ...]
       :where [?e :block/uid ?uid]]`,
     uids,
-    /* eslint-disable-next-line @typescript-eslint/naming-convention */
   )) as [string, { ":node/title"?: string; ":block/string"?: string }][];
 
   const map = new Map<string, string>();

--- a/apps/roam/src/utils/syncDgNodesToSupabase.ts
+++ b/apps/roam/src/utils/syncDgNodesToSupabase.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import posthog from "posthog-js";
 import {
   getAllDiscourseNodesSince,

--- a/apps/roam/src/utils/upsertNodesAsContentWithEmbeddings.ts
+++ b/apps/roam/src/utils/upsertNodesAsContentWithEmbeddings.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import { type RoamDiscourseNodeData } from "./getAllDiscourseNodesSince";
 import { type SupabaseContext } from "./supabaseContext";
 import { nextApiRoot } from "@repo/utils/execContext";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR removes all `@typescript-eslint/naming-convention` eslint-disable comments from the `apps/roam` directory, following the relaxed naming-convention rules introduced in ENG-1777.

## Changes

- Removed all `/* eslint-disable @typescript-eslint/naming-convention */` block comments
- Removed all `// eslint-disable-next-line @typescript-eslint/naming-convention` inline comments
- Removed all `// eslint-disable-line @typescript-eslint/naming-convention` end-of-line comments

## Testing

- ✅ Ran `pnpm lint` - all checks passed with exit code 0
- ✅ No new naming-convention warnings introduced
- ✅ The relaxed naming rules from ENG-1777 are working correctly for:
  - Object literal properties with hyphens and underscores
  - Destructured variables
  - Type properties
  - Leading underscores

## Related Issues

- Closes ENG-1779
- Follows up on ENG-1777
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-1779](https://linear.app/discourse-graphs/issue/ENG-1779/remove-naming-convention-comments-from-appsroam)

<div><a href="https://cursor.com/agents/bc-042fb9c2-5c45-4787-9242-35598461877d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-042fb9c2-5c45-4787-9242-35598461877d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

