### PR TITLE
ENG-1588 Fix intermittent canvas relation handle error

### DIFF
--- a/apps/roam/src/components/canvas/DiscourseRelationShape/DiscourseRelationTool.tsx
+++ b/apps/roam/src/components/canvas/DiscourseRelationShape/DiscourseRelationTool.tsx
@@ -81,6 +81,7 @@ export const createAllReferencedNodeTools = (
             this.shapeType = `${action}`;
           } else {
             this.cancelAndWarn(`Starting node must be one of ${sourceName}`);
+            return;
           }
           if (!target) {
             this.createArrowShape();
@@ -375,6 +376,7 @@ export const createAllRelationShapeTools = (
             this.cancelAndWarn(
               `Starting node must be one of ${uniqueTypes.join(", ")}`,
             );
+            return;
           }
           if (!target) {
             this.createArrowShape();

--- a/apps/roam/src/components/canvas/Tldraw.tsx
+++ b/apps/roam/src/components/canvas/Tldraw.tsx
@@ -37,7 +37,6 @@ import {
   TLAssetId,
   getHashForString,
   TLShapeId,
-  TLShape,
   TLStore,
   TLStoreWithStatus,
   useToasts,


### PR DESCRIPTION
https://www.loom.com/share/affaa6b71da145b09b283f3ecfc20c6c

## Summary
- Prevent relation tool from continuing after invalid start node warning, avoiding stale relation type state.

## Bug explanation
- The relation tool could hit an invalid start click (empty canvas / wrong node type), call `cancelAndWarn(...)`, but continue executing the rest of `onEnter`.
- Because `cancel()` doesn’t unwind the current call stack or clear `shapeType`, the tool could proceed with a stale `shapeType` from a prior valid interaction and create an arrow anyway.
- That stale arrow state later caused intermittent `expected handles for arrow` errors when tldraw attempted to resolve/update handles.
- Fix: return immediately after `cancelAndWarn(...)` in `onEnter` to stop the state machine from continuing after an invalid start.

## Context
Linear: ENG-1588

## Test plan
- Open Roam canvas
- Select relation tool
- Click empty canvas, then create relation from a valid node
- Verify no 'expected handles for arrow' error occurs

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href=\"https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/1093\" target=\"_blank\">
  <picture>
    <source media=\"(prefers-color-scheme: dark)\" srcset=\"https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1\">
    <img src=\"https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1\" alt=\"Open in Devin Review\">
  </picture>
</a>
<!-- devin-review-badge-end -->