### PR TITLE
Convert Obsidian UI text to sentence case

### DIFF
--- a/apps/obsidian/src/components/BulkIdentifyDiscourseNodesModal.tsx
+++ b/apps/obsidian/src/components/BulkIdentifyDiscourseNodesModal.tsx
@@ -298,7 +298,7 @@ const BulkImportContent = ({ plugin, onClose }: BulkImportModalProps) => {
 
     return (
       <div>
-        <h3 className="mb-4">Review Candidates</h3>
+        <h3 className="mb-4">Review candidates</h3>
         <p className="text-muted mb-4 text-sm">
           {candidates.length} potential matches found. Review and select which
           files to identify as discourse nodes.

--- a/apps/obsidian/src/components/ImportNodesModal.tsx
+++ b/apps/obsidian/src/components/ImportNodesModal.tsx
@@ -295,7 +295,7 @@ const ImportNodesContent = ({ plugin, onClose }: ImportNodesModalProps) => {
 
     return (
       <div>
-        <h3 className="mb-4">Select Nodes to Import</h3>
+        <h3 className="mb-4">Select nodes to import</h3>
         <p className="text-muted mb-4 text-sm">
           {totalNodes > 0
             ? `${totalNodes} importable node(s) found. Select which nodes to import into your vault.`
@@ -411,7 +411,7 @@ const ImportNodesContent = ({ plugin, onClose }: ImportNodesModalProps) => {
 
     return (
       <div>
-        <h3 className="mb-2">Import Preview</h3>
+        <h3 className="mb-2">Import preview</h3>
         <p className="text-muted mb-4 text-sm">
           Review what will be imported and created.
         </p>

--- a/apps/obsidian/src/components/NodeTypeSettings.tsx
+++ b/apps/obsidian/src/components/NodeTypeSettings.tsx
@@ -840,7 +840,7 @@ const NodeTypeSettings = () => {
   const confirmDeleteNodeType = (index: number): void => {
     const nodeType = nodeTypes[index] || { name: "Unnamed" };
     const modal = new ConfirmationModal(plugin.app, {
-      title: "Delete Node Type",
+      title: "Delete node type",
       message: `Are you sure you want to delete the node type "${nodeType.name}"?`,
       onConfirm: () => void handleDeleteNodeType(index),
     });
@@ -1137,7 +1137,7 @@ const NodeTypeSettings = () => {
     return (
       <div className="node-type-list">
         <button onClick={handleAddNodeType} className="mod-cta">
-          Add Node Type
+          Add node type
         </button>
 
         {localNodeTypes.length > 0 && (
@@ -1192,7 +1192,7 @@ const NodeTypeSettings = () => {
           <h3 className="dg-h3">
             {isEditingImported
               ? `[Read only] Imported from ${getAndFormatImportSource(editingNodeType.importedFromRid || "", plugin.settings.spaceNames)}`
-              : "Edit Node Type"}
+              : "Edit node type"}
           </h3>
         </div>
         {FIELD_CONFIG_ARRAY.map(renderField)}

--- a/apps/obsidian/src/components/RelationshipSettings.tsx
+++ b/apps/obsidian/src/components/RelationshipSettings.tsx
@@ -132,7 +132,7 @@ const RelationshipSettings = () => {
     }
 
     const modal = new ConfirmationModal(plugin.app, {
-      title: "Delete Relation",
+      title: "Delete relation",
       message,
       onConfirm: () => handleDeleteRelation(index),
     });
@@ -339,7 +339,7 @@ const RelationshipSettings = () => {
           <div className="setting-item mt-4">
             <div className="flex gap-2">
               <button onClick={handleAddRelation} className="p-2">
-                Add Relation
+                Add relation
               </button>
             </div>
           </div>

--- a/apps/obsidian/src/components/RelationshipTypeSettings.tsx
+++ b/apps/obsidian/src/components/RelationshipTypeSettings.tsx
@@ -219,7 +219,7 @@ const RelationshipTypeSettings = () => {
       color: DEFAULT_TLDRAW_COLOR,
     };
     const modal = new ConfirmationModal(plugin.app, {
-      title: "Delete Relation Type",
+      title: "Delete relation type",
       message: `Are you sure you want to delete the relation type "${relationType.label}"?`,
       onConfirm: () => {
         void handleDeleteRelationType(index);
@@ -394,7 +394,7 @@ const RelationshipTypeSettings = () => {
       <div className="setting-item mt-4">
         <div className="flex gap-2">
           <button onClick={handleAddRelationType} className="p-2">
-            Add Relation Type
+            Add relation type
           </button>
         </div>
       </div>

--- a/apps/obsidian/src/components/Settings.tsx
+++ b/apps/obsidian/src/components/Settings.tsx
@@ -50,7 +50,7 @@ const Settings = () => {
               : "!bg-transparent"
           }`}
         >
-          Node Types
+          Node types
         </button>
         <button
           onClick={() => setActiveTab("relationTypes")}
@@ -60,7 +60,7 @@ const Settings = () => {
               : "!bg-transparent"
           }`}
         >
-          Relation Types
+          Relation types
         </button>
         <button
           onClick={() => setActiveTab("relations")}
@@ -70,12 +70,12 @@ const Settings = () => {
               : "!bg-transparent"
           }`}
         >
-          Discourse Relations
+          Discourse relations
         </button>
         {/* Hidden Admin Panel tab - only visible when activeTab is "admin-panel" */}
         {activeTab === "admin-panel" && (
           <button className="!bg-modifier-hover accent-border-bottom mr-2 cursor-pointer border-0 px-4 py-2">
-            Admin Panel
+            Admin panel
           </button>
         )}
       </div>

--- a/apps/obsidian/src/components/canvas/overlays/RelationPanel.tsx
+++ b/apps/obsidian/src/components/canvas/overlays/RelationPanel.tsx
@@ -360,7 +360,7 @@ export const RelationsPanel = ({
       if (!sourceId || !destId) {
         showToast({
           severity: "error",
-          title: "Could Not Resolve Nodes",
+          title: "Could not resolve nodes",
           description:
             "Could not resolve node instance IDs for the selected files.",
           targetCanvasId: canvasFile.path,

--- a/apps/obsidian/src/components/canvas/overlays/RelationPanel.tsx
+++ b/apps/obsidian/src/components/canvas/overlays/RelationPanel.tsx
@@ -329,7 +329,7 @@ export const RelationsPanel = ({
     } catch (e) {
       showToast({
         severity: "error",
-        title: "Failed to Delete Relation",
+        title: "Failed to delete relation",
         description: "Could not delete relation",
         targetCanvasId: canvasFile.path,
       });
@@ -452,7 +452,7 @@ export const RelationsPanel = ({
       console.error("Failed to create relation to file", e);
       showToast({
         severity: "error",
-        title: "Failed to Create Relation",
+        title: "Failed to create relation",
         description: "Could not create relation to file",
         targetCanvasId: canvasFile.path,
       });

--- a/apps/obsidian/src/components/canvas/utils/nodeCreationFlow.ts
+++ b/apps/obsidian/src/components/canvas/utils/nodeCreationFlow.ts
@@ -103,7 +103,7 @@ export const openCreateDiscourseNodeAt = (args: CreateNodeAtArgs): void => {
         console.error("Error creating discourse node:", error);
         showToast({
           severity: "error",
-          title: "Failed to Create Node",
+          title: "Failed to create node",
           description: `Could not create discourse node: ${error instanceof Error ? error.message : "Unknown error"}`,
           targetCanvasId: canvasFile.path,
         });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR converts all UI text in the Obsidian Discourse Graphs plugin from title case to sentence case, following the Obsidian style guide requirements.

## Changes

### Settings Tabs
- "Node Types" → "Node types"
- "Relation Types" → "Relation types"
- "Discourse Relations" → "Discourse relations"
- "Admin Panel" → "Admin panel"

### Modal Titles
- "Edit Node Type" → "Edit node type"
- "Delete Node Type" → "Delete node type"
- "Add Node Type" → "Add node type"
- "Delete Relation Type" → "Delete relation type"
- "Add Relation Type" → "Add relation type"
- "Delete Relation" → "Delete relation"
- "Add Relation" → "Add relation"

### Section Headings
- "Review Candidates" → "Review candidates"
- "Import Preview" → "Import preview"
- "Select Nodes to Import" → "Select nodes to import"

### Error Messages / Toast Titles
- "Failed to Create Node" → "Failed to create node"
- "Failed to Delete Relation" → "Failed to delete relation"
- "Failed to Create Relation" → "Failed to create relation"
- "Could Not Resolve Nodes" → "Could not resolve nodes"

## Files Modified
- `apps/obsidian/src/components/Settings.tsx`
- `apps/obsidian/src/components/NodeTypeSettings.tsx`
- `apps/obsidian/src/components/RelationshipTypeSettings.tsx`
- `apps/obsidian/src/components/RelationshipSettings.tsx`
- `apps/obsidian/src/components/ImportNodesModal.tsx`
- `apps/obsidian/src/components/BulkIdentifyDiscourseNodesModal.tsx`
- `apps/obsidian/src/components/canvas/overlays/RelationPanel.tsx`
- `apps/obsidian/src/components/canvas/utils/nodeCreationFlow.ts`

## Related Issue

Resolves ENG-1816

## Testing

The changes are purely cosmetic text updates to UI elements. No functional changes were made. The plugin should work exactly as before, with all UI text now following sentence case conventions.

## Compliance

This change aligns with the Obsidian Plugin Store Guidelines which require:
> Use sentence case in settings headings and labels (not title case)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-1816](https://linear.app/discourse-graphs/issue/ENG-1816/sentence-case-obsidian-menu-tabs-sections)

<div><a href="https://cursor.com/agents/bc-1b197d59-0a0b-4dcf-8112-3b5c280e0fb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1b197d59-0a0b-4dcf-8112-3b5c280e0fb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/1113" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->