### PR TITLE
Set Obsidian plugin to desktop-only to suppress mobile loading errors

### DIFF
--- a/apps/obsidian/manifest.json
+++ b/apps/obsidian/manifest.json
@@ -8,4 +8,3 @@
   "authorUrl": "https://discoursegraphs.com",
   "isDesktopOnly": true
 }
-

--- a/apps/obsidian/manifest.json
+++ b/apps/obsidian/manifest.json
@@ -6,5 +6,6 @@
   "description": "Add semantic structure to your notes with the Discourse Graph protocol.",
   "author": "Discourse Graphs",
   "authorUrl": "https://discoursegraphs.com",
-  "isDesktopOnly": false
+  "isDesktopOnly": true
 }
+


### PR DESCRIPTION
## Summary

- Sets `isDesktopOnly: true` in `apps/obsidian/manifest.json` to prevent the plugin from loading on mobile devices
- The plugin currently relies on desktop-specific APIs (CodeMirror 6 editor extensions, tldraw canvas views, DOM event handlers for drag-and-drop) that cause errors when Obsidian attempts to load it on mobile
- This is intended as a stopgap — iPad support is plausible in the future since most of the plugin's core functionality (CM6 extensions, vault access, Supabase sync) can work on tablet, but a dedicated mobile compatibility effort would be needed for touch interactions and canvas features

> Reposted from [DiscourseGraphs/discourse-graph-obsidian#6](https://github.com/DiscourseGraphs/discourse-graph-obsidian/pull/6) per @trangdoan982's guidance, since the publish mirror gets overwritten from this monorepo.

## Test plan

- [x] Verify plugin loads normally on desktop Obsidian
- [x] Verify plugin no longer appears / causes errors on Obsidian mobile
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/1109" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->