### PR TITLE
ENG-1809: Sync template setting when template file is renamed

### DIFF
--- a/apps/obsidian/src/index.ts
+++ b/apps/obsidian/src/index.ts
@@ -39,6 +39,7 @@ import {
   mergeAllRelationsJsonToRoot,
 } from "~/utils/relationsStore";
 import { migrateImportFolderMetadata } from "./utils/importFolderMetadata";
+import { registerTemplateSettingsSync } from "~/utils/templateSettingsSync";
 
 export default class DiscourseGraphPlugin extends Plugin {
   settings: Settings = { ...DEFAULT_SETTINGS };
@@ -62,6 +63,8 @@ export default class DiscourseGraphPlugin extends Plugin {
     await migrateImportFolderMetadata(this).catch((error) => {
       console.error("Failed to migrate import folder metadata:", error);
     });
+
+    registerTemplateSettingsSync(this);
 
     if (this.settings.syncModeEnabled === true) {
       void initializeSupabaseSync(this).catch((error) => {

--- a/apps/obsidian/src/utils/templateSettingsSync.ts
+++ b/apps/obsidian/src/utils/templateSettingsSync.ts
@@ -1,0 +1,81 @@
+import { Notice, TAbstractFile, TFile } from "obsidian";
+import type DiscourseGraphPlugin from "~/index";
+import { syncNodeTypeTemplatesOnTemplateFileChange } from "~/utils/templates";
+
+const formatNodeTypeList = (nodeTypeNames: string[]): string => {
+  if (nodeTypeNames.length === 1) {
+    return nodeTypeNames[0] ?? "";
+  }
+
+  if (nodeTypeNames.length === 2) {
+    return `${nodeTypeNames[0]} and ${nodeTypeNames[1]}`;
+  }
+
+  const lastNodeType = nodeTypeNames[nodeTypeNames.length - 1];
+  return `${nodeTypeNames.slice(0, -1).join(", ")}, and ${lastNodeType}`;
+};
+
+const applyTemplateSettingsSync = async ({
+  plugin,
+  oldPath,
+  newFile,
+}: {
+  plugin: DiscourseGraphPlugin;
+  oldPath: string;
+  newFile?: TFile;
+}): Promise<void> => {
+  const result = syncNodeTypeTemplatesOnTemplateFileChange({
+    plugin,
+    oldPath,
+    newFile,
+  });
+
+  if (result.updatedNodeTypeNames.length === 0 || !result.action) {
+    return;
+  }
+
+  await plugin.saveSettings();
+
+  const nodeTypeList = formatNodeTypeList(result.updatedNodeTypeNames);
+  const message =
+    result.action === "updated"
+      ? `Updated template for ${nodeTypeList}`
+      : `Cleared template for ${nodeTypeList}`;
+
+  new Notice(message, 3000);
+};
+
+const isMarkdownFile = (file: TAbstractFile): file is TFile => {
+  return file instanceof TFile && file.extension === "md";
+};
+
+export const registerTemplateSettingsSync = (
+  plugin: DiscourseGraphPlugin,
+): void => {
+  plugin.registerEvent(
+    plugin.app.vault.on("rename", (file: TAbstractFile, oldPath: string) => {
+      if (!isMarkdownFile(file)) {
+        return;
+      }
+
+      void applyTemplateSettingsSync({
+        plugin,
+        oldPath,
+        newFile: file,
+      });
+    }),
+  );
+
+  plugin.registerEvent(
+    plugin.app.vault.on("delete", (file: TAbstractFile) => {
+      if (!isMarkdownFile(file)) {
+        return;
+      }
+
+      void applyTemplateSettingsSync({
+        plugin,
+        oldPath: file.path,
+      });
+    }),
+  );
+};

--- a/apps/obsidian/src/utils/templates.ts
+++ b/apps/obsidian/src/utils/templates.ts
@@ -5,6 +5,7 @@ import {
   TAbstractFile,
   getFrontMatterInfo,
 } from "obsidian";
+import type { Settings } from "~/types";
 
 type TemplatePluginInfo = {
   isEnabled: boolean;
@@ -62,6 +63,105 @@ export const getTemplatePluginInfo = (app: App): TemplatePluginInfo => {
     console.error("Error accessing Templates plugin:", error);
     return { isEnabled: false, folderPath: "" };
   }
+};
+
+export const getTemplateBasenameFromPath = (path: string): string | null => {
+  if (!path.toLowerCase().endsWith(".md")) {
+    return null;
+  }
+
+  const fileName = path.split("/").pop();
+  if (!fileName) {
+    return null;
+  }
+
+  return fileName.replace(/\.md$/i, "");
+};
+
+export const isDirectTemplateChild = (
+  path: string,
+  folderPath: string,
+): boolean => {
+  const basename = getTemplateBasenameFromPath(path);
+  if (!basename) {
+    return false;
+  }
+
+  return path === `${folderPath}/${basename}.md`;
+};
+
+export type TemplateSettingsSyncResult = {
+  updatedNodeTypeNames: string[];
+  action: "updated" | "cleared" | null;
+};
+
+type TemplateSyncContext = {
+  app: App;
+  settings: Settings;
+};
+
+export const syncNodeTypeTemplatesOnTemplateFileChange = ({
+  plugin,
+  oldPath,
+  newFile,
+}: {
+  plugin: TemplateSyncContext;
+  oldPath: string;
+  newFile?: TFile;
+}): TemplateSettingsSyncResult => {
+  const { isEnabled, folderPath } = getTemplatePluginInfo(plugin.app);
+
+  if (!isEnabled || !folderPath) {
+    return { updatedNodeTypeNames: [], action: null };
+  }
+
+  if (!isDirectTemplateChild(oldPath, folderPath)) {
+    return { updatedNodeTypeNames: [], action: null };
+  }
+
+  const oldBasename = getTemplateBasenameFromPath(oldPath);
+  if (!oldBasename) {
+    return { updatedNodeTypeNames: [], action: null };
+  }
+
+  const matchingNodeTypes = plugin.settings.nodeTypes.filter(
+    (nodeType) => nodeType.template === oldBasename,
+  );
+
+  if (matchingNodeTypes.length === 0) {
+    return { updatedNodeTypeNames: [], action: null };
+  }
+
+  const now = Date.now();
+  let action: "updated" | "cleared";
+
+  if (newFile) {
+    if (isDirectTemplateChild(newFile.path, folderPath)) {
+      const newBasename = newFile.basename;
+      for (const nodeType of matchingNodeTypes) {
+        nodeType.template = newBasename;
+        nodeType.modified = now;
+      }
+      action = "updated";
+    } else {
+      for (const nodeType of matchingNodeTypes) {
+        nodeType.template = undefined;
+        nodeType.modified = now;
+      }
+      action = "cleared";
+    }
+  } else {
+    for (const nodeType of matchingNodeTypes) {
+      nodeType.template = undefined;
+      nodeType.modified = now;
+    }
+    action = "cleared";
+  }
+
+  return {
+    updatedNodeTypeNames: matchingNodeTypes.map((nodeType) => nodeType.name),
+    action,
+  };
 };
 
 export const getTemplateFiles = (app: App): string[] => {


### PR DESCRIPTION
https://www.loom.com/share/d889d0cde4a441f1bd1247e8fa7e88d7

## Summary
- Add vault rename/delete listeners that keep `nodeType.template` in sync when template files change in the Obsidian Templates folder
- Update matching node type settings to the new template basename on rename within the Templates folder
- Clear template settings when a referenced template file is moved out of the Templates folder or deleted
- Show a brief notice when affected node types are updated or cleared

## Test plan
- [x] Assign a template to a node type in DG settings
- [x] Rename the template file within the Templates folder and confirm the node type setting updates
- [x] Create a new node of that type and confirm the template applies without warning
- [x] Move the template file outside the Templates folder and confirm the node type template clears
- [x] Delete a referenced template file and confirm the node type template clears
- [x] Repeat with two node types sharing the same template and confirm both update/clear together
- [x] Rename an unrelated markdown file and confirm no settings change or notice appears


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/1111" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->