### PR TITLE
ENG-1797 Add links to existing docs

### DIFF
--- a/apps/roam/package.json
+++ b/apps/roam/package.json
@@ -74,7 +74,7 @@
     "react-draggable": "4.4.5",
     "react-in-viewport": "1.0.0-alpha.20",
     "react-vertical-timeline-component": "3.5.2",
-    "roamjs-components": "0.87.0",
+    "roamjs-components": "0.88.0",
     "tldraw": "2.4.6",
     "use-sync-external-store": "1.5.0",
     "xregexp": "^5.0.0",

--- a/apps/roam/package.json
+++ b/apps/roam/package.json
@@ -74,7 +74,7 @@
     "react-draggable": "4.4.5",
     "react-in-viewport": "1.0.0-alpha.20",
     "react-vertical-timeline-component": "3.5.2",
-    "roamjs-components": "0.88.0",
+    "roamjs-components": "0.88.1",
     "tldraw": "2.4.6",
     "use-sync-external-store": "1.5.0",
     "xregexp": "^5.0.0",

--- a/apps/roam/src/components/settings/CanvasShortcutSettings.tsx
+++ b/apps/roam/src/components/settings/CanvasShortcutSettings.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { Checkbox, InputGroup, Tabs, Tab } from "@blueprintjs/core";
-import Description from "roamjs-components/components/Description";
+import Description from "~/components/settings/SettingsDescription";
 import getDiscourseNodes, {
   excludeDefaultNodes,
 } from "~/utils/getDiscourseNodes";

--- a/apps/roam/src/components/settings/DiscourseNodeSuggestiveRules.tsx
+++ b/apps/roam/src/components/settings/DiscourseNodeSuggestiveRules.tsx
@@ -17,6 +17,7 @@ import {
   TEMPLATE_SETTING_KEYS,
 } from "~/components/settings/utils/settingKeys";
 import { RenderRoamBlock } from "~/utils/roamReactComponents";
+import { ROAM_DOCS, withDocsLink } from "./utils/docs";
 
 const DiscourseNodeSuggestiveRules = ({
   node,
@@ -72,7 +73,10 @@ const DiscourseNodeSuggestiveRules = ({
       <DualWriteBlocksPanel
         nodeType={node.type}
         title="Template"
-        description={`The template that auto fills ${node.text} page when generated.`}
+        description={withDocsLink(
+          `The template that auto fills ${node.text} page when generated.`,
+          ROAM_DOCS.creatingNodes,
+        )}
         settingKeys={TEMPLATE_SETTING_KEYS}
         uid={templateUid}
         defaultValue={node.template}

--- a/apps/roam/src/components/settings/ExportSettings.tsx
+++ b/apps/roam/src/components/settings/ExportSettings.tsx
@@ -29,7 +29,7 @@ const DiscourseGraphExport = ({
         <GlobalFlagPanel
           title="remove special characters"
           description={withDocsLink(
-            "Whether or not to remove the special characters in a file name",
+            "Whether or not to remove the special characters in a file name.",
             ROAM_DOCS.sharing,
           )}
           settingKeys={[
@@ -45,7 +45,7 @@ const DiscourseGraphExport = ({
         <GlobalFlagPanel
           title="resolve block references"
           description={withDocsLink(
-            "Replaces block references in the markdown content with the block's content",
+            "Replaces block references in the markdown content with the block's content.",
             ROAM_DOCS.sharing,
           )}
           settingKeys={[GLOBAL_KEYS.export, EXPORT_KEYS.resolveBlockReferences]}
@@ -57,7 +57,7 @@ const DiscourseGraphExport = ({
         <GlobalFlagPanel
           title="resolve block embeds"
           description={withDocsLink(
-            "Replaces block embeds in the markdown content with the block's content tree",
+            "Replaces block embeds in the markdown content with the block's content tree.",
             ROAM_DOCS.sharing,
           )}
           settingKeys={[GLOBAL_KEYS.export, EXPORT_KEYS.resolveBlockEmbeds]}
@@ -70,7 +70,7 @@ const DiscourseGraphExport = ({
         <GlobalFlagPanel
           title="append referenced node"
           description={withDocsLink(
-            "If a referenced node is defined in a node's format, it will be appended to the discourse context",
+            "If a referenced node is defined in a node's format, it will be appended to the discourse context.",
             ROAM_DOCS.sharing,
           )}
           settingKeys={[GLOBAL_KEYS.export, EXPORT_KEYS.appendReferencedNode]}
@@ -98,7 +98,7 @@ const DiscourseGraphExport = ({
       <GlobalNumberPanel
         title="max filename length"
         description={withDocsLink(
-          "Set the maximum name length for markdown file exports",
+          "Set the maximum name length for markdown file exports.",
           ROAM_DOCS.sharing,
         )}
         settingKeys={[GLOBAL_KEYS.export, EXPORT_KEYS.maxFilenameLength]}
@@ -110,7 +110,7 @@ const DiscourseGraphExport = ({
       <GlobalMultiTextPanel
         title="frontmatter"
         description={withDocsLink(
-          "Specify all the lines that should go to the Frontmatter of the markdown file",
+          "Specify all the lines that should go to the Frontmatter of the markdown file.",
           ROAM_DOCS.sharing,
         )}
         settingKeys={[GLOBAL_KEYS.export, EXPORT_KEYS.frontmatter]}

--- a/apps/roam/src/components/settings/ExportSettings.tsx
+++ b/apps/roam/src/components/settings/ExportSettings.tsx
@@ -11,6 +11,7 @@ import {
   EXPORT_KEYS,
 } from "~/components/settings/utils/settingKeys";
 import { type SettingsSnapshot } from "./utils/accessors";
+import { ROAM_DOCS, withDocsLink } from "./utils/docs";
 
 const DiscourseGraphExport = ({
   globalSettings,
@@ -27,7 +28,10 @@ const DiscourseGraphExport = ({
       <div>
         <GlobalFlagPanel
           title="remove special characters"
-          description="Whether or not to remove the special characters in a file name"
+          description={withDocsLink(
+            "Whether or not to remove the special characters in a file name",
+            ROAM_DOCS.sharing,
+          )}
           settingKeys={[
             GLOBAL_KEYS.export,
             EXPORT_KEYS.removeSpecialCharacters,
@@ -40,7 +44,10 @@ const DiscourseGraphExport = ({
 
         <GlobalFlagPanel
           title="resolve block references"
-          description="Replaces block references in the markdown content with the block's content"
+          description={withDocsLink(
+            "Replaces block references in the markdown content with the block's content",
+            ROAM_DOCS.sharing,
+          )}
           settingKeys={[GLOBAL_KEYS.export, EXPORT_KEYS.resolveBlockReferences]}
           initialValue={exportBlockProps[EXPORT_KEYS.resolveBlockReferences]}
           order={3}
@@ -49,7 +56,10 @@ const DiscourseGraphExport = ({
         />
         <GlobalFlagPanel
           title="resolve block embeds"
-          description="Replaces block embeds in the markdown content with the block's content tree"
+          description={withDocsLink(
+            "Replaces block embeds in the markdown content with the block's content tree",
+            ROAM_DOCS.sharing,
+          )}
           settingKeys={[GLOBAL_KEYS.export, EXPORT_KEYS.resolveBlockEmbeds]}
           initialValue={exportBlockProps[EXPORT_KEYS.resolveBlockEmbeds]}
           order={4}
@@ -59,7 +69,10 @@ const DiscourseGraphExport = ({
 
         <GlobalFlagPanel
           title="append referenced node"
-          description="If a referenced node is defined in a node's format, it will be appended to the discourse context"
+          description={withDocsLink(
+            "If a referenced node is defined in a node's format, it will be appended to the discourse context",
+            ROAM_DOCS.sharing,
+          )}
           settingKeys={[GLOBAL_KEYS.export, EXPORT_KEYS.appendReferencedNode]}
           initialValue={exportBlockProps[EXPORT_KEYS.appendReferencedNode]}
           order={6}
@@ -70,7 +83,10 @@ const DiscourseGraphExport = ({
       <div className="link-type-select-wrapper">
         <GlobalSelectPanel
           title="link type"
-          description="How to format links that appear in your export."
+          description={withDocsLink(
+            "How to format links that appear in your export.",
+            ROAM_DOCS.sharing,
+          )}
           settingKeys={[GLOBAL_KEYS.export, EXPORT_KEYS.linkType]}
           initialValue={exportBlockProps[EXPORT_KEYS.linkType]}
           order={5}
@@ -81,7 +97,10 @@ const DiscourseGraphExport = ({
       </div>
       <GlobalNumberPanel
         title="max filename length"
-        description="Set the maximum name length for markdown file exports"
+        description={withDocsLink(
+          "Set the maximum name length for markdown file exports",
+          ROAM_DOCS.sharing,
+        )}
         settingKeys={[GLOBAL_KEYS.export, EXPORT_KEYS.maxFilenameLength]}
         initialValue={exportBlockProps[EXPORT_KEYS.maxFilenameLength]}
         order={0}
@@ -90,7 +109,10 @@ const DiscourseGraphExport = ({
       />
       <GlobalMultiTextPanel
         title="frontmatter"
-        description="Specify all the lines that should go to the Frontmatter of the markdown file"
+        description={withDocsLink(
+          "Specify all the lines that should go to the Frontmatter of the markdown file",
+          ROAM_DOCS.sharing,
+        )}
         settingKeys={[GLOBAL_KEYS.export, EXPORT_KEYS.frontmatter]}
         initialValue={exportBlockProps[EXPORT_KEYS.frontmatter]}
         order={2}

--- a/apps/roam/src/components/settings/GeneralSettings.tsx
+++ b/apps/roam/src/components/settings/GeneralSettings.tsx
@@ -15,6 +15,7 @@ import {
   getUidAndStringSetting,
 } from "~/utils/getExportSettings";
 import { DISCOURSE_CONFIG_PAGE_TITLE } from "~/data/constants";
+import { ROAM_DOCS, withDocsLink } from "./utils/docs";
 
 const DiscourseGraphHome = ({
   globalSettings,
@@ -47,7 +48,10 @@ const DiscourseGraphHome = ({
           Update titles to Sentence case once read side is migrated to block props. */}
       <GlobalTextPanel
         title="trigger"
-        description="The trigger to create the node menu."
+        description={withDocsLink(
+          "The trigger to create the node menu.",
+          ROAM_DOCS.creatingNodes,
+        )}
         settingKeys={[GLOBAL_KEYS.trigger]}
         initialValue={globalSettings[GLOBAL_KEYS.trigger]}
         order={0}

--- a/apps/roam/src/components/settings/HomePersonalSettings.tsx
+++ b/apps/roam/src/components/settings/HomePersonalSettings.tsx
@@ -35,6 +35,7 @@ import posthog from "posthog-js";
 import internalError from "~/utils/internalError";
 import { setPersonalSetting, type SettingsSnapshot } from "./utils/accessors";
 import { getStoredRelationsEnabled } from "~/utils/storedRelations";
+import { ROAM_DOCS, withDocsLink } from "./utils/docs";
 
 const enum RelationMigrationDialog {
   "none",
@@ -119,7 +120,12 @@ const HomePersonalSettings = ({
     <div className="flex flex-col gap-4 p-1">
       <Label>
         Personal node menu trigger
-        <Description description="Override the global trigger for the discourse node menu." />
+        <Description
+          description={withDocsLink(
+            "Override the global trigger for the discourse node menu.",
+            ROAM_DOCS.creatingNodes,
+          )}
+        />
         <NodeMenuTriggerComponent
           extensionAPI={extensionAPI}
           initialValue={personalSettings[PERSONAL_KEYS.personalNodeMenuTrigger]}
@@ -138,13 +144,19 @@ const HomePersonalSettings = ({
         settingKey={DISCOURSE_TOOL_SHORTCUT_KEY}
         blockPropKey={PERSONAL_KEYS.discourseToolShortcut}
         label="Discourse tool keyboard shortcut"
-        description="Set a single key to activate the discourse tool in tldraw. Only single keys (no modifiers) are supported. Leave empty for no shortcut."
+        description={withDocsLink(
+          "Set a single key to activate the discourse tool in tldraw. Only single keys (no modifiers) are supported. Leave empty for no shortcut.",
+          ROAM_DOCS.creatingNodes,
+        )}
         placeholder="Click to set single key"
         initialValue={personalSettings[PERSONAL_KEYS.discourseToolShortcut]}
       />
       <PersonalFlagPanel
         title="Overlay"
-        description="Whether or not to overlay discourse context information over discourse node references."
+        description={withDocsLink(
+          "Whether or not to overlay discourse context information over discourse node references.",
+          ROAM_DOCS.discourseContextOverlay,
+        )}
         settingKeys={[PERSONAL_KEYS.discourseContextOverlay]}
         initialValue={personalSettings[PERSONAL_KEYS.discourseContextOverlay]}
         onChange={(checked) => {
@@ -157,7 +169,10 @@ const HomePersonalSettings = ({
       />
       <PersonalFlagPanel
         title="Enable stored relations"
-        description="Use stored relations instead of legacy pattern-based relations"
+        description={withDocsLink(
+          "Use stored relations instead of legacy pattern-based relations",
+          ROAM_DOCS.migrationToStoredRelations,
+        )}
         settingKeys={["Reified relation triples"]}
         initialValue={personalSettings["Reified relation triples"]}
         value={storedRelations}
@@ -179,7 +194,10 @@ const HomePersonalSettings = ({
 
       <PersonalFlagPanel
         title="Text selection popup"
-        description="Whether or not to show the discourse node menu when selecting text."
+        description={withDocsLink(
+          "Whether or not to show the discourse node menu when selecting text.",
+          ROAM_DOCS.creatingNodes,
+        )}
         settingKeys={[PERSONAL_KEYS.textSelectionPopup]}
         initialValue={personalSettings[PERSONAL_KEYS.textSelectionPopup]}
         onChange={(checked) => {
@@ -221,7 +239,10 @@ const HomePersonalSettings = ({
       />
       <PersonalFlagPanel
         title="Auto canvas relations"
-        description="Automatically add discourse relations to canvas when a node is added"
+        description={withDocsLink(
+          "Automatically add discourse relations to canvas when a node is added",
+          ROAM_DOCS.storedRelations,
+        )}
         settingKeys={[PERSONAL_KEYS.autoCanvasRelations]}
         initialValue={personalSettings[PERSONAL_KEYS.autoCanvasRelations]}
         onChange={(checked) => {
@@ -231,7 +252,10 @@ const HomePersonalSettings = ({
 
       <PersonalFlagPanel
         title="(BETA) Overlay in canvas"
-        description="Whether or not to overlay discourse context information over canvas nodes."
+        description={withDocsLink(
+          "Whether or not to overlay discourse context information over canvas nodes.",
+          ROAM_DOCS.discourseContextOverlay,
+        )}
         settingKeys={[PERSONAL_KEYS.overlayInCanvas]}
         initialValue={personalSettings[PERSONAL_KEYS.overlayInCanvas]}
         onChange={(checked) => {

--- a/apps/roam/src/components/settings/HomePersonalSettings.tsx
+++ b/apps/roam/src/components/settings/HomePersonalSettings.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { OnloadArgs } from "roamjs-components/types";
 import { render as renderToast } from "roamjs-components/components/Toast";
 import { Label, Dialog, Button, Intent, Classes } from "@blueprintjs/core";
-import Description from "roamjs-components/components/Description";
+import Description from "~/components/settings/SettingsDescription";
 import { addStyle } from "roamjs-components/dom";
 import { NodeMenuTriggerComponent } from "~/components/DiscourseNodeMenu";
 import {

--- a/apps/roam/src/components/settings/KeyboardShortcutInput.tsx
+++ b/apps/roam/src/components/settings/KeyboardShortcutInput.tsx
@@ -7,7 +7,7 @@ import {
   IKeyCombo,
   Label,
 } from "@blueprintjs/core";
-import Description from "roamjs-components/components/Description";
+import Description from "~/components/settings/SettingsDescription";
 import { DISCOURSE_TOOL_SHORTCUT_KEY } from "~/data/userSettings";
 import { setPersonalSetting } from "~/components/settings/utils/accessors";
 import { comboToString } from "~/components/DiscourseNodeMenu";

--- a/apps/roam/src/components/settings/KeyboardShortcutInput.tsx
+++ b/apps/roam/src/components/settings/KeyboardShortcutInput.tsx
@@ -18,7 +18,7 @@ type KeyboardShortcutInputProps = {
   settingKey: string;
   blockPropKey: keyof PersonalSettings;
   label: string;
-  description: string;
+  description: React.ReactNode;
   initialValue: IKeyCombo;
   placeholder?: string;
 };

--- a/apps/roam/src/components/settings/NodeConfig.tsx
+++ b/apps/roam/src/components/settings/NodeConfig.tsx
@@ -2,7 +2,7 @@ import React, { useState, useCallback, useEffect } from "react";
 import getDiscourseNodes, { DiscourseNode } from "~/utils/getDiscourseNodes";
 import DualWriteBlocksPanel from "./components/EphemeralBlocksPanel";
 import { getSubTree } from "roamjs-components/util";
-import Description from "roamjs-components/components/Description";
+import Description from "~/components/settings/SettingsDescription";
 import {
   Label,
   Tabs,

--- a/apps/roam/src/components/settings/NodeConfig.tsx
+++ b/apps/roam/src/components/settings/NodeConfig.tsx
@@ -39,6 +39,7 @@ import {
   DiscourseNodeFlagPanel,
   DiscourseNodeSelectPanel,
 } from "./components/BlockPropSettingPanels";
+import { ROAM_DOCS, withDocsLink } from "./utils/docs";
 
 export const getCleanTagText = (tag: string): string => {
   return tag.replace(/^#+/, "").trim().toUpperCase();
@@ -209,7 +210,10 @@ const NodeConfig = ({
               <DiscourseNodeTextPanel
                 nodeType={node.type}
                 title="Description"
-                description={`Describing what the ${node.text} node represents in your graph.`}
+                description={withDocsLink(
+                  `Describing what the ${node.text} node represents in your graph.`,
+                  ROAM_DOCS.grammarNodes,
+                )}
                 settingKeys={[DISCOURSE_NODE_KEYS.description]}
                 initialValue={node.description}
                 multiline
@@ -220,7 +224,10 @@ const NodeConfig = ({
               <DiscourseNodeTextPanel
                 nodeType={node.type}
                 title="Shortcut"
-                description={`The trigger to quickly create a ${node.text} page from the node menu.`}
+                description={withDocsLink(
+                  `The trigger to quickly create a ${node.text} page from the node menu.`,
+                  ROAM_DOCS.creatingNodes,
+                )}
                 settingKeys={[DISCOURSE_NODE_KEYS.shortcut]}
                 initialValue={node.shortcut}
                 error={shortcutError}
@@ -233,7 +240,10 @@ const NodeConfig = ({
                 <DiscourseNodeTextPanel
                   nodeType={node.type}
                   title="Tag"
-                  description={`Designate a hashtag for marking potential ${node.text}.`}
+                  description={withDocsLink(
+                    `Designate a hashtag for marking potential ${node.text}.`,
+                    ROAM_DOCS.taggingCandidateNodes,
+                  )}
                   settingKeys={[DISCOURSE_NODE_KEYS.tag]}
                   initialValue={node.tag}
                   placeholder={generateTagPlaceholder(node)}
@@ -330,7 +340,10 @@ const NodeConfig = ({
               <DiscourseNodeTextPanel
                 nodeType={node.type}
                 title="Format"
-                description={`DEPRECATED - Use specification instead. The format ${node.text} pages should have.`}
+                description={withDocsLink(
+                  `DEPRECATED - Use specification instead. The format ${node.text} pages should have.`,
+                  ROAM_DOCS.grammarNodes,
+                )}
                 settingKeys={[DISCOURSE_NODE_KEYS.format]}
                 initialValue={node.format}
                 error={formatError}
@@ -342,9 +355,10 @@ const NodeConfig = ({
               <Label>
                 Specification
                 <Description
-                  description={
-                    "The conditions specified to identify a ${nodeText} node."
-                  }
+                  description={withDocsLink(
+                    `The conditions specified to identify a ${node.text} node.`,
+                    ROAM_DOCS.grammarNodes,
+                  )}
                 />
                 <DiscourseNodeSpecification
                   node={node}
@@ -369,7 +383,10 @@ const NodeConfig = ({
               <DualWriteBlocksPanel
                 nodeType={node.type}
                 title="Template"
-                description={`The template that auto fills ${node.text} page when generated.`}
+                description={withDocsLink(
+                  `The template that auto fills ${node.text} page when generated.`,
+                  ROAM_DOCS.creatingNodes,
+                )}
                 settingKeys={TEMPLATE_SETTING_KEYS}
                 uid={templateUid}
                 defaultValue={node.template}
@@ -393,7 +410,10 @@ const NodeConfig = ({
               <DiscourseNodeSelectPanel
                 nodeType={node.type}
                 title="Overlay"
-                description="Select which attribute is used for the discourse overlay"
+                description={withDocsLink(
+                  "Select which attribute is used for the discourse overlay",
+                  ROAM_DOCS.discourseAttributes,
+                )}
                 settingKeys={[DISCOURSE_NODE_KEYS.overlay]}
                 options={attributeNode.children.map((c) => c.text)}
                 initialValue={

--- a/apps/roam/src/components/settings/PageGroupPanel.tsx
+++ b/apps/roam/src/components/settings/PageGroupPanel.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback } from "react";
 import { Label, Button, Intent, Tag, InputGroup } from "@blueprintjs/core";
-import Description from "roamjs-components/components/Description";
+import Description from "~/components/settings/SettingsDescription";
 import AutocompleteInput from "roamjs-components/components/AutocompleteInput";
 import createBlock from "roamjs-components/writes/createBlock";
 import deleteBlock from "roamjs-components/writes/deleteBlock";

--- a/apps/roam/src/components/settings/QuerySettings.tsx
+++ b/apps/roam/src/components/settings/QuerySettings.tsx
@@ -15,6 +15,7 @@ import {
 } from "~/components/settings/utils/settingKeys";
 import { type SettingsSnapshot } from "./utils/accessors";
 import posthog from "posthog-js";
+import { ROAM_DOCS, withDocsLink } from "./utils/docs";
 
 const QuerySettings = ({
   extensionAPI,
@@ -28,7 +29,10 @@ const QuerySettings = ({
     <div className="flex flex-col gap-4 p-1">
       <PersonalFlagPanel
         title="Hide query metadata"
-        description="Hide the Roam blocks that are used to power each query"
+        description={withDocsLink(
+          "Hide the Roam blocks that are used to power each query",
+          ROAM_DOCS.querying,
+        )}
         settingKeys={[PERSONAL_KEYS.query, QUERY_KEYS.hideQueryMetadata]}
         initialValue={querySettings[QUERY_KEYS.hideQueryMetadata]}
         onChange={(checked) => {
@@ -40,7 +44,10 @@ const QuerySettings = ({
       />
       <PersonalNumberPanel
         title="Default page size"
-        description="The default page size used for query results"
+        description={withDocsLink(
+          "The default page size used for query results",
+          ROAM_DOCS.querying,
+        )}
         settingKeys={[PERSONAL_KEYS.query, QUERY_KEYS.defaultPageSize]}
         initialValue={querySettings[QUERY_KEYS.defaultPageSize]}
         onChange={(value) => {
@@ -52,7 +59,10 @@ const QuerySettings = ({
       />
       <PersonalMultiTextPanel
         title="Query pages"
-        description="The title formats of pages that you would like to serve as pages that generate queries"
+        description={withDocsLink(
+          "The title formats of pages that you would like to serve as pages that generate queries",
+          ROAM_DOCS.querying,
+        )}
         settingKeys={[PERSONAL_KEYS.query, QUERY_KEYS.queryPages]}
         initialValue={querySettings[QUERY_KEYS.queryPages]}
         onChange={(values) => {
@@ -62,9 +72,10 @@ const QuerySettings = ({
       <Label>
         Default filters
         <Description
-          description={
-            "Any filters that should be applied to your results by default"
-          }
+          description={withDocsLink(
+            "Any filters that should be applied to your results by default",
+            ROAM_DOCS.querying,
+          )}
         />
         <DefaultFilters
           extensionAPI={extensionAPI}

--- a/apps/roam/src/components/settings/QuerySettings.tsx
+++ b/apps/roam/src/components/settings/QuerySettings.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { OnloadArgs } from "roamjs-components/types";
 import { Label } from "@blueprintjs/core";
-import Description from "roamjs-components/components/Description";
+import Description from "~/components/settings/SettingsDescription";
 import { DEFAULT_PAGE_SIZE_KEY, HIDE_METADATA_KEY } from "~/data/userSettings";
 import DefaultFilters from "./DefaultFilters";
 import {

--- a/apps/roam/src/components/settings/SettingsDescription.tsx
+++ b/apps/roam/src/components/settings/SettingsDescription.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import Description from "roamjs-components/components/Description";
+
+type SettingsDescriptionProps = React.ComponentProps<typeof Description>;
+
+const SettingsDescription = (
+  props: SettingsDescriptionProps,
+): React.ReactElement => <Description {...props} interactionKind="hover" />;
+
+export default SettingsDescription;

--- a/apps/roam/src/components/settings/components/BlockPropSettingPanels.tsx
+++ b/apps/roam/src/components/settings/components/BlockPropSettingPanels.tsx
@@ -45,7 +45,7 @@ type NumberSetter = (keys: string[], value: number) => void;
 type MultiTextSetter = (keys: string[], value: string[]) => void;
 type BaseTextPanelProps = {
   title: string;
-  description: string;
+  description: React.ReactNode;
   settingKeys: string[];
   setter: TextSetter;
   initialValue: string;
@@ -58,7 +58,7 @@ type BaseTextPanelProps = {
 
 type BaseFlagPanelProps = {
   title: string;
-  description: string;
+  description: React.ReactNode;
   settingKeys: string[];
   setter: FlagSetter;
   initialValue: boolean;
@@ -70,7 +70,7 @@ type BaseFlagPanelProps = {
 
 type BaseNumberPanelProps = {
   title: string;
-  description: string;
+  description: React.ReactNode;
   settingKeys: string[];
   setter: NumberSetter;
   initialValue: number;
@@ -81,7 +81,7 @@ type BaseNumberPanelProps = {
 
 type BaseSelectPanelProps = {
   title: string;
-  description: string;
+  description: React.ReactNode;
   settingKeys: string[];
   setter: TextSetter;
   options: string[];
@@ -90,7 +90,7 @@ type BaseSelectPanelProps = {
 
 type BaseMultiTextPanelProps = {
   title: string;
-  description: string;
+  description: React.ReactNode;
   settingKeys: string[];
   setter: MultiTextSetter;
   initialValue: string[];
@@ -534,7 +534,7 @@ export const FeatureFlagPanel = ({
   order,
 }: {
   title: string;
-  description: string;
+  description: React.ReactNode;
   featureKey: keyof FeatureFlags;
   initialValue?: boolean;
   value?: boolean;
@@ -625,7 +625,7 @@ const createDiscourseNodeSetter =
 export type DiscourseNodeBaseProps = {
   nodeType: string;
   title: string;
-  description: string;
+  description: React.ReactNode;
   settingKeys: string[];
 };
 

--- a/apps/roam/src/components/settings/components/BlockPropSettingPanels.tsx
+++ b/apps/roam/src/components/settings/components/BlockPropSettingPanels.tsx
@@ -15,7 +15,7 @@ import {
   Tag,
   TextArea,
 } from "@blueprintjs/core";
-import Description from "roamjs-components/components/Description";
+import Description from "~/components/settings/SettingsDescription";
 import useSingleChildValue from "roamjs-components/components/ConfigPanels/useSingleChildValue";
 import getShallowTreeByParentUid from "roamjs-components/queries/getShallowTreeByParentUid";
 import refreshConfigTree from "~/utils/refreshConfigTree";

--- a/apps/roam/src/components/settings/components/EphemeralBlocksPanel.tsx
+++ b/apps/roam/src/components/settings/components/EphemeralBlocksPanel.tsx
@@ -1,6 +1,6 @@
 import React, { useRef, useEffect, useCallback, useState } from "react";
 import { Label } from "@blueprintjs/core";
-import Description from "roamjs-components/components/Description";
+import Description from "~/components/settings/SettingsDescription";
 import createBlock from "roamjs-components/writes/createBlock";
 import deleteBlock from "roamjs-components/writes/deleteBlock";
 import getFullTreeByParentUid from "roamjs-components/queries/getFullTreeByParentUid";

--- a/apps/roam/src/components/settings/utils/docs.tsx
+++ b/apps/roam/src/components/settings/utils/docs.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+
+const ROAM_DOCS_BASE_URL = "https://discoursegraphs.com/docs/roam";
+
+export const ROAM_DOCS = {
+  creatingNodes: `${ROAM_DOCS_BASE_URL}/guides/creating-discourse-nodes`,
+  taggingCandidateNodes: `${ROAM_DOCS_BASE_URL}/guides/tagging-candidate-nodes`,
+  querying: `${ROAM_DOCS_BASE_URL}/guides/querying-discourse-graph`,
+  sharing: `${ROAM_DOCS_BASE_URL}/guides/sharing-discourse-graph`,
+  migrationToStoredRelations: `${ROAM_DOCS_BASE_URL}/guides/migration-to-stored-relations`,
+  storedRelations: `${ROAM_DOCS_BASE_URL}/fundamentals/grammar/stored-relations`,
+  grammarNodes: `${ROAM_DOCS_BASE_URL}/fundamentals/grammar/nodes`,
+  discourseContextOverlay: `${ROAM_DOCS_BASE_URL}/guides/exploring-discourse-graph/discourse-context-overlay`,
+  discourseAttributes: `${ROAM_DOCS_BASE_URL}/guides/exploring-discourse-graph/discourse-attributes`,
+} as const;
+
+export const withDocsLink = (
+  description: React.ReactNode,
+  href: string,
+): React.ReactNode => (
+  <>
+    {description}{" "}
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      onClick={(event) => event.stopPropagation()}
+      onMouseDown={(event) => event.stopPropagation()}
+    >
+      See more.
+    </a>
+  </>
+);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -342,8 +342,8 @@ importers:
         specifier: 3.5.2
         version: 3.5.2(react@18.2.0)
       roamjs-components:
-        specifier: 0.88.0
-        version: 0.88.0(6fc269b31b2749e4d441ca378d1de710)
+        specifier: 0.88.1
+        version: 0.88.1(f3dd466ad63c875d7b4d2c35ecf33e51)
       tldraw:
         specifier: 2.4.6
         version: 2.4.6(patch_hash=56e196052862c9a58a11b43e5e121384cd1d6548416afa0f16e9fbfbf0e4080d)(@types/react-dom@18.2.17)(@types/react@18.2.21)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -395,7 +395,7 @@ importers:
         version: 0.17.14
       tailwindcss:
         specifier: ^3.4.17
-        version: 3.4.17(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.5.4))
+        version: 3.4.17(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.9.3))
       tsx:
         specifier: ^4.19.2
         version: 4.20.5
@@ -653,10 +653,10 @@ importers:
         version: link:../typescript-config
       tailwindcss:
         specifier: ^3.4.1
-        version: 3.4.17(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.5.4))
+        version: 3.4.17(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.9.3))
       tailwindcss-animate:
         specifier: ^1.0.7
-        version: 1.0.7(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.5.4)))
+        version: 1.0.7(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.9.3)))
 
   packages/types: {}
 
@@ -10148,8 +10148,8 @@ packages:
     deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
-  roamjs-components@0.88.0:
-    resolution: {integrity: sha512-61IpHBWxE3ItCZuXtLzqSgyfLu41A8MQIkapmPj13hSHYYSIj8dIxGfD9E9x2Exh97fmWDPQc4GOuVZoE5owEw==}
+  roamjs-components@0.88.1:
+    resolution: {integrity: sha512-AnL+30xUDRKPfmoUQyS5FTAEUwNAGzqyTYTNzDzDZbD9bYSJCguS43eOwUYXI66gAHYgul4xiZuUtNWxKwmLpg==}
     engines: {node: '>=16.0.0', npm: '>=7.0.0'}
     hasBin: true
     peerDependencies:
@@ -15831,22 +15831,22 @@ snapshots:
 
   '@rushstack/eslint-patch@1.12.0': {}
 
-  '@samepage/scripts@0.74.5(@aws-sdk/client-lambda@3.882.0)(@aws-sdk/client-s3@3.882.0)(@samepage/testing@0.74.5(@playwright/test@1.29.0)(@testing-library/react@16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.2.17)(@types/react@18.2.21)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1))(@types/jsdom@20.0.1)(c8@7.14.0)(debug@4.4.3)(dotenv@16.6.1)(jsdom@20.0.3)(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.5.4)))(archiver@5.3.2)(axios@0.27.2(debug@4.4.3))(debug@4.4.3)(dotenv@16.6.1)(esbuild@0.17.14)(patch-package@6.5.1)(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.5.4)))(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.5.4))(zod@3.25.76)':
+  '@samepage/scripts@0.74.5(@aws-sdk/client-lambda@3.882.0)(@aws-sdk/client-s3@3.882.0)(@samepage/testing@0.74.5(@playwright/test@1.29.0)(@testing-library/react@16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.2.17)(@types/react@18.2.21)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1))(@types/jsdom@20.0.1)(c8@7.14.0)(debug@4.4.3)(dotenv@16.6.1)(jsdom@20.0.3)(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.9.3)))(archiver@5.3.2)(axios@0.27.2(debug@4.4.3))(debug@4.4.3)(dotenv@16.6.1)(esbuild@0.17.14)(patch-package@6.5.1)(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.9.3)))(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.9.3))(zod@3.25.76)':
     dependencies:
       '@aws-sdk/client-lambda': 3.882.0
       '@aws-sdk/client-s3': 3.882.0
-      '@samepage/testing': 0.74.5(@playwright/test@1.29.0)(@testing-library/react@16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.2.17)(@types/react@18.2.21)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1))(@types/jsdom@20.0.1)(c8@7.14.0)(debug@4.4.3)(dotenv@16.6.1)(jsdom@20.0.3)(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.5.4))
+      '@samepage/testing': 0.74.5(@playwright/test@1.29.0)(@testing-library/react@16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.2.17)(@types/react@18.2.21)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1))(@types/jsdom@20.0.1)(c8@7.14.0)(debug@4.4.3)(dotenv@16.6.1)(jsdom@20.0.3)(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.9.3))
       archiver: 5.3.2
       axios: 0.27.2(debug@4.4.3)
       debug: 4.4.3
       dotenv: 16.6.1
       esbuild: 0.17.14
       patch-package: 6.5.1
-      tailwindcss: 3.4.17(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.5.4))
-      ts-node: 10.9.2(@types/node@20.19.13)(typescript@5.5.4)
+      tailwindcss: 3.4.17(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.9.3))
+      ts-node: 10.9.2(@types/node@20.19.13)(typescript@5.9.3)
       zod: 3.25.76
 
-  '@samepage/testing@0.74.5(@playwright/test@1.29.0)(@testing-library/react@16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.2.17)(@types/react@18.2.21)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1))(@types/jsdom@20.0.1)(c8@7.14.0)(debug@4.4.3)(dotenv@16.6.1)(jsdom@20.0.3)(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.5.4))':
+  '@samepage/testing@0.74.5(@playwright/test@1.29.0)(@testing-library/react@16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.2.17)(@types/react@18.2.21)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1))(@types/jsdom@20.0.1)(c8@7.14.0)(debug@4.4.3)(dotenv@16.6.1)(jsdom@20.0.3)(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.9.3))':
     dependencies:
       '@playwright/test': 1.29.0
       '@testing-library/react': 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.2.17)(@types/react@18.2.21)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -15856,7 +15856,7 @@ snapshots:
       debug: 4.4.3
       dotenv: 16.6.1
       jsdom: 20.0.3
-      ts-node: 10.9.2(@types/node@20.19.13)(typescript@5.5.4)
+      ts-node: 10.9.2(@types/node@20.19.13)(typescript@5.9.3)
 
   '@selderee/plugin-htmlparser2@0.11.0':
     dependencies:
@@ -22540,6 +22540,14 @@ snapshots:
       postcss: 8.5.6
       ts-node: 10.9.2(@types/node@20.19.13)(typescript@5.5.4)
 
+  postcss-load-config@4.0.2(postcss@8.5.6)(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.9.3)):
+    dependencies:
+      lilconfig: 3.1.3
+      yaml: 2.8.1
+    optionalDependencies:
+      postcss: 8.5.6
+      ts-node: 10.9.2(@types/node@20.19.13)(typescript@5.9.3)
+
   postcss-nested@6.2.0(postcss@8.5.6):
     dependencies:
       postcss: 8.5.6
@@ -23489,12 +23497,12 @@ snapshots:
     dependencies:
       glob: 7.2.3
 
-  roamjs-components@0.88.0(6fc269b31b2749e4d441ca378d1de710):
+  roamjs-components@0.88.1(f3dd466ad63c875d7b4d2c35ecf33e51):
     dependencies:
       '@blueprintjs/core': 3.50.4(patch_hash=51c5847e0a73a1be0cc263036ff64d8fada46f3b65831ed938dbca5eecf3edc0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@blueprintjs/datetime': 3.23.14(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@blueprintjs/select': 3.19.1(patch_hash=5b2821b0bf7274e9b64d7824648c596b9e73c61f421d699a6d4c494f12f62355)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@samepage/scripts': 0.74.5(@aws-sdk/client-lambda@3.882.0)(@aws-sdk/client-s3@3.882.0)(@samepage/testing@0.74.5(@playwright/test@1.29.0)(@testing-library/react@16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.2.17)(@types/react@18.2.21)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1))(@types/jsdom@20.0.1)(c8@7.14.0)(debug@4.4.3)(dotenv@16.6.1)(jsdom@20.0.3)(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.5.4)))(archiver@5.3.2)(axios@0.27.2(debug@4.4.3))(debug@4.4.3)(dotenv@16.6.1)(esbuild@0.17.14)(patch-package@6.5.1)(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.5.4)))(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.5.4))(zod@3.25.76)
+      '@samepage/scripts': 0.74.5(@aws-sdk/client-lambda@3.882.0)(@aws-sdk/client-s3@3.882.0)(@samepage/testing@0.74.5(@playwright/test@1.29.0)(@testing-library/react@16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.2.17)(@types/react@18.2.21)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1))(@types/jsdom@20.0.1)(c8@7.14.0)(debug@4.4.3)(dotenv@16.6.1)(jsdom@20.0.3)(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.9.3)))(archiver@5.3.2)(axios@0.27.2(debug@4.4.3))(debug@4.4.3)(dotenv@16.6.1)(esbuild@0.17.14)(patch-package@6.5.1)(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.9.3)))(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.9.3))(zod@3.25.76)
       '@types/crypto-js': 4.1.1
       '@types/cytoscape': 3.21.9
       '@types/file-saver': 2.0.5
@@ -24290,6 +24298,10 @@ snapshots:
     dependencies:
       tailwindcss: 3.4.17(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.5.4))
 
+  tailwindcss-animate@1.0.7(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.9.3))):
+    dependencies:
+      tailwindcss: 3.4.17(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.9.3))
+
   tailwindcss@3.4.17(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.5.4)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
@@ -24310,6 +24322,33 @@ snapshots:
       postcss-import: 15.1.0(postcss@8.5.6)
       postcss-js: 4.0.1(postcss@8.5.6)
       postcss-load-config: 4.0.2(postcss@8.5.6)(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.5.4))
+      postcss-nested: 6.2.0(postcss@8.5.6)
+      postcss-selector-parser: 6.1.2
+      resolve: 1.22.10
+      sucrase: 3.35.0
+    transitivePeerDependencies:
+      - ts-node
+
+  tailwindcss@3.4.17(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.9.3)):
+    dependencies:
+      '@alloc/quick-lru': 5.2.0
+      arg: 5.0.2
+      chokidar: 3.6.0
+      didyoumean: 1.2.2
+      dlv: 1.1.3
+      fast-glob: 3.3.3
+      glob-parent: 6.0.2
+      is-glob: 4.0.3
+      jiti: 1.21.7
+      lilconfig: 3.1.3
+      micromatch: 4.0.8
+      normalize-path: 3.0.0
+      object-hash: 3.0.0
+      picocolors: 1.1.1
+      postcss: 8.5.6
+      postcss-import: 15.1.0(postcss@8.5.6)
+      postcss-js: 4.0.1(postcss@8.5.6)
+      postcss-load-config: 4.0.2(postcss@8.5.6)(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.9.3))
       postcss-nested: 6.2.0(postcss@8.5.6)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.10
@@ -24570,6 +24609,24 @@ snapshots:
       diff: 4.0.2
       make-error: 1.3.6
       typescript: 5.5.4
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+
+  ts-node@10.9.2(@types/node@20.19.13)(typescript@5.9.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 20.19.13
+      acorn: 8.15.0
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.9.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -342,8 +342,8 @@ importers:
         specifier: 3.5.2
         version: 3.5.2(react@18.2.0)
       roamjs-components:
-        specifier: 0.87.0
-        version: 0.87.0(f3dd466ad63c875d7b4d2c35ecf33e51)
+        specifier: 0.88.0
+        version: 0.88.0(6fc269b31b2749e4d441ca378d1de710)
       tldraw:
         specifier: 2.4.6
         version: 2.4.6(patch_hash=56e196052862c9a58a11b43e5e121384cd1d6548416afa0f16e9fbfbf0e4080d)(@types/react-dom@18.2.17)(@types/react@18.2.21)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -395,7 +395,7 @@ importers:
         version: 0.17.14
       tailwindcss:
         specifier: ^3.4.17
-        version: 3.4.17(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.9.3))
+        version: 3.4.17(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.5.4))
       tsx:
         specifier: ^4.19.2
         version: 4.20.5
@@ -653,10 +653,10 @@ importers:
         version: link:../typescript-config
       tailwindcss:
         specifier: ^3.4.1
-        version: 3.4.17(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.9.3))
+        version: 3.4.17(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.5.4))
       tailwindcss-animate:
         specifier: ^1.0.7
-        version: 1.0.7(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.9.3)))
+        version: 1.0.7(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.5.4)))
 
   packages/types: {}
 
@@ -5822,7 +5822,7 @@ packages:
   basic-ftp@5.0.5:
     resolution: {integrity: sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==}
     engines: {node: '>=10.0.0'}
-    deprecated: Security vulnerability fixed in 5.2.1, please upgrade
+    deprecated: Security vulnerability fixed in 5.2.0, please upgrade
 
   before-after-hook@3.0.2:
     resolution: {integrity: sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A==}
@@ -10148,8 +10148,8 @@ packages:
     deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
-  roamjs-components@0.87.0:
-    resolution: {integrity: sha512-WRy/1xN2CacPzcaAl79pTM1ZqTDWQ7HyGM2Q/fb8m59QCXbLk3+jianOnMNATk4j8xahlJh3WyZzYQOsGwOuzg==}
+  roamjs-components@0.88.0:
+    resolution: {integrity: sha512-61IpHBWxE3ItCZuXtLzqSgyfLu41A8MQIkapmPj13hSHYYSIj8dIxGfD9E9x2Exh97fmWDPQc4GOuVZoE5owEw==}
     engines: {node: '>=16.0.0', npm: '>=7.0.0'}
     hasBin: true
     peerDependencies:
@@ -15831,22 +15831,22 @@ snapshots:
 
   '@rushstack/eslint-patch@1.12.0': {}
 
-  '@samepage/scripts@0.74.5(@aws-sdk/client-lambda@3.882.0)(@aws-sdk/client-s3@3.882.0)(@samepage/testing@0.74.5(@playwright/test@1.29.0)(@testing-library/react@16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.2.17)(@types/react@18.2.21)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1))(@types/jsdom@20.0.1)(c8@7.14.0)(debug@4.4.3)(dotenv@16.6.1)(jsdom@20.0.3)(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.9.3)))(archiver@5.3.2)(axios@0.27.2(debug@4.4.3))(debug@4.4.3)(dotenv@16.6.1)(esbuild@0.17.14)(patch-package@6.5.1)(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.9.3)))(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.9.3))(zod@3.25.76)':
+  '@samepage/scripts@0.74.5(@aws-sdk/client-lambda@3.882.0)(@aws-sdk/client-s3@3.882.0)(@samepage/testing@0.74.5(@playwright/test@1.29.0)(@testing-library/react@16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.2.17)(@types/react@18.2.21)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1))(@types/jsdom@20.0.1)(c8@7.14.0)(debug@4.4.3)(dotenv@16.6.1)(jsdom@20.0.3)(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.5.4)))(archiver@5.3.2)(axios@0.27.2(debug@4.4.3))(debug@4.4.3)(dotenv@16.6.1)(esbuild@0.17.14)(patch-package@6.5.1)(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.5.4)))(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.5.4))(zod@3.25.76)':
     dependencies:
       '@aws-sdk/client-lambda': 3.882.0
       '@aws-sdk/client-s3': 3.882.0
-      '@samepage/testing': 0.74.5(@playwright/test@1.29.0)(@testing-library/react@16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.2.17)(@types/react@18.2.21)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1))(@types/jsdom@20.0.1)(c8@7.14.0)(debug@4.4.3)(dotenv@16.6.1)(jsdom@20.0.3)(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.9.3))
+      '@samepage/testing': 0.74.5(@playwright/test@1.29.0)(@testing-library/react@16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.2.17)(@types/react@18.2.21)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1))(@types/jsdom@20.0.1)(c8@7.14.0)(debug@4.4.3)(dotenv@16.6.1)(jsdom@20.0.3)(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.5.4))
       archiver: 5.3.2
       axios: 0.27.2(debug@4.4.3)
       debug: 4.4.3
       dotenv: 16.6.1
       esbuild: 0.17.14
       patch-package: 6.5.1
-      tailwindcss: 3.4.17(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.9.3))
-      ts-node: 10.9.2(@types/node@20.19.13)(typescript@5.9.3)
+      tailwindcss: 3.4.17(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.5.4))
+      ts-node: 10.9.2(@types/node@20.19.13)(typescript@5.5.4)
       zod: 3.25.76
 
-  '@samepage/testing@0.74.5(@playwright/test@1.29.0)(@testing-library/react@16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.2.17)(@types/react@18.2.21)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1))(@types/jsdom@20.0.1)(c8@7.14.0)(debug@4.4.3)(dotenv@16.6.1)(jsdom@20.0.3)(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.9.3))':
+  '@samepage/testing@0.74.5(@playwright/test@1.29.0)(@testing-library/react@16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.2.17)(@types/react@18.2.21)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1))(@types/jsdom@20.0.1)(c8@7.14.0)(debug@4.4.3)(dotenv@16.6.1)(jsdom@20.0.3)(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.5.4))':
     dependencies:
       '@playwright/test': 1.29.0
       '@testing-library/react': 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.2.17)(@types/react@18.2.21)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -15856,7 +15856,7 @@ snapshots:
       debug: 4.4.3
       dotenv: 16.6.1
       jsdom: 20.0.3
-      ts-node: 10.9.2(@types/node@20.19.13)(typescript@5.9.3)
+      ts-node: 10.9.2(@types/node@20.19.13)(typescript@5.5.4)
 
   '@selderee/plugin-htmlparser2@0.11.0':
     dependencies:
@@ -22540,14 +22540,6 @@ snapshots:
       postcss: 8.5.6
       ts-node: 10.9.2(@types/node@20.19.13)(typescript@5.5.4)
 
-  postcss-load-config@4.0.2(postcss@8.5.6)(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.9.3)):
-    dependencies:
-      lilconfig: 3.1.3
-      yaml: 2.8.1
-    optionalDependencies:
-      postcss: 8.5.6
-      ts-node: 10.9.2(@types/node@20.19.13)(typescript@5.9.3)
-
   postcss-nested@6.2.0(postcss@8.5.6):
     dependencies:
       postcss: 8.5.6
@@ -23497,12 +23489,12 @@ snapshots:
     dependencies:
       glob: 7.2.3
 
-  roamjs-components@0.87.0(f3dd466ad63c875d7b4d2c35ecf33e51):
+  roamjs-components@0.88.0(6fc269b31b2749e4d441ca378d1de710):
     dependencies:
       '@blueprintjs/core': 3.50.4(patch_hash=51c5847e0a73a1be0cc263036ff64d8fada46f3b65831ed938dbca5eecf3edc0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@blueprintjs/datetime': 3.23.14(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@blueprintjs/select': 3.19.1(patch_hash=5b2821b0bf7274e9b64d7824648c596b9e73c61f421d699a6d4c494f12f62355)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@samepage/scripts': 0.74.5(@aws-sdk/client-lambda@3.882.0)(@aws-sdk/client-s3@3.882.0)(@samepage/testing@0.74.5(@playwright/test@1.29.0)(@testing-library/react@16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.2.17)(@types/react@18.2.21)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1))(@types/jsdom@20.0.1)(c8@7.14.0)(debug@4.4.3)(dotenv@16.6.1)(jsdom@20.0.3)(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.9.3)))(archiver@5.3.2)(axios@0.27.2(debug@4.4.3))(debug@4.4.3)(dotenv@16.6.1)(esbuild@0.17.14)(patch-package@6.5.1)(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.9.3)))(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.9.3))(zod@3.25.76)
+      '@samepage/scripts': 0.74.5(@aws-sdk/client-lambda@3.882.0)(@aws-sdk/client-s3@3.882.0)(@samepage/testing@0.74.5(@playwright/test@1.29.0)(@testing-library/react@16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.2.17)(@types/react@18.2.21)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1))(@types/jsdom@20.0.1)(c8@7.14.0)(debug@4.4.3)(dotenv@16.6.1)(jsdom@20.0.3)(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.5.4)))(archiver@5.3.2)(axios@0.27.2(debug@4.4.3))(debug@4.4.3)(dotenv@16.6.1)(esbuild@0.17.14)(patch-package@6.5.1)(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.5.4)))(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.5.4))(zod@3.25.76)
       '@types/crypto-js': 4.1.1
       '@types/cytoscape': 3.21.9
       '@types/file-saver': 2.0.5
@@ -24298,10 +24290,6 @@ snapshots:
     dependencies:
       tailwindcss: 3.4.17(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.5.4))
 
-  tailwindcss-animate@1.0.7(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.9.3))):
-    dependencies:
-      tailwindcss: 3.4.17(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.9.3))
-
   tailwindcss@3.4.17(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.5.4)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
@@ -24322,33 +24310,6 @@ snapshots:
       postcss-import: 15.1.0(postcss@8.5.6)
       postcss-js: 4.0.1(postcss@8.5.6)
       postcss-load-config: 4.0.2(postcss@8.5.6)(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.5.4))
-      postcss-nested: 6.2.0(postcss@8.5.6)
-      postcss-selector-parser: 6.1.2
-      resolve: 1.22.10
-      sucrase: 3.35.0
-    transitivePeerDependencies:
-      - ts-node
-
-  tailwindcss@3.4.17(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.9.3)):
-    dependencies:
-      '@alloc/quick-lru': 5.2.0
-      arg: 5.0.2
-      chokidar: 3.6.0
-      didyoumean: 1.2.2
-      dlv: 1.1.3
-      fast-glob: 3.3.3
-      glob-parent: 6.0.2
-      is-glob: 4.0.3
-      jiti: 1.21.7
-      lilconfig: 3.1.3
-      micromatch: 4.0.8
-      normalize-path: 3.0.0
-      object-hash: 3.0.0
-      picocolors: 1.1.1
-      postcss: 8.5.6
-      postcss-import: 15.1.0(postcss@8.5.6)
-      postcss-js: 4.0.1(postcss@8.5.6)
-      postcss-load-config: 4.0.2(postcss@8.5.6)(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.9.3))
       postcss-nested: 6.2.0(postcss@8.5.6)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.10
@@ -24609,24 +24570,6 @@ snapshots:
       diff: 4.0.2
       make-error: 1.3.6
       typescript: 5.5.4
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-
-  ts-node@10.9.2(@types/node@20.19.13)(typescript@5.9.3):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.11
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 20.19.13
-      acorn: 8.15.0
-      acorn-walk: 8.3.4
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 5.9.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 


### PR DESCRIPTION
## Summary
- Bump `roamjs-components` to `0.88.0` so tooltip descriptions can render JSX links.
- Add a shared Roam docs helper and append `See more.` links to matching settings across Roam config screens.
- Cover the main settings surfaces that already have corresponding docs: node creation, tagging, querying, export, stored relations, discourse context, and node grammar.

## Testing
- `pnpm --filter roam check-types`
- `pnpm --filter roam build`
- `pnpm --filter roam lint` (passes with existing repo warnings, no new errors)