### PR TITLE
Fix: Remove leading # from search result tags in advanced search

### DIFF
--- a/apps/roam/src/components/AdvancedNodeSearchDialog/AdvancedSearchDialog.tsx
+++ b/apps/roam/src/components/AdvancedNodeSearchDialog/AdvancedSearchDialog.tsx
@@ -49,8 +49,10 @@ import { AdvancedSearchFooter } from "./AdvancedSearchFooter";
 
 type Props = Record<string, unknown>;
 
-const getNodeBadgeText = (node: DiscourseNode): string =>
-  (node.tag?.trim() || node.text).slice(0, 3).toUpperCase();
+const getNodeBadgeText = (node: DiscourseNode): string => {
+  const text = (node.tag?.trim() || node.text).replace(/^#/, "");
+  return text.slice(0, 3).toUpperCase();
+};
 
 const getTagStyle = (node: DiscourseNode | undefined): React.CSSProperties => {
   const color = node?.canvasSettings?.color;
@@ -102,7 +104,9 @@ const ResultRow = ({
     }}
   >
     <Tag minimal style={getTagStyle(nodeConfig)}>
-      {nodeConfig ? getNodeBadgeText(nodeConfig) : result.nodeTypeLabel}
+      {nodeConfig
+        ? getNodeBadgeText(nodeConfig)
+        : result.nodeTypeLabel.replace(/^#/, "").slice(0, 3).toUpperCase()}
     </Tag>
     <span className="min-w-0 break-words text-sm leading-snug text-gray-900">
       {renderHighlightedText(stripTypePrefix(result.title), keywords)}

--- a/apps/roam/src/components/AdvancedNodeSearchDialog/AdvancedSearchDialog.tsx
+++ b/apps/roam/src/components/AdvancedNodeSearchDialog/AdvancedSearchDialog.tsx
@@ -1,10 +1,4 @@
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import {
   Button,
   Dialog,
@@ -37,6 +31,7 @@ import {
   type SearchResult,
   type SortConfig,
   buildSearchIndex,
+  formatBadgeText,
   formatMetadataDate,
   searchIndexedNodes,
   sortSearchResults,
@@ -50,8 +45,7 @@ import { AdvancedSearchFooter } from "./AdvancedSearchFooter";
 type Props = Record<string, unknown>;
 
 const getNodeBadgeText = (node: DiscourseNode): string => {
-  const text = (node.tag?.trim() || node.text).replace(/^#/, "");
-  return text.slice(0, 3).toUpperCase();
+  return formatBadgeText(node.tag?.trim() || node.text);
 };
 
 const getTagStyle = (node: DiscourseNode | undefined): React.CSSProperties => {
@@ -106,7 +100,7 @@ const ResultRow = ({
     <Tag minimal style={getTagStyle(nodeConfig)}>
       {nodeConfig
         ? getNodeBadgeText(nodeConfig)
-        : result.nodeTypeLabel.replace(/^#/, "").slice(0, 3).toUpperCase()}
+        : formatBadgeText(result.nodeTypeLabel)}
     </Tag>
     <span className="min-w-0 break-words text-sm leading-snug text-gray-900">
       {renderHighlightedText(stripTypePrefix(result.title), keywords)}

--- a/apps/roam/src/components/AdvancedNodeSearchDialog/utils.ts
+++ b/apps/roam/src/components/AdvancedNodeSearchDialog/utils.ts
@@ -68,6 +68,9 @@ export const formatMetadataDate = (value: string): string => {
   });
 };
 
+export const formatBadgeText = (text: string): string =>
+  text.replace(/^#/, "").slice(0, 3).toUpperCase();
+
 export const stripTypePrefix = (title: string): string => {
   const match = title.match(/^\[\[.*?\]\]\s*-\s*(.*)/s);
   return match ? match[1] : title;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

In the advanced search dialog, node type tags were displaying with a leading `#` character, showing abbreviated forms like `#CL` and `#QU` instead of the intended `CLM` and `QUE`.

## Solution

Updated the tag display logic to strip the leading `#` character before extracting the 3-letter abbreviation:

- Modified `getNodeBadgeText()` to remove `#` prefix using `.replace(/^#/, "")` before slicing
- Applied same fix to the fallback case when `nodeConfig` is unavailable

## Changes

- `apps/roam/src/components/AdvancedNodeSearchDialog/AdvancedSearchDialog.tsx`
  - Updated `getNodeBadgeText` function to strip leading `#` before taking first 3 characters
  - Updated inline tag rendering to handle `nodeTypeLabel` fallback with same `#` stripping logic

## Testing

✅ **Build**: Compiled successfully with 0 errors  
✅ **Type checking**: No TypeScript errors  
✅ **Linting**: All style checks passed  
✅ **Logic verification**: Tested with multiple scenarios

### Test Cases Verified

| Input | Before | After |
|-------|--------|-------|
| `#CLM` | `#CL` ❌ | `CLM` ✅ |
| `#QUE` | `#QU` ❌ | `QUE` ✅ |
| `#CLAIM` | `#CL` ❌ | `CLA` ✅ |
| `CLAIM` | `CLA` ✅ | `CLA` ✅ |

The fix ensures that:
- Tags starting with `#` have the prefix removed before abbreviation
- Tags without `#` continue to work as expected
- All node type tags display their correct 3-letter abbreviations

Fixes ENG-1839
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-1839](https://linear.app/discourse-graphs/issue/ENG-1839/included-in-search-result-tag)

<div><a href="https://cursor.com/agents/bc-b8904faf-875c-47ea-9238-8eeec112e4c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b8904faf-875c-47ea-9238-8eeec112e4c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

