### PR TITLE
ENG-1731: Add keyboard-only filtering with tag chips

### DIFF
--- a/apps/roam/src/components/AdvancedNodeSearchDialog/AdvancedSearchDialog.tsx
+++ b/apps/roam/src/components/AdvancedNodeSearchDialog/AdvancedSearchDialog.tsx
@@ -482,27 +482,25 @@ const AdvancedNodeSearchDialog = ({
               selectedTypeIds={selectedNodeTypeIds}
             />
           </div>
-          <div className="flex h-9 shrink-0 items-center gap-1">
-            <DiscourseNodeTypeFilter
-              layoutAnchorKey={selectedNodeTypeIds.length}
-              nodeTypes={discourseNodes}
-              onPopoverOpenChange={setIsTypeFilterPopoverOpen}
-              onSelectedTypeIdsChange={setSelectedNodeTypeIds}
-              selectedTypeIds={selectedNodeTypeIds}
-            />
-            <DiscourseNodeSortControl
-              disabled={isIndexLoading || indexError}
-              onSortChange={handleSortChange}
-              sort={sort}
-            />
-            <Button
-              className="shrink-0"
-              icon="cross"
-              minimal
-              onClick={onClose}
-              title="Close search"
-            />
-          </div>
+          <DiscourseNodeTypeFilter
+            layoutAnchorKey={selectedNodeTypeIds.length}
+            nodeTypes={discourseNodes}
+            onPopoverOpenChange={setIsTypeFilterPopoverOpen}
+            onSelectedTypeIdsChange={setSelectedNodeTypeIds}
+            selectedTypeIds={selectedNodeTypeIds}
+          />
+          <DiscourseNodeSortControl
+            disabled={isIndexLoading || indexError}
+            onSortChange={handleSortChange}
+            sort={sort}
+          />
+          <Button
+            className="shrink-0"
+            icon="cross"
+            minimal
+            onClick={onClose}
+            title="Close search"
+          />
         </div>
         <div className="flex min-h-0 w-full flex-1 overflow-hidden">
           {showSplitView ? (

--- a/apps/roam/src/components/AdvancedNodeSearchDialog/AdvancedSearchDialog.tsx
+++ b/apps/roam/src/components/AdvancedNodeSearchDialog/AdvancedSearchDialog.tsx
@@ -365,18 +365,21 @@ const AdvancedNodeSearchDialog = ({
     onClose();
   }, [activeResult, contentState, onClose]);
 
-  const onKeyDown = useCallback(
-    (event: React.KeyboardEvent<HTMLDivElement>) => {
-      if (event.defaultPrevented) return;
+  const handleSearchKeyDown = useCallback(
+    (event: React.KeyboardEvent): void => {
       if (event.key === "ArrowDown" && results.length) {
         event.preventDefault();
         setActiveIndex((index) =>
           Math.min(Math.max(index, 0) + 1, results.length - 1),
         );
-      } else if (event.key === "ArrowUp" && results.length) {
+        return;
+      }
+      if (event.key === "ArrowUp" && results.length) {
         event.preventDefault();
         setActiveIndex((index) => Math.max(index - 1, 0));
-      } else if (
+        return;
+      }
+      if (
         event.key === "Enter" &&
         event.altKey &&
         contentState === "results" &&
@@ -394,7 +397,9 @@ const AdvancedNodeSearchDialog = ({
         event.preventDefault();
         if (event.shiftKey) void onOpenInSidebar();
         else void onOpen();
-      } else if (
+        return;
+      }
+      if (
         event.key === "Enter" &&
         (event.metaKey || event.ctrlKey) &&
         contentState === "results" &&
@@ -403,7 +408,9 @@ const AdvancedNodeSearchDialog = ({
       ) {
         event.preventDefault();
         void onInsert();
-      } else if (event.key === "Escape") {
+        return;
+      }
+      if (event.key === "Escape") {
         if (isTypeFilterPopoverOpen) return;
         event.preventDefault();
         onClose();
@@ -421,6 +428,14 @@ const AdvancedNodeSearchDialog = ({
       onOpenInSidebar,
       results.length,
     ],
+  );
+
+  const onKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (event.defaultPrevented) return;
+      handleSearchKeyDown(event);
+    },
+    [handleSearchKeyDown],
   );
 
   const showSplitView = contentState === "results";
@@ -447,10 +462,7 @@ const AdvancedNodeSearchDialog = ({
         className="flex min-h-0 flex-1 flex-col overflow-hidden"
       >
         <div className="flex w-full flex-none items-start gap-2 border-b border-gray-200 px-3 py-2">
-          <div
-            className="flex min-h-9 w-full min-w-0 flex-1 items-center rounded border border-gray-300 bg-white px-2 py-1"
-            style={{ flex: "1 1 0", minWidth: 0 }}
-          >
+          <div className="flex min-h-9 min-w-0 flex-1 items-center rounded border border-gray-300 bg-white px-2 py-1">
             <Icon
               className="mr-2 shrink-0 self-center text-gray-500"
               icon="search"
@@ -459,48 +471,34 @@ const AdvancedNodeSearchDialog = ({
             <NodeTypeChipsSearchInput
               inputRef={inputRef}
               nodeTypes={discourseNodes}
-              onArrowDown={() => {
-                if (!results.length) return;
-                setActiveIndex((index) =>
-                  Math.min(Math.max(index, 0) + 1, results.length - 1),
-                );
-              }}
-              onArrowUp={() => {
-                if (!results.length) return;
-                setActiveIndex((index) => Math.max(index - 1, 0));
-              }}
-              onCmdEnter={() => void onInsert()}
-              onEnter={() => void onOpen()}
-              onEscape={() => {
-                if (isTypeFilterPopoverOpen) return;
-                onClose();
-              }}
+              onSearchKeyDown={handleSearchKeyDown}
               onSearchTermChange={setSearchTerm}
               onSelectedTypeIdsChange={setSelectedNodeTypeIds}
-              onShiftEnter={() => void onOpenInSidebar()}
               searchTerm={searchTerm}
               selectedTypeIds={selectedNodeTypeIds}
             />
           </div>
-          <DiscourseNodeTypeFilter
-            layoutAnchorKey={selectedNodeTypeIds.length}
-            nodeTypes={discourseNodes}
-            onPopoverOpenChange={setIsTypeFilterPopoverOpen}
-            onSelectedTypeIdsChange={setSelectedNodeTypeIds}
-            selectedTypeIds={selectedNodeTypeIds}
-          />
-          <DiscourseNodeSortControl
-            disabled={isIndexLoading || indexError}
-            onSortChange={handleSortChange}
-            sort={sort}
-          />
-          <Button
-            className="shrink-0"
-            icon="cross"
-            minimal
-            onClick={onClose}
-            title="Close search"
-          />
+          <div className="flex h-9 shrink-0 items-center gap-1">
+            <DiscourseNodeTypeFilter
+              layoutAnchorKey={selectedNodeTypeIds.length}
+              nodeTypes={discourseNodes}
+              onPopoverOpenChange={setIsTypeFilterPopoverOpen}
+              onSelectedTypeIdsChange={setSelectedNodeTypeIds}
+              selectedTypeIds={selectedNodeTypeIds}
+            />
+            <DiscourseNodeSortControl
+              disabled={isIndexLoading || indexError}
+              onSortChange={handleSortChange}
+              sort={sort}
+            />
+            <Button
+              className="shrink-0"
+              icon="cross"
+              minimal
+              onClick={onClose}
+              title="Close search"
+            />
+          </div>
         </div>
         <div className="flex min-h-0 w-full flex-1 overflow-hidden">
           {showSplitView ? (

--- a/apps/roam/src/components/AdvancedNodeSearchDialog/AdvancedSearchDialog.tsx
+++ b/apps/roam/src/components/AdvancedNodeSearchDialog/AdvancedSearchDialog.tsx
@@ -28,7 +28,6 @@ import { mountAdvancedSearchInSidebar } from "./mountAdvancedSearchInSidebar";
 import {
   DEBOUNCE_MS,
   DEFAULT_SORT_CONFIG,
-  MAX_RESULTS,
   type SearchResult,
   type SortConfig,
   buildSearchIndex,

--- a/apps/roam/src/components/AdvancedNodeSearchDialog/AdvancedSearchDialog.tsx
+++ b/apps/roam/src/components/AdvancedNodeSearchDialog/AdvancedSearchDialog.tsx
@@ -478,27 +478,25 @@ const AdvancedNodeSearchDialog = ({
               selectedTypeIds={selectedNodeTypeIds}
             />
           </div>
-          <div className="flex h-9 shrink-0 items-center gap-1">
-            <DiscourseNodeTypeFilter
-              layoutAnchorKey={selectedNodeTypeIds.length}
-              nodeTypes={discourseNodes}
-              onPopoverOpenChange={setIsTypeFilterPopoverOpen}
-              onSelectedTypeIdsChange={setSelectedNodeTypeIds}
-              selectedTypeIds={selectedNodeTypeIds}
-            />
-            <DiscourseNodeSortControl
-              disabled={isIndexLoading || indexError}
-              onSortChange={handleSortChange}
-              sort={sort}
-            />
-            <Button
-              className="shrink-0"
-              icon="cross"
-              minimal
-              onClick={onClose}
-              title="Close search"
-            />
-          </div>
+          <DiscourseNodeTypeFilter
+            layoutAnchorKey={selectedNodeTypeIds.length}
+            nodeTypes={discourseNodes}
+            onPopoverOpenChange={setIsTypeFilterPopoverOpen}
+            onSelectedTypeIdsChange={setSelectedNodeTypeIds}
+            selectedTypeIds={selectedNodeTypeIds}
+          />
+          <DiscourseNodeSortControl
+            disabled={isIndexLoading || indexError}
+            onSortChange={handleSortChange}
+            sort={sort}
+          />
+          <Button
+            className="shrink-0"
+            icon="cross"
+            minimal
+            onClick={onClose}
+            title="Close search"
+          />
         </div>
         <div className="flex min-h-0 w-full flex-1 overflow-hidden">
           {showSplitView ? (

--- a/apps/roam/src/components/AdvancedNodeSearchDialog/AdvancedSearchDialog.tsx
+++ b/apps/roam/src/components/AdvancedNodeSearchDialog/AdvancedSearchDialog.tsx
@@ -370,7 +370,9 @@ const AdvancedNodeSearchDialog = ({
       if (event.defaultPrevented) return;
       if (event.key === "ArrowDown" && results.length) {
         event.preventDefault();
-        setActiveIndex((index) => Math.min(index + 1, results.length - 1));
+        setActiveIndex((index) =>
+          Math.min(Math.max(index, 0) + 1, results.length - 1),
+        );
       } else if (event.key === "ArrowUp" && results.length) {
         event.preventDefault();
         setActiveIndex((index) => Math.max(index - 1, 0));
@@ -444,20 +446,22 @@ const AdvancedNodeSearchDialog = ({
         onMouseUp={(event) => event.stopPropagation()}
         className="flex min-h-0 flex-1 flex-col overflow-hidden"
       >
-        <div className="flex flex-none items-start gap-2 border-b border-gray-200 px-3 py-2">
+        <div className="flex flex-none items-center gap-2 border-b border-gray-200 px-3 py-2">
           <div className="flex min-w-0 flex-1 items-center rounded border border-gray-300 bg-white px-2 py-1">
             <Icon icon="search" size={16} className="mr-2 text-gray-500" />
             <NodeTypeChipsSearchInput
               inputRef={inputRef}
               nodeTypes={discourseNodes}
-              onArrowDown={() =>
+              onArrowDown={() => {
+                if (!results.length) return;
                 setActiveIndex((index) =>
-                  Math.min(index + 1, results.length - 1),
-                )
-              }
-              onArrowUp={() =>
-                setActiveIndex((index) => Math.max(index - 1, 0))
-              }
+                  Math.min(Math.max(index, 0) + 1, results.length - 1),
+                );
+              }}
+              onArrowUp={() => {
+                if (!results.length) return;
+                setActiveIndex((index) => Math.max(index - 1, 0));
+              }}
               onCmdEnter={() => void onInsert()}
               onEnter={() => void onOpen()}
               onEscape={() => {
@@ -471,23 +475,19 @@ const AdvancedNodeSearchDialog = ({
               selectedTypeIds={selectedNodeTypeIds}
             />
           </div>
-          <div className="self-start">
-            <DiscourseNodeTypeFilter
-              nodeTypes={discourseNodes}
-              onPopoverOpenChange={setIsTypeFilterPopoverOpen}
-              onSelectedTypeIdsChange={setSelectedNodeTypeIds}
-              selectedTypeIds={selectedNodeTypeIds}
-            />
-          </div>
-          <div className="self-start">
-            <DiscourseNodeSortControl
-              disabled={isIndexLoading || indexError}
-              onSortChange={handleSortChange}
-              sort={sort}
-            />
-          </div>
+          <DiscourseNodeTypeFilter
+            nodeTypes={discourseNodes}
+            onPopoverOpenChange={setIsTypeFilterPopoverOpen}
+            onSelectedTypeIdsChange={setSelectedNodeTypeIds}
+            selectedTypeIds={selectedNodeTypeIds}
+          />
+          <DiscourseNodeSortControl
+            disabled={isIndexLoading || indexError}
+            onSortChange={handleSortChange}
+            sort={sort}
+          />
           <Button
-            className="shrink-0 self-start"
+            className="shrink-0"
             icon="cross"
             minimal
             onClick={onClose}

--- a/apps/roam/src/components/AdvancedNodeSearchDialog/AdvancedSearchDialog.tsx
+++ b/apps/roam/src/components/AdvancedNodeSearchDialog/AdvancedSearchDialog.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useRef, useState } from "react";
 import {
   Button,
   Dialog,
-  InputGroup,
+  Icon,
   NonIdealState,
   Spinner,
   SpinnerSize,
@@ -28,6 +28,7 @@ import { mountAdvancedSearchInSidebar } from "./mountAdvancedSearchInSidebar";
 import {
   DEBOUNCE_MS,
   DEFAULT_SORT_CONFIG,
+  MAX_RESULTS,
   type SearchResult,
   type SortConfig,
   buildSearchIndex,
@@ -40,6 +41,7 @@ import {
 import { DiscourseNodeTypeFilter } from "~/components/AdvancedNodeSearchDialog/DiscourseNodeTypeFilter";
 import { RenderRoamBlock, RenderRoamPage } from "~/utils/roamReactComponents";
 import { AdvancedSearchFooter } from "./AdvancedSearchFooter";
+import { NodeTypeChipsSearchInput } from "./NodeTypeChipsSearchInput";
 import {
   type SearchIndex,
   useAdvancedNodeSearchResults,
@@ -161,6 +163,7 @@ const AdvancedNodeSearchDialog = ({
   const [sort, setSort] = useState<SortConfig>(DEFAULT_SORT_CONFIG);
   const [discourseNodes, setDiscourseNodes] = useState<DiscourseNode[]>([]);
   const [selectedNodeTypeIds, setSelectedNodeTypeIds] = useState<string[]>([]);
+  const [isTypeFilterPopoverOpen, setIsTypeFilterPopoverOpen] = useState(false);
   const resultsPanelRef = useRef<HTMLDivElement | null>(null);
   const inputRef = useRef<HTMLInputElement | null>(null);
   const [insertTarget, setInsertTarget] = useState<InsertTarget | null>(null);
@@ -291,7 +294,7 @@ const AdvancedNodeSearchDialog = ({
     ? "error"
     : isIndexLoading
       ? "indexing"
-      : !debouncedSearchTerm
+      : !debouncedSearchTerm && selectedNodeTypeIds.length === 0
         ? "initial"
         : !results.length
           ? "empty"
@@ -364,6 +367,7 @@ const AdvancedNodeSearchDialog = ({
 
   const onKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (event.defaultPrevented) return;
       if (event.key === "ArrowDown" && results.length) {
         event.preventDefault();
         setActiveIndex((index) => Math.min(index + 1, results.length - 1));
@@ -398,6 +402,7 @@ const AdvancedNodeSearchDialog = ({
         event.preventDefault();
         void onInsert();
       } else if (event.key === "Escape") {
+        if (isTypeFilterPopoverOpen) return;
         event.preventDefault();
         onClose();
       }
@@ -405,6 +410,7 @@ const AdvancedNodeSearchDialog = ({
     [
       activeResult,
       contentState,
+      isTypeFilterPopoverOpen,
       insertTarget,
       onClose,
       onOpenSearchSidebar,
@@ -439,18 +445,35 @@ const AdvancedNodeSearchDialog = ({
         className="flex min-h-0 flex-1 flex-col overflow-hidden"
       >
         <div className="flex flex-none items-center gap-2 border-b border-gray-200 px-3 py-2">
-          <InputGroup
-            fill
-            inputRef={inputRef}
-            leftIcon="search"
-            onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
-              setSearchTerm(event.target.value)
-            }
-            placeholder="Search discourse nodes..."
-            value={searchTerm}
-          />
+          <div className="flex min-w-0 flex-1 items-center rounded border border-gray-300 bg-white px-2 py-1">
+            <Icon icon="search" size={16} className="mr-2 text-gray-500" />
+            <NodeTypeChipsSearchInput
+              inputRef={inputRef}
+              nodeTypes={discourseNodes}
+              onArrowDown={() =>
+                setActiveIndex((index) =>
+                  Math.min(index + 1, results.length - 1),
+                )
+              }
+              onArrowUp={() =>
+                setActiveIndex((index) => Math.max(index - 1, 0))
+              }
+              onCmdEnter={() => void onInsert()}
+              onEnter={() => void onOpen()}
+              onEscape={() => {
+                if (isTypeFilterPopoverOpen) return;
+                onClose();
+              }}
+              onSearchTermChange={setSearchTerm}
+              onSelectedTypeIdsChange={setSelectedNodeTypeIds}
+              onShiftEnter={() => void onOpenInSidebar()}
+              searchTerm={searchTerm}
+              selectedTypeIds={selectedNodeTypeIds}
+            />
+          </div>
           <DiscourseNodeTypeFilter
             nodeTypes={discourseNodes}
+            onPopoverOpenChange={setIsTypeFilterPopoverOpen}
             onSelectedTypeIdsChange={setSelectedNodeTypeIds}
             selectedTypeIds={selectedNodeTypeIds}
           />
@@ -498,7 +521,7 @@ const AdvancedNodeSearchDialog = ({
                 <Spinner size={SpinnerSize.SMALL} />
               )}
               {contentState === "empty" && (
-                <span>No matches. Try another keyword.</span>
+                <span>No matches. Try another keyword or filter.</span>
               )}
               {contentState === "error" && (
                 <span>

--- a/apps/roam/src/components/AdvancedNodeSearchDialog/AdvancedSearchDialog.tsx
+++ b/apps/roam/src/components/AdvancedNodeSearchDialog/AdvancedSearchDialog.tsx
@@ -430,7 +430,7 @@ const AdvancedNodeSearchDialog = ({
       autoFocus={false}
       canEscapeKeyClose
       canOutsideClickClose
-      className="flex max-w-4xl flex-col overflow-hidden bg-white p-0"
+      className="flex w-full max-w-4xl flex-col overflow-hidden bg-white p-0"
       enforceFocus={false}
       isOpen={isOpen}
       onClose={onClose}
@@ -446,9 +446,16 @@ const AdvancedNodeSearchDialog = ({
         onMouseUp={(event) => event.stopPropagation()}
         className="flex min-h-0 flex-1 flex-col overflow-hidden"
       >
-        <div className="flex flex-none items-center gap-2 border-b border-gray-200 px-3 py-2">
-          <div className="flex min-w-0 flex-1 items-center rounded border border-gray-300 bg-white px-2 py-1">
-            <Icon icon="search" size={16} className="mr-2 text-gray-500" />
+        <div className="flex w-full flex-none items-start gap-2 border-b border-gray-200 px-3 py-2">
+          <div
+            className="flex min-h-9 w-full min-w-0 flex-1 items-center rounded border border-gray-300 bg-white px-2 py-1"
+            style={{ flex: "1 1 0", minWidth: 0 }}
+          >
+            <Icon
+              className="mr-2 shrink-0 self-center text-gray-500"
+              icon="search"
+              size={16}
+            />
             <NodeTypeChipsSearchInput
               inputRef={inputRef}
               nodeTypes={discourseNodes}
@@ -475,24 +482,27 @@ const AdvancedNodeSearchDialog = ({
               selectedTypeIds={selectedNodeTypeIds}
             />
           </div>
-          <DiscourseNodeTypeFilter
-            nodeTypes={discourseNodes}
-            onPopoverOpenChange={setIsTypeFilterPopoverOpen}
-            onSelectedTypeIdsChange={setSelectedNodeTypeIds}
-            selectedTypeIds={selectedNodeTypeIds}
-          />
-          <DiscourseNodeSortControl
-            disabled={isIndexLoading || indexError}
-            onSortChange={handleSortChange}
-            sort={sort}
-          />
-          <Button
-            className="shrink-0"
-            icon="cross"
-            minimal
-            onClick={onClose}
-            title="Close search"
-          />
+          <div className="flex h-9 shrink-0 items-center gap-1">
+            <DiscourseNodeTypeFilter
+              layoutAnchorKey={selectedNodeTypeIds.length}
+              nodeTypes={discourseNodes}
+              onPopoverOpenChange={setIsTypeFilterPopoverOpen}
+              onSelectedTypeIdsChange={setSelectedNodeTypeIds}
+              selectedTypeIds={selectedNodeTypeIds}
+            />
+            <DiscourseNodeSortControl
+              disabled={isIndexLoading || indexError}
+              onSortChange={handleSortChange}
+              sort={sort}
+            />
+            <Button
+              className="shrink-0"
+              icon="cross"
+              minimal
+              onClick={onClose}
+              title="Close search"
+            />
+          </div>
         </div>
         <div className="flex min-h-0 w-full flex-1 overflow-hidden">
           {showSplitView ? (

--- a/apps/roam/src/components/AdvancedNodeSearchDialog/AdvancedSearchDialog.tsx
+++ b/apps/roam/src/components/AdvancedNodeSearchDialog/AdvancedSearchDialog.tsx
@@ -444,7 +444,7 @@ const AdvancedNodeSearchDialog = ({
         onMouseUp={(event) => event.stopPropagation()}
         className="flex min-h-0 flex-1 flex-col overflow-hidden"
       >
-        <div className="flex flex-none items-center gap-2 border-b border-gray-200 px-3 py-2">
+        <div className="flex flex-none items-start gap-2 border-b border-gray-200 px-3 py-2">
           <div className="flex min-w-0 flex-1 items-center rounded border border-gray-300 bg-white px-2 py-1">
             <Icon icon="search" size={16} className="mr-2 text-gray-500" />
             <NodeTypeChipsSearchInput
@@ -471,19 +471,23 @@ const AdvancedNodeSearchDialog = ({
               selectedTypeIds={selectedNodeTypeIds}
             />
           </div>
-          <DiscourseNodeTypeFilter
-            nodeTypes={discourseNodes}
-            onPopoverOpenChange={setIsTypeFilterPopoverOpen}
-            onSelectedTypeIdsChange={setSelectedNodeTypeIds}
-            selectedTypeIds={selectedNodeTypeIds}
-          />
-          <DiscourseNodeSortControl
-            disabled={isIndexLoading || indexError}
-            onSortChange={handleSortChange}
-            sort={sort}
-          />
+          <div className="self-start">
+            <DiscourseNodeTypeFilter
+              nodeTypes={discourseNodes}
+              onPopoverOpenChange={setIsTypeFilterPopoverOpen}
+              onSelectedTypeIdsChange={setSelectedNodeTypeIds}
+              selectedTypeIds={selectedNodeTypeIds}
+            />
+          </div>
+          <div className="self-start">
+            <DiscourseNodeSortControl
+              disabled={isIndexLoading || indexError}
+              onSortChange={handleSortChange}
+              sort={sort}
+            />
+          </div>
           <Button
-            className="shrink-0"
+            className="shrink-0 self-start"
             icon="cross"
             minimal
             onClick={onClose}

--- a/apps/roam/src/components/AdvancedNodeSearchDialog/DiscourseNodeTypeFilter.tsx
+++ b/apps/roam/src/components/AdvancedNodeSearchDialog/DiscourseNodeTypeFilter.tsx
@@ -28,6 +28,8 @@ export type DiscourseNodeTypeFilterProps = {
   selectedTypeIds: string[];
   onSelectedTypeIdsChange: (ids: string[]) => void;
   onPopoverOpenChange?: (isOpen: boolean) => void;
+  /** Bumps when surrounding layout changes (e.g. chip wrap) so the popover repositions. */
+  layoutAnchorKey?: number;
 };
 
 const NodeTypeFilterRow = ({
@@ -183,6 +185,7 @@ const FilterPopoverPanel = ({
 };
 
 export const DiscourseNodeTypeFilter = ({
+  layoutAnchorKey = 0,
   nodeTypes,
   onPopoverOpenChange,
   onSelectedTypeIdsChange,
@@ -245,6 +248,11 @@ export const DiscourseNodeTypeFilter = ({
   );
 
   const isTriggerActive = isOpen || isFilterActive;
+
+  useEffect(() => {
+    if (!isOpen) return;
+    window.dispatchEvent(new Event("resize"));
+  }, [isOpen, layoutAnchorKey]);
 
   const filterButton = (
     <span className="relative inline-flex shrink-0 items-center">
@@ -311,7 +319,7 @@ export const DiscourseNodeTypeFilter = ({
         onInteraction={handlePopoverInteraction}
         popoverClassName="p-0 overflow-hidden"
         popoverRef={popoverRef}
-        position={Position.BOTTOM_RIGHT}
+        position={Position.BOTTOM}
         target={filterButton}
         usePortal
       />

--- a/apps/roam/src/components/AdvancedNodeSearchDialog/NodeTypeChipsSearchInput.tsx
+++ b/apps/roam/src/components/AdvancedNodeSearchDialog/NodeTypeChipsSearchInput.tsx
@@ -1,0 +1,309 @@
+import { Button, Classes, Icon } from "@blueprintjs/core";
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { getNodeTagStyles } from "~/utils/getDiscourseNodeColors";
+import { type DiscourseNode } from "~/utils/getDiscourseNodes";
+
+type NodeTypeChipsSearchInputProps = {
+  nodeTypes: DiscourseNode[];
+  searchTerm: string;
+  selectedTypeIds: string[];
+  inputRef: React.RefObject<HTMLInputElement>;
+  onSearchTermChange: (value: string) => void;
+  onSelectedTypeIdsChange: (ids: string[]) => void;
+  onArrowDown: () => void;
+  onArrowUp: () => void;
+  onEnter: () => void;
+  onShiftEnter: () => void;
+  onCmdEnter: () => void;
+  onEscape: () => void;
+};
+
+const isPlainCharacterKey = (event: React.KeyboardEvent): boolean =>
+  event.key.length === 1 && !event.altKey && !event.ctrlKey && !event.metaKey;
+
+const getUniquePrefixMatch = ({
+  nodeTypes,
+  query,
+  selectedTypeIds,
+}: {
+  nodeTypes: DiscourseNode[];
+  query: string;
+  selectedTypeIds: string[];
+}): DiscourseNode | null => {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) return null;
+
+  const selectedTypeIdSet = new Set(selectedTypeIds);
+  const matches = nodeTypes.filter(
+    (node) =>
+      !selectedTypeIdSet.has(node.type) &&
+      node.text.toLowerCase().startsWith(normalizedQuery),
+  );
+
+  return matches.length === 1 ? matches[0] : null;
+};
+
+export const NodeTypeChipsSearchInput = ({
+  nodeTypes,
+  searchTerm,
+  selectedTypeIds,
+  inputRef,
+  onSearchTermChange,
+  onSelectedTypeIdsChange,
+  onArrowDown,
+  onArrowUp,
+  onEnter,
+  onShiftEnter,
+  onCmdEnter,
+  onEscape,
+}: NodeTypeChipsSearchInputProps): React.ReactElement => {
+  const [focusedChipIndex, setFocusedChipIndex] = useState(-1);
+  const chipRefs = useRef<(HTMLSpanElement | null)[]>([]);
+
+  const nodeTypeById = useMemo(
+    () =>
+      Object.fromEntries(
+        nodeTypes.map((nodeType) => [nodeType.type, nodeType]),
+      ),
+    [nodeTypes],
+  );
+
+  const selectedNodeTypes = useMemo(
+    () =>
+      selectedTypeIds
+        .map((typeId) => nodeTypeById[typeId])
+        .filter((nodeType): nodeType is DiscourseNode => !!nodeType),
+    [nodeTypeById, selectedTypeIds],
+  );
+
+  const uniquePrefixMatch = useMemo(
+    () =>
+      getUniquePrefixMatch({
+        nodeTypes,
+        query: searchTerm,
+        selectedTypeIds,
+      }),
+    [nodeTypes, searchTerm, selectedTypeIds],
+  );
+
+  const completionSuffix = useMemo(() => {
+    if (!uniquePrefixMatch) return "";
+    const normalizedQuery = searchTerm.trim();
+    const nodeText = uniquePrefixMatch.text;
+    if (nodeText.toLowerCase() === normalizedQuery.toLowerCase()) return "";
+    return nodeText.slice(normalizedQuery.length);
+  }, [searchTerm, uniquePrefixMatch]);
+
+  useEffect(() => {
+    if (focusedChipIndex < 0) return;
+    chipRefs.current[focusedChipIndex]?.focus();
+  }, [focusedChipIndex]);
+
+  const focusInput = (): void => {
+    setFocusedChipIndex(-1);
+    requestAnimationFrame(() => {
+      inputRef.current?.focus();
+    });
+  };
+
+  const commitNodeType = (nodeType: DiscourseNode): void => {
+    if (selectedTypeIds.includes(nodeType.type)) return;
+    onSelectedTypeIdsChange([...selectedTypeIds, nodeType.type]);
+    onSearchTermChange("");
+  };
+
+  const removeChipAtIndex = (chipIndex: number): void => {
+    const nextIds = selectedTypeIds.filter((_, index) => index !== chipIndex);
+    onSelectedTypeIdsChange(nextIds);
+  };
+
+  const handleChipKeyDown = (
+    event: React.KeyboardEvent<HTMLSpanElement>,
+    chipIndex: number,
+  ): void => {
+    if (event.key === "ArrowLeft") {
+      event.preventDefault();
+      setFocusedChipIndex(Math.max(0, chipIndex - 1));
+      return;
+    }
+    if (event.key === "ArrowRight") {
+      event.preventDefault();
+      if (chipIndex >= selectedTypeIds.length - 1) {
+        focusInput();
+        return;
+      }
+      setFocusedChipIndex(chipIndex + 1);
+      return;
+    }
+    if (event.key === "Backspace" || event.key === "Delete") {
+      event.preventDefault();
+      const nextIds = selectedTypeIds.filter((_, index) => index !== chipIndex);
+      onSelectedTypeIdsChange(nextIds);
+      if (nextIds.length === 0) {
+        focusInput();
+        return;
+      }
+      if (event.key === "Backspace") {
+        setFocusedChipIndex(Math.max(0, chipIndex - 1));
+        return;
+      }
+      if (chipIndex >= nextIds.length) {
+        focusInput();
+        return;
+      }
+      setFocusedChipIndex(chipIndex);
+      return;
+    }
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      onArrowDown();
+      return;
+    }
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      onArrowUp();
+      return;
+    }
+    if (event.key === "Escape") {
+      event.preventDefault();
+      onEscape();
+      return;
+    }
+    if (isPlainCharacterKey(event)) {
+      event.preventDefault();
+      onSearchTermChange(event.key);
+      focusInput();
+    }
+  };
+
+  const handleInputKeyDown = (
+    event: React.KeyboardEvent<HTMLInputElement>,
+  ): void => {
+    if (event.key === "Tab") {
+      if (uniquePrefixMatch) {
+        event.preventDefault();
+        commitNodeType(uniquePrefixMatch);
+      }
+      return;
+    }
+
+    if (event.key === "Backspace") {
+      const input = inputRef.current;
+      if (
+        input &&
+        input.selectionStart === 0 &&
+        input.selectionEnd === 0 &&
+        searchTerm.length === 0 &&
+        selectedTypeIds.length > 0
+      ) {
+        event.preventDefault();
+        setFocusedChipIndex(selectedTypeIds.length - 1);
+        return;
+      }
+    }
+
+    if (event.key === "ArrowLeft") {
+      const input = inputRef.current;
+      if (
+        input &&
+        input.selectionStart === 0 &&
+        input.selectionEnd === 0 &&
+        selectedTypeIds.length > 0
+      ) {
+        event.preventDefault();
+        setFocusedChipIndex(selectedTypeIds.length - 1);
+        return;
+      }
+    }
+
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      onArrowDown();
+      return;
+    }
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      onArrowUp();
+      return;
+    }
+    if (event.key === "Enter") {
+      event.preventDefault();
+      if (event.metaKey || event.ctrlKey) onCmdEnter();
+      else if (event.shiftKey) onShiftEnter();
+      else onEnter();
+      return;
+    }
+    if (event.key === "Escape") {
+      event.preventDefault();
+      onEscape();
+    }
+  };
+
+  return (
+    <div className="flex min-w-0 flex-1 items-center gap-1 py-0.5">
+      {selectedNodeTypes.map((nodeType, index) => {
+        const isFocused = focusedChipIndex === index;
+        return (
+          <span
+            key={nodeType.type}
+            ref={(element) => {
+              chipRefs.current[index] = element;
+            }}
+            role="button"
+            tabIndex={-1}
+            onClick={() => setFocusedChipIndex(index)}
+            onKeyDown={(event) => handleChipKeyDown(event, index)}
+            style={{
+              boxShadow: isFocused
+                ? "0 0 0 2px rgba(95, 87, 192, 0.2)"
+                : undefined,
+              borderRadius: 3,
+            }}
+          >
+            <span
+              className="inline-flex items-center gap-1.5 rounded px-2 py-1 text-xs"
+              style={getNodeTagStyles(nodeType.canvasSettings?.color)}
+            >
+              <span className="truncate leading-4">{nodeType.text}</span>
+              <Button
+                className="!h-4 !min-h-0 !w-4 !min-w-0 !p-0"
+                aria-label={`Remove ${nodeType.text} filter`}
+                icon={<Icon icon="cross" size={10} />}
+                minimal
+                onClick={(event) => {
+                  event.stopPropagation();
+                  removeChipAtIndex(index);
+                  focusInput();
+                }}
+                onMouseDown={(event) => event.preventDefault()}
+                small
+              />
+            </span>
+          </span>
+        );
+      })}
+      <span className="relative min-w-0 flex-1">
+        {completionSuffix && (
+          <span className="pointer-events-none absolute inset-0 flex items-center overflow-hidden whitespace-nowrap text-sm">
+            <span className="invisible">{searchTerm}</span>
+            <span className="text-gray-400">{completionSuffix}</span>
+            <span className="ml-2 rounded bg-gray-100 px-1 text-[10px] uppercase tracking-wide text-gray-500">
+              Tab
+            </span>
+          </span>
+        )}
+        <input
+          className={`${Classes.INPUT} w-full border-none bg-transparent px-0 py-0 text-sm shadow-none outline-none placeholder:text-gray-400 focus:shadow-none`}
+          onChange={(event) => onSearchTermChange(event.target.value)}
+          onKeyDown={handleInputKeyDown}
+          placeholder={
+            selectedTypeIds.length ? "" : "Search discourse nodes..."
+          }
+          ref={inputRef}
+          spellCheck={false}
+          value={searchTerm}
+        />
+      </span>
+    </div>
+  );
+};

--- a/apps/roam/src/components/AdvancedNodeSearchDialog/NodeTypeChipsSearchInput.tsx
+++ b/apps/roam/src/components/AdvancedNodeSearchDialog/NodeTypeChipsSearchInput.tsx
@@ -1,6 +1,6 @@
 import { Classes, Tag } from "@blueprintjs/core";
 import React, { useEffect, useRef, useState } from "react";
-import { getNodeTagStyles } from "~/utils/getDiscourseNodeColors";
+import { getNodeTagColorStyles } from "~/utils/getDiscourseNodeColors";
 import { type DiscourseNode } from "~/utils/getDiscourseNodes";
 
 type NodeTypeChipsSearchInputProps = {
@@ -239,7 +239,10 @@ export const NodeTypeChipsSearchInput = ({
   };
 
   return (
-    <div className="flex min-w-0 flex-1 flex-wrap items-center gap-1 py-0.5">
+    <div
+      className="flex w-full min-w-0 flex-1 flex-wrap items-center gap-1 py-0.5"
+      style={{ flex: "1 1 0", minWidth: 0, width: "100%" }}
+    >
       {selectedNodeTypes.map((nodeType, index) => {
         const isFocused = focusedChipIndex === index;
         return (
@@ -271,9 +274,14 @@ export const NodeTypeChipsSearchInput = ({
                 );
                 focusInput();
               }}
-              style={getNodeTagStyles(
-                nodeType.canvasSettings?.color ?? "#000000",
-              )}
+              style={{
+                ...getNodeTagColorStyles(
+                  nodeType.canvasSettings?.color ?? "#000000",
+                ),
+                alignItems: "center",
+                display: "inline-flex",
+                flexDirection: "row",
+              }}
             >
               <span
                 className="truncate"
@@ -285,7 +293,10 @@ export const NodeTypeChipsSearchInput = ({
           </span>
         );
       })}
-      <span className="relative flex-1" style={{ minWidth: INPUT_MIN_WIDTH }}>
+      <span
+        className="relative min-w-0 flex-1"
+        style={{ minWidth: INPUT_MIN_WIDTH }}
+      >
         {completionSuffix && (
           <span className="pointer-events-none absolute inset-0 flex items-center overflow-hidden whitespace-nowrap text-sm">
             <span className="invisible">{searchTerm}</span>

--- a/apps/roam/src/components/AdvancedNodeSearchDialog/NodeTypeChipsSearchInput.tsx
+++ b/apps/roam/src/components/AdvancedNodeSearchDialog/NodeTypeChipsSearchInput.tsx
@@ -21,7 +21,7 @@ type NodeTypeChipsSearchInputProps = {
 const isPlainCharacterKey = (event: React.KeyboardEvent): boolean =>
   event.key.length === 1 && !event.altKey && !event.ctrlKey && !event.metaKey;
 
-const getUniquePrefixMatch = ({
+const getBestPrefixMatch = ({
   nodeTypes,
   query,
   selectedTypeIds,
@@ -40,7 +40,12 @@ const getUniquePrefixMatch = ({
       node.text.toLowerCase().startsWith(normalizedQuery),
   );
 
-  return matches.length === 1 ? matches[0] : null;
+  if (!matches.length) return null;
+
+  const exactMatch = matches.find(
+    (node) => node.text.toLowerCase() === normalizedQuery,
+  );
+  return exactMatch ?? matches[0];
 };
 
 export const NodeTypeChipsSearchInput = ({
@@ -76,9 +81,9 @@ export const NodeTypeChipsSearchInput = ({
     [nodeTypeById, selectedTypeIds],
   );
 
-  const uniquePrefixMatch = useMemo(
+  const bestPrefixMatch = useMemo(
     () =>
-      getUniquePrefixMatch({
+      getBestPrefixMatch({
         nodeTypes,
         query: searchTerm,
         selectedTypeIds,
@@ -87,12 +92,12 @@ export const NodeTypeChipsSearchInput = ({
   );
 
   const completionSuffix = useMemo(() => {
-    if (!uniquePrefixMatch) return "";
+    if (!bestPrefixMatch) return "";
     const normalizedQuery = searchTerm.trim();
-    const nodeText = uniquePrefixMatch.text;
+    const nodeText = bestPrefixMatch.text;
     if (nodeText.toLowerCase() === normalizedQuery.toLowerCase()) return "";
     return nodeText.slice(normalizedQuery.length);
-  }, [searchTerm, uniquePrefixMatch]);
+  }, [bestPrefixMatch, searchTerm]);
 
   useEffect(() => {
     if (focusedChipIndex < 0) return;
@@ -110,11 +115,6 @@ export const NodeTypeChipsSearchInput = ({
     if (selectedTypeIds.includes(nodeType.type)) return;
     onSelectedTypeIdsChange([...selectedTypeIds, nodeType.type]);
     onSearchTermChange("");
-  };
-
-  const removeChipAtIndex = (chipIndex: number): void => {
-    const nextIds = selectedTypeIds.filter((_, index) => index !== chipIndex);
-    onSelectedTypeIdsChange(nextIds);
   };
 
   const handleChipKeyDown = (
@@ -180,9 +180,9 @@ export const NodeTypeChipsSearchInput = ({
     event: React.KeyboardEvent<HTMLInputElement>,
   ): void => {
     if (event.key === "Tab") {
-      if (uniquePrefixMatch) {
+      if (bestPrefixMatch) {
         event.preventDefault();
-        commitNodeType(uniquePrefixMatch);
+        commitNodeType(bestPrefixMatch);
       }
       return;
     }
@@ -240,7 +240,7 @@ export const NodeTypeChipsSearchInput = ({
   };
 
   return (
-    <div className="flex min-w-0 flex-1 items-center gap-1 py-0.5">
+    <div className="flex min-w-0 flex-1 flex-wrap items-center gap-1 py-0.5">
       {selectedNodeTypes.map((nodeType, index) => {
         const isFocused = focusedChipIndex === index;
         return (
@@ -262,9 +262,13 @@ export const NodeTypeChipsSearchInput = ({
           >
             <span
               className="inline-flex items-center gap-1.5 rounded px-2 py-1 text-xs"
-              style={getNodeTagStyles(nodeType.canvasSettings?.color)}
+              style={getNodeTagStyles(
+                nodeType.canvasSettings?.color ?? "#000000",
+              )}
             >
-              <span className="truncate leading-4">{nodeType.text}</span>
+              <span className="max-w-[10rem] truncate leading-4">
+                {nodeType.text}
+              </span>
               <Button
                 className="!h-4 !min-h-0 !w-4 !min-w-0 !p-0"
                 aria-label={`Remove ${nodeType.text} filter`}
@@ -272,7 +276,11 @@ export const NodeTypeChipsSearchInput = ({
                 minimal
                 onClick={(event) => {
                   event.stopPropagation();
-                  removeChipAtIndex(index);
+                  onSelectedTypeIdsChange(
+                    selectedTypeIds.filter(
+                      (_, chipIndex) => chipIndex !== index,
+                    ),
+                  );
                   focusInput();
                 }}
                 onMouseDown={(event) => event.preventDefault()}
@@ -282,7 +290,7 @@ export const NodeTypeChipsSearchInput = ({
           </span>
         );
       })}
-      <span className="relative min-w-0 flex-1">
+      <span className="relative min-w-[12ch] flex-1">
         {completionSuffix && (
           <span className="pointer-events-none absolute inset-0 flex items-center overflow-hidden whitespace-nowrap text-sm">
             <span className="invisible">{searchTerm}</span>

--- a/apps/roam/src/components/AdvancedNodeSearchDialog/NodeTypeChipsSearchInput.tsx
+++ b/apps/roam/src/components/AdvancedNodeSearchDialog/NodeTypeChipsSearchInput.tsx
@@ -3,6 +3,11 @@ import React, { useEffect, useRef, useState } from "react";
 import { getNodeTagColorStyles } from "~/utils/getDiscourseNodeColors";
 import { type DiscourseNode } from "~/utils/getDiscourseNodes";
 
+/**
+ * Blueprint `Tag` for filter chips; custom `<input>` for inline ghost Tab completion.
+ * `TagInput` does not support ghost suggest + Tab commit, and its Enter handler
+ * conflicts with opening search results (see AdvancedSearchDialog key handling).
+ */
 type NodeTypeChipsSearchInputProps = {
   nodeTypes: DiscourseNode[];
   searchTerm: string;
@@ -10,12 +15,7 @@ type NodeTypeChipsSearchInputProps = {
   inputRef: React.RefObject<HTMLInputElement>;
   onSearchTermChange: (value: string) => void;
   onSelectedTypeIdsChange: (ids: string[]) => void;
-  onArrowDown: () => void;
-  onArrowUp: () => void;
-  onEnter: () => void;
-  onShiftEnter: () => void;
-  onCmdEnter: () => void;
-  onEscape: () => void;
+  onSearchKeyDown: (event: React.KeyboardEvent) => void;
 };
 
 const CHIP_LABEL_MAX_WIDTH = "10rem";
@@ -72,12 +72,7 @@ export const NodeTypeChipsSearchInput = ({
   inputRef,
   onSearchTermChange,
   onSelectedTypeIdsChange,
-  onArrowDown,
-  onArrowUp,
-  onEnter,
-  onShiftEnter,
-  onCmdEnter,
-  onEscape,
+  onSearchKeyDown,
 }: NodeTypeChipsSearchInputProps): React.ReactElement => {
   const [focusedChipIndex, setFocusedChipIndex] = useState(-1);
   const chipRefs = useRef<(HTMLSpanElement | null)[]>([]);
@@ -153,19 +148,13 @@ export const NodeTypeChipsSearchInput = ({
       setFocusedChipIndex(chipIndex);
       return;
     }
-    if (event.key === "ArrowDown") {
+    if (
+      event.key === "ArrowDown" ||
+      event.key === "ArrowUp" ||
+      event.key === "Escape"
+    ) {
       event.preventDefault();
-      onArrowDown();
-      return;
-    }
-    if (event.key === "ArrowUp") {
-      event.preventDefault();
-      onArrowUp();
-      return;
-    }
-    if (event.key === "Escape") {
-      event.preventDefault();
-      onEscape();
+      onSearchKeyDown(event);
       return;
     }
     if (isPlainCharacterKey(event)) {
@@ -215,34 +204,19 @@ export const NodeTypeChipsSearchInput = ({
       }
     }
 
-    if (event.key === "ArrowDown") {
+    if (
+      event.key === "ArrowDown" ||
+      event.key === "ArrowUp" ||
+      event.key === "Enter" ||
+      event.key === "Escape"
+    ) {
       event.preventDefault();
-      onArrowDown();
-      return;
-    }
-    if (event.key === "ArrowUp") {
-      event.preventDefault();
-      onArrowUp();
-      return;
-    }
-    if (event.key === "Enter") {
-      event.preventDefault();
-      if (event.metaKey || event.ctrlKey) onCmdEnter();
-      else if (event.shiftKey) onShiftEnter();
-      else onEnter();
-      return;
-    }
-    if (event.key === "Escape") {
-      event.preventDefault();
-      onEscape();
+      onSearchKeyDown(event);
     }
   };
 
   return (
-    <div
-      className="flex w-full min-w-0 flex-1 flex-wrap items-center gap-1 py-0.5"
-      style={{ flex: "1 1 0", minWidth: 0, width: "100%" }}
-    >
+    <div className="flex w-full min-w-0 flex-1 flex-wrap items-center gap-1 py-0.5">
       {selectedNodeTypes.map((nodeType, index) => {
         const isFocused = focusedChipIndex === index;
         return (
@@ -255,13 +229,6 @@ export const NodeTypeChipsSearchInput = ({
             tabIndex={-1}
             onClick={() => setFocusedChipIndex(index)}
             onKeyDown={(event) => handleChipKeyDown(event, index)}
-            style={{
-              borderRadius: 3,
-              boxShadow: isFocused
-                ? "0 0 0 2px rgba(95, 87, 192, 0.2)"
-                : undefined,
-              display: "inline-flex",
-            }}
           >
             <Tag
               active={isFocused}

--- a/apps/roam/src/components/AdvancedNodeSearchDialog/NodeTypeChipsSearchInput.tsx
+++ b/apps/roam/src/components/AdvancedNodeSearchDialog/NodeTypeChipsSearchInput.tsx
@@ -1,5 +1,5 @@
-import { Button, Classes, Icon } from "@blueprintjs/core";
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import { Classes, Tag } from "@blueprintjs/core";
+import React, { useEffect, useRef, useState } from "react";
 import { getNodeTagStyles } from "~/utils/getDiscourseNodeColors";
 import { type DiscourseNode } from "~/utils/getDiscourseNodes";
 
@@ -17,6 +17,9 @@ type NodeTypeChipsSearchInputProps = {
   onCmdEnter: () => void;
   onEscape: () => void;
 };
+
+const CHIP_LABEL_MAX_WIDTH = "10rem";
+const INPUT_MIN_WIDTH = "12ch";
 
 const isPlainCharacterKey = (event: React.KeyboardEvent): boolean =>
   event.key.length === 1 && !event.altKey && !event.ctrlKey && !event.metaKey;
@@ -48,6 +51,20 @@ const getBestPrefixMatch = ({
   return exactMatch ?? matches[0];
 };
 
+const getCompletionSuffix = ({
+  bestPrefixMatch,
+  searchTerm,
+}: {
+  bestPrefixMatch: DiscourseNode | null;
+  searchTerm: string;
+}): string => {
+  if (!bestPrefixMatch) return "";
+  const normalizedQuery = searchTerm.trim();
+  const nodeText = bestPrefixMatch.text;
+  if (nodeText.toLowerCase() === normalizedQuery.toLowerCase()) return "";
+  return nodeText.slice(normalizedQuery.length);
+};
+
 export const NodeTypeChipsSearchInput = ({
   nodeTypes,
   searchTerm,
@@ -65,39 +82,21 @@ export const NodeTypeChipsSearchInput = ({
   const [focusedChipIndex, setFocusedChipIndex] = useState(-1);
   const chipRefs = useRef<(HTMLSpanElement | null)[]>([]);
 
-  const nodeTypeById = useMemo(
-    () =>
-      Object.fromEntries(
-        nodeTypes.map((nodeType) => [nodeType.type, nodeType]),
-      ),
-    [nodeTypes],
-  );
+  const nodeTypeById = Object.fromEntries(
+    nodeTypes.map((nodeType) => [nodeType.type, nodeType]),
+  ) as Record<string, DiscourseNode | undefined>;
 
-  const selectedNodeTypes = useMemo(
-    () =>
-      selectedTypeIds
-        .map((typeId) => nodeTypeById[typeId])
-        .filter((nodeType): nodeType is DiscourseNode => !!nodeType),
-    [nodeTypeById, selectedTypeIds],
-  );
+  const selectedNodeTypes = selectedTypeIds
+    .map((typeId) => nodeTypeById[typeId])
+    .filter((nodeType): nodeType is DiscourseNode => !!nodeType);
 
-  const bestPrefixMatch = useMemo(
-    () =>
-      getBestPrefixMatch({
-        nodeTypes,
-        query: searchTerm,
-        selectedTypeIds,
-      }),
-    [nodeTypes, searchTerm, selectedTypeIds],
-  );
+  const bestPrefixMatch = getBestPrefixMatch({
+    nodeTypes,
+    query: searchTerm,
+    selectedTypeIds,
+  });
 
-  const completionSuffix = useMemo(() => {
-    if (!bestPrefixMatch) return "";
-    const normalizedQuery = searchTerm.trim();
-    const nodeText = bestPrefixMatch.text;
-    if (nodeText.toLowerCase() === normalizedQuery.toLowerCase()) return "";
-    return nodeText.slice(normalizedQuery.length);
-  }, [bestPrefixMatch, searchTerm]);
+  const completionSuffix = getCompletionSuffix({ bestPrefixMatch, searchTerm });
 
   useEffect(() => {
     if (focusedChipIndex < 0) return;
@@ -254,48 +253,44 @@ export const NodeTypeChipsSearchInput = ({
             onClick={() => setFocusedChipIndex(index)}
             onKeyDown={(event) => handleChipKeyDown(event, index)}
             style={{
+              borderRadius: 3,
               boxShadow: isFocused
                 ? "0 0 0 2px rgba(95, 87, 192, 0.2)"
                 : undefined,
-              borderRadius: 3,
+              display: "inline-flex",
             }}
           >
-            <span
-              className="inline-flex items-center gap-1.5 rounded px-2 py-1 text-xs"
+            <Tag
+              active={isFocused}
+              htmlTitle={nodeType.text}
+              minimal
+              onRemove={(event) => {
+                event.stopPropagation();
+                onSelectedTypeIdsChange(
+                  selectedTypeIds.filter((_, chipIndex) => chipIndex !== index),
+                );
+                focusInput();
+              }}
               style={getNodeTagStyles(
                 nodeType.canvasSettings?.color ?? "#000000",
               )}
             >
-              <span className="max-w-[10rem] truncate leading-4">
+              <span
+                className="truncate"
+                style={{ maxWidth: CHIP_LABEL_MAX_WIDTH }}
+              >
                 {nodeType.text}
               </span>
-              <Button
-                className="!h-4 !min-h-0 !w-4 !min-w-0 !p-0"
-                aria-label={`Remove ${nodeType.text} filter`}
-                icon={<Icon icon="cross" size={10} />}
-                minimal
-                onClick={(event) => {
-                  event.stopPropagation();
-                  onSelectedTypeIdsChange(
-                    selectedTypeIds.filter(
-                      (_, chipIndex) => chipIndex !== index,
-                    ),
-                  );
-                  focusInput();
-                }}
-                onMouseDown={(event) => event.preventDefault()}
-                small
-              />
-            </span>
+            </Tag>
           </span>
         );
       })}
-      <span className="relative min-w-[12ch] flex-1">
+      <span className="relative flex-1" style={{ minWidth: INPUT_MIN_WIDTH }}>
         {completionSuffix && (
           <span className="pointer-events-none absolute inset-0 flex items-center overflow-hidden whitespace-nowrap text-sm">
             <span className="invisible">{searchTerm}</span>
             <span className="text-gray-400">{completionSuffix}</span>
-            <span className="ml-2 rounded bg-gray-100 px-1 text-[10px] uppercase tracking-wide text-gray-500">
+            <span className="ml-2 rounded bg-gray-100 px-1 text-xs uppercase tracking-wide text-gray-500">
               Tab
             </span>
           </span>

--- a/apps/roam/src/utils/getDiscourseNodeColors.ts
+++ b/apps/roam/src/utils/getDiscourseNodeColors.ts
@@ -42,7 +42,9 @@ export const getDiscourseNodeColors = ({
   return { backgroundColor, textColor };
 };
 
-export const getNodeTagStyles = (color: string): CSSProperties | undefined => {
+const getNodeTagColorProperties = (
+  color: string,
+): Pick<CSSProperties, "backgroundColor" | "color" | "border"> | undefined => {
   const formattedColor = formatHexColor(color);
   if (!formattedColor) return undefined;
   const { background, text, border } = getPleasingColors(
@@ -52,6 +54,19 @@ export const getNodeTagStyles = (color: string): CSSProperties | undefined => {
     backgroundColor: background,
     color: text,
     border: `1px solid ${border}`,
+  };
+};
+
+/** Color tokens for Blueprint `Tag` (layout handled by the component). */
+export const getNodeTagColorStyles = (
+  color: string,
+): CSSProperties | undefined => getNodeTagColorProperties(color);
+
+export const getNodeTagStyles = (color: string): CSSProperties | undefined => {
+  const colorStyles = getNodeTagColorProperties(color);
+  if (!colorStyles) return undefined;
+  return {
+    ...colorStyles,
     fontWeight: "500",
     padding: "2px 6px",
     borderRadius: "12px",


### PR DESCRIPTION
https://www.loom.com/share/dd5b9491a87b436395a5fb2344b51c24

## Summary
- replace the advanced search text input with a keyboard-friendly chip input for node-type filters
- add ghost completion + `Tab` commit behavior (prefix-only) and chip keyboard navigation/removal
- keep chip state synchronized with the existing type filter dropdown and support chips-only result filtering

## Test plan
- [x] Open advanced search in Roam and verify ghost completion appears for unique node-type prefix
- [x] Press `Tab` to commit a ghost completion into a chip and confirm search term clears
- [x] Verify Backspace/Arrow Left-Right chip navigation/removal behavior without mouse
- [x] Toggle filters via dropdown and confirm chips/results stay in sync

Made with [Cursor](https://cursor.com)