### PR TITLE
ENG-1829 Genenv now gives invalid production URI

### DIFF
--- a/packages/database/scripts/createEnv.mts
+++ b/packages/database/scripts/createEnv.mts
@@ -108,17 +108,22 @@ const makeBranchEnv = async (vercel: Vercel, vercelToken: string) => {
 };
 
 const makeProductionEnv = async (vercel: Vercel, vercelToken: string) => {
-  const result = await vercel.deployments.getDeployments({
+  const result = await vercel.projects.getProjectDomains({
     ...baseParams,
-    projectId: projectIdOrName,
-    limit: 1,
-    target: "production",
-    state: "READY",
+    idOrName: projectIdOrName,
+    production: "true",
   });
-  if (result.deployments.length == 0) {
-    throw new Error("No production deployment found");
+  const domains = result.domains.filter(
+    (d) => !d.redirect && d.apexName.indexOf("vercel") < 0,
+  );
+  if (domains.length === 0) {
+    throw new Error("No production domains found");
   }
-  const url = result.deployments[0]!.url;
+  if (domains.length > 1) {
+    console.log(domains);
+    throw new Error("Too many production domains found");
+  }
+  const url = domains[0]!.name;
   execSync(
     `vercel -t ${vercelToken} env pull --environment production .env.production`,
   );


### PR DESCRIPTION
https://linear.app/discourse-graphs/issue/ENG-1829/genenv-now-gives-invalid-production-uri

https://www.loom.com/share/7b039a2fe3e242d4b41002fc027cc9be

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/1102" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->