### PR TITLE
[ENG-1851] Add Roam single-node publish action

### DIFF
--- a/apps/roam/src/components/Export.tsx
+++ b/apps/roam/src/components/Export.tsx
@@ -128,7 +128,7 @@ export type ExportDialogProps = {
   title?: string;
   columns?: Column[];
   isExportDiscourseGraph?: boolean;
-  initialPanel?: "sendTo" | "export";
+  initialPanel?: "sendTo" | "export" | "publish";
 };
 
 type ExportDialogComponent = (
@@ -141,6 +141,14 @@ const EXPORT_DESTINATIONS = [
   { id: "github", label: "Send to GitHub", active: true },
 ];
 const SEND_TO_DESTINATIONS = ["page", "graph"];
+const INITIAL_PANEL_TO_TAB_ID: Record<
+  NonNullable<ExportDialogProps["initialPanel"]>,
+  string
+> = {
+  sendTo: "sendto",
+  export: "export",
+  publish: "publish",
+};
 
 const exportDestinationById = Object.fromEntries(
   EXPORT_DESTINATIONS.map((ed) => [ed.id, ed]),
@@ -211,7 +219,7 @@ const ExportDialog: ExportDialogComponent = ({
   const [livePages, setLivePages] = useState<Result[]>([]);
   const [selectedTabId, setSelectedTabId] = useState("sendto");
   useEffect(() => {
-    if (initialPanel === "export") setSelectedTabId("export");
+    if (initialPanel) setSelectedTabId(INITIAL_PANEL_TO_TAB_ID[initialPanel]);
   }, [initialPanel]);
   const [includeDiscourseContext, setIncludeDiscourseContext] = useState(false);
   const [gitHubAccessToken, setGitHubAccessToken] = useState<string | null>(

--- a/apps/roam/src/components/Export.tsx
+++ b/apps/roam/src/components/Export.tsx
@@ -217,10 +217,12 @@ const ExportDialog: ExportDialogComponent = ({
     useState<(typeof SEND_TO_DESTINATIONS)[number]>("page");
   const isSendToGraph = activeSendToDestination === "graph";
   const [livePages, setLivePages] = useState<Result[]>([]);
+  const syncEnabled = useMemo(() => isSyncEnabled(), []);
   const [selectedTabId, setSelectedTabId] = useState("sendto");
   useEffect(() => {
+    if (initialPanel === "publish" && !syncEnabled) return;
     if (initialPanel) setSelectedTabId(INITIAL_PANEL_TO_TAB_ID[initialPanel]);
-  }, [initialPanel]);
+  }, [initialPanel, syncEnabled]);
   const [includeDiscourseContext, setIncludeDiscourseContext] = useState(false);
   const [gitHubAccessToken, setGitHubAccessToken] = useState<string | null>(
     getSetting<string | null>("oauth-github", null),
@@ -228,7 +230,6 @@ const ExportDialog: ExportDialogComponent = ({
 
   const [canSendToGitHub, setCanSendToGitHub] = useState(false);
 
-  const syncEnabled = useMemo(() => isSyncEnabled(), []);
   const [myGroups, setMyGroups] = useState<MyGroup[]>([]);
   const [groupsLoading, setGroupsLoading] = useState(false);
   const [groupsLoaded, setGroupsLoaded] = useState(false);

--- a/apps/roam/src/components/PublishNodeTitleButton.tsx
+++ b/apps/roam/src/components/PublishNodeTitleButton.tsx
@@ -1,0 +1,54 @@
+import { Button } from "@blueprintjs/core";
+import posthog from "posthog-js";
+import React from "react";
+import { handleTitleAdditions } from "~/utils/handleTitleAdditions";
+import { openShareNodeDialog } from "~/utils/openShareNodeDialog";
+
+const PUBLISH_TITLE_BUTTON_ATTRIBUTE = "data-roamjs-publish-node-title-button";
+
+const PublishNodeTitleButton = ({
+  uid,
+  title,
+  nodeType,
+}: {
+  uid: string;
+  title: string;
+  nodeType: string;
+}): JSX.Element => (
+  <div className="discourse-graph-publish-title-button flex space-x-2">
+    <Button
+      text="Publish"
+      icon="upload"
+      minimal
+      outlined
+      onClick={() => {
+        posthog.capture("Share Node: Page Title Button Triggered", {
+          pageUid: uid,
+          nodeType,
+        });
+        openShareNodeDialog({ uid, title, nodeType });
+      }}
+    />
+  </div>
+);
+
+export const renderPublishNodeTitleButton = ({
+  h1,
+  uid,
+  title,
+  nodeType,
+}: {
+  h1: HTMLHeadingElement;
+  uid: string;
+  title: string;
+  nodeType: string;
+}): void => {
+  if (!uid) return;
+  if (h1.getAttribute(PUBLISH_TITLE_BUTTON_ATTRIBUTE) === uid) return;
+
+  h1.setAttribute(PUBLISH_TITLE_BUTTON_ATTRIBUTE, uid);
+  handleTitleAdditions(
+    h1,
+    <PublishNodeTitleButton uid={uid} title={title} nodeType={nodeType} />,
+  );
+};

--- a/apps/roam/src/components/PublishNodeTitleButton.tsx
+++ b/apps/roam/src/components/PublishNodeTitleButton.tsx
@@ -50,5 +50,6 @@ export const renderPublishNodeTitleButton = ({
   handleTitleAdditions(
     h1,
     <PublishNodeTitleButton uid={uid} title={title} nodeType={nodeType} />,
+    { layout: "inline" },
   );
 };

--- a/apps/roam/src/components/PublishNodeTitleButton.tsx
+++ b/apps/roam/src/components/PublishNodeTitleButton.tsx
@@ -15,7 +15,7 @@ const PublishNodeTitleButton = ({
   title: string;
   nodeType: string;
 }): JSX.Element => (
-  <div className="discourse-graph-publish-title-button flex space-x-2">
+  <div className="flex space-x-2">
     <Button
       text="Publish"
       icon="upload"

--- a/apps/roam/src/components/PublishNodeTitleButton.tsx
+++ b/apps/roam/src/components/PublishNodeTitleButton.tsx
@@ -15,21 +15,19 @@ const PublishNodeTitleButton = ({
   title: string;
   nodeType: string;
 }): JSX.Element => (
-  <div className="flex space-x-2">
-    <Button
-      text="Publish"
-      icon="upload"
-      minimal
-      outlined
-      onClick={() => {
-        posthog.capture("Share Node: Page Title Button Triggered", {
-          pageUid: uid,
-          nodeType,
-        });
-        openShareNodeDialog({ uid, title, nodeType });
-      }}
-    />
-  </div>
+  <Button
+    text="Publish"
+    icon="upload"
+    minimal
+    outlined
+    onClick={() => {
+      posthog.capture("Share Node: Page Title Button Triggered", {
+        pageUid: uid,
+        nodeType,
+      });
+      openShareNodeDialog({ uid, title, nodeType });
+    }}
+  />
 );
 
 export const renderPublishNodeTitleButton = ({

--- a/apps/roam/src/styles/styles.css
+++ b/apps/roam/src/styles/styles.css
@@ -2,24 +2,6 @@
   outline-width: 2px;
 }
 
-.discourse-graph-title-additions {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: flex-start;
-  column-gap: 8px;
-  row-gap: 8px;
-}
-
-.discourse-graph-title-addition-inline {
-  flex: 0 0 auto;
-  min-width: 0;
-}
-
-.discourse-graph-title-addition-block {
-  flex: 1 0 100%;
-  min-width: 0;
-}
-
 .roamjs-item-dirty,
 .roamjs-item-dirty.bp3-menu-item .bp3-icon,
 .roamjs-item-dirty.bp3-button .bp3-icon {

--- a/apps/roam/src/styles/styles.css
+++ b/apps/roam/src/styles/styles.css
@@ -2,6 +2,24 @@
   outline-width: 2px;
 }
 
+.discourse-graph-title-additions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  column-gap: 8px;
+  row-gap: 8px;
+}
+
+.discourse-graph-title-addition-inline {
+  flex: 0 0 auto;
+  min-width: 0;
+}
+
+.discourse-graph-title-addition-block {
+  flex: 1 0 100%;
+  min-width: 0;
+}
+
 .roamjs-item-dirty,
 .roamjs-item-dirty.bp3-menu-item .bp3-icon,
 .roamjs-item-dirty.bp3-button .bp3-icon {

--- a/apps/roam/src/utils/handleTitleAdditions.ts
+++ b/apps/roam/src/utils/handleTitleAdditions.ts
@@ -3,10 +3,15 @@ import ReactDOM from "react-dom";
 
 const ROAM_TITLE_CONTAINER_CLASS = "rm-title-display-container";
 const ADDITIONS_CONTAINER_CLASS = "discourse-graph-title-additions";
+const INLINE_ADDITION_CLASS = "discourse-graph-title-addition-inline";
+const BLOCK_ADDITION_CLASS = "discourse-graph-title-addition-block";
+
+type TitleAdditionLayout = "inline" | "block";
 
 export const handleTitleAdditions = (
   h1: HTMLHeadingElement,
   element: React.ReactNode,
+  { layout = "block" }: { layout?: TitleAdditionLayout } = {},
 ): void => {
   const titleDisplayContainer =
     h1.closest(`.${ROAM_TITLE_CONTAINER_CLASS}`) ||
@@ -25,7 +30,7 @@ export const handleTitleAdditions = (
     if (!parent) return;
 
     container = document.createElement("div");
-    container.className = `${ADDITIONS_CONTAINER_CLASS} flex flex-col`;
+    container.className = ADDITIONS_CONTAINER_CLASS;
 
     const oldMarginBottom = getComputedStyle(h1).marginBottom;
     const oldMarginBottomNum = Number.isFinite(parseFloat(oldMarginBottom))
@@ -45,6 +50,8 @@ export const handleTitleAdditions = (
 
   if (React.isValidElement(element)) {
     const renderContainer = document.createElement("div");
+    renderContainer.className =
+      layout === "inline" ? INLINE_ADDITION_CLASS : BLOCK_ADDITION_CLASS;
     container.appendChild(renderContainer);
     // eslint-disable-next-line react/no-deprecated
     ReactDOM.render(element, renderContainer);

--- a/apps/roam/src/utils/handleTitleAdditions.ts
+++ b/apps/roam/src/utils/handleTitleAdditions.ts
@@ -3,8 +3,9 @@ import ReactDOM from "react-dom";
 
 const ROAM_TITLE_CONTAINER_CLASS = "rm-title-display-container";
 const ADDITIONS_CONTAINER_CLASS = "discourse-graph-title-additions";
-const INLINE_ADDITION_CLASS = "discourse-graph-title-addition-inline";
-const BLOCK_ADDITION_CLASS = "discourse-graph-title-addition-block";
+const ADDITIONS_CONTAINER_CLASSES = `${ADDITIONS_CONTAINER_CLASS} flex flex-wrap items-start gap-x-2 gap-y-2`;
+const INLINE_ADDITION_CLASSES = "min-w-0 flex-none";
+const BLOCK_ADDITION_CLASSES = "min-w-0 basis-full grow shrink-0";
 
 type TitleAdditionLayout = "inline" | "block";
 
@@ -30,7 +31,7 @@ export const handleTitleAdditions = (
     if (!parent) return;
 
     container = document.createElement("div");
-    container.className = ADDITIONS_CONTAINER_CLASS;
+    container.className = ADDITIONS_CONTAINER_CLASSES;
 
     const oldMarginBottom = getComputedStyle(h1).marginBottom;
     const oldMarginBottomNum = Number.isFinite(parseFloat(oldMarginBottom))
@@ -51,7 +52,7 @@ export const handleTitleAdditions = (
   if (React.isValidElement(element)) {
     const renderContainer = document.createElement("div");
     renderContainer.className =
-      layout === "inline" ? INLINE_ADDITION_CLASS : BLOCK_ADDITION_CLASS;
+      layout === "inline" ? INLINE_ADDITION_CLASSES : BLOCK_ADDITION_CLASSES;
     container.appendChild(renderContainer);
     // eslint-disable-next-line react/no-deprecated
     ReactDOM.render(element, renderContainer);

--- a/apps/roam/src/utils/initializeObserversAndListeners.ts
+++ b/apps/roam/src/utils/initializeObserversAndListeners.ts
@@ -124,13 +124,15 @@ export const initObservers = ({
 
       const isDiscourseNode = node && node.backedBy !== "default";
       if (isDiscourseNode) {
-        renderDiscourseContext({ h1, uid });
         renderPublishNodeTitleButton({
           h1,
           uid,
           title,
           nodeType: node.type,
         });
+        if (settings.personalSettings[PERSONAL_KEYS.discourseContextOverlay]) {
+          renderDiscourseContext({ h1, uid });
+        }
         if (getFeatureFlag("Duplicate node alert enabled")) {
           renderPossibleDuplicates(h1, title, node);
         }

--- a/apps/roam/src/utils/initializeObserversAndListeners.ts
+++ b/apps/roam/src/utils/initializeObserversAndListeners.ts
@@ -49,6 +49,7 @@ import { getFeatureFlag } from "~/components/settings/utils/accessors";
 import { getCleanTagText } from "~/components/settings/NodeConfig";
 import { getNodeTagStyles } from "~/utils/getDiscourseNodeColors";
 import { renderPossibleDuplicates } from "~/components/VectorDuplicateMatches";
+import { renderPublishNodeTitleButton } from "~/components/PublishNodeTitleButton";
 import { renderCanvasEmbed } from "~/components/canvas/CanvasEmbed";
 import getPageUidByPageTitle from "roamjs-components/queries/getPageUidByPageTitle";
 import getPageTitleByPageUid from "roamjs-components/queries/getPageTitleByPageUid";
@@ -124,6 +125,12 @@ export const initObservers = ({
       const isDiscourseNode = node && node.backedBy !== "default";
       if (isDiscourseNode) {
         renderDiscourseContext({ h1, uid });
+        renderPublishNodeTitleButton({
+          h1,
+          uid,
+          title,
+          nodeType: node.type,
+        });
         if (getFeatureFlag("Duplicate node alert enabled")) {
           renderPossibleDuplicates(h1, title, node);
         }

--- a/apps/roam/src/utils/initializeObserversAndListeners.ts
+++ b/apps/roam/src/utils/initializeObserversAndListeners.ts
@@ -55,8 +55,6 @@ import getPageTitleByPageUid from "roamjs-components/queries/getPageTitleByPageU
 import findDiscourseNode from "./findDiscourseNode";
 import {
   bulkReadSettings,
-  getFeatureFlag,
-  isSyncEnabled,
   type SettingsSnapshot,
 } from "~/components/settings/utils/accessors";
 import {
@@ -64,6 +62,7 @@ import {
   settingKeys,
 } from "~/components/settings/utils/settingsEmitter";
 import {
+  FEATURE_FLAG_KEYS,
   PERSONAL_KEYS,
   GLOBAL_KEYS,
 } from "~/components/settings/utils/settingKeys";
@@ -125,7 +124,10 @@ export const initObservers = ({
 
       const isDiscourseNode = node && node.backedBy !== "default";
       if (isDiscourseNode) {
-        if (isSyncEnabled() && node.backedBy === "user") {
+        const syncEnabled =
+          settings.featureFlags[FEATURE_FLAG_KEYS.duplicateNodeAlertEnabled] ||
+          settings.featureFlags[FEATURE_FLAG_KEYS.suggestiveModeOverlayEnabled];
+        if (syncEnabled && node.backedBy === "user") {
           renderPublishNodeTitleButton({
             h1,
             uid,
@@ -136,7 +138,9 @@ export const initObservers = ({
         if (settings.personalSettings[PERSONAL_KEYS.discourseContextOverlay]) {
           renderDiscourseContext({ h1, uid });
         }
-        if (getFeatureFlag("Duplicate node alert enabled")) {
+        if (
+          settings.featureFlags[FEATURE_FLAG_KEYS.duplicateNodeAlertEnabled]
+        ) {
           renderPossibleDuplicates(h1, title, node);
         }
         const linkedReferencesDiv = document.querySelector(
@@ -223,7 +227,7 @@ export const initObservers = ({
       });
   }) as EventListener;
 
-  if (getFeatureFlag("Suggestive mode overlay enabled")) {
+  if (settings.featureFlags[FEATURE_FLAG_KEYS.suggestiveModeOverlayEnabled]) {
     addPageRefObserver(getSuggestiveOverlayHandler(onloadArgs));
   }
 

--- a/apps/roam/src/utils/initializeObserversAndListeners.ts
+++ b/apps/roam/src/utils/initializeObserversAndListeners.ts
@@ -45,7 +45,6 @@ import {
 import { renderNodeTagPopupButton } from "./renderNodeTagPopup";
 import { renderImageToolsMenu } from "./renderImageToolsMenu";
 import { mountLeftSidebar } from "~/components/LeftSidebarView";
-import { getFeatureFlag } from "~/components/settings/utils/accessors";
 import { getCleanTagText } from "~/components/settings/NodeConfig";
 import { getNodeTagStyles } from "~/utils/getDiscourseNodeColors";
 import { renderPossibleDuplicates } from "~/components/VectorDuplicateMatches";
@@ -56,6 +55,8 @@ import getPageTitleByPageUid from "roamjs-components/queries/getPageTitleByPageU
 import findDiscourseNode from "./findDiscourseNode";
 import {
   bulkReadSettings,
+  getFeatureFlag,
+  isSyncEnabled,
   type SettingsSnapshot,
 } from "~/components/settings/utils/accessors";
 import {
@@ -124,12 +125,14 @@ export const initObservers = ({
 
       const isDiscourseNode = node && node.backedBy !== "default";
       if (isDiscourseNode) {
-        renderPublishNodeTitleButton({
-          h1,
-          uid,
-          title,
-          nodeType: node.type,
-        });
+        if (isSyncEnabled() && node.backedBy === "user") {
+          renderPublishNodeTitleButton({
+            h1,
+            uid,
+            title,
+            nodeType: node.type,
+          });
+        }
         if (settings.personalSettings[PERSONAL_KEYS.discourseContextOverlay]) {
           renderDiscourseContext({ h1, uid });
         }

--- a/apps/roam/src/utils/openShareNodeDialog.ts
+++ b/apps/roam/src/utils/openShareNodeDialog.ts
@@ -1,0 +1,17 @@
+import { render as exportRender } from "~/components/Export";
+
+export const openShareNodeDialog = ({
+  uid,
+  title,
+  nodeType,
+}: {
+  uid: string;
+  title: string;
+  nodeType: string;
+}): void => {
+  exportRender({
+    results: [{ uid, text: title, type: nodeType }],
+    isExportDiscourseGraph: true,
+    initialPanel: "publish",
+  });
+};

--- a/apps/roam/src/utils/registerCommandPaletteCommands.ts
+++ b/apps/roam/src/utils/registerCommandPaletteCommands.ts
@@ -281,6 +281,7 @@ export const registerCommandPaletteCommands = (onloadArgs: OnloadArgs) => {
     exportRender({
       results: [{ uid: pageUid, text: pageTitle, type: discourseNode.type }],
       isExportDiscourseGraph: true,
+      initialPanel: "publish",
     });
   };
 

--- a/apps/roam/src/utils/registerCommandPaletteCommands.ts
+++ b/apps/roam/src/utils/registerCommandPaletteCommands.ts
@@ -247,6 +247,14 @@ export const registerCommandPaletteCommands = (onloadArgs: OnloadArgs) => {
   };
 
   const shareCurrentNode = () => {
+    if (!isSyncEnabled()) {
+      renderToast({
+        id: "share-node-sync-disabled",
+        content: "Sync must be enabled to publish discourse nodes.",
+      });
+      return;
+    }
+
     const pageUid = getCurrentPageUid();
     if (!pageUid) {
       renderToast({
@@ -266,10 +274,10 @@ export const registerCommandPaletteCommands = (onloadArgs: OnloadArgs) => {
     }
 
     const discourseNode = findDiscourseNode({ uid: pageUid, title: pageTitle });
-    if (!discourseNode || discourseNode.backedBy === "default") {
+    if (!discourseNode || discourseNode.backedBy !== "user") {
       renderToast({
         id: "share-node-not-a-node",
-        content: "This page is not a discourse node, so it can't be shared.",
+        content: "This page is not a publishable discourse node.",
       });
       return;
     }

--- a/apps/roam/src/utils/registerCommandPaletteCommands.ts
+++ b/apps/roam/src/utils/registerCommandPaletteCommands.ts
@@ -29,6 +29,7 @@ import {
   getPersonalSetting,
   setPersonalSetting,
   setGlobalSetting,
+  isSyncEnabled,
 } from "~/components/settings/utils/accessors";
 import {
   DISCOURSE_NODE_KEYS,
@@ -244,6 +245,45 @@ export const registerCommandPaletteCommands = (onloadArgs: OnloadArgs) => {
     });
   };
 
+  const shareCurrentNode = () => {
+    const pageUid = getCurrentPageUid();
+    if (!pageUid) {
+      renderToast({
+        id: "share-node-no-page",
+        content: "Navigate to a discourse node page to share it.",
+      });
+      return;
+    }
+
+    const pageTitle = getPageTitleByPageUid(pageUid);
+    if (!pageTitle) {
+      renderToast({
+        id: "share-node-no-title",
+        content: "Could not determine the current page title.",
+      });
+      return;
+    }
+
+    const discourseNode = findDiscourseNode({ uid: pageUid, title: pageTitle });
+    if (!discourseNode || discourseNode.backedBy === "default") {
+      renderToast({
+        id: "share-node-not-a-node",
+        content: "This page is not a discourse node, so it can't be shared.",
+      });
+      return;
+    }
+
+    posthog.capture("Share Node: Current Node Command Triggered", {
+      pageUid,
+      nodeType: discourseNode.type,
+    });
+
+    exportRender({
+      results: [{ uid: pageUid, text: pageTitle, type: discourseNode.type }],
+      isExportDiscourseGraph: true,
+    });
+  };
+
   const exportDiscourseGraph = async () => {
     posthog.capture("Export: Discourse Graph Command Triggered");
     const discourseNodes = getDiscourseNodes().filter(excludeDefaultNodes);
@@ -364,6 +404,9 @@ export const registerCommandPaletteCommands = (onloadArgs: OnloadArgs) => {
   void addCommand("DG: Export - Current page", exportCurrentPage);
   void addCommand("DG: Export - Discourse graph", exportDiscourseGraph);
   void addCommand("DG: Open - Discourse settings", renderSettingsPopup);
+  if (isSyncEnabled()) {
+    void addCommand("DG: Share current node", shareCurrentNode);
+  }
   if (getFeatureFlag("Advanced node search enabled")) {
     void addCommand("DG: Open Node Search", () => {
       posthog.capture("Node Search: Open Command Triggered");

--- a/apps/roam/src/utils/registerCommandPaletteCommands.ts
+++ b/apps/roam/src/utils/registerCommandPaletteCommands.ts
@@ -1,6 +1,7 @@
 import { openQueryDrawer } from "~/components/QueryDrawer";
 import { render as exportRender } from "~/components/Export";
 import { render as renderToast } from "roamjs-components/components/Toast";
+import { openShareNodeDialog } from "~/utils/openShareNodeDialog";
 import { createBlock, updateBlock } from "roamjs-components/writes";
 import {
   getCurrentPageUid,
@@ -278,10 +279,10 @@ export const registerCommandPaletteCommands = (onloadArgs: OnloadArgs) => {
       nodeType: discourseNode.type,
     });
 
-    exportRender({
-      results: [{ uid: pageUid, text: pageTitle, type: discourseNode.type }],
-      isExportDiscourseGraph: true,
-      initialPanel: "publish",
+    openShareNodeDialog({
+      uid: pageUid,
+      title: pageTitle,
+      nodeType: discourseNode.type,
     });
   };
 

--- a/apps/roam/src/utils/renderLinkedReferenceAdditions.ts
+++ b/apps/roam/src/utils/renderLinkedReferenceAdditions.ts
@@ -20,6 +20,7 @@ export const renderDiscourseContext = ({
       uid,
       id: nanoid(),
     }),
+    { layout: "inline" },
   );
   h1.setAttribute("data-roamjs-top-discourse-context", "true");
 };


### PR DESCRIPTION
https://www.loom.com/share/7c761a98168a41f1a58dd046b593bd18

## What changed

ENG-1851 is now stacked on ENG-1890 and wires Roam single-node publishing into the existing Share Data dialog.

- Adds `DG: Share current node` for the current user-backed discourse node.
- Adds a page-title `Publish` button on discourse node pages.
- Opens Share Data directly on the `Publish` tab with exactly one selected node.
- Reuses ENG-1890's Publish tab/group-grant path instead of duplicating publish logic.
- Aligns title additions so `Publish` and the discourse context overlay render side by side, while full-width panels such as Possible Duplicates remain below.

## Test result

Built and copied the Roam extension bundle to `/mnt/data/projects/dg-test-eng-1851` with Supabase env loaded.

Runtime test:

- Published `[[NOD]] - test page 3` via the page-title `Publish` button.
- Selected/source-local node UID: `WIsbIYJIA`.
- Selected group: `1a752508-6281-4270-a5ef-3a23cbfc047c`.
- Source space: `105833`.

Supabase verification:

- `ResourceAccess` exists for selected node UID `WIsbIYJIA` and group `1a752508-6281-4270-a5ef-3a23cbfc047c`.
- `SpaceAccess.permissions = partial` exists for the same group and space.
- Schema/type dependency grant exists for source-local id `lwEYjIASO` (`NODE 1`).

This proves the actual publish path rather than duplicate-node/vector-search behavior, because duplicate detection may use synced concepts/content/embeddings but does not create `ResourceAccess` or `SpaceAccess` group grants.

## Scope note

This validates ENG-1851's action/wiring and group-scoped publish grant behavior. Full cross-user discovery/consumption remains ENG-1854 validation territory.
