### PR TITLE
ENG-1840: Align advanced search highlight with Roam/BlueprintJS

### DIFF
--- a/apps/roam/src/components/AdvancedNodeSearchDialog/AdvancedSearchDialog.tsx
+++ b/apps/roam/src/components/AdvancedNodeSearchDialog/AdvancedSearchDialog.tsx
@@ -9,6 +9,8 @@ import {
   Button,
   Dialog,
   InputGroup,
+  Menu,
+  MenuItem,
   NonIdealState,
   Spinner,
   SpinnerSize,
@@ -87,27 +89,23 @@ const ResultRow = ({
   onMouseEnter: () => void;
   result: SearchResult;
 }) => (
-  <Button
-    alignText="left"
-    aria-selected={active}
-    className="flex-none !items-start gap-2 !px-3 !py-2"
-    fill
-    minimal
+  <MenuItem
+    className={`flex items-start${active ? "advanced-search-result-focused" : ""}`}
+    data-active={active}
+    icon={
+      <Tag minimal style={getTagStyle(nodeConfig)}>
+        {nodeConfig ? getNodeBadgeText(nodeConfig) : result.nodeTypeLabel}
+      </Tag>
+    }
+    multiline
     onClick={onClick}
     onMouseEnter={onMouseEnter}
-    role="option"
-    style={{
-      background: active ? "rgba(95, 87, 192, 0.08)" : undefined,
-      boxShadow: active ? "inset 3px 0 0 #5f57c0" : undefined,
-    }}
-  >
-    <Tag minimal style={getTagStyle(nodeConfig)}>
-      {nodeConfig ? getNodeBadgeText(nodeConfig) : result.nodeTypeLabel}
-    </Tag>
-    <span className="min-w-0 break-words text-sm leading-snug text-gray-900">
-      {renderHighlightedText(stripTypePrefix(result.title), keywords)}
-    </span>
-  </Button>
+    text={
+      <span className="min-w-0 break-words text-sm leading-snug text-gray-900">
+        {renderHighlightedText(stripTypePrefix(result.title), keywords)}
+      </span>
+    }
+  />
 );
 
 const PreviewPane = ({ result }: { result: SearchResult | null }) => {
@@ -284,8 +282,20 @@ const AdvancedNodeSearchDialog = ({
     const panel = resultsPanelRef.current;
     if (!panel) return;
 
-    const activeRow = panel.querySelector('[aria-selected="true"]');
-    activeRow?.scrollIntoView({ block: "nearest" });
+    const activeRow = panel.querySelector(
+      '[data-active="true"]',
+    ) as HTMLElement | null;
+    if (!activeRow) return;
+
+    const containerRect = panel.getBoundingClientRect();
+    const itemRect = activeRow.getBoundingClientRect();
+
+    if (
+      itemRect.bottom > containerRect.bottom ||
+      itemRect.top < containerRect.top
+    ) {
+      activeRow.scrollIntoView({ block: "nearest", behavior: "auto" });
+    }
   }, [activeIndex, activeResult?.uid, debouncedSearchTerm]);
 
   const onInsert = useCallback(async () => {
@@ -450,21 +460,22 @@ const AdvancedNodeSearchDialog = ({
             <>
               <div
                 aria-label="Search results"
-                className="w-1/3 shrink-0 overflow-y-auto border-r border-gray-200 py-1"
+                className="advanced-node-search-results w-1/3 shrink-0 overflow-y-auto border-r border-gray-200"
                 ref={resultsPanelRef}
-                role="listbox"
               >
-                {results.map((result, index) => (
-                  <ResultRow
-                    active={index === activeIndex}
-                    key={result.uid}
-                    keywords={keywords}
-                    nodeConfig={nodeConfigByType[result.type]}
-                    onClick={() => setActiveIndex(index)}
-                    onMouseEnter={() => setActiveIndex(index)}
-                    result={result}
-                  />
-                ))}
+                <Menu>
+                  {results.map((result, index) => (
+                    <ResultRow
+                      active={index === activeIndex}
+                      key={result.uid}
+                      keywords={keywords}
+                      nodeConfig={nodeConfigByType[result.type]}
+                      onClick={() => setActiveIndex(index)}
+                      onMouseEnter={() => setActiveIndex(index)}
+                      result={result}
+                    />
+                  ))}
+                </Menu>
               </div>
               <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
                 <PreviewPane result={activeResult} />

--- a/apps/roam/src/components/AdvancedNodeSearchDialog/AdvancedSearchDialog.tsx
+++ b/apps/roam/src/components/AdvancedNodeSearchDialog/AdvancedSearchDialog.tsx
@@ -1,10 +1,4 @@
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import {
   Button,
   Dialog,
@@ -282,9 +276,7 @@ const AdvancedNodeSearchDialog = ({
     const panel = resultsPanelRef.current;
     if (!panel) return;
 
-    const activeRow = panel.querySelector(
-      '[data-active="true"]',
-    ) as HTMLElement | null;
+    const activeRow = panel.querySelector('[data-active="true"]');
     if (!activeRow) return;
 
     const containerRect = panel.getBoundingClientRect();

--- a/apps/roam/src/components/AdvancedNodeSearchDialog/AdvancedSearchDialog.tsx
+++ b/apps/roam/src/components/AdvancedNodeSearchDialog/AdvancedSearchDialog.tsx
@@ -1,10 +1,14 @@
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
   Button,
   Dialog,
   InputGroup,
-  Menu,
-  MenuItem,
   NonIdealState,
   Spinner,
   SpinnerSize,
@@ -83,23 +87,27 @@ const ResultRow = ({
   onMouseEnter: () => void;
   result: SearchResult;
 }) => (
-  <MenuItem
-    className={`flex items-start${active ? "advanced-search-result-focused" : ""}`}
-    data-active={active}
-    icon={
-      <Tag minimal style={getTagStyle(nodeConfig)}>
-        {nodeConfig ? getNodeBadgeText(nodeConfig) : result.nodeTypeLabel}
-      </Tag>
-    }
-    multiline
+  <Button
+    alignText="left"
+    aria-selected={active}
+    className="flex-none !items-start gap-2 !px-3 !py-2"
+    fill
+    minimal
     onClick={onClick}
     onMouseEnter={onMouseEnter}
-    text={
-      <span className="min-w-0 break-words text-sm leading-snug text-gray-900">
-        {renderHighlightedText(stripTypePrefix(result.title), keywords)}
-      </span>
-    }
-  />
+    role="option"
+    style={{
+      background: active ? "rgba(167, 182, 194, 0.3)" : undefined,
+      boxShadow: active ? "inset 3px 0 0 rgba(167, 182, 194, 0.3)" : undefined,
+    }}
+  >
+    <Tag minimal style={getTagStyle(nodeConfig)}>
+      {nodeConfig ? getNodeBadgeText(nodeConfig) : result.nodeTypeLabel}
+    </Tag>
+    <span className="min-w-0 break-words text-sm leading-snug text-gray-900">
+      {renderHighlightedText(stripTypePrefix(result.title), keywords)}
+    </span>
+  </Button>
 );
 
 const PreviewPane = ({ result }: { result: SearchResult | null }) => {
@@ -276,18 +284,8 @@ const AdvancedNodeSearchDialog = ({
     const panel = resultsPanelRef.current;
     if (!panel) return;
 
-    const activeRow = panel.querySelector('[data-active="true"]');
-    if (!activeRow) return;
-
-    const containerRect = panel.getBoundingClientRect();
-    const itemRect = activeRow.getBoundingClientRect();
-
-    if (
-      itemRect.bottom > containerRect.bottom ||
-      itemRect.top < containerRect.top
-    ) {
-      activeRow.scrollIntoView({ block: "nearest", behavior: "auto" });
-    }
+    const activeRow = panel.querySelector('[aria-selected="true"]');
+    activeRow?.scrollIntoView({ block: "nearest" });
   }, [activeIndex, activeResult?.uid, debouncedSearchTerm]);
 
   const onInsert = useCallback(async () => {
@@ -452,22 +450,21 @@ const AdvancedNodeSearchDialog = ({
             <>
               <div
                 aria-label="Search results"
-                className="advanced-node-search-results w-1/3 shrink-0 overflow-y-auto border-r border-gray-200"
+                className="w-1/3 shrink-0 overflow-y-auto border-r border-gray-200 py-1"
                 ref={resultsPanelRef}
+                role="listbox"
               >
-                <Menu>
-                  {results.map((result, index) => (
-                    <ResultRow
-                      active={index === activeIndex}
-                      key={result.uid}
-                      keywords={keywords}
-                      nodeConfig={nodeConfigByType[result.type]}
-                      onClick={() => setActiveIndex(index)}
-                      onMouseEnter={() => setActiveIndex(index)}
-                      result={result}
-                    />
-                  ))}
-                </Menu>
+                {results.map((result, index) => (
+                  <ResultRow
+                    active={index === activeIndex}
+                    key={result.uid}
+                    keywords={keywords}
+                    nodeConfig={nodeConfigByType[result.type]}
+                    onClick={() => setActiveIndex(index)}
+                    onMouseEnter={() => setActiveIndex(index)}
+                    result={result}
+                  />
+                ))}
               </div>
               <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
                 <PreviewPane result={activeResult} />

--- a/apps/roam/src/components/AdvancedNodeSearchDialog/DiscourseNodeTypeFilter.tsx
+++ b/apps/roam/src/components/AdvancedNodeSearchDialog/DiscourseNodeTypeFilter.tsx
@@ -252,14 +252,17 @@ export const DiscourseNodeTypeFilter = ({
   const filterButton = (
     <span className="relative inline-flex shrink-0 items-center">
       <Button
-        active={isTriggerActive}
         aria-expanded={isOpen}
         aria-label={
           activeFilterCount > 0
             ? `Filter by type, ${activeFilterCount} selected`
             : "Filter by type"
         }
-        className="!text-gray-600 hover:!bg-gray-100 hover:!text-gray-900"
+        className={
+          isTriggerActive
+            ? "!bg-[rgba(167, 182, 194, 0.3)] !text-[#5f57c0]"
+            : "!text-gray-600 hover:!bg-gray-100 hover:!text-gray-900"
+        }
         disabled={!isFilterReady}
         elementRef={triggerRef}
         icon="filter"

--- a/apps/roam/src/components/AdvancedNodeSearchDialog/DiscourseNodeTypeFilter.tsx
+++ b/apps/roam/src/components/AdvancedNodeSearchDialog/DiscourseNodeTypeFilter.tsx
@@ -252,17 +252,14 @@ export const DiscourseNodeTypeFilter = ({
   const filterButton = (
     <span className="relative inline-flex shrink-0 items-center">
       <Button
+        active={isTriggerActive}
         aria-expanded={isOpen}
         aria-label={
           activeFilterCount > 0
             ? `Filter by type, ${activeFilterCount} selected`
             : "Filter by type"
         }
-        className={
-          isTriggerActive
-            ? "!bg-[rgba(95,87,192,0.1)] !text-[#5f57c0]"
-            : "!text-gray-600 hover:!bg-gray-100 hover:!text-gray-900"
-        }
+        className="!text-gray-600 hover:!bg-gray-100 hover:!text-gray-900"
         disabled={!isFilterReady}
         elementRef={triggerRef}
         icon="filter"

--- a/apps/roam/src/components/DiscourseNodeSortControl.tsx
+++ b/apps/roam/src/components/DiscourseNodeSortControl.tsx
@@ -116,14 +116,11 @@ export const DiscourseNodeSortControl = ({
 
   const sortButton = (
     <Button
+      active={isTriggerActive}
       aria-expanded={isOpen}
       aria-haspopup="listbox"
       aria-label={`Sort by ${sortLabel}`}
-      className={`${
-        isTriggerActive
-          ? "!bg-[rgba(95,87,192,0.1)] !text-[#5f57c0]"
-          : "!text-gray-600 hover:!bg-gray-100 hover:!text-gray-900"
-      }`}
+      className="!text-gray-600 hover:!bg-gray-100 hover:!text-gray-900"
       disabled={disabled}
       elementRef={triggerRef}
       icon="sort"

--- a/apps/roam/src/components/DiscourseNodeSortControl.tsx
+++ b/apps/roam/src/components/DiscourseNodeSortControl.tsx
@@ -116,11 +116,14 @@ export const DiscourseNodeSortControl = ({
 
   const sortButton = (
     <Button
-      active={isTriggerActive}
       aria-expanded={isOpen}
       aria-haspopup="listbox"
       aria-label={`Sort by ${sortLabel}`}
-      className="!text-gray-600 hover:!bg-gray-100 hover:!text-gray-900"
+      className={`${
+        isTriggerActive
+          ? "!bg-[rgba(167, 182, 194, 0.3)] !text-[#5f57c0]"
+          : "!text-gray-600 hover:!bg-gray-100 hover:!text-gray-900"
+      }`}
       disabled={disabled}
       elementRef={triggerRef}
       icon="sort"

--- a/apps/roam/src/styles/styles.css
+++ b/apps/roam/src/styles/styles.css
@@ -191,3 +191,10 @@
 #dg-left-sidebar-root .bp3-dark .bp3-button:not([class*="bp3-intent-"]):hover {
   color: #f5f8fa;
 }
+
+/* Advanced search: persist Blueprint menu-item hover styling for keyboard focus */
+.advanced-node-search-results .bp3-menu-item.advanced-search-result-focused {
+  background-color: rgba(167, 182, 194, 0.3);
+  cursor: pointer;
+  text-decoration: none;
+}

--- a/apps/roam/src/styles/styles.css
+++ b/apps/roam/src/styles/styles.css
@@ -191,10 +191,3 @@
 #dg-left-sidebar-root .bp3-dark .bp3-button:not([class*="bp3-intent-"]):hover {
   color: #f5f8fa;
 }
-
-/* Advanced search: persist Blueprint menu-item hover styling for keyboard focus */
-.advanced-node-search-results .bp3-menu-item.advanced-search-result-focused {
-  background-color: rgba(167, 182, 194, 0.3);
-  cursor: pointer;
-  text-decoration: none;
-}


### PR DESCRIPTION

<img width="1020" height="687" alt="image" src="https://github.com/user-attachments/assets/e8c43fe8-5efa-4c60-b5bf-3cfe1d053fb1" />


## Summary
- Replace the purple custom color with a gray that matches Roam 
- can't use bp3.menu-item-active because the default is blue instead of gray
## Test plan
- [x] Open Advanced Node Search in Roam and search for a keyword
- [x] Confirm focused result rows use gray Blueprint hover styling (not purple or blue)
- [x] Verify ArrowUp/ArrowDown navigation and scroll-into-view for long result lists
- [x] Confirm filter and sort buttons show Blueprint active state when open or applied
- [x] Verify Enter, Shift+Enter, Cmd/Ctrl+Enter, and Escape still work as expected


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/1117" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->