### PR TITLE
ENG-1747: Placeholder text in input field for Node tag hotkey setting showing two slashes

### DIFF
--- a/apps/obsidian/src/components/GeneralSettings.tsx
+++ b/apps/obsidian/src/components/GeneralSettings.tsx
@@ -301,7 +301,7 @@ const GeneralSettings = () => {
                 handleNodeTagHotkeyChange("");
               }
             }}
-            placeholder="\\"
+            placeholder="\"
             maxLength={1}
           />
         </div>


### PR DESCRIPTION
Before:
<img width="802" height="157" alt="image" src="https://github.com/user-attachments/assets/85199eff-995a-46ad-a721-370c3f1e23c3" />


After:

<img width="687" height="99" alt="image" src="https://github.com/user-attachments/assets/f3850a20-c0a4-4e08-9ff6-c575bf899386" />
