### PR TITLE
[ENG-1890] Add Publish tab to Roam query-results share dialog

### DIFF
--- a/apps/obsidian/src/components/ImportNodesModal.tsx
+++ b/apps/obsidian/src/components/ImportNodesModal.tsx
@@ -4,9 +4,9 @@ import { StrictMode, useState, useEffect, useCallback } from "react";
 import type DiscourseGraphPlugin from "../index";
 import type { ImportableNode, GroupWithNodes } from "~/types";
 import { getUserNameById } from "~/utils/typeUtils";
+import { getAvailableGroupIds } from "@repo/database/lib/groups";
 import {
   fetchUserNames,
-  getAvailableGroupIds,
   getPublishedNodesForGroups,
   getLocalNodeInstanceIds,
   getSpaceNameFromIds,

--- a/apps/obsidian/src/components/PublishGroupDropdown.tsx
+++ b/apps/obsidian/src/components/PublishGroupDropdown.tsx
@@ -11,7 +11,7 @@ import {
   publishToSelectedGroupWithNotice,
   withPublishedState,
 } from "~/utils/publishGroupSelection";
-import type { MyGroup } from "~/utils/importNodes";
+import type { MyGroup } from "@repo/database/lib/groups";
 
 type PublishGroupDropdownProps = {
   plugin: DiscourseGraphPlugin;

--- a/apps/obsidian/src/utils/importNodes.ts
+++ b/apps/obsidian/src/utils/importNodes.ts
@@ -21,12 +21,6 @@ import {
 import { createTemplateFile } from "./templates";
 import { resolveFolderForSpaceUri } from "./importFolderMetadata";
 
-// Group membership helpers were promoted to @repo/database/lib/groups so Roam
-// can share them (apps can't cross-import). Re-exported here for existing
-// Obsidian importers.
-export type { MyGroup } from "@repo/database/lib/groups";
-export { getAvailableGroupIds, getMyGroups } from "@repo/database/lib/groups";
-
 type PublishedNode = {
   source_local_id: string;
   space_id: number;

--- a/apps/obsidian/src/utils/importNodes.ts
+++ b/apps/obsidian/src/utils/importNodes.ts
@@ -21,53 +21,11 @@ import {
 import { createTemplateFile } from "./templates";
 import { resolveFolderForSpaceUri } from "./importFolderMetadata";
 
-export type MyGroup = {
-  id: string;
-  name: string;
-};
-
-export const getAvailableGroupIds = async (
-  client: DGSupabaseClient,
-): Promise<string[]> => {
-  const { data, error } = await client
-    .from("group_membership")
-    .select("group_id")
-    .eq("member_id", (await client.auth.getUser()).data.user?.id || "");
-
-  if (error) {
-    console.error("Error fetching groups:", error);
-    throw new Error(`Failed to fetch groups: ${error.message}`);
-  }
-
-  return (data || []).map((g) => g.group_id);
-};
-
-export const getMyGroups = async (
-  client: DGSupabaseClient,
-): Promise<MyGroup[]> => {
-  const userId = (await client.auth.getUser()).data.user?.id ?? "";
-  const { data, error } = await client
-    .from("group_membership")
-    .select("group_id, my_groups!group_id(name)")
-    .eq("member_id", userId);
-
-  if (error) {
-    console.error("Error fetching groups:", error);
-    throw new Error(`Failed to fetch groups: ${error.message}`);
-  }
-
-  return (data ?? [])
-    .filter(
-      (row): row is { group_id: string; my_groups: { name: string | null } } =>
-        typeof row.group_id === "string" &&
-        row.my_groups !== null &&
-        typeof row.my_groups === "object",
-    )
-    .map((row) => ({
-      id: row.group_id,
-      name: row.my_groups.name ?? row.group_id,
-    }));
-};
+// Group membership helpers were promoted to @repo/database/lib/groups so Roam
+// can share them (apps can't cross-import). Re-exported here for existing
+// Obsidian importers.
+export type { MyGroup } from "@repo/database/lib/groups";
+export { getAvailableGroupIds, getMyGroups } from "@repo/database/lib/groups";
 
 type PublishedNode = {
   source_local_id: string;

--- a/apps/obsidian/src/utils/publishGroupSelection.ts
+++ b/apps/obsidian/src/utils/publishGroupSelection.ts
@@ -1,11 +1,11 @@
 import { Notice, type FrontMatterCache, type TFile } from "obsidian";
-import type DiscourseGraphPlugin from "~/index";
-import { PublishGroupSuggestModal } from "~/components/PublishGroupSuggestModal";
 import {
   getAvailableGroupIds,
   getMyGroups,
   type MyGroup,
-} from "~/utils/importNodes";
+} from "@repo/database/lib/groups";
+import type DiscourseGraphPlugin from "~/index";
+import { PublishGroupSuggestModal } from "~/components/PublishGroupSuggestModal";
 import { getLoggedInClient } from "~/utils/supabaseContext";
 import {
   getPublishedToGroups,

--- a/apps/obsidian/src/utils/publishNode.ts
+++ b/apps/obsidian/src/utils/publishNode.ts
@@ -11,7 +11,7 @@ import {
   type RelationsFile,
 } from "./relationsStore";
 import type { RelationInstance } from "~/types";
-import { getAvailableGroupIds } from "./importNodes";
+import { getAvailableGroupIds } from "@repo/database/lib/groups";
 import {
   syncAllNodesAndRelations,
   syncPublishedNodeAssets,

--- a/apps/obsidian/src/utils/templateImport.ts
+++ b/apps/obsidian/src/utils/templateImport.ts
@@ -1,9 +1,9 @@
 /* eslint-disable @typescript-eslint/naming-convention -- Supabase query results use snake_case column names */
 import type { Json } from "@repo/database/dbTypes";
+import { getAvailableGroupIds } from "@repo/database/lib/groups";
 import type DiscourseGraphPlugin from "~/index";
 import {
   fetchUserNames,
-  getAvailableGroupIds,
   getSpaceNameFromIds,
   getSpaceUris,
 } from "./importNodes";

--- a/apps/roam/src/components/Export.tsx
+++ b/apps/roam/src/components/Export.tsx
@@ -234,7 +234,9 @@ const ExportDialog: ExportDialogComponent = ({
         ? results
             .map((r) => {
               const node = findDiscourseNode({ uid: r.uid });
-              return node ? { uid: r.uid, type: node.type } : null;
+              return node && node.backedBy === "user"
+                ? { uid: r.uid, type: node.type }
+                : null;
             })
             .filter((n): n is PublishNode => n !== null)
         : [],
@@ -843,11 +845,16 @@ const ExportDialog: ExportDialogComponent = ({
         nonDiscourseCount,
         failedGroupCount: failedGroupIds.length,
       });
-      const messages = [
-        `Published ${publishedNodeUids.length} node${
-          publishedNodeUids.length === 1 ? "" : "s"
-        } to ${okGroupIds.length} group${okGroupIds.length === 1 ? "" : "s"}.`,
-      ];
+      const hasPublishedNodes = publishedNodeUids.length > 0;
+      const messages = hasPublishedNodes
+        ? [
+            `Published ${publishedNodeUids.length} node${
+              publishedNodeUids.length === 1 ? "" : "s"
+            } to ${okGroupIds.length} group${
+              okGroupIds.length === 1 ? "" : "s"
+            }.`,
+          ]
+        : ["No nodes were published."];
       if (skippedUnsyncedUids.length)
         messages.push(
           `${skippedUnsyncedUids.length} not synced yet — try again shortly.`,
@@ -862,10 +869,11 @@ const ExportDialog: ExportDialogComponent = ({
         );
       renderToast({
         content: messages.join(" "),
-        intent: failedGroupIds.length ? "warning" : "success",
+        intent:
+          failedGroupIds.length || !hasPublishedNodes ? "warning" : "success",
         id: "query-builder-publish-success",
       });
-      onClose();
+      if (hasPublishedNodes) onClose();
     } catch (e) {
       internalError({
         error: e as Error,
@@ -1160,7 +1168,7 @@ const ExportDialog: ExportDialogComponent = ({
   const PublishPanel = (
     <>
       <div className={Classes.DIALOG_BODY}>
-        {groupsLoading ? (
+        {groupsLoading || !groupsLoaded ? (
           <div className="my-2.5">Loading groups…</div>
         ) : groupsError ? (
           <div className="my-2.5">{groupsError}</div>

--- a/apps/roam/src/components/Export.tsx
+++ b/apps/roam/src/components/Export.tsx
@@ -11,7 +11,6 @@ import {
   Toast,
   Tooltip,
   Tab,
-  Tag,
   Tabs,
   RadioGroup,
   Radio,
@@ -87,7 +86,6 @@ import { AddReferencedNodeType } from "./canvas/DiscourseRelationShape/Discourse
 import posthog from "posthog-js";
 import { getMyGroups, type MyGroup } from "@repo/database/lib/groups";
 import {
-  getPublishedNodeCountsByGroup,
   publishNodesToGroups,
   type PublishNode,
 } from "~/utils/publishNodesToGroups";
@@ -155,44 +153,6 @@ const INITIAL_PANEL_TO_TAB_ID: Record<
 const exportDestinationById = Object.fromEntries(
   EXPORT_DESTINATIONS.map((ed) => [ed.id, ed]),
 );
-
-const getReferencedUids = (uid: string): string[] => {
-  const result =
-    (window.roamAlphaAPI?.pull?.("[{:block/refs [:block/uid]}]", [
-      ":block/uid",
-      uid,
-    ]) as { [":block/refs"]?: { ":block/uid"?: string }[] } | null) || {};
-  return (result[":block/refs"] || []).flatMap((ref) =>
-    ref[":block/uid"] ? [ref[":block/uid"]] : [],
-  );
-};
-
-const getResultPublishNodes = (result: Result): PublishNode[] => {
-  const directNode = findDiscourseNode({ uid: result.uid });
-  if (directNode && directNode.backedBy === "user")
-    return [{ uid: result.uid, type: directNode.type }];
-  return getReferencedUids(result.uid).flatMap((uid) => {
-    const node = findDiscourseNode({ uid });
-    return node && node.backedBy === "user" ? [{ uid, type: node.type }] : [];
-  });
-};
-
-type PublishableNodesState = {
-  publishableNodes: PublishNode[];
-  nonDiscourseCount: number;
-};
-
-type GroupShareState = {
-  sharedNodeCount: number;
-  publishableNodeCount: number;
-  isFullyShared: boolean;
-  isPartiallyShared: boolean;
-};
-
-const EMPTY_PUBLISHABLE_NODES_STATE: PublishableNodesState = {
-  publishableNodes: [],
-  nonDiscourseCount: 0,
-};
 
 const ExportDialog: ExportDialogComponent = ({
   onClose,
@@ -274,52 +234,24 @@ const ExportDialog: ExportDialogComponent = ({
   const [groupsLoading, setGroupsLoading] = useState(false);
   const [groupsLoaded, setGroupsLoaded] = useState(false);
   const [selectedGroupIds, setSelectedGroupIds] = useState<string[]>([]);
-  const [sharedNodeCountsByGroupId, setSharedNodeCountsByGroupId] = useState<
-    Record<string, number>
-  >({});
   const [groupsError, setGroupsError] = useState("");
   const [publishError, setPublishError] = useState("");
 
-  const { publishableNodes, nonDiscourseCount } =
-    useMemo<PublishableNodesState>(() => {
-      if (!syncEnabled) return EMPTY_PUBLISHABLE_NODES_STATE;
-      const seen = new Set<string>();
-      const publishableNodes: PublishNode[] = [];
-      let nonDiscourseCount = 0;
-      for (const result of results) {
-        const resolved = getResultPublishNodes(result);
-        if (resolved.length === 0) {
-          nonDiscourseCount += 1;
-          continue;
-        }
-        for (const node of resolved) {
-          if (seen.has(node.uid)) continue;
-          seen.add(node.uid);
-          publishableNodes.push(node);
-        }
-      }
-      return { publishableNodes, nonDiscourseCount };
-    }, [results, syncEnabled]);
-
-  const publishableNodeUids = useMemo(
-    () => publishableNodes.map((node) => node.uid),
-    [publishableNodes],
+  const publishableNodes = useMemo(
+    () =>
+      syncEnabled
+        ? results
+            .map((r) => {
+              const node = findDiscourseNode({ uid: r.uid });
+              return node && node.backedBy === "user"
+                ? { uid: r.uid, type: node.type }
+                : null;
+            })
+            .filter((n): n is PublishNode => n !== null)
+        : [],
+    [results, syncEnabled],
   );
-
-  const getGroupShareState = (groupId: string): GroupShareState => {
-    const sharedNodeCount = sharedNodeCountsByGroupId[groupId] ?? 0;
-    const publishableNodeCount = publishableNodeUids.length;
-    const isFullyShared =
-      publishableNodeCount > 0 && sharedNodeCount === publishableNodeCount;
-    const isPartiallyShared =
-      sharedNodeCount > 0 && sharedNodeCount < publishableNodeCount;
-    return {
-      sharedNodeCount,
-      publishableNodeCount,
-      isFullyShared,
-      isPartiallyShared,
-    };
-  };
+  const nonDiscourseCount = results.length - publishableNodes.length;
 
   const writeFileToRepo = async ({
     filename,
@@ -887,27 +819,6 @@ const ExportDialog: ExportDialogComponent = ({
         const client = await getLoggedInClient();
         if (!client) throw new Error("Could not connect to sync.");
         const groups = await getMyGroups(client);
-        const groupIds = groups.map((group) => group.id);
-        if (publishableNodeUids.length > 0) {
-          const context = await getSupabaseContext();
-          if (!context) throw new Error("Could not connect to sync.");
-          const sharedNodeCounts = await getPublishedNodeCountsByGroup({
-            client,
-            spaceId: context.spaceId,
-            groupIds,
-            nodeUids: publishableNodeUids,
-          });
-          setSharedNodeCountsByGroupId(sharedNodeCounts);
-          setSelectedGroupIds((prev) =>
-            prev.filter(
-              (groupId) =>
-                (sharedNodeCounts[groupId] ?? 0) < publishableNodeUids.length,
-            ),
-          );
-        } else {
-          setSharedNodeCountsByGroupId({});
-          setSelectedGroupIds([]);
-        }
         setMyGroups(groups);
       } catch (e) {
         setGroupsError((e as Error).message || "Failed to load groups.");
@@ -916,14 +827,7 @@ const ExportDialog: ExportDialogComponent = ({
         setGroupsLoaded(true);
       }
     })();
-  }, [
-    syncEnabled,
-    isOpen,
-    selectedTabId,
-    groupsLoaded,
-    groupsLoading,
-    publishableNodeUids,
-  ]);
+  }, [syncEnabled, isOpen, selectedTabId, groupsLoaded, groupsLoading]);
 
   const handlePublish = async () => {
     setPublishError("");
@@ -1284,46 +1188,21 @@ const ExportDialog: ExportDialogComponent = ({
         ) : (
           <>
             <Label>Publish to group(s)</Label>
-            {myGroups.map((group) => {
-              const {
-                sharedNodeCount,
-                publishableNodeCount,
-                isFullyShared,
-                isPartiallyShared,
-              } = getGroupShareState(group.id);
-              const isSelected = selectedGroupIds.includes(group.id);
-              return (
-                <Checkbox
-                  key={group.id}
-                  checked={isFullyShared || isSelected}
-                  disabled={isFullyShared}
-                  indeterminate={isPartiallyShared && !isSelected}
-                  labelElement={
-                    <span>
-                      {group.name}{" "}
-                      {isFullyShared ? (
-                        <Tag minimal intent={Intent.SUCCESS}>
-                          Already shared
-                        </Tag>
-                      ) : isPartiallyShared ? (
-                        <Tag minimal>
-                          {sharedNodeCount}/{publishableNodeCount} shared
-                        </Tag>
-                      ) : null}
-                    </span>
-                  }
-                  onChange={(e) => {
-                    if (isFullyShared) return;
-                    const { checked } = e.target as HTMLInputElement;
-                    setSelectedGroupIds((prev) =>
-                      checked
-                        ? [...new Set([...prev, group.id])]
-                        : prev.filter((id) => id !== group.id),
-                    );
-                  }}
-                />
-              );
-            })}
+            {myGroups.map((group) => (
+              <Checkbox
+                key={group.id}
+                checked={selectedGroupIds.includes(group.id)}
+                label={group.name}
+                onChange={(e) => {
+                  const { checked } = e.target as HTMLInputElement;
+                  setSelectedGroupIds((prev) =>
+                    checked
+                      ? [...prev, group.id]
+                      : prev.filter((id) => id !== group.id),
+                  );
+                }}
+              />
+            ))}
             <div className="mt-2.5">
               {`Publishing ${publishableNodes.length} discourse node${
                 publishableNodes.length === 1 ? "" : "s"

--- a/apps/roam/src/components/Export.tsx
+++ b/apps/roam/src/components/Export.tsx
@@ -146,6 +146,27 @@ const exportDestinationById = Object.fromEntries(
   EXPORT_DESTINATIONS.map((ed) => [ed.id, ed]),
 );
 
+const getReferencedUids = (uid: string): string[] => {
+  const result =
+    (window.roamAlphaAPI?.pull?.("[{:block/refs [:block/uid]}]", [
+      ":block/uid",
+      uid,
+    ]) as { [":block/refs"]?: { ":block/uid"?: string }[] } | null) || {};
+  return (result[":block/refs"] || []).flatMap((ref) =>
+    ref[":block/uid"] ? [ref[":block/uid"]] : [],
+  );
+};
+
+const getResultPublishNodes = (result: Result): PublishNode[] => {
+  const directNode = findDiscourseNode({ uid: result.uid });
+  if (directNode && directNode.backedBy === "user")
+    return [{ uid: result.uid, type: directNode.type }];
+  return getReferencedUids(result.uid).flatMap((uid) => {
+    const node = findDiscourseNode({ uid });
+    return node && node.backedBy === "user" ? [{ uid, type: node.type }] : [];
+  });
+};
+
 const ExportDialog: ExportDialogComponent = ({
   onClose,
   isOpen,
@@ -228,21 +249,26 @@ const ExportDialog: ExportDialogComponent = ({
   const [groupsError, setGroupsError] = useState("");
   const [publishError, setPublishError] = useState("");
 
-  const publishableNodes = useMemo(
-    () =>
-      syncEnabled
-        ? results
-            .map((r) => {
-              const node = findDiscourseNode({ uid: r.uid });
-              return node && node.backedBy === "user"
-                ? { uid: r.uid, type: node.type }
-                : null;
-            })
-            .filter((n): n is PublishNode => n !== null)
-        : [],
-    [results, syncEnabled],
-  );
-  const nonDiscourseCount = results.length - publishableNodes.length;
+  const { publishableNodes, nonDiscourseCount } = useMemo(() => {
+    if (!syncEnabled)
+      return { publishableNodes: [] as PublishNode[], nonDiscourseCount: 0 };
+    const seen = new Set<string>();
+    const publishableNodes: PublishNode[] = [];
+    let nonDiscourseCount = 0;
+    for (const result of results) {
+      const resolved = getResultPublishNodes(result);
+      if (resolved.length === 0) {
+        nonDiscourseCount += 1;
+        continue;
+      }
+      for (const node of resolved) {
+        if (seen.has(node.uid)) continue;
+        seen.add(node.uid);
+        publishableNodes.push(node);
+      }
+    }
+    return { publishableNodes, nonDiscourseCount };
+  }, [results, syncEnabled]);
 
   const writeFileToRepo = async ({
     filename,

--- a/apps/roam/src/components/Export.tsx
+++ b/apps/roam/src/components/Export.tsx
@@ -11,6 +11,7 @@ import {
   Toast,
   Tooltip,
   Tab,
+  Tag,
   Tabs,
   RadioGroup,
   Radio,
@@ -86,6 +87,7 @@ import { AddReferencedNodeType } from "./canvas/DiscourseRelationShape/Discourse
 import posthog from "posthog-js";
 import { getMyGroups, type MyGroup } from "@repo/database/lib/groups";
 import {
+  getPublishedNodeCountsByGroup,
   publishNodesToGroups,
   type PublishNode,
 } from "~/utils/publishNodesToGroups";
@@ -175,6 +177,23 @@ const getResultPublishNodes = (result: Result): PublishNode[] => {
   });
 };
 
+type PublishableNodesState = {
+  publishableNodes: PublishNode[];
+  nonDiscourseCount: number;
+};
+
+type GroupShareState = {
+  sharedNodeCount: number;
+  publishableNodeCount: number;
+  isFullyShared: boolean;
+  isPartiallyShared: boolean;
+};
+
+const EMPTY_PUBLISHABLE_NODES_STATE: PublishableNodesState = {
+  publishableNodes: [],
+  nonDiscourseCount: 0,
+};
+
 const ExportDialog: ExportDialogComponent = ({
   onClose,
   isOpen,
@@ -255,29 +274,52 @@ const ExportDialog: ExportDialogComponent = ({
   const [groupsLoading, setGroupsLoading] = useState(false);
   const [groupsLoaded, setGroupsLoaded] = useState(false);
   const [selectedGroupIds, setSelectedGroupIds] = useState<string[]>([]);
+  const [sharedNodeCountsByGroupId, setSharedNodeCountsByGroupId] = useState<
+    Record<string, number>
+  >({});
   const [groupsError, setGroupsError] = useState("");
   const [publishError, setPublishError] = useState("");
 
-  const { publishableNodes, nonDiscourseCount } = useMemo(() => {
-    if (!syncEnabled)
-      return { publishableNodes: [] as PublishNode[], nonDiscourseCount: 0 };
-    const seen = new Set<string>();
-    const publishableNodes: PublishNode[] = [];
-    let nonDiscourseCount = 0;
-    for (const result of results) {
-      const resolved = getResultPublishNodes(result);
-      if (resolved.length === 0) {
-        nonDiscourseCount += 1;
-        continue;
+  const { publishableNodes, nonDiscourseCount } =
+    useMemo<PublishableNodesState>(() => {
+      if (!syncEnabled) return EMPTY_PUBLISHABLE_NODES_STATE;
+      const seen = new Set<string>();
+      const publishableNodes: PublishNode[] = [];
+      let nonDiscourseCount = 0;
+      for (const result of results) {
+        const resolved = getResultPublishNodes(result);
+        if (resolved.length === 0) {
+          nonDiscourseCount += 1;
+          continue;
+        }
+        for (const node of resolved) {
+          if (seen.has(node.uid)) continue;
+          seen.add(node.uid);
+          publishableNodes.push(node);
+        }
       }
-      for (const node of resolved) {
-        if (seen.has(node.uid)) continue;
-        seen.add(node.uid);
-        publishableNodes.push(node);
-      }
-    }
-    return { publishableNodes, nonDiscourseCount };
-  }, [results, syncEnabled]);
+      return { publishableNodes, nonDiscourseCount };
+    }, [results, syncEnabled]);
+
+  const publishableNodeUids = useMemo(
+    () => publishableNodes.map((node) => node.uid),
+    [publishableNodes],
+  );
+
+  const getGroupShareState = (groupId: string): GroupShareState => {
+    const sharedNodeCount = sharedNodeCountsByGroupId[groupId] ?? 0;
+    const publishableNodeCount = publishableNodeUids.length;
+    const isFullyShared =
+      publishableNodeCount > 0 && sharedNodeCount === publishableNodeCount;
+    const isPartiallyShared =
+      sharedNodeCount > 0 && sharedNodeCount < publishableNodeCount;
+    return {
+      sharedNodeCount,
+      publishableNodeCount,
+      isFullyShared,
+      isPartiallyShared,
+    };
+  };
 
   const writeFileToRepo = async ({
     filename,
@@ -845,6 +887,27 @@ const ExportDialog: ExportDialogComponent = ({
         const client = await getLoggedInClient();
         if (!client) throw new Error("Could not connect to sync.");
         const groups = await getMyGroups(client);
+        const groupIds = groups.map((group) => group.id);
+        if (publishableNodeUids.length > 0) {
+          const context = await getSupabaseContext();
+          if (!context) throw new Error("Could not connect to sync.");
+          const sharedNodeCounts = await getPublishedNodeCountsByGroup({
+            client,
+            spaceId: context.spaceId,
+            groupIds,
+            nodeUids: publishableNodeUids,
+          });
+          setSharedNodeCountsByGroupId(sharedNodeCounts);
+          setSelectedGroupIds((prev) =>
+            prev.filter(
+              (groupId) =>
+                (sharedNodeCounts[groupId] ?? 0) < publishableNodeUids.length,
+            ),
+          );
+        } else {
+          setSharedNodeCountsByGroupId({});
+          setSelectedGroupIds([]);
+        }
         setMyGroups(groups);
       } catch (e) {
         setGroupsError((e as Error).message || "Failed to load groups.");
@@ -853,7 +916,14 @@ const ExportDialog: ExportDialogComponent = ({
         setGroupsLoaded(true);
       }
     })();
-  }, [syncEnabled, isOpen, selectedTabId, groupsLoaded, groupsLoading]);
+  }, [
+    syncEnabled,
+    isOpen,
+    selectedTabId,
+    groupsLoaded,
+    groupsLoading,
+    publishableNodeUids,
+  ]);
 
   const handlePublish = async () => {
     setPublishError("");
@@ -1214,21 +1284,46 @@ const ExportDialog: ExportDialogComponent = ({
         ) : (
           <>
             <Label>Publish to group(s)</Label>
-            {myGroups.map((group) => (
-              <Checkbox
-                key={group.id}
-                checked={selectedGroupIds.includes(group.id)}
-                label={group.name}
-                onChange={(e) => {
-                  const { checked } = e.target as HTMLInputElement;
-                  setSelectedGroupIds((prev) =>
-                    checked
-                      ? [...prev, group.id]
-                      : prev.filter((id) => id !== group.id),
-                  );
-                }}
-              />
-            ))}
+            {myGroups.map((group) => {
+              const {
+                sharedNodeCount,
+                publishableNodeCount,
+                isFullyShared,
+                isPartiallyShared,
+              } = getGroupShareState(group.id);
+              const isSelected = selectedGroupIds.includes(group.id);
+              return (
+                <Checkbox
+                  key={group.id}
+                  checked={isFullyShared || isSelected}
+                  disabled={isFullyShared}
+                  indeterminate={isPartiallyShared && !isSelected}
+                  labelElement={
+                    <span>
+                      {group.name}{" "}
+                      {isFullyShared ? (
+                        <Tag minimal intent={Intent.SUCCESS}>
+                          Already shared
+                        </Tag>
+                      ) : isPartiallyShared ? (
+                        <Tag minimal>
+                          {sharedNodeCount}/{publishableNodeCount} shared
+                        </Tag>
+                      ) : null}
+                    </span>
+                  }
+                  onChange={(e) => {
+                    if (isFullyShared) return;
+                    const { checked } = e.target as HTMLInputElement;
+                    setSelectedGroupIds((prev) =>
+                      checked
+                        ? [...new Set([...prev, group.id])]
+                        : prev.filter((id) => id !== group.id),
+                    );
+                  }}
+                />
+              );
+            })}
             <div className="mt-2.5">
               {`Publishing ${publishableNodes.length} discourse node${
                 publishableNodes.length === 1 ? "" : "s"

--- a/apps/roam/src/components/Export.tsx
+++ b/apps/roam/src/components/Export.tsx
@@ -128,7 +128,7 @@ export type ExportDialogProps = {
   title?: string;
   columns?: Column[];
   isExportDiscourseGraph?: boolean;
-  initialPanel?: "sendTo" | "export";
+  initialPanel?: "sendTo" | "export" | "publish";
 };
 
 type ExportDialogComponent = (
@@ -141,6 +141,14 @@ const EXPORT_DESTINATIONS = [
   { id: "github", label: "Send to GitHub", active: true },
 ];
 const SEND_TO_DESTINATIONS = ["page", "graph"];
+const INITIAL_PANEL_TO_TAB_ID: Record<
+  NonNullable<ExportDialogProps["initialPanel"]>,
+  string
+> = {
+  sendTo: "sendto",
+  export: "export",
+  publish: "publish",
+};
 
 const exportDestinationById = Object.fromEntries(
   EXPORT_DESTINATIONS.map((ed) => [ed.id, ed]),
@@ -230,10 +238,12 @@ const ExportDialog: ExportDialogComponent = ({
     useState<(typeof SEND_TO_DESTINATIONS)[number]>("page");
   const isSendToGraph = activeSendToDestination === "graph";
   const [livePages, setLivePages] = useState<Result[]>([]);
+  const syncEnabled = useMemo(() => isSyncEnabled(), []);
   const [selectedTabId, setSelectedTabId] = useState("sendto");
   useEffect(() => {
-    if (initialPanel === "export") setSelectedTabId("export");
-  }, [initialPanel]);
+    if (initialPanel === "publish" && !syncEnabled) return;
+    if (initialPanel) setSelectedTabId(INITIAL_PANEL_TO_TAB_ID[initialPanel]);
+  }, [initialPanel, syncEnabled]);
   const [includeDiscourseContext, setIncludeDiscourseContext] = useState(false);
   const [gitHubAccessToken, setGitHubAccessToken] = useState<string | null>(
     getSetting<string | null>("oauth-github", null),
@@ -241,7 +251,6 @@ const ExportDialog: ExportDialogComponent = ({
 
   const [canSendToGitHub, setCanSendToGitHub] = useState(false);
 
-  const syncEnabled = useMemo(() => isSyncEnabled(), []);
   const [myGroups, setMyGroups] = useState<MyGroup[]>([]);
   const [groupsLoading, setGroupsLoading] = useState(false);
   const [groupsLoaded, setGroupsLoaded] = useState(false);

--- a/apps/roam/src/components/Export.tsx
+++ b/apps/roam/src/components/Export.tsx
@@ -978,7 +978,7 @@ const ExportDialog: ExportDialogComponent = ({
       </div>
       <div className={Classes.DIALOG_FOOTER}>
         <div className={Classes.DIALOG_FOOTER_ACTIONS}>
-          <span style={{ color: "darkred" }}>{error}</span>
+          <span className="text-red-700">{error}</span>
           <Button text={"Cancel"} intent={Intent.NONE} onClick={onClose} />
           <Button
             text={"Export"}
@@ -1217,7 +1217,7 @@ const ExportDialog: ExportDialogComponent = ({
       </div>
       <div className={Classes.DIALOG_FOOTER}>
         <div className={Classes.DIALOG_FOOTER_ACTIONS}>
-          <span style={{ color: "darkred" }}>{publishError}</span>
+          <span className="text-red-700">{publishError}</span>
           <Button text={"Cancel"} intent={Intent.NONE} onClick={onClose} />
           <Button
             text={"Publish"}

--- a/apps/roam/src/components/Export.tsx
+++ b/apps/roam/src/components/Export.tsx
@@ -84,6 +84,13 @@ import getDiscourseRelations, {
 } from "~/utils/getDiscourseRelations";
 import { AddReferencedNodeType } from "./canvas/DiscourseRelationShape/DiscourseRelationTool";
 import posthog from "posthog-js";
+import { getMyGroups, type MyGroup } from "@repo/database/lib/groups";
+import {
+  publishNodesToGroups,
+  type PublishNode,
+} from "~/utils/publishNodesToGroups";
+import { getLoggedInClient, getSupabaseContext } from "~/utils/supabaseContext";
+import { isSyncEnabled } from "~/components/settings/utils/accessors";
 
 const ExportProgress = ({ id }: { id: string }) => {
   const [progress, setProgress] = useState(0);
@@ -212,6 +219,28 @@ const ExportDialog: ExportDialogComponent = ({
   );
 
   const [canSendToGitHub, setCanSendToGitHub] = useState(false);
+
+  const syncEnabled = useMemo(() => isSyncEnabled(), []);
+  const [myGroups, setMyGroups] = useState<MyGroup[]>([]);
+  const [groupsLoading, setGroupsLoading] = useState(false);
+  const [groupsLoaded, setGroupsLoaded] = useState(false);
+  const [selectedGroupIds, setSelectedGroupIds] = useState<string[]>([]);
+  const [groupsError, setGroupsError] = useState("");
+  const [publishError, setPublishError] = useState("");
+
+  const publishableNodes = useMemo(
+    () =>
+      syncEnabled
+        ? results
+            .map((r) => {
+              const node = findDiscourseNode({ uid: r.uid });
+              return node ? { uid: r.uid, type: node.type } : null;
+            })
+            .filter((n): n is PublishNode => n !== null)
+        : [],
+    [results, syncEnabled],
+  );
+  const nonDiscourseCount = results.length - publishableNodes.length;
 
   const writeFileToRepo = async ({
     filename,
@@ -764,6 +793,92 @@ const ExportDialog: ExportDialogComponent = ({
       });
     }
   };
+  useEffect(() => {
+    if (
+      !syncEnabled ||
+      !isOpen ||
+      selectedTabId !== "publish" ||
+      groupsLoaded ||
+      groupsLoading
+    )
+      return;
+    setGroupsLoading(true);
+    void (async () => {
+      try {
+        const client = await getLoggedInClient();
+        if (!client) throw new Error("Could not connect to sync.");
+        const groups = await getMyGroups(client);
+        setMyGroups(groups);
+      } catch (e) {
+        setGroupsError((e as Error).message || "Failed to load groups.");
+      } finally {
+        setGroupsLoading(false);
+        setGroupsLoaded(true);
+      }
+    })();
+  }, [syncEnabled, isOpen, selectedTabId, groupsLoaded, groupsLoading]);
+
+  const handlePublish = async () => {
+    setPublishError("");
+    setLoading(true);
+    try {
+      const client = await getLoggedInClient();
+      const context = await getSupabaseContext();
+      if (!client || !context) throw new Error("Could not connect to sync.");
+      const {
+        publishedNodeUids,
+        skippedUnsyncedUids,
+        okGroupIds,
+        failedGroupIds,
+      } = await publishNodesToGroups({
+        client,
+        spaceId: context.spaceId,
+        groupIds: selectedGroupIds,
+        nodes: publishableNodes,
+      });
+      posthog.capture("Export Dialog: Publish", {
+        groupCount: okGroupIds.length,
+        publishedNodeCount: publishedNodeUids.length,
+        skippedUnsyncedCount: skippedUnsyncedUids.length,
+        nonDiscourseCount,
+        failedGroupCount: failedGroupIds.length,
+      });
+      const messages = [
+        `Published ${publishedNodeUids.length} node${
+          publishedNodeUids.length === 1 ? "" : "s"
+        } to ${okGroupIds.length} group${okGroupIds.length === 1 ? "" : "s"}.`,
+      ];
+      if (skippedUnsyncedUids.length)
+        messages.push(
+          `${skippedUnsyncedUids.length} not synced yet — try again shortly.`,
+        );
+      if (nonDiscourseCount)
+        messages.push(`${nonDiscourseCount} skipped (not discourse nodes).`);
+      if (failedGroupIds.length)
+        messages.push(
+          `${failedGroupIds.length} group${
+            failedGroupIds.length === 1 ? "" : "s"
+          } failed.`,
+        );
+      renderToast({
+        content: messages.join(" "),
+        intent: failedGroupIds.length ? "warning" : "success",
+        id: "query-builder-publish-success",
+      });
+      onClose();
+    } catch (e) {
+      internalError({
+        error: e as Error,
+        type: "Publish Dialog Failed",
+        userMessage:
+          "Looks like there was an error publishing. The team has been notified.",
+      });
+      setPublishError((e as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
   const ExportPanel = (
     <>
       <div className={Classes.DIALOG_BODY}>
@@ -1042,6 +1157,68 @@ const ExportDialog: ExportDialogComponent = ({
     </>
   );
 
+  const PublishPanel = (
+    <>
+      <div className={Classes.DIALOG_BODY}>
+        {groupsLoading ? (
+          <div className="my-2.5">Loading groups…</div>
+        ) : groupsError ? (
+          <div className="my-2.5">{groupsError}</div>
+        ) : myGroups.length === 0 ? (
+          <div className="my-2.5">
+            You are not a member of any sharing group.
+          </div>
+        ) : (
+          <>
+            <Label>Publish to group(s)</Label>
+            {myGroups.map((group) => (
+              <Checkbox
+                key={group.id}
+                checked={selectedGroupIds.includes(group.id)}
+                label={group.name}
+                onChange={(e) => {
+                  const { checked } = e.target as HTMLInputElement;
+                  setSelectedGroupIds((prev) =>
+                    checked
+                      ? [...prev, group.id]
+                      : prev.filter((id) => id !== group.id),
+                  );
+                }}
+              />
+            ))}
+            <div className="mt-2.5">
+              {`Publishing ${publishableNodes.length} discourse node${
+                publishableNodes.length === 1 ? "" : "s"
+              }`}
+              {nonDiscourseCount > 0 &&
+                ` (${nonDiscourseCount} non-discourse result${
+                  nonDiscourseCount === 1 ? "" : "s"
+                } will be skipped)`}
+            </div>
+          </>
+        )}
+      </div>
+      <div className={Classes.DIALOG_FOOTER}>
+        <div className={Classes.DIALOG_FOOTER_ACTIONS}>
+          <span style={{ color: "darkred" }}>{publishError}</span>
+          <Button text={"Cancel"} intent={Intent.NONE} onClick={onClose} />
+          <Button
+            text={"Publish"}
+            intent={Intent.PRIMARY}
+            onClick={() => void handlePublish()}
+            loading={loading}
+            disabled={
+              loading ||
+              selectedGroupIds.length === 0 ||
+              publishableNodes.length === 0
+            }
+            style={{ minWidth: 64 }}
+          />
+        </div>
+      </div>
+    </>
+  );
+
   return (
     <>
       <Dialog
@@ -1067,6 +1244,9 @@ const ExportDialog: ExportDialogComponent = ({
         >
           <Tab id="sendto" title="Send To" panel={SendToPanel} />
           <Tab id="export" title="Export" panel={ExportPanel} />
+          {syncEnabled && (
+            <Tab id="publish" title="Publish" panel={PublishPanel} />
+          )}
         </Tabs>
       </Dialog>
       <ExportProgress id={exportId} />

--- a/apps/roam/src/components/PublishNodeTitleButton.tsx
+++ b/apps/roam/src/components/PublishNodeTitleButton.tsx
@@ -1,0 +1,53 @@
+import { Button } from "@blueprintjs/core";
+import posthog from "posthog-js";
+import React from "react";
+import { handleTitleAdditions } from "~/utils/handleTitleAdditions";
+import { openShareNodeDialog } from "~/utils/openShareNodeDialog";
+
+const PUBLISH_TITLE_BUTTON_ATTRIBUTE = "data-roamjs-publish-node-title-button";
+
+const PublishNodeTitleButton = ({
+  uid,
+  title,
+  nodeType,
+}: {
+  uid: string;
+  title: string;
+  nodeType: string;
+}): JSX.Element => (
+  <Button
+    text="Publish"
+    icon="upload"
+    minimal
+    outlined
+    onClick={() => {
+      posthog.capture("Share Node: Page Title Button Triggered", {
+        pageUid: uid,
+        nodeType,
+      });
+      openShareNodeDialog({ uid, title, nodeType });
+    }}
+  />
+);
+
+export const renderPublishNodeTitleButton = ({
+  h1,
+  uid,
+  title,
+  nodeType,
+}: {
+  h1: HTMLHeadingElement;
+  uid: string;
+  title: string;
+  nodeType: string;
+}): void => {
+  if (!uid) return;
+  if (h1.getAttribute(PUBLISH_TITLE_BUTTON_ATTRIBUTE) === uid) return;
+
+  h1.setAttribute(PUBLISH_TITLE_BUTTON_ATTRIBUTE, uid);
+  handleTitleAdditions(
+    h1,
+    <PublishNodeTitleButton uid={uid} title={title} nodeType={nodeType} />,
+    { layout: "inline" },
+  );
+};

--- a/apps/roam/src/utils/handleTitleAdditions.ts
+++ b/apps/roam/src/utils/handleTitleAdditions.ts
@@ -3,10 +3,16 @@ import ReactDOM from "react-dom";
 
 const ROAM_TITLE_CONTAINER_CLASS = "rm-title-display-container";
 const ADDITIONS_CONTAINER_CLASS = "discourse-graph-title-additions";
+const ADDITIONS_CONTAINER_CLASSES = `${ADDITIONS_CONTAINER_CLASS} flex flex-wrap items-start gap-x-2 gap-y-2`;
+const INLINE_ADDITION_CLASSES = "min-w-0 flex-none";
+const BLOCK_ADDITION_CLASSES = "min-w-0 basis-full grow shrink-0";
+
+type TitleAdditionLayout = "inline" | "block";
 
 export const handleTitleAdditions = (
   h1: HTMLHeadingElement,
   element: React.ReactNode,
+  { layout = "block" }: { layout?: TitleAdditionLayout } = {},
 ): void => {
   const titleDisplayContainer =
     h1.closest(`.${ROAM_TITLE_CONTAINER_CLASS}`) ||
@@ -25,7 +31,7 @@ export const handleTitleAdditions = (
     if (!parent) return;
 
     container = document.createElement("div");
-    container.className = `${ADDITIONS_CONTAINER_CLASS} flex flex-col`;
+    container.className = ADDITIONS_CONTAINER_CLASSES;
 
     const oldMarginBottom = getComputedStyle(h1).marginBottom;
     const oldMarginBottomNum = Number.isFinite(parseFloat(oldMarginBottom))
@@ -45,6 +51,8 @@ export const handleTitleAdditions = (
 
   if (React.isValidElement(element)) {
     const renderContainer = document.createElement("div");
+    renderContainer.className =
+      layout === "inline" ? INLINE_ADDITION_CLASSES : BLOCK_ADDITION_CLASSES;
     container.appendChild(renderContainer);
     // eslint-disable-next-line react/no-deprecated
     ReactDOM.render(element, renderContainer);

--- a/apps/roam/src/utils/initializeObserversAndListeners.ts
+++ b/apps/roam/src/utils/initializeObserversAndListeners.ts
@@ -45,10 +45,10 @@ import {
 import { renderNodeTagPopupButton } from "./renderNodeTagPopup";
 import { renderImageToolsMenu } from "./renderImageToolsMenu";
 import { mountLeftSidebar } from "~/components/LeftSidebarView";
-import { getFeatureFlag } from "~/components/settings/utils/accessors";
 import { getCleanTagText } from "~/components/settings/NodeConfig";
 import { getNodeTagStyles } from "~/utils/getDiscourseNodeColors";
 import { renderPossibleDuplicates } from "~/components/VectorDuplicateMatches";
+import { renderPublishNodeTitleButton } from "~/components/PublishNodeTitleButton";
 import { renderCanvasEmbed } from "~/components/canvas/CanvasEmbed";
 import getPageUidByPageTitle from "roamjs-components/queries/getPageUidByPageTitle";
 import getPageTitleByPageUid from "roamjs-components/queries/getPageTitleByPageUid";
@@ -62,6 +62,7 @@ import {
   settingKeys,
 } from "~/components/settings/utils/settingsEmitter";
 import {
+  FEATURE_FLAG_KEYS,
   PERSONAL_KEYS,
   GLOBAL_KEYS,
 } from "~/components/settings/utils/settingKeys";
@@ -123,8 +124,23 @@ export const initObservers = ({
 
       const isDiscourseNode = node && node.backedBy !== "default";
       if (isDiscourseNode) {
-        renderDiscourseContext({ h1, uid });
-        if (getFeatureFlag("Duplicate node alert enabled")) {
+        const syncEnabled =
+          settings.featureFlags[FEATURE_FLAG_KEYS.duplicateNodeAlertEnabled] ||
+          settings.featureFlags[FEATURE_FLAG_KEYS.suggestiveModeOverlayEnabled];
+        if (syncEnabled && node.backedBy === "user") {
+          renderPublishNodeTitleButton({
+            h1,
+            uid,
+            title,
+            nodeType: node.type,
+          });
+        }
+        if (settings.personalSettings[PERSONAL_KEYS.discourseContextOverlay]) {
+          renderDiscourseContext({ h1, uid });
+        }
+        if (
+          settings.featureFlags[FEATURE_FLAG_KEYS.duplicateNodeAlertEnabled]
+        ) {
           renderPossibleDuplicates(h1, title, node);
         }
         const linkedReferencesDiv = document.querySelector(
@@ -211,7 +227,7 @@ export const initObservers = ({
       });
   }) as EventListener;
 
-  if (getFeatureFlag("Suggestive mode overlay enabled")) {
+  if (settings.featureFlags[FEATURE_FLAG_KEYS.suggestiveModeOverlayEnabled]) {
     addPageRefObserver(getSuggestiveOverlayHandler(onloadArgs));
   }
 

--- a/apps/roam/src/utils/openShareNodeDialog.ts
+++ b/apps/roam/src/utils/openShareNodeDialog.ts
@@ -1,0 +1,17 @@
+import { render as exportRender } from "~/components/Export";
+
+export const openShareNodeDialog = ({
+  uid,
+  title,
+  nodeType,
+}: {
+  uid: string;
+  title: string;
+  nodeType: string;
+}): void => {
+  exportRender({
+    results: [{ uid, text: title, type: nodeType }],
+    isExportDiscourseGraph: true,
+    initialPanel: "publish",
+  });
+};

--- a/apps/roam/src/utils/publishNodesToGroups.ts
+++ b/apps/roam/src/utils/publishNodesToGroups.ts
@@ -13,6 +13,52 @@ type PublishNodesResult = {
   failedGroupIds: string[];
 };
 
+export const getPublishedNodeCountsByGroup = async ({
+  client,
+  spaceId,
+  groupIds,
+  nodeUids,
+}: {
+  client: DGSupabaseClient;
+  spaceId: number;
+  groupIds: string[];
+  nodeUids: string[];
+}): Promise<Record<string, number>> => {
+  const uniqueGroupIds = [...new Set(groupIds)];
+  const uniqueNodeUids = [...new Set(nodeUids)];
+  if (uniqueGroupIds.length === 0 || uniqueNodeUids.length === 0) return {};
+
+  const groupIdSet = new Set(uniqueGroupIds);
+  const nodeUidSet = new Set(uniqueNodeUids);
+  const accessRes = await client
+    .from("ResourceAccess")
+    .select("account_uid, source_local_id")
+    .eq("space_id", spaceId)
+    .in("account_uid", uniqueGroupIds)
+    .in("source_local_id", uniqueNodeUids);
+  if (accessRes.error) throw accessRes.error;
+
+  const nodeUidsByGroupId = new Map<string, Set<string>>();
+  for (const row of accessRes.data ?? []) {
+    if (
+      !groupIdSet.has(row.account_uid) ||
+      !nodeUidSet.has(row.source_local_id)
+    )
+      continue;
+    const sharedNodeUids =
+      nodeUidsByGroupId.get(row.account_uid) ?? new Set<string>();
+    sharedNodeUids.add(row.source_local_id);
+    nodeUidsByGroupId.set(row.account_uid, sharedNodeUids);
+  }
+
+  return Object.fromEntries(
+    uniqueGroupIds.map((groupId) => [
+      groupId,
+      nodeUidsByGroupId.get(groupId)?.size ?? 0,
+    ]),
+  );
+};
+
 // 23505 = unique_violation: the grant already exists, which counts as success.
 const isIgnorableUpsertError = (error: { code?: string } | null): boolean =>
   !error || error.code === "23505";

--- a/apps/roam/src/utils/publishNodesToGroups.ts
+++ b/apps/roam/src/utils/publishNodesToGroups.ts
@@ -1,0 +1,114 @@
+import type { DGSupabaseClient } from "@repo/database/lib/client";
+
+export type PublishNode = {
+  uid: string;
+  type: string;
+};
+
+type PublishNodesResult = {
+  publishedNodeUids: string[];
+  skippedUnsyncedUids: string[];
+  okGroupIds: string[];
+  failedGroupIds: string[];
+};
+
+// 23505 = unique_violation: the grant already exists, which counts as success.
+const isIgnorableUpsertError = (error: { code?: string } | null): boolean =>
+  !error || error.code === "23505";
+
+const onlyStrings = (values: (string | null)[]): string[] =>
+  values.filter((value): value is string => typeof value === "string");
+
+// Grants a group access to already-synced discourse nodes by mirroring the
+// Obsidian publish-to-group access model (SpaceAccess + ResourceAccess),
+// without its file/frontmatter/relation/asset coupling.
+//
+// ResourceAccess has no foreign key on source_local_id, so granting access to a
+// node that has not synced yet would create an orphaned row. We therefore only
+// publish nodes confirmed present as instance concepts in this space, and
+// report the rest as not-yet-synced (they self-heal on the next sync).
+export const publishNodesToGroups = async ({
+  client,
+  spaceId,
+  groupIds,
+  nodes,
+}: {
+  client: DGSupabaseClient;
+  spaceId: number;
+  groupIds: string[];
+  nodes: PublishNode[];
+}): Promise<PublishNodesResult> => {
+  const result: PublishNodesResult = {
+    publishedNodeUids: [],
+    skippedUnsyncedUids: [],
+    okGroupIds: [],
+    failedGroupIds: [],
+  };
+  if (nodes.length === 0 || groupIds.length === 0) return result;
+
+  const uids = [...new Set(nodes.map((node) => node.uid))];
+
+  const syncedRes = await client
+    .from("my_concepts")
+    .select("source_local_id")
+    .eq("space_id", spaceId)
+    .eq("is_schema", false)
+    .in("source_local_id", uids);
+  if (syncedRes.error) throw syncedRes.error;
+  const syncedUids = new Set(
+    onlyStrings((syncedRes.data ?? []).map((row) => row.source_local_id)),
+  );
+
+  result.skippedUnsyncedUids = uids.filter((uid) => !syncedUids.has(uid));
+  const syncedNodeUids = uids.filter((uid) => syncedUids.has(uid));
+  if (syncedNodeUids.length === 0) return result;
+
+  // Required dependency: the node-type schema concept, when it is synced too.
+  const types = [
+    ...new Set(
+      nodes.filter((node) => syncedUids.has(node.uid)).map((node) => node.type),
+    ),
+  ];
+  const schemaRes = await client
+    .from("my_concepts")
+    .select("source_local_id")
+    .eq("space_id", spaceId)
+    .eq("is_schema", true)
+    .in("source_local_id", types);
+  const syncedSchemaIds = onlyStrings(
+    (schemaRes.data ?? []).map((row) => row.source_local_id),
+  );
+
+  const resourceIds = [...syncedNodeUids, ...syncedSchemaIds];
+
+  for (const groupId of groupIds) {
+    const spaceAccessRes = await client
+      .from("SpaceAccess")
+      .upsert(
+        { account_uid: groupId, space_id: spaceId, permissions: "partial" },
+        { ignoreDuplicates: true },
+      );
+    if (!isIgnorableUpsertError(spaceAccessRes.error)) {
+      result.failedGroupIds.push(groupId);
+      continue;
+    }
+
+    const grantRes = await client.from("ResourceAccess").upsert(
+      resourceIds.map((sourceLocalId) => ({
+        account_uid: groupId,
+        source_local_id: sourceLocalId,
+        space_id: spaceId,
+      })),
+      { ignoreDuplicates: true },
+    );
+    if (!isIgnorableUpsertError(grantRes.error)) {
+      result.failedGroupIds.push(groupId);
+      continue;
+    }
+
+    result.okGroupIds.push(groupId);
+  }
+
+  result.publishedNodeUids = result.okGroupIds.length > 0 ? syncedNodeUids : [];
+  return result;
+};

--- a/apps/roam/src/utils/publishNodesToGroups.ts
+++ b/apps/roam/src/utils/publishNodesToGroups.ts
@@ -13,52 +13,6 @@ type PublishNodesResult = {
   failedGroupIds: string[];
 };
 
-export const getPublishedNodeCountsByGroup = async ({
-  client,
-  spaceId,
-  groupIds,
-  nodeUids,
-}: {
-  client: DGSupabaseClient;
-  spaceId: number;
-  groupIds: string[];
-  nodeUids: string[];
-}): Promise<Record<string, number>> => {
-  const uniqueGroupIds = [...new Set(groupIds)];
-  const uniqueNodeUids = [...new Set(nodeUids)];
-  if (uniqueGroupIds.length === 0 || uniqueNodeUids.length === 0) return {};
-
-  const groupIdSet = new Set(uniqueGroupIds);
-  const nodeUidSet = new Set(uniqueNodeUids);
-  const accessRes = await client
-    .from("ResourceAccess")
-    .select("account_uid, source_local_id")
-    .eq("space_id", spaceId)
-    .in("account_uid", uniqueGroupIds)
-    .in("source_local_id", uniqueNodeUids);
-  if (accessRes.error) throw accessRes.error;
-
-  const nodeUidsByGroupId = new Map<string, Set<string>>();
-  for (const row of accessRes.data ?? []) {
-    if (
-      !groupIdSet.has(row.account_uid) ||
-      !nodeUidSet.has(row.source_local_id)
-    )
-      continue;
-    const sharedNodeUids =
-      nodeUidsByGroupId.get(row.account_uid) ?? new Set<string>();
-    sharedNodeUids.add(row.source_local_id);
-    nodeUidsByGroupId.set(row.account_uid, sharedNodeUids);
-  }
-
-  return Object.fromEntries(
-    uniqueGroupIds.map((groupId) => [
-      groupId,
-      nodeUidsByGroupId.get(groupId)?.size ?? 0,
-    ]),
-  );
-};
-
 // 23505 = unique_violation: the grant already exists, which counts as success.
 const isIgnorableUpsertError = (error: { code?: string } | null): boolean =>
   !error || error.code === "23505";

--- a/apps/roam/src/utils/publishNodesToGroups.ts
+++ b/apps/roam/src/utils/publishNodesToGroups.ts
@@ -1,4 +1,5 @@
 import type { DGSupabaseClient } from "@repo/database/lib/client";
+import { getAvailableGroupIds } from "@repo/database/lib/groups";
 
 export type PublishNode = {
   uid: string;
@@ -46,6 +47,16 @@ export const publishNodesToGroups = async ({
   };
   if (nodes.length === 0 || groupIds.length === 0) return result;
 
+  const availableGroupIds = new Set(await getAvailableGroupIds(client));
+  const requestedGroupIds = [...new Set(groupIds)];
+  const targetGroupIds = requestedGroupIds.filter((groupId) =>
+    availableGroupIds.has(groupId),
+  );
+  result.failedGroupIds = requestedGroupIds.filter(
+    (groupId) => !availableGroupIds.has(groupId),
+  );
+  if (targetGroupIds.length === 0) return result;
+
   const uids = [...new Set(nodes.map((node) => node.uid))];
 
   const syncedRes = await client
@@ -75,13 +86,15 @@ export const publishNodesToGroups = async ({
     .eq("space_id", spaceId)
     .eq("is_schema", true)
     .in("source_local_id", types);
+  if (schemaRes.error) throw schemaRes.error;
   const syncedSchemaIds = onlyStrings(
     (schemaRes.data ?? []).map((row) => row.source_local_id),
   );
 
   const resourceIds = [...syncedNodeUids, ...syncedSchemaIds];
 
-  for (const groupId of groupIds) {
+  for (const groupId of targetGroupIds) {
+    // Existing reader/editor access is broader than partial, so leave it intact.
     const spaceAccessRes = await client
       .from("SpaceAccess")
       .upsert(

--- a/apps/roam/src/utils/registerCommandPaletteCommands.ts
+++ b/apps/roam/src/utils/registerCommandPaletteCommands.ts
@@ -1,6 +1,7 @@
 import { openQueryDrawer } from "~/components/QueryDrawer";
 import { render as exportRender } from "~/components/Export";
 import { render as renderToast } from "roamjs-components/components/Toast";
+import { openShareNodeDialog } from "~/utils/openShareNodeDialog";
 import { createBlock, updateBlock } from "roamjs-components/writes";
 import {
   getCurrentPageUid,
@@ -29,6 +30,7 @@ import {
   getPersonalSetting,
   setPersonalSetting,
   setGlobalSetting,
+  isSyncEnabled,
 } from "~/components/settings/utils/accessors";
 import {
   DISCOURSE_NODE_KEYS,
@@ -244,6 +246,54 @@ export const registerCommandPaletteCommands = (onloadArgs: OnloadArgs) => {
     });
   };
 
+  const shareCurrentNode = () => {
+    if (!isSyncEnabled()) {
+      renderToast({
+        id: "share-node-sync-disabled",
+        content: "Sync must be enabled to publish discourse nodes.",
+      });
+      return;
+    }
+
+    const pageUid = getCurrentPageUid();
+    if (!pageUid) {
+      renderToast({
+        id: "share-node-no-page",
+        content: "Navigate to a discourse node page to share it.",
+      });
+      return;
+    }
+
+    const pageTitle = getPageTitleByPageUid(pageUid);
+    if (!pageTitle) {
+      renderToast({
+        id: "share-node-no-title",
+        content: "Could not determine the current page title.",
+      });
+      return;
+    }
+
+    const discourseNode = findDiscourseNode({ uid: pageUid, title: pageTitle });
+    if (!discourseNode || discourseNode.backedBy !== "user") {
+      renderToast({
+        id: "share-node-not-a-node",
+        content: "This page is not a publishable discourse node.",
+      });
+      return;
+    }
+
+    posthog.capture("Share Node: Current Node Command Triggered", {
+      pageUid,
+      nodeType: discourseNode.type,
+    });
+
+    openShareNodeDialog({
+      uid: pageUid,
+      title: pageTitle,
+      nodeType: discourseNode.type,
+    });
+  };
+
   const exportDiscourseGraph = async () => {
     posthog.capture("Export: Discourse Graph Command Triggered");
     const discourseNodes = getDiscourseNodes().filter(excludeDefaultNodes);
@@ -364,6 +414,9 @@ export const registerCommandPaletteCommands = (onloadArgs: OnloadArgs) => {
   void addCommand("DG: Export - Current page", exportCurrentPage);
   void addCommand("DG: Export - Discourse graph", exportDiscourseGraph);
   void addCommand("DG: Open - Discourse settings", renderSettingsPopup);
+  if (isSyncEnabled()) {
+    void addCommand("DG: Share current node", shareCurrentNode);
+  }
   if (getFeatureFlag("Advanced node search enabled")) {
     void addCommand("DG: Open Node Search", () => {
       posthog.capture("Node Search: Open Command Triggered");

--- a/apps/roam/src/utils/renderLinkedReferenceAdditions.ts
+++ b/apps/roam/src/utils/renderLinkedReferenceAdditions.ts
@@ -20,6 +20,7 @@ export const renderDiscourseContext = ({
       uid,
       id: nanoid(),
     }),
+    { layout: "inline" },
   );
   h1.setAttribute("data-roamjs-top-discourse-context", "true");
 };

--- a/packages/database/src/lib/groups.ts
+++ b/packages/database/src/lib/groups.ts
@@ -1,0 +1,49 @@
+import type { DGSupabaseClient } from "./client";
+
+export type MyGroup = {
+  id: string;
+  name: string;
+};
+
+export const getAvailableGroupIds = async (
+  client: DGSupabaseClient,
+): Promise<string[]> => {
+  const { data, error } = await client
+    .from("group_membership")
+    .select("group_id")
+    .eq("member_id", (await client.auth.getUser()).data.user?.id || "");
+
+  if (error) {
+    console.error("Error fetching groups:", error);
+    throw new Error(`Failed to fetch groups: ${error.message}`);
+  }
+
+  return (data || []).map((g) => g.group_id);
+};
+
+export const getMyGroups = async (
+  client: DGSupabaseClient,
+): Promise<MyGroup[]> => {
+  const userId = (await client.auth.getUser()).data.user?.id ?? "";
+  const { data, error } = await client
+    .from("group_membership")
+    .select("group_id, my_groups!group_id(name)")
+    .eq("member_id", userId);
+
+  if (error) {
+    console.error("Error fetching groups:", error);
+    throw new Error(`Failed to fetch groups: ${error.message}`);
+  }
+
+  return (data ?? [])
+    .filter(
+      (row): row is { group_id: string; my_groups: { name: string | null } } =>
+        typeof row.group_id === "string" &&
+        row.my_groups !== null &&
+        typeof row.my_groups === "object",
+    )
+    .map((row) => ({
+      id: row.group_id,
+      name: row.my_groups.name ?? row.group_id,
+    }));
+};


### PR DESCRIPTION
https://www.loom.com/share/d7cd9e76c02f46c6ad13fcda24088b90



Adds a "Publish" tab to the Roam Share Data / query-results dialog (Export.tsx), gated on isSyncEnabled(), that grants a sharing group access to the selected query-result discourse nodes via the existing SpaceAccess/ResourceAccess group-targeted model.

- Promote getMyGroups/getAvailableGroupIds/MyGroup from Obsidian's importNodes util to shared @repo/database/lib/groups; Obsidian's file becomes a behaviour-preserving re-export shim.
- New apps/roam/src/utils/publishNodesToGroups.ts: grants access only to nodes already synced (present in my_concepts) and reports the rest as not-yet-synced; upserts SpaceAccess (partial) + ResourceAccess for each node and its schema concept.
- PublishPanel with multi-group picker, non-discourse-result filter, and a success/skipped/failed count toast.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/1133" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->