### PR TITLE
ENG-1625 Add command to convert active page to discourse node

### DIFF
--- a/apps/obsidian/src/utils/createNode.ts
+++ b/apps/obsidian/src/utils/createNode.ts
@@ -1,10 +1,4 @@
-import {
-  Editor,
-  FrontMatterInfo,
-  MetadataCache,
-  Notice,
-  TFile,
-} from "obsidian";
+import { Editor, Notice, TFile } from "obsidian";
 import { DiscourseNode } from "~/types";
 import { getDiscourseNodeFormatExpression } from "./getDiscourseNodeFormatExpression";
 import { checkInvalidChars } from "./validateNodeType";
@@ -87,18 +81,16 @@ export const createDiscourseNodeFile = async ({
     }
 
     const notice = new DocumentFragment();
-    const spanEl = notice.createEl("span", {
-      text: "Created discourse node: ",
-    });
-
-    const linkEl = spanEl.createEl("a", {
-      text: formattedNodeName,
-      cls: "clickable-link",
-    });
-    linkEl.style.textDecoration = "underline";
-    linkEl.style.cursor = "pointer";
+    const linkEl = notice
+      .createEl("span", {
+        text: "Created discourse node: ",
+      })
+      .createEl("a", {
+        text: formattedNodeName,
+        cls: "dg-clickable-link",
+      });
     linkEl.addEventListener("click", () => {
-      app.workspace.openLinkText(formattedNodeName, "", false);
+      void app.workspace.openLinkText(formattedNodeName, "", false);
     });
 
     new Notice(notice, 10000);
@@ -189,16 +181,14 @@ export const convertPageToDiscourseNode = async ({
       destinationFile.path !== file.path
     ) {
       const notice = new DocumentFragment();
-      const spanEl = notice.createEl("span", {
-        text: "Destination file already exists at ",
-      });
-
-      const linkEl = spanEl.createEl("a", {
-        text: destinationFile.path,
-        cls: "clickable-link",
-      });
-      linkEl.style.textDecoration = "underline";
-      linkEl.style.cursor = "pointer";
+      const linkEl = notice
+        .createEl("span", {
+          text: "Destination file already exists at ",
+        })
+        .createEl("a", {
+          text: destinationFile.path,
+          cls: "dg-clickable-link",
+        });
       linkEl.addEventListener("click", () => {
         void plugin.app.workspace.openLinkText(destinationFile.path, "", false);
       });

--- a/apps/obsidian/src/utils/createNode.ts
+++ b/apps/obsidian/src/utils/createNode.ts
@@ -1,4 +1,10 @@
-import { Editor, Notice, TFile } from "obsidian";
+import {
+  Editor,
+  FrontMatterInfo,
+  MetadataCache,
+  Notice,
+  TFile,
+} from "obsidian";
 import { DiscourseNode } from "~/types";
 import { getDiscourseNodeFormatExpression } from "./getDiscourseNodeFormatExpression";
 import { checkInvalidChars } from "./validateNodeType";
@@ -165,18 +171,10 @@ export const convertPageToDiscourseNode = async ({
       return;
     }
 
-    await plugin.app.fileManager.processFrontMatter(file, (fm) => {
-      fm.nodeTypeId = nodeType.id;
-    });
-
     let newPath = "";
     const folderPath =
       nodeType.folderPath?.trim() || plugin.settings.nodesFolderPath.trim();
     if (folderPath) {
-      const folderExists = plugin.app.vault.getAbstractFileByPath(folderPath);
-      if (!folderExists) {
-        await plugin.app.vault.createFolder(folderPath);
-      }
       newPath = `${folderPath}/${formattedNodeName}.md`;
     } else {
       const dirPath = file.parent?.path ?? "";
@@ -184,7 +182,47 @@ export const convertPageToDiscourseNode = async ({
         ? `${dirPath}/${formattedNodeName}.md`
         : `${formattedNodeName}.md`;
     }
-    await plugin.app.fileManager.renameFile(file, newPath);
+
+    const destinationFile = plugin.app.vault.getAbstractFileByPath(newPath);
+    if (
+      destinationFile instanceof TFile &&
+      destinationFile.path !== file.path
+    ) {
+      const notice = new DocumentFragment();
+      const spanEl = notice.createEl("span", {
+        text: "Destination file already exists at ",
+      });
+
+      const linkEl = spanEl.createEl("a", {
+        text: destinationFile.path,
+        cls: "clickable-link",
+      });
+      linkEl.style.textDecoration = "underline";
+      linkEl.style.cursor = "pointer";
+      linkEl.addEventListener("click", () => {
+        void plugin.app.workspace.openLinkText(destinationFile.path, "", false);
+      });
+
+      new Notice(notice, 5000);
+      return;
+    }
+
+    if (file.path !== newPath) {
+      if (folderPath) {
+        const folderExists = plugin.app.vault.getAbstractFileByPath(folderPath);
+        if (!folderExists) {
+          await plugin.app.vault.createFolder(folderPath);
+        }
+      }
+      await plugin.app.fileManager.renameFile(file, newPath);
+    }
+
+    await plugin.app.fileManager.processFrontMatter(
+      file,
+      (fm: Record<string, unknown>) => {
+        fm.nodeTypeId = nodeType.id;
+      },
+    );
 
     new Notice("Converted page to discourse node", 10000);
   } catch (error) {

--- a/apps/obsidian/src/utils/createNode.ts
+++ b/apps/obsidian/src/utils/createNode.ts
@@ -81,14 +81,13 @@ export const createDiscourseNodeFile = async ({
     }
 
     const notice = new DocumentFragment();
-    const linkEl = notice
-      .createEl("span", {
-        text: "Created discourse node: ",
-      })
-      .createEl("a", {
-        text: formattedNodeName,
-        cls: "dg-clickable-link",
-      });
+    const wrapper = document.createElement("span");
+    wrapper.textContent = "Created discourse node: ";
+    const linkEl = document.createElement("a");
+    linkEl.textContent = formattedNodeName;
+    linkEl.classList.add("dg-clickable-link");
+    wrapper.appendChild(linkEl);
+    notice.appendChild(wrapper);
     linkEl.addEventListener("click", () => {
       void app.workspace.openLinkText(formattedNodeName, "", false);
     });
@@ -181,14 +180,13 @@ export const convertPageToDiscourseNode = async ({
       destinationFile.path !== file.path
     ) {
       const notice = new DocumentFragment();
-      const linkEl = notice
-        .createEl("span", {
-          text: "Destination file already exists at ",
-        })
-        .createEl("a", {
-          text: destinationFile.path,
-          cls: "dg-clickable-link",
-        });
+      const wrapper = document.createElement("span");
+      wrapper.textContent = "Destination file already exists at ";
+      const linkEl = document.createElement("a");
+      linkEl.textContent = destinationFile.path;
+      linkEl.classList.add("dg-clickable-link");
+      wrapper.appendChild(linkEl);
+      notice.appendChild(wrapper);
       linkEl.addEventListener("click", () => {
         void plugin.app.workspace.openLinkText(destinationFile.path, "", false);
       });

--- a/apps/obsidian/src/utils/registerCommands.ts
+++ b/apps/obsidian/src/utils/registerCommands.ts
@@ -89,11 +89,17 @@ export const registerCommands = (plugin: DiscourseGraphPlugin) => {
 
       if (!checking) {
         const fileCache = plugin.app.metadataCache.getFileCache(file);
-        const fileNodeType = fileCache?.frontmatter?.nodeTypeId;
+        const frontmatter = fileCache?.frontmatter as
+          | Record<string, unknown>
+          | undefined;
+        const fileNodeTypeId =
+          typeof frontmatter?.nodeTypeId === "string"
+            ? frontmatter.nodeTypeId
+            : undefined;
         const isAlreadyDiscourseNode =
-          !!fileNodeType &&
+          !!fileNodeTypeId &&
           plugin.settings.nodeTypes.some(
-            (nodeType) => nodeType.id === fileNodeType,
+            (nodeType) => nodeType.id === fileNodeTypeId,
           );
 
         if (isAlreadyDiscourseNode) {

--- a/apps/obsidian/src/utils/registerCommands.ts
+++ b/apps/obsidian/src/utils/registerCommands.ts
@@ -4,7 +4,7 @@ import { NodeTypeModal } from "~/components/NodeTypeModal";
 import ModifyNodeModal from "~/components/ModifyNodeModal";
 import { BulkIdentifyDiscourseNodesModal } from "~/components/BulkIdentifyDiscourseNodesModal";
 import { ImportNodesModal } from "~/components/ImportNodesModal";
-import { createDiscourseNode } from "./createNode";
+import { convertPageToDiscourseNode, createDiscourseNode } from "./createNode";
 import { refreshAllImportedFiles } from "./importNodes";
 import { VIEW_TYPE_MARKDOWN, VIEW_TYPE_TLDRAW_DG_PREVIEW } from "~/constants";
 import { createCanvas } from "~/components/canvas/utils/tldraw";
@@ -76,6 +76,49 @@ export const registerCommands = (plugin: DiscourseGraphPlugin) => {
         initialTitle: selectedText,
         onSubmit: createModifyNodeModalSubmitHandler(plugin, editor),
       }).open();
+    },
+  });
+
+  plugin.addCommand({
+    id: "convert-current-page-to-discourse-node",
+    name: "Convert current page to discourse node",
+    checkCallback: (checking: boolean) => {
+      const activeView = plugin.app.workspace.getActiveViewOfType(MarkdownView);
+      const file = activeView?.file;
+      if (!file) return false;
+
+      if (!checking) {
+        const fileCache = plugin.app.metadataCache.getFileCache(file);
+        const fileNodeType = fileCache?.frontmatter?.nodeTypeId;
+        const isAlreadyDiscourseNode =
+          !!fileNodeType &&
+          plugin.settings.nodeTypes.some(
+            (nodeType) => nodeType.id === fileNodeType,
+          );
+
+        if (isAlreadyDiscourseNode) {
+          new Notice("Current page is already a discourse node", 3000);
+          return true;
+        }
+
+        new ModifyNodeModal(plugin.app, {
+          nodeTypes: plugin.settings.nodeTypes,
+          plugin,
+          initialTitle: file.basename,
+          // Command palette flow should mirror file-menu conversion.
+          disableExistingNodeSearch: true,
+          onSubmit: async ({ nodeType, title }) => {
+            await convertPageToDiscourseNode({
+              plugin,
+              file,
+              nodeType,
+              title,
+            });
+          },
+        }).open();
+      }
+
+      return true;
     },
   });
 

--- a/apps/obsidian/styles.css
+++ b/apps/obsidian/styles.css
@@ -35,6 +35,11 @@
   background: var(--interactive-accent-hover);
 }
 
+.dg-clickable-link {
+  text-decoration: underline;
+  cursor: pointer;
+}
+
 /* Neutralize host button styling inside our editor */
 .tldraw__editor button {
   background: transparent !important;

--- a/apps/obsidian/styles.css
+++ b/apps/obsidian/styles.css
@@ -6,16 +6,16 @@
 }
 
 .dg-h1 {
-  @apply text-3xl font-bold mb-4;
+  @apply mb-4 text-3xl font-bold;
 }
 .dg-h2 {
-  @apply text-2xl font-bold mb-3;
+  @apply mb-3 text-2xl font-bold;
 }
 .dg-h3 {
-  @apply text-xl font-semibold mb-2;
+  @apply mb-2 text-xl font-semibold;
 }
 .dg-h4 {
-  @apply text-lg font-bold mb-2;
+  @apply mb-2 text-lg font-bold;
 }
 
 .dg-create-node-button {


### PR DESCRIPTION
https://www.loom.com/share/db9c6f1c2f684755bc0c77ab8d02aeeb

## Summary
- add a single Obsidian command palette action to convert the active markdown page to a discourse node using the same `ModifyNodeModal` flow as file-menu conversion
- show `Current page is already a discourse node` when conversion is invoked on an already-converted note
- make `convertPageToDiscourseNode` convert-or-no-op by checking destination collisions before writes, so frontmatter is not mutated when rename would fail

## Test plan
- [x] `pnpm --filter @discourse-graphs/obsidian check-types`
- [x] `pnpm --filter @discourse-graphs/obsidian lint` (warnings only; no new errors)
- [x] In Obsidian, run `Convert current page to discourse node` from command palette on a normal markdown note and confirm modal conversion succeeds
- [x] In Obsidian, run the same command on an already-converted note and confirm the notice appears
- [x] In Obsidian, convert to a node whose destination file already exists and confirm no frontmatter mutation occurs


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/1089" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->