### PR TITLE
ENG-1798 Fix website docs search

### DIFF
--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -6,8 +6,8 @@
   "license": "Apache-2.0",
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
-    "postbuild": "node ./scripts/build-docs-search-index.mjs",
+    "build": "next build && node ./scripts/build-docs-search-index.mjs",
+    "build:search": "node ./scripts/build-docs-search-index.mjs",
     "start": "next start",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/apps/website/scripts/build-docs-search-index.test.mjs
+++ b/apps/website/scripts/build-docs-search-index.test.mjs
@@ -1,5 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import fs from "node:fs";
 import path from "node:path";
 import {
   markdownToSearchText,
@@ -76,5 +77,27 @@ void test("searchFiltersFromContentFile scopes docs records by platform", () => 
       path.join(process.cwd(), "content", "index.mdx"),
     ),
     undefined,
+  );
+});
+
+void test("build configuration includes generated Pagefind assets", () => {
+  const packageJson = JSON.parse(fs.readFileSync("package.json", "utf8"));
+  assert.match(
+    packageJson.scripts.build,
+    /build-docs-search-index\.mjs/u,
+    "website build must generate the Pagefind index when run by Turbo",
+  );
+  assert.doesNotMatch(
+    packageJson.scripts.postbuild ?? "",
+    /build-docs-search-index\.mjs/u,
+    "Turbo does not run package postbuild hooks for this task",
+  );
+
+  const turboJson = JSON.parse(
+    fs.readFileSync(path.join("..", "..", "turbo.json"), "utf8"),
+  );
+  assert.ok(
+    turboJson.tasks.build.outputs.includes("public/_pagefind/**"),
+    "Turbo must cache and restore the generated Pagefind assets",
   );
 });

--- a/apps/website/scripts/build-docs-search-index.test.mjs
+++ b/apps/website/scripts/build-docs-search-index.test.mjs
@@ -8,6 +8,61 @@ import {
   searchFiltersFromContentFile,
 } from "./build-docs-search-index.mjs";
 
+/**
+ * @typedef {{ scripts: { build: string, postbuild?: string } }} WebsitePackageJson
+ * @typedef {{ tasks: { build: { outputs: string[] } } }} TurboJson
+ */
+
+/**
+ * @param {unknown} value
+ * @returns {value is Record<string, unknown>}
+ */
+const isRecord = (value) =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+/**
+ * @param {unknown} value
+ * @returns {value is string[]}
+ */
+const isStringArray = (value) =>
+  Array.isArray(value) && value.every((item) => typeof item === "string");
+
+/**
+ * @param {string} filePath
+ * @returns {unknown}
+ */
+const readJsonFile = (filePath) =>
+  /** @type {unknown} */ (JSON.parse(fs.readFileSync(filePath, "utf8")));
+
+/**
+ * @param {unknown} value
+ * @returns {WebsitePackageJson}
+ */
+const assertWebsitePackageJson = (value) => {
+  assert.ok(isRecord(value));
+  assert.ok(isRecord(value.scripts));
+  assert.equal(typeof value.scripts.build, "string");
+  assert.ok(
+    value.scripts.postbuild === undefined ||
+      typeof value.scripts.postbuild === "string",
+  );
+
+  return /** @type {WebsitePackageJson} */ (value);
+};
+
+/**
+ * @param {unknown} value
+ * @returns {TurboJson}
+ */
+const assertTurboJson = (value) => {
+  assert.ok(isRecord(value));
+  assert.ok(isRecord(value.tasks));
+  assert.ok(isRecord(value.tasks.build));
+  assert.ok(isStringArray(value.tasks.build.outputs));
+
+  return /** @type {TurboJson} */ (value);
+};
+
 void test("routePathFromContentFile maps content files to canonical docs routes", () => {
   assert.equal(
     routePathFromContentFile(
@@ -81,7 +136,7 @@ void test("searchFiltersFromContentFile scopes docs records by platform", () => 
 });
 
 void test("build configuration includes generated Pagefind assets", () => {
-  const packageJson = JSON.parse(fs.readFileSync("package.json", "utf8"));
+  const packageJson = assertWebsitePackageJson(readJsonFile("package.json"));
   assert.match(
     packageJson.scripts.build,
     /build-docs-search-index\.mjs/u,
@@ -93,8 +148,8 @@ void test("build configuration includes generated Pagefind assets", () => {
     "Turbo does not run package postbuild hooks for this task",
   );
 
-  const turboJson = JSON.parse(
-    fs.readFileSync(path.join("..", "..", "turbo.json"), "utf8"),
+  const turboJson = assertTurboJson(
+    readJsonFile(path.join("..", "..", "turbo.json")),
   );
   assert.ok(
     turboJson.tasks.build.outputs.includes("public/_pagefind/**"),

--- a/turbo.json
+++ b/turbo.json
@@ -48,7 +48,13 @@
       "env": ["ROAM_BUILD_SCRIPT"],
       "dependsOn": ["@repo/database#genenv"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
-      "outputs": [".next/**", "!.next/cache/**", "dist/**", "src/dbTypes.ts"]
+      "outputs": [
+        ".next/**",
+        "!.next/cache/**",
+        "dist/**",
+        "public/_pagefind/**",
+        "src/dbTypes.ts"
+      ]
     },
     "build-schema": {
       "inputs": ["$TURBO_DEFAULT$", ".env*"],


### PR DESCRIPTION
## Summary
- Move docs search index generation into the website `build` script so Turbo builds always produce the Pagefind assets.
- Add `public/_pagefind/**` to Turbo build outputs so cached builds restore the search bundle correctly.
- Add a regression test that guards the build wiring and output config.

## Testing
- `node --test apps/website/scripts/build-docs-search-index.test.mjs`
- Verified the website build path generates `public/_pagefind/pagefind.js` during a local production build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined the build process by consolidating docs search index generation into the main build step.
  * Refined build task output configuration to improve caching efficiency.
  * Added validation tests to ensure build configuration integrity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DiscourseGraphs/discourse-graph/pull/1081?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->