### PR TITLE
fix: remove leading '#' from search result tags

### DIFF
--- a/apps/roam/src/components/AdvancedNodeSearchDialog/AdvancedSearchDialog.tsx
+++ b/apps/roam/src/components/AdvancedNodeSearchDialog/AdvancedSearchDialog.tsx
@@ -46,11 +46,15 @@ import {
 import { DiscourseNodeTypeFilter } from "~/components/AdvancedNodeSearchDialog/DiscourseNodeTypeFilter";
 import { RenderRoamBlock, RenderRoamPage } from "~/utils/roamReactComponents";
 import { AdvancedSearchFooter } from "./AdvancedSearchFooter";
+import { getCleanTagText } from "~/components/settings/NodeConfig";
 
 type Props = Record<string, unknown>;
 
-const getNodeBadgeText = (node: DiscourseNode): string =>
-  (node.tag?.trim() || node.text).slice(0, 3).toUpperCase();
+const getNodeBadgeText = (node: DiscourseNode): string => {
+  const tagText = node.tag?.trim() || node.text;
+  const cleanedTag = getCleanTagText(tagText);
+  return cleanedTag.slice(0, 3);
+};
 
 const getTagStyle = (node: DiscourseNode | undefined): React.CSSProperties => {
   const color = node?.canvasSettings?.color;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

In the advanced search dialog, discourse node type tags were displaying with the "#" prefix included. For example:
- "CLM" was showing as "#CL"
- "QUE" was showing as "#QU"

This was because the `getNodeBadgeText` function was taking the first 3 characters of `node.tag`, which includes the "#" prefix.

## Solution

- Import the existing `getCleanTagText` utility function from `~/components/settings/NodeConfig`
- Use it in `getNodeBadgeText` to strip the "#" prefix (and handle other cleanup) before taking the first 3 characters
- This ensures tags display correctly as "CLM", "QUE", etc.

## Testing

- TypeScript type checking passes
- Linter passes
- Build completes successfully with no errors
- Code uses existing utility function that's already being used elsewhere in the codebase for the same purpose

Resolves Linear issue ENG-1839
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-1839](https://linear.app/discourse-graphs/issue/ENG-1839/included-in-search-result-tag)

<div><a href="https://cursor.com/agents/bc-e830b48a-470f-45fb-a3ac-8a6bafefcd53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e830b48a-470f-45fb-a3ac-8a6bafefcd53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

