### PR TITLE
ENG-1812 Allow non-admin group members to see view group membership

### DIFF
--- a/apps/website/app/components/auth/ListGroups.tsx
+++ b/apps/website/app/components/auth/ListGroups.tsx
@@ -69,11 +69,7 @@ export const ListGroups = async () => {
             <ul className="list-inside list-disc space-y-2">
               {groupData.map((d) => (
                 <li key={d.id}>
-                  {adminData[d.id || ""] ? (
-                    <Link href={"/auth/group/" + d.id!}>{d.name}</Link>
-                  ) : (
-                    d.name
-                  )}
+                  <Link href={"/auth/group/" + d.id!}>{d.name}</Link>
                 </li>
               ))}
             </ul>

--- a/apps/website/app/components/auth/ListGroups.tsx
+++ b/apps/website/app/components/auth/ListGroups.tsx
@@ -17,7 +17,7 @@ export const ListGroups = async () => {
     if (!userData) {
       throw new Error("Not logged in.\nPlease log in from application.");
     }
-    const { name, type, id } = userData;
+    const { name, type } = userData;
     if (type === "anonymous") userName = "Space " + name;
     else if (type === "group") userName = "group " + name;
     else if (type === "person") userName = name;
@@ -29,16 +29,6 @@ export const ListGroups = async () => {
       throw new Error("Could not access Discourse Graphs");
     }
     groupData = groupResponse.data;
-    const membershipReq = await client
-      .from("group_membership")
-      .select("group_id,admin")
-      .eq("member_id", id);
-    if (membershipReq.error) {
-      internalError({
-        error: membershipReq.error,
-      });
-      throw new Error("Could not access Discourse Graphs");
-    }
   } catch (e) {
     error = e instanceof Error ? e.message : "An unknown error occured";
   }

--- a/apps/website/app/components/auth/ListGroups.tsx
+++ b/apps/website/app/components/auth/ListGroups.tsx
@@ -8,7 +8,6 @@ type GroupData = Tables<"my_groups">;
 
 export const ListGroups = async () => {
   let groupData: GroupData[] | null = null;
-  let adminData: Record<string, boolean> = {};
   let userName: string | undefined;
   let error: string | undefined;
 
@@ -40,13 +39,6 @@ export const ListGroups = async () => {
       });
       throw new Error("Could not access Discourse Graphs");
     }
-    adminData = Object.fromEntries(
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      membershipReq.data.map(({ group_id, admin }) => [
-        group_id,
-        admin || false,
-      ]),
-    );
   } catch (e) {
     error = e instanceof Error ? e.message : "An unknown error occured";
   }


### PR DESCRIPTION
https://linear.app/discourse-graphs/issue/ENG-1812/allow-non-admin-group-members-to-see-view-group-membership
https://www.loom.com/share/4a64c368bb464251a6a668cad0d98afd

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/1091" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->