### PR TITLE
Remove eslint-disable naming-convention comments

### DIFF
--- a/packages/ui/src/components/ui/button.tsx
+++ b/packages/ui/src/components/ui/button.tsx
@@ -40,7 +40,6 @@ type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> &
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     const Comp = asChild ? Slot : "button";
     return (
       <Comp


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the remaining `eslint-disable @typescript-eslint/naming-convention` comment from the codebase, specifically from `packages/ui/src/components/ui/button.tsx`.

## Context

Following the relaxed naming-convention lint rules added to `base.js`, we can now remove the eslint-disable comments that were previously necessary.

The relaxed rules now properly handle:
- PascalCase for function variables (e.g., React components)
- Leading underscores for various selectors
- Flexible naming conventions for object properties and destructured variables

## Changes

- Removed `eslint-disable-next-line @typescript-eslint/naming-convention` from the `Comp` variable in `button.tsx`

## Testing

- Ran `pnpm lint` on the entire workspace - all checks pass ✅
- Verified no new naming-convention warnings were introduced
- The `Comp` variable (PascalCase) is now properly handled by the relaxed rules for function-type variables
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-1783](https://linear.app/discourse-graphs/issue/ENG-1783/remove-naming-convention-comments-from-everywhere-else)

<div><a href="https://cursor.com/agents/bc-f354986d-3d08-4db4-8615-297d5ce4ee73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f354986d-3d08-4db4-8615-297d5ce4ee73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

