### PR TITLE
FEE-823 Make BRAT repository URLs copyable on installation docs page

### DIFF
--- a/apps/website/content/obsidian/welcome/installation.md
+++ b/apps/website/content/obsidian/welcome/installation.md
@@ -21,10 +21,13 @@ published: true
 2. Go to "Community Plugins" → "BRAT"
 3. Click "Add Beta Plugin"
    ![Add plugin](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FdMtstUHPXe.png?alt=media&token=3f139ab9-9802-404d-9554-4a63bac080c5)
-4. Enter the repository URL: `https://github.com/blacksmithgu/datacore` and choose "Latest version"
-   ![Add datacore](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FEY3vNGt1Rf.png?alt=media&token=32c60ff1-5272-4cde-8b5f-8f049fb2cf50)
-5. Check the box for "Enable after installing the plugin"
-6. Click "Add plugin"
+4. Enter the repository URL below and choose "Latest version"
+
+```
+https://github.com/blacksmithgu/datacore
+```
+
+![Add datacore](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FEY3vNGt1Rf.png?alt=media&token=32c60ff1-5272-4cde-8b5f-8f049fb2cf50) 5. Check the box for "Enable after installing the plugin" 6. Click "Add plugin"
 
 ## Install Discourse Graphs
 
@@ -32,7 +35,10 @@ published: true
 2. Go to "Community Plugins" → "BRAT"
 3. Click "Add Beta Plugin"
    ![Add plugin](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FdMtstUHPXe.png?alt=media&token=3f139ab9-9802-404d-9554-4a63bac080c5)
-4. Enter the repository URL: `https://github.com/DiscourseGraphs/discourse-graph-obsidian` and choose "Latest version"
-   ![Add discourse graph](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FSBCK-2lkcu.png?alt=media&token=0375c828-da4d-43b4-8f2c-e691692cb019)
-5. Check the box for "Enable after installing the plugin"
-6. Click "Add Plugin"
+4. Enter the repository URL below and choose "Latest version"
+
+```
+https://github.com/DiscourseGraphs/discourse-graph-obsidian
+```
+
+![Add discourse graph](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FSBCK-2lkcu.png?alt=media&token=0375c828-da4d-43b4-8f2c-e691692cb019) 5. Check the box for "Enable after installing the plugin" 6. Click "Add Plugin"

--- a/apps/website/content/obsidian/welcome/installation.md
+++ b/apps/website/content/obsidian/welcome/installation.md
@@ -27,7 +27,10 @@ published: true
 https://github.com/blacksmithgu/datacore
 ```
 
-![Add datacore](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FEY3vNGt1Rf.png?alt=media&token=32c60ff1-5272-4cde-8b5f-8f049fb2cf50) 5. Check the box for "Enable after installing the plugin" 6. Click "Add plugin"
+![Add datacore](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FEY3vNGt1Rf.png?alt=media&token=32c60ff1-5272-4cde-8b5f-8f049fb2cf50)
+
+5. Check the box for "Enable after installing the plugin"
+6. Click "Add plugin"
 
 ## Install Discourse Graphs
 
@@ -41,4 +44,7 @@ https://github.com/blacksmithgu/datacore
 https://github.com/DiscourseGraphs/discourse-graph-obsidian
 ```
 
-![Add discourse graph](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FSBCK-2lkcu.png?alt=media&token=0375c828-da4d-43b4-8f2c-e691692cb019) 5. Check the box for "Enable after installing the plugin" 6. Click "Add Plugin"
+![Add discourse graph](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FSBCK-2lkcu.png?alt=media&token=0375c828-da4d-43b4-8f2c-e691692cb019)
+
+5. Check the box for "Enable after installing the plugin"
+6. Click "Add Plugin"

--- a/apps/website/next.config.ts
+++ b/apps/website/next.config.ts
@@ -13,6 +13,7 @@ process.env.NEXT_PUBLIC_SUPABASE_URL = process.env.SUPABASE_URL;
 
 const withNextra = nextra({
   contentDirBasePath: "/docs",
+  defaultShowCopyCode: true,
 });
 
 const nextConfig: NextConfig = {


### PR DESCRIPTION
## Summary

- Wraps both BRAT repository URLs in fenced code blocks so Nextra renders a copy button on hover
- Enables `defaultShowCopyCode: true` in the Nextra config (applies site-wide to all docs code blocks)
- Updates step text to "Enter the repository URL below and choose 'Latest version'"

## Test plan

- [ ] Visit `/docs/obsidian/welcome/installation` and hover over both repository URL code blocks — copy button should appear
- [ ] Verify steps 5 and 6 still render correctly after each code block
- [ ] Spot-check other docs pages to confirm copy buttons appear on existing code blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/1122" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->