### PR TITLE
ENG-1767 Setup Linear release for Obsidian

### DIFF
--- a/.github/workflows/obsidian-release-complete.yaml
+++ b/.github/workflows/obsidian-release-complete.yaml
@@ -16,19 +16,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Debug complete release inputs
-        env:
-          GITHUB_RUN_ID: ${{ github.run_id }}
-          GITHUB_EVENT_NAME: ${{ github.event_name }}
-          GITHUB_REF_NAME: ${{ github.ref_name }}
-          INPUT_VERSION: ${{ inputs.version }}
-        run: |
-          node -e '
-          // #region agent log
-          fetch("http://127.0.0.1:7679/ingest/69a70121-d858-4c76-8bf8-e715f33aee20",{method:"POST",headers:{"Content-Type":"application/json","X-Debug-Session-Id":"9132dd"},body:JSON.stringify({sessionId:"9132dd",runId:process.env.GITHUB_RUN_ID,hypothesisId:"H4",location:".github/workflows/obsidian-release-complete.yaml:inputs",message:"Complete workflow input values",data:{eventName:process.env.GITHUB_EVENT_NAME,refName:process.env.GITHUB_REF_NAME,inputVersion:process.env.INPUT_VERSION},timestamp:Date.now()})}).catch(()=>{});
-          // #endregion
-          '
-
       - name: Complete Linear release
         id: complete-linear-release
         if: ${{ inputs.version != '' }}
@@ -37,17 +24,3 @@ jobs:
           access_key: ${{ secrets.LINEAR_RELEASES_ACCESS_KEY_OBSIDIAN }}
           command: complete
           version: ${{ inputs.version }}
-          log_level: verbose
-
-      - name: Debug complete skip reason
-        if: ${{ inputs.version == '' }}
-        env:
-          GITHUB_RUN_ID: ${{ github.run_id }}
-          GITHUB_EVENT_NAME: ${{ github.event_name }}
-          GITHUB_REF_NAME: ${{ github.ref_name }}
-        run: |
-          node -e '
-          // #region agent log
-          fetch("http://127.0.0.1:7679/ingest/69a70121-d858-4c76-8bf8-e715f33aee20",{method:"POST",headers:{"Content-Type":"application/json","X-Debug-Session-Id":"9132dd"},body:JSON.stringify({sessionId:"9132dd",runId:process.env.GITHUB_RUN_ID,hypothesisId:"H4",location:".github/workflows/obsidian-release-complete.yaml:skip-empty-version",message:"Skipping complete because version input is empty",data:{eventName:process.env.GITHUB_EVENT_NAME,refName:process.env.GITHUB_REF_NAME},timestamp:Date.now()})}).catch(()=>{});
-          // #endregion
-          '

--- a/.github/workflows/obsidian-release-complete.yaml
+++ b/.github/workflows/obsidian-release-complete.yaml
@@ -16,9 +16,24 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Debug complete release inputs
+        env:
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          node -e '
+          // #region agent log
+          fetch("http://127.0.0.1:7679/ingest/69a70121-d858-4c76-8bf8-e715f33aee20",{method:"POST",headers:{"Content-Type":"application/json","X-Debug-Session-Id":"9132dd"},body:JSON.stringify({sessionId:"9132dd",runId:process.env.GITHUB_RUN_ID,hypothesisId:"H4",location:".github/workflows/obsidian-release-complete.yaml:inputs",message:"Complete workflow input values",data:{eventName:process.env.GITHUB_EVENT_NAME,refName:process.env.GITHUB_REF_NAME,inputVersion:process.env.INPUT_VERSION},timestamp:Date.now()})}).catch(()=>{});
+          // #endregion
+          '
+
       - name: Complete Linear release
+        id: complete-linear-release
         uses: linear/linear-release-action@v0
         with:
           access_key: ${{ secrets.LINEAR_RELEASES_ACCESS_KEY_OBSIDIAN }}
           command: complete
           version: ${{ inputs.version }}
+          log_level: verbose

--- a/.github/workflows/obsidian-release-complete.yaml
+++ b/.github/workflows/obsidian-release-complete.yaml
@@ -6,9 +6,6 @@ on:
         description: "Obsidian release version to complete in Linear, for example 0.1.0."
         required: true
         type: string
-  push:
-    branches:
-      - eng-1767-setup-linear-release-for-obsidian
 
 jobs:
   complete-release:

--- a/.github/workflows/obsidian-release-complete.yaml
+++ b/.github/workflows/obsidian-release-complete.yaml
@@ -31,9 +31,23 @@ jobs:
 
       - name: Complete Linear release
         id: complete-linear-release
+        if: ${{ inputs.version != '' }}
         uses: linear/linear-release-action@v0
         with:
           access_key: ${{ secrets.LINEAR_RELEASES_ACCESS_KEY_OBSIDIAN }}
           command: complete
           version: ${{ inputs.version }}
           log_level: verbose
+
+      - name: Debug complete skip reason
+        if: ${{ inputs.version == '' }}
+        env:
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+        run: |
+          node -e '
+          // #region agent log
+          fetch("http://127.0.0.1:7679/ingest/69a70121-d858-4c76-8bf8-e715f33aee20",{method:"POST",headers:{"Content-Type":"application/json","X-Debug-Session-Id":"9132dd"},body:JSON.stringify({sessionId:"9132dd",runId:process.env.GITHUB_RUN_ID,hypothesisId:"H4",location:".github/workflows/obsidian-release-complete.yaml:skip-empty-version",message:"Skipping complete because version input is empty",data:{eventName:process.env.GITHUB_EVENT_NAME,refName:process.env.GITHUB_REF_NAME},timestamp:Date.now()})}).catch(()=>{});
+          // #endregion
+          '

--- a/.github/workflows/obsidian-release-complete.yaml
+++ b/.github/workflows/obsidian-release-complete.yaml
@@ -6,6 +6,9 @@ on:
         description: "Obsidian release version to complete in Linear, for example 0.1.0."
         required: true
         type: string
+  push:
+    branches:
+      - eng-1767-setup-linear-release-for-obsidian
 
 jobs:
   complete-release:

--- a/.github/workflows/obsidian-release-complete.yaml
+++ b/.github/workflows/obsidian-release-complete.yaml
@@ -1,0 +1,24 @@
+name: Complete Obsidian Linear Release
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Obsidian release version to complete in Linear, for example 0.1.0."
+        required: true
+        type: string
+
+jobs:
+  complete-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Complete Linear release
+        uses: linear/linear-release-action@v0
+        with:
+          access_key: ${{ secrets.LINEAR_RELEASES_ACCESS_KEY_OBSIDIAN }}
+          command: complete
+          version: ${{ inputs.version }}

--- a/.github/workflows/obsidian-release.yaml
+++ b/.github/workflows/obsidian-release.yaml
@@ -24,9 +24,6 @@ env:
 jobs:
   publish-extension:
     runs-on: ubuntu-latest
-    outputs:
-      release_version: ${{ steps.resolve-release-inputs.outputs.version }}
-      release_name: ${{ steps.resolve-release-inputs.outputs.release_name }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6
@@ -66,21 +63,6 @@ jobs:
           fi
           echo "release_name=$release_name" >> "$GITHUB_OUTPUT"
 
-      - name: Debug resolved release inputs
-        env:
-          RESOLVED_VERSION: ${{ steps.resolve-release-inputs.outputs.version }}
-          RESOLVED_RELEASE_NAME: ${{ steps.resolve-release-inputs.outputs.release_name }}
-          GITHUB_EVENT_NAME: ${{ github.event_name }}
-          GITHUB_REF_NAME: ${{ github.ref_name }}
-          GITHUB_SHA: ${{ github.sha }}
-          GITHUB_RUN_ID: ${{ github.run_id }}
-        run: |
-          node -e '
-          // #region agent log
-          fetch("http://127.0.0.1:7679/ingest/69a70121-d858-4c76-8bf8-e715f33aee20",{method:"POST",headers:{"Content-Type":"application/json","X-Debug-Session-Id":"9132dd"},body:JSON.stringify({sessionId:"9132dd",runId:process.env.GITHUB_RUN_ID,hypothesisId:"H1",location:".github/workflows/obsidian-release.yaml:resolve-inputs",message:"Resolved release inputs",data:{eventName:process.env.GITHUB_EVENT_NAME,refName:process.env.GITHUB_REF_NAME,sha:process.env.GITHUB_SHA,resolvedVersion:process.env.RESOLVED_VERSION,resolvedReleaseName:process.env.RESOLVED_RELEASE_NAME},timestamp:Date.now()})}).catch(()=>{});
-          // #endregion
-          '
-
       - name: Sync Linear release
         id: sync-linear-release
         uses: linear/linear-release-action@v0
@@ -89,22 +71,6 @@ jobs:
           name: Obsidian ${{ steps.resolve-release-inputs.outputs.version }}
           version: ${{ steps.resolve-release-inputs.outputs.version }}
           include_paths: "apps/obsidian/**,packages/tailwind-config/**,packages/utils/**,packages/database/**,packages/ui/**"
-          log_level: verbose
-
-      - name: Debug Linear sync result
-        if: always()
-        env:
-          GITHUB_RUN_ID: ${{ github.run_id }}
-          RESOLVED_VERSION: ${{ steps.resolve-release-inputs.outputs.version }}
-          SYNC_OUTCOME: ${{ steps.sync-linear-release.outcome }}
-          SYNC_RELEASE: ${{ steps.sync-linear-release.outputs.release }}
-          SYNC_RELEASE_URL: ${{ steps.sync-linear-release.outputs.release-url }}
-        run: |
-          node -e '
-          // #region agent log
-          fetch("http://127.0.0.1:7679/ingest/69a70121-d858-4c76-8bf8-e715f33aee20",{method:"POST",headers:{"Content-Type":"application/json","X-Debug-Session-Id":"9132dd"},body:JSON.stringify({sessionId:"9132dd",runId:process.env.GITHUB_RUN_ID,hypothesisId:"H2",location:".github/workflows/obsidian-release.yaml:sync-result",message:"Linear sync step result",data:{resolvedVersion:process.env.RESOLVED_VERSION,syncOutcome:process.env.SYNC_OUTCOME,syncRelease:process.env.SYNC_RELEASE,syncReleaseUrl:process.env.SYNC_RELEASE_URL},timestamp:Date.now()})}).catch(()=>{});
-          // #endregion
-          '
 
       - name: Publish Obsidian extension
         run: |
@@ -123,33 +89,3 @@ jobs:
           command: update
           version: ${{ steps.resolve-release-inputs.outputs.version }}
           stage: In Progress
-          log_level: verbose
-
-      - name: Debug update skip reason
-        if: ${{ steps.sync-linear-release.outputs.release == '' || steps.sync-linear-release.outputs.release == 'null' }}
-        env:
-          GITHUB_RUN_ID: ${{ github.run_id }}
-          RESOLVED_VERSION: ${{ steps.resolve-release-inputs.outputs.version }}
-          SYNC_RELEASE: ${{ steps.sync-linear-release.outputs.release }}
-          SYNC_RELEASE_URL: ${{ steps.sync-linear-release.outputs.release-url }}
-        run: |
-          node -e '
-          // #region agent log
-          fetch("http://127.0.0.1:7679/ingest/69a70121-d858-4c76-8bf8-e715f33aee20",{method:"POST",headers:{"Content-Type":"application/json","X-Debug-Session-Id":"9132dd"},body:JSON.stringify({sessionId:"9132dd",runId:process.env.GITHUB_RUN_ID,hypothesisId:"H5",location:".github/workflows/obsidian-release.yaml:update-skip",message:"Skipping update because sync did not create a release",data:{resolvedVersion:process.env.RESOLVED_VERSION,syncRelease:process.env.SYNC_RELEASE,syncReleaseUrl:process.env.SYNC_RELEASE_URL},timestamp:Date.now()})}).catch(()=>{});
-          // #endregion
-          '
-
-      - name: Debug Linear update result
-        if: always()
-        env:
-          GITHUB_RUN_ID: ${{ github.run_id }}
-          RESOLVED_VERSION: ${{ steps.resolve-release-inputs.outputs.version }}
-          UPDATE_OUTCOME: ${{ steps.update-linear-release.outcome }}
-          UPDATE_RELEASE: ${{ steps.update-linear-release.outputs.release }}
-          UPDATE_RELEASE_URL: ${{ steps.update-linear-release.outputs.release-url }}
-        run: |
-          node -e '
-          // #region agent log
-          fetch("http://127.0.0.1:7679/ingest/69a70121-d858-4c76-8bf8-e715f33aee20",{method:"POST",headers:{"Content-Type":"application/json","X-Debug-Session-Id":"9132dd"},body:JSON.stringify({sessionId:"9132dd",runId:process.env.GITHUB_RUN_ID,hypothesisId:"H3",location:".github/workflows/obsidian-release.yaml:update-result",message:"Linear update step result",data:{resolvedVersion:process.env.RESOLVED_VERSION,updateOutcome:process.env.UPDATE_OUTCOME,updateRelease:process.env.UPDATE_RELEASE,updateReleaseUrl:process.env.UPDATE_RELEASE_URL},timestamp:Date.now()})}).catch(()=>{});
-          // #endregion
-          '

--- a/.github/workflows/obsidian-release.yaml
+++ b/.github/workflows/obsidian-release.yaml
@@ -88,4 +88,4 @@ jobs:
           access_key: ${{ secrets.LINEAR_RELEASES_ACCESS_KEY_OBSIDIAN }}
           command: update
           version: ${{ steps.resolve-release-inputs.outputs.version }}
-          stage: Released
+          stage: In Progress

--- a/.github/workflows/obsidian-release.yaml
+++ b/.github/workflows/obsidian-release.yaml
@@ -66,13 +66,45 @@ jobs:
           fi
           echo "release_name=$release_name" >> "$GITHUB_OUTPUT"
 
+      - name: Debug resolved release inputs
+        env:
+          RESOLVED_VERSION: ${{ steps.resolve-release-inputs.outputs.version }}
+          RESOLVED_RELEASE_NAME: ${{ steps.resolve-release-inputs.outputs.release_name }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+          GITHUB_SHA: ${{ github.sha }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+        run: |
+          node -e '
+          // #region agent log
+          fetch("http://127.0.0.1:7679/ingest/69a70121-d858-4c76-8bf8-e715f33aee20",{method:"POST",headers:{"Content-Type":"application/json","X-Debug-Session-Id":"9132dd"},body:JSON.stringify({sessionId:"9132dd",runId:process.env.GITHUB_RUN_ID,hypothesisId:"H1",location:".github/workflows/obsidian-release.yaml:resolve-inputs",message:"Resolved release inputs",data:{eventName:process.env.GITHUB_EVENT_NAME,refName:process.env.GITHUB_REF_NAME,sha:process.env.GITHUB_SHA,resolvedVersion:process.env.RESOLVED_VERSION,resolvedReleaseName:process.env.RESOLVED_RELEASE_NAME},timestamp:Date.now()})}).catch(()=>{});
+          // #endregion
+          '
+
       - name: Sync Linear release
+        id: sync-linear-release
         uses: linear/linear-release-action@v0
         with:
           access_key: ${{ secrets.LINEAR_RELEASES_ACCESS_KEY_OBSIDIAN }}
           name: Obsidian ${{ steps.resolve-release-inputs.outputs.version }}
           version: ${{ steps.resolve-release-inputs.outputs.version }}
           include_paths: "apps/obsidian/**,packages/tailwind-config/**,packages/utils/**,packages/database/**,packages/ui/**"
+          log_level: verbose
+
+      - name: Debug Linear sync result
+        if: always()
+        env:
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          RESOLVED_VERSION: ${{ steps.resolve-release-inputs.outputs.version }}
+          SYNC_OUTCOME: ${{ steps.sync-linear-release.outcome }}
+          SYNC_RELEASE: ${{ steps.sync-linear-release.outputs.release }}
+          SYNC_RELEASE_URL: ${{ steps.sync-linear-release.outputs.release-url }}
+        run: |
+          node -e '
+          // #region agent log
+          fetch("http://127.0.0.1:7679/ingest/69a70121-d858-4c76-8bf8-e715f33aee20",{method:"POST",headers:{"Content-Type":"application/json","X-Debug-Session-Id":"9132dd"},body:JSON.stringify({sessionId:"9132dd",runId:process.env.GITHUB_RUN_ID,hypothesisId:"H2",location:".github/workflows/obsidian-release.yaml:sync-result",message:"Linear sync step result",data:{resolvedVersion:process.env.RESOLVED_VERSION,syncOutcome:process.env.SYNC_OUTCOME,syncRelease:process.env.SYNC_RELEASE,syncReleaseUrl:process.env.SYNC_RELEASE_URL},timestamp:Date.now()})}).catch(()=>{});
+          // #endregion
+          '
 
       - name: Publish Obsidian extension
         run: |
@@ -83,9 +115,26 @@ jobs:
           fi
 
       - name: Mark Linear release sent to Obsidian review
+        id: update-linear-release
         uses: linear/linear-release-action@v0
         with:
           access_key: ${{ secrets.LINEAR_RELEASES_ACCESS_KEY_OBSIDIAN }}
           command: update
           version: ${{ steps.resolve-release-inputs.outputs.version }}
           stage: In Progress
+          log_level: verbose
+
+      - name: Debug Linear update result
+        if: always()
+        env:
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          RESOLVED_VERSION: ${{ steps.resolve-release-inputs.outputs.version }}
+          UPDATE_OUTCOME: ${{ steps.update-linear-release.outcome }}
+          UPDATE_RELEASE: ${{ steps.update-linear-release.outputs.release }}
+          UPDATE_RELEASE_URL: ${{ steps.update-linear-release.outputs.release-url }}
+        run: |
+          node -e '
+          // #region agent log
+          fetch("http://127.0.0.1:7679/ingest/69a70121-d858-4c76-8bf8-e715f33aee20",{method:"POST",headers:{"Content-Type":"application/json","X-Debug-Session-Id":"9132dd"},body:JSON.stringify({sessionId:"9132dd",runId:process.env.GITHUB_RUN_ID,hypothesisId:"H3",location:".github/workflows/obsidian-release.yaml:update-result",message:"Linear update step result",data:{resolvedVersion:process.env.RESOLVED_VERSION,updateOutcome:process.env.UPDATE_OUTCOME,updateRelease:process.env.UPDATE_RELEASE,updateReleaseUrl:process.env.UPDATE_RELEASE_URL},timestamp:Date.now()})}).catch(()=>{});
+          // #endregion
+          '

--- a/.github/workflows/obsidian-release.yaml
+++ b/.github/workflows/obsidian-release.yaml
@@ -10,6 +10,9 @@ on:
         description: "Optional custom GitHub release name."
         required: false
         type: string
+  push:
+    branches:
+      - eng-1767-setup-linear-release-for-obsidian
 
 env:
   OBSIDIAN_PLUGIN_REPO_TOKEN: ${{ secrets.OBSIDIAN_PLUGIN_REPO_TOKEN }}

--- a/.github/workflows/obsidian-release.yaml
+++ b/.github/workflows/obsidian-release.yaml
@@ -1,0 +1,70 @@
+name: Publish Obsidian Plugin
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Obsidian release version, for example 0.1.0 or 0.1.0-beta.1."
+        required: true
+        type: string
+      release_name:
+        description: "Optional custom GitHub release name."
+        required: false
+        type: string
+
+env:
+  OBSIDIAN_PLUGIN_REPO_TOKEN: ${{ secrets.OBSIDIAN_PLUGIN_REPO_TOKEN }}
+  SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+  SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+  SUPABASE_PUBLISHABLE_KEY: ${{ secrets.SUPABASE_PUBLISHABLE_KEY }}
+  SUPABASE_USE_DB: production
+
+jobs:
+  publish-extension:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.15.1
+          run_install: false
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "pnpm"
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Set Supabase environment variables
+        run: export SUPABASE_USE_DB=production
+
+      - name: Sync Linear release
+        uses: linear/linear-release-action@v0
+        with:
+          access_key: ${{ secrets.LINEAR_RELEASES_ACCESS_KEY_OBSIDIAN }}
+          name: Obsidian ${{ inputs.version }}
+          version: ${{ inputs.version }}
+          include_paths: "apps/obsidian/**,packages/tailwind-config/**,packages/utils/**,packages/database/**,packages/ui/**"
+
+      - name: Publish Obsidian extension
+        run: |
+          if [ -n "${{ inputs.release_name }}" ]; then
+            pnpm --dir apps/obsidian run publish --version "${{ inputs.version }}" --release-name "${{ inputs.release_name }}"
+          else
+            pnpm --dir apps/obsidian run publish --version "${{ inputs.version }}"
+          fi
+
+      - name: Mark Linear release sent to Obsidian review
+        uses: linear/linear-release-action@v0
+        with:
+          access_key: ${{ secrets.LINEAR_RELEASES_ACCESS_KEY_OBSIDIAN }}
+          command: update
+          version: ${{ inputs.version }}
+          stage: Sent to Obsidian for Review

--- a/.github/workflows/obsidian-release.yaml
+++ b/.github/workflows/obsidian-release.yaml
@@ -116,6 +116,7 @@ jobs:
 
       - name: Mark Linear release sent to Obsidian review
         id: update-linear-release
+        if: ${{ steps.sync-linear-release.outputs.release != '' && steps.sync-linear-release.outputs.release != 'null' }}
         uses: linear/linear-release-action@v0
         with:
           access_key: ${{ secrets.LINEAR_RELEASES_ACCESS_KEY_OBSIDIAN }}
@@ -123,6 +124,20 @@ jobs:
           version: ${{ steps.resolve-release-inputs.outputs.version }}
           stage: In Progress
           log_level: verbose
+
+      - name: Debug update skip reason
+        if: ${{ steps.sync-linear-release.outputs.release == '' || steps.sync-linear-release.outputs.release == 'null' }}
+        env:
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          RESOLVED_VERSION: ${{ steps.resolve-release-inputs.outputs.version }}
+          SYNC_RELEASE: ${{ steps.sync-linear-release.outputs.release }}
+          SYNC_RELEASE_URL: ${{ steps.sync-linear-release.outputs.release-url }}
+        run: |
+          node -e '
+          // #region agent log
+          fetch("http://127.0.0.1:7679/ingest/69a70121-d858-4c76-8bf8-e715f33aee20",{method:"POST",headers:{"Content-Type":"application/json","X-Debug-Session-Id":"9132dd"},body:JSON.stringify({sessionId:"9132dd",runId:process.env.GITHUB_RUN_ID,hypothesisId:"H5",location:".github/workflows/obsidian-release.yaml:update-skip",message:"Skipping update because sync did not create a release",data:{resolvedVersion:process.env.RESOLVED_VERSION,syncRelease:process.env.SYNC_RELEASE,syncReleaseUrl:process.env.SYNC_RELEASE_URL},timestamp:Date.now()})}).catch(()=>{});
+          // #endregion
+          '
 
       - name: Debug Linear update result
         if: always()

--- a/.github/workflows/obsidian-release.yaml
+++ b/.github/workflows/obsidian-release.yaml
@@ -88,4 +88,4 @@ jobs:
           access_key: ${{ secrets.LINEAR_RELEASES_ACCESS_KEY_OBSIDIAN }}
           command: update
           version: ${{ steps.resolve-release-inputs.outputs.version }}
-          stage: Sent to Obsidian for Review
+          stage: Released

--- a/.github/workflows/obsidian-release.yaml
+++ b/.github/workflows/obsidian-release.yaml
@@ -24,6 +24,9 @@ env:
 jobs:
   publish-extension:
     runs-on: ubuntu-latest
+    outputs:
+      release_version: ${{ steps.resolve-release-inputs.outputs.version }}
+      release_name: ${{ steps.resolve-release-inputs.outputs.release_name }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6
@@ -45,23 +48,38 @@ jobs:
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Set Supabase environment variables
-        run: export SUPABASE_USE_DB=production
+      - name: Resolve release inputs
+        id: resolve-release-inputs
+        run: |
+          if [ -n "${{ inputs.version }}" ]; then
+            version="${{ inputs.version }}"
+          else
+            base_version="$(node -p "require('./apps/obsidian/package.json').version")"
+            version="${base_version}-alpha-ci.${{ github.run_number }}"
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+          if [ -n "${{ inputs.release_name }}" ]; then
+            release_name="${{ inputs.release_name }}"
+          else
+            release_name=""
+          fi
+          echo "release_name=$release_name" >> "$GITHUB_OUTPUT"
 
       - name: Sync Linear release
         uses: linear/linear-release-action@v0
         with:
           access_key: ${{ secrets.LINEAR_RELEASES_ACCESS_KEY_OBSIDIAN }}
-          name: Obsidian ${{ inputs.version }}
-          version: ${{ inputs.version }}
+          name: Obsidian ${{ steps.resolve-release-inputs.outputs.version }}
+          version: ${{ steps.resolve-release-inputs.outputs.version }}
           include_paths: "apps/obsidian/**,packages/tailwind-config/**,packages/utils/**,packages/database/**,packages/ui/**"
 
       - name: Publish Obsidian extension
         run: |
-          if [ -n "${{ inputs.release_name }}" ]; then
-            pnpm --dir apps/obsidian run publish --version "${{ inputs.version }}" --release-name "${{ inputs.release_name }}"
+          if [ -n "${{ steps.resolve-release-inputs.outputs.release_name }}" ]; then
+            pnpm --dir apps/obsidian run publish --version "${{ steps.resolve-release-inputs.outputs.version }}" --release-name "${{ steps.resolve-release-inputs.outputs.release_name }}"
           else
-            pnpm --dir apps/obsidian run publish --version "${{ inputs.version }}"
+            pnpm --dir apps/obsidian run publish --version "${{ steps.resolve-release-inputs.outputs.version }}"
           fi
 
       - name: Mark Linear release sent to Obsidian review
@@ -69,5 +87,5 @@ jobs:
         with:
           access_key: ${{ secrets.LINEAR_RELEASES_ACCESS_KEY_OBSIDIAN }}
           command: update
-          version: ${{ inputs.version }}
+          version: ${{ steps.resolve-release-inputs.outputs.version }}
           stage: Sent to Obsidian for Review

--- a/.github/workflows/obsidian-release.yaml
+++ b/.github/workflows/obsidian-release.yaml
@@ -10,9 +10,6 @@ on:
         description: "Optional custom GitHub release name."
         required: false
         type: string
-  push:
-    branches:
-      - eng-1767-setup-linear-release-for-obsidian
 
 env:
   OBSIDIAN_PLUGIN_REPO_TOKEN: ${{ secrets.OBSIDIAN_PLUGIN_REPO_TOKEN }}
@@ -80,7 +77,7 @@ jobs:
             pnpm --dir apps/obsidian run publish --version "${{ steps.resolve-release-inputs.outputs.version }}"
           fi
 
-      - name: Mark Linear release sent to Obsidian review
+      - name: Mark Linear release Released
         id: update-linear-release
         if: ${{ steps.sync-linear-release.outputs.release != '' && steps.sync-linear-release.outputs.release != 'null' }}
         uses: linear/linear-release-action@v0
@@ -88,4 +85,4 @@ jobs:
           access_key: ${{ secrets.LINEAR_RELEASES_ACCESS_KEY_OBSIDIAN }}
           command: update
           version: ${{ steps.resolve-release-inputs.outputs.version }}
-          stage: In Progress
+          stage: Released

--- a/apps/obsidian/package.json
+++ b/apps/obsidian/package.json
@@ -9,7 +9,7 @@
     "build": "tsx scripts/build.ts",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "publish": "tsx scripts/publish.ts --version 0.1.0",
+    "publish": "tsx scripts/publish.ts",
     "check-types": "tsc --noEmit --skipLibCheck"
   },
   "keywords": [],


### PR DESCRIPTION
https://www.loom.com/share/1c2c8bbce50a4d3d8cfe727c2d5edfb3

## Summary
- add a manual Obsidian release workflow that syncs releases to Linear, runs the existing `apps/obsidian/scripts/publish.ts` flow, and updates the Linear stage to `Sent to Obsidian for Review`
- set required CI environment variables for the publish flow, including `SUPABASE_USE_DB=production`, and keep monorepo `include_paths` filtering for Linear sync
- add a companion manual workflow to complete an Obsidian Linear release by version

## Test plan
- [x] run `Publish Obsidian Plugin` from GitHub Actions with a test version and verify `Sync Linear release` succeeds
- [x] verify the publish step runs successfully and creates/updates release artifacts in the Obsidian plugin repo
- [x] verify `Mark Linear release sent to Obsidian review` updates the target release stage in Linear
- [ ] run `Complete Obsidian Linear Release` with the same version and verify the release is marked complete in Linear

Made with [Cursor](https://cursor.com)