### PR TITLE
ENG-1896 Remove legacy anchor-backed discourse node type support

### DIFF
--- a/apps/roam/src/components/DiscourseContext.tsx
+++ b/apps/roam/src/components/DiscourseContext.tsx
@@ -1,24 +1,6 @@
-import {
-  Button,
-  Icon,
-  Portal,
-  Switch,
-  Tabs,
-  Tab,
-  Tooltip,
-  Spinner,
-} from "@blueprintjs/core";
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-  useRef,
-} from "react";
-import getPageTitleByPageUid from "roamjs-components/queries/getPageTitleByPageUid";
-import getShallowTreeByParentUid from "roamjs-components/queries/getShallowTreeByParentUid";
+import { Switch, Tabs, Tab, Spinner } from "@blueprintjs/core";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { Result } from "roamjs-components/types/query-builder";
-import nanoId from "nanoid";
 import getDiscourseContextResults from "~/utils/getDiscourseContextResults";
 import ResultsView from "./results-view/ResultsView";
 import posthog from "posthog-js";
@@ -34,188 +16,12 @@ type Props = {
   overlayRefresh?: () => void;
 };
 
-const ExtraColumnRow = (r: Result) => {
-  const [contextOpen, setContextOpen] = useState(false);
-  const [contextRowReady, setContextRowReady] = useState(false);
-  const contextId = useMemo(() => `td-${nanoId()}`, []);
-  const anchorId = useMemo(() => `td-${nanoId()}`, []);
-  const [anchorOpen, setAnchorOpen] = useState(false);
-  const [anchorRowReady, setAnchorRowReady] = useState(false);
-  const containerRef = useRef<HTMLSpanElement>(null);
-  const contextPageTitle = useMemo(
-    () =>
-      r["context-uid"] && getPageTitleByPageUid(r["context-uid"].toString()),
-    [r["context-uid"]],
-  );
-  const contextBreadCrumbs = useMemo(
-    () =>
-      r["context-uid"]
-        ? window.roamAlphaAPI
-            .q(
-              `[:find (pull ?p [:node/title :block/string :block/uid]) :where
-              [?b :block/uid "${r["context-uid"]}"]
-              [?b :block/parents ?p]
-            ]`,
-            )
-            .map(
-              (a) => a[0] as { string?: string; title?: string; uid: string },
-            )
-            .map((a) => ({ uid: a.uid, text: a.string || a.title || "" }))
-        : [],
-    [r["context-uid"]],
-  );
-  const contextChildren = useMemo(
-    () =>
-      r["context-uid"] && contextPageTitle
-        ? getShallowTreeByParentUid(r["context-uid"].toString()).map(
-            ({ uid }) => uid,
-          )
-        : [r["context-uid"].toString()],
-    [r["context-uid"], contextPageTitle, r.uid],
-  );
-  useEffect(() => {
-    if (contextOpen && containerRef.current) {
-      const row = containerRef.current.closest("tr");
-      const contextElement = document.createElement("tr");
-      const contextTd = document.createElement("td");
-      contextTd.colSpan = row?.childElementCount || 0;
-      contextElement.id = contextId;
-      row?.parentElement?.insertBefore(contextElement, row.nextElementSibling);
-      contextElement.append(contextTd);
-      setContextRowReady(true);
-    } else {
-      setContextRowReady(false);
-      document.getElementById(contextId)?.remove();
-    }
-  }, [contextOpen, setContextRowReady, contextId]);
-  useEffect(() => {
-    if (contextRowReady) {
-      setTimeout(() => {
-        contextChildren.forEach((uid) => {
-          const el = document.querySelector<HTMLElement>(
-            `tr#${contextId} div[data-uid="${uid}"]`,
-          );
-          if (el)
-            window.roamAlphaAPI.ui.components.renderBlock({
-              uid,
-              el,
-            });
-        });
-      }, 1);
-    }
-  }, [contextRowReady]);
-  useEffect(() => {
-    if (anchorOpen) {
-      const row = containerRef.current?.closest("tr");
-      const anchorElement = document.createElement("tr");
-      const anchorTd = document.createElement("td");
-      anchorTd.colSpan = row?.childElementCount || 0;
-      anchorElement.id = anchorId;
-      row?.parentElement?.insertBefore(anchorElement, row.nextElementSibling);
-      anchorElement.append(anchorTd);
-      setAnchorRowReady(true);
-    } else {
-      setAnchorRowReady(false);
-      document.getElementById(anchorId)?.remove();
-    }
-  }, [anchorOpen, setAnchorRowReady, anchorId]);
-  return (
-    <span ref={containerRef}>
-      {r["context-uid"] && (
-        <Tooltip content={"Context"}>
-          <Button
-            onClick={() => setContextOpen(!contextOpen)}
-            small
-            active={contextOpen}
-            style={{
-              opacity: 0.5,
-              fontSize: "0.8em",
-              ...(contextOpen
-                ? {
-                    opacity: 1,
-                    color: "#8A9BA8",
-                    backgroundColor: "#F5F8FA",
-                  }
-                : {}),
-            }}
-            minimal
-            icon="info-sign"
-          />
-        </Tooltip>
-      )}
-      <style>
-        {`#${contextId} td,
-#${anchorId} td {
-  position: relative;
-  background-color: #F5F8FA;
-  padding: 16px;
-  max-height: 240px;
-  overflow-y: scroll;
-}
-#${contextId} .bp3-portal,
-#${anchorId} .bp3-portal {
-  position: relative;
-}`}
-      </style>
-      {contextRowReady && (
-        <Portal
-          container={
-            document.getElementById(contextId)
-              ?.firstElementChild as HTMLDataElement
-          }
-          className={"relative"}
-        >
-          {contextPageTitle ? (
-            <h3 style={{ margin: 0 }}>{contextPageTitle}</h3>
-          ) : (
-            <div className="rm-zoom">
-              {contextBreadCrumbs.map((bc) => (
-                <div key={bc.uid} className="rm-zoom-item">
-                  <span className="rm-zoom-item-content">{bc.text}</span>
-                  <Icon icon={"chevron-right"} />
-                </div>
-              ))}
-            </div>
-          )}
-          {contextChildren.map((uid) => (
-            <div data-uid={uid} key={uid}></div>
-          ))}
-        </Portal>
-      )}
-      {r.anchor && (
-        <Tooltip content={"See Related Relations"}>
-          <Button
-            onClick={() => setAnchorOpen(!anchorOpen)}
-            active={anchorOpen}
-            small
-            style={{
-              opacity: 0.5,
-              fontSize: "0.8em",
-              ...(anchorOpen
-                ? {
-                    opacity: 1,
-                    color: "#8A9BA8",
-                    backgroundColor: "#F5F8FA",
-                  }
-                : {}),
-            }}
-            minimal
-            icon={"resolve"}
-          />
-        </Tooltip>
-      )}
-      {anchorRowReady && (
-        <Portal
-          container={
-            document.getElementById(anchorId)
-              ?.firstElementChild as HTMLDataElement
-          }
-        >
-          <ContextContent uid={r["anchor-uid"]} results={[]} />
-        </Portal>
-      )}
-    </span>
-  );
+const removeTargetFromResult = (
+  result: Partial<Result & { target: string }>,
+): Result => {
+  const tableResult = { ...result };
+  delete tableResult.target;
+  return tableResult as Result;
 };
 
 const ContextTab = ({
@@ -270,7 +76,7 @@ const ContextTab = ({
       // TODO - always save settings, but maybe separate from root `parentUid`?
       preventSavingSettings
       parentUid={parentUid}
-      results={Object.values(results).map(({ target, ...a }) => a as Result)}
+      results={Object.values(results).map(removeTargetFromResult)}
       columns={columns}
       onRefresh={onRefresh}
       header={

--- a/apps/roam/src/components/DiscourseContextOverlay.tsx
+++ b/apps/roam/src/components/DiscourseContextOverlay.tsx
@@ -38,7 +38,7 @@ const getOverlayInfo = async (
 ): Promise<DiscourseData> => {
   try {
     const relations = getDiscourseRelations();
-    const nodes = getDiscourseNodes(relations);
+    const nodes = getDiscourseNodes();
 
     const [results, refs] = await Promise.all([
       getDiscourseContextResults({

--- a/apps/roam/src/components/DiscourseNodeMenu.tsx
+++ b/apps/roam/src/components/DiscourseNodeMenu.tsx
@@ -62,9 +62,7 @@ const NodeMenu = ({
   );
   const userDiscourseNodes = useMemo(
     () =>
-      getDiscourseNodes(undefined, settingsSnapshot).filter(
-        (n) => n.backedBy === "user",
-      ),
+      getDiscourseNodes(settingsSnapshot).filter((n) => n.backedBy === "user"),
     [settingsSnapshot],
   );
   const discourseNodes = userDiscourseNodes.filter(

--- a/apps/roam/src/components/Export.tsx
+++ b/apps/roam/src/components/Export.tsx
@@ -327,7 +327,7 @@ const ExportDialog: ExportDialogComponent = ({
       );
       const allRelations = relations;
       const allRelationIds = allRelations.map((r) => r.id);
-      const allNodes = getDiscourseNodes(allRelations);
+      const allNodes = getDiscourseNodes();
       const allAddReferencedNodeByAction = (() => {
         const obj: AddReferencedNodeType = {};
 

--- a/apps/roam/src/components/SuggestionsBody.tsx
+++ b/apps/roam/src/components/SuggestionsBody.tsx
@@ -51,7 +51,7 @@ const getOverlayInfo = async (
   try {
     if (cache[tag]) return cache[tag];
 
-    const nodes = getDiscourseNodes(relations);
+    const nodes = getDiscourseNodes();
 
     const [results, refs] = await Promise.all([
       getDiscourseContextResults({

--- a/apps/roam/src/components/canvas/Tldraw.tsx
+++ b/apps/roam/src/components/canvas/Tldraw.tsx
@@ -486,12 +486,12 @@ const TldrawCanvasShared = ({
     return Object.keys(discourseContext.relations);
   }, []);
   const allNodes = useMemo(() => {
-    const allNodes = getDiscourseNodes(allRelations);
+    const allNodes = getDiscourseNodes();
     discourseContext.nodes = Object.fromEntries(
       allNodes.map((n, index) => [n.type, { ...n, index }]),
     );
     return allNodes;
-  }, [allRelations]);
+  }, []);
 
   const allAddReferencedNodeByAction = useMemo(() => {
     const obj: AddReferencedNodeType = {};

--- a/apps/roam/src/utils/deriveDiscourseNodeAttribute.ts
+++ b/apps/roam/src/utils/deriveDiscourseNodeAttribute.ts
@@ -47,7 +47,7 @@ const deriveNodeAttribute = async ({
   uid: string;
 }): Promise<string | number> => {
   const relations = getDiscourseRelations();
-  const nodes = getDiscourseNodes(relations);
+  const nodes = getDiscourseNodes();
   const discourseNode = findDiscourseNode({ uid, nodes });
   if (!discourseNode) return 0;
   const nodeType = discourseNode.type;

--- a/apps/roam/src/utils/findDiscourseNode.ts
+++ b/apps/roam/src/utils/findDiscourseNode.ts
@@ -27,7 +27,7 @@ const findDiscourseNode = ({
     return discourseNodeTypeCache[uid];
   }
 
-  const resolvedNodes = nodes ?? getDiscourseNodes(undefined, snapshot);
+  const resolvedNodes = nodes ?? getDiscourseNodes(snapshot);
   const matchingNode =
     resolvedNodes.find((node) =>
       title === undefined

--- a/apps/roam/src/utils/getDiscourseContextResults.ts
+++ b/apps/roam/src/utils/getDiscourseContextResults.ts
@@ -50,12 +50,6 @@ const buildSelections = ({
       label: "context",
       text: `node:${conditionUid}-Context`,
     });
-  } else if (r.triples.some((t) => t.some((a) => /anchor/i.test(a)))) {
-    selections.push({
-      uid: window.roamAlphaAPI.util.generateUID(),
-      label: "anchor",
-      text: `node:${conditionUid}-Anchor`,
-    });
   }
 
   return selections;

--- a/apps/roam/src/utils/getDiscourseContextResults.ts
+++ b/apps/roam/src/utils/getDiscourseContextResults.ts
@@ -166,7 +166,7 @@ const buildQueryConfig = ({
 const getDiscourseContextResults = async ({
   uid: targetUid,
   relations = getDiscourseRelations(),
-  nodes = getDiscourseNodes(relations),
+  nodes = getDiscourseNodes(),
   ignoreCache,
   onResult,
 }: {

--- a/apps/roam/src/utils/getDiscourseNodes.ts
+++ b/apps/roam/src/utils/getDiscourseNodes.ts
@@ -115,83 +115,54 @@ const getDiscourseNodes = (
   const newStoreEnabled = snapshot
     ? snapshot.featureFlags["Use new settings store"]
     : isNewSettingsStoreEnabled();
-  const configuredNodes = (
-    newStoreEnabled
-      ? getAllDiscourseNodes()
-      : Object.entries(discourseConfigRef.nodes).map(
-          ([type, { text, children }]): DiscourseNode => {
-            const suggestiveRules = getSubTree({
-              tree: children,
-              key: "Suggestive Rules",
-            });
-            const embeddingBlockRef = getSubTree({
-              tree: suggestiveRules.children,
-              key: "Embedding Block Ref",
-            });
+  const configuredNodes = newStoreEnabled
+    ? getAllDiscourseNodes()
+    : Object.entries(discourseConfigRef.nodes).map(
+        ([type, { text, children }]): DiscourseNode => {
+          const suggestiveRules = getSubTree({
+            tree: children,
+            key: "Suggestive Rules",
+          });
+          const embeddingBlockRef = getSubTree({
+            tree: suggestiveRules.children,
+            key: "Embedding Block Ref",
+          });
 
-            return {
-              format: getSettingValueFromTree({
-                tree: children,
-                key: "format",
-              }),
-              text,
-              shortcut: getSettingValueFromTree({
-                tree: children,
-                key: "shortcut",
-              }),
-              tag: getSettingValueFromTree({ tree: children, key: "tag" }),
-              type,
-              specification: getSpecification(children),
-              backedBy: "user",
-              canvasSettings: Object.fromEntries(
-                getSubTree({ tree: children, key: "canvas" }).children.map(
-                  (c) => [c.text, c.children[0]?.text || ""] as const,
-                ),
+          return {
+            format: getSettingValueFromTree({
+              tree: children,
+              key: "format",
+            }),
+            text,
+            shortcut: getSettingValueFromTree({
+              tree: children,
+              key: "shortcut",
+            }),
+            tag: getSettingValueFromTree({ tree: children, key: "tag" }),
+            type,
+            specification: getSpecification(children),
+            backedBy: "user",
+            canvasSettings: Object.fromEntries(
+              getSubTree({ tree: children, key: "canvas" }).children.map(
+                (c) => [c.text, c.children[0]?.text || ""] as const,
               ),
-              graphOverview:
-                children.filter((c) => c.text === "Graph Overview").length > 0,
-              description: getSettingValueFromTree({
-                tree: children,
-                key: "description",
-              }),
-              template: getSubTree({ tree: children, key: "template" })
-                .children,
-              embeddingRef: embeddingBlockRef?.children?.[0]?.text,
-              embeddingRefUid: embeddingBlockRef?.uid,
-              isFirstChild: getUidAndBooleanSetting({
-                tree: suggestiveRules.children,
-                text: "First Child",
-              }),
-            };
-          },
-        )
-  ).concat(
-    resolvedRelations
-      .filter((r) => r.triples.some((t) => t.some((n) => /anchor/i.test(n))))
-      .map((r) => ({
-        format: "",
-        text: r.label,
-        type: r.id,
-        shortcut: r.label.slice(0, 1),
-        tag: "",
-        specification: r.triples.map(([source, relation, target]) => ({
-          type: "clause",
-          source: /anchor/i.test(source) ? r.label : source,
-          relation,
-          target:
-            target === "source"
-              ? r.source
-              : target === "destination"
-                ? r.destination
-                : /anchor/i.test(target)
-                  ? r.label
-                  : target,
-          uid: window.roamAlphaAPI.util.generateUID(),
-        })),
-        backedBy: "relation",
-        canvasSettings: {},
-      })),
-  );
+            ),
+            graphOverview:
+              children.filter((c) => c.text === "Graph Overview").length > 0,
+            description: getSettingValueFromTree({
+              tree: children,
+              key: "description",
+            }),
+            template: getSubTree({ tree: children, key: "template" }).children,
+            embeddingRef: embeddingBlockRef?.children?.[0]?.text,
+            embeddingRefUid: embeddingBlockRef?.uid,
+            isFirstChild: getUidAndBooleanSetting({
+              tree: suggestiveRules.children,
+              text: "First Child",
+            }),
+          };
+        },
+      );
   const configuredNodeTexts = new Set(configuredNodes.map((n) => n.text));
   const defaultNodes = DEFAULT_NODES.filter(
     (n) => !configuredNodeTexts.has(n.text),

--- a/apps/roam/src/utils/getDiscourseNodes.ts
+++ b/apps/roam/src/utils/getDiscourseNodes.ts
@@ -6,7 +6,6 @@ import {
   type SettingsSnapshot,
 } from "~/components/settings/utils/accessors";
 import discourseConfigRef from "./discourseConfigRef";
-import getDiscourseRelations from "./getDiscourseRelations";
 import { roamNodeToCondition } from "./parseQuery";
 import { Condition } from "./types";
 import { InputTextNode, RoamBasicNode } from "roamjs-components/types";
@@ -22,7 +21,7 @@ export type DiscourseNode = {
   shortcut: string;
   tag?: string;
   specification: Condition[];
-  backedBy: "user" | "default" | "relation";
+  backedBy: "user" | "default";
   canvasSettings: {
     [k: string]: string;
   };
@@ -107,11 +106,7 @@ const getUidAndBooleanSetting = ({
   };
 };
 
-const getDiscourseNodes = (
-  relations?: ReturnType<typeof getDiscourseRelations>,
-  snapshot?: SettingsSnapshot,
-) => {
-  const resolvedRelations = relations ?? getDiscourseRelations(snapshot);
+const getDiscourseNodes = (snapshot?: SettingsSnapshot) => {
   const newStoreEnabled = snapshot
     ? snapshot.featureFlags["Use new settings store"]
     : isNewSettingsStoreEnabled();

--- a/apps/roam/src/utils/getExportTypes.ts
+++ b/apps/roam/src/utils/getExportTypes.ts
@@ -75,7 +75,7 @@ const getExportTypes = ({
 }: getExportTypesProps): ExportTypes => {
   const settings = settingsSnapshot ?? bulkReadSettings();
   const allRelations = getDiscourseRelations(settings);
-  const allNodes = getDiscourseNodes(allRelations, settings);
+  const allNodes = getDiscourseNodes(settings);
   const nodeLabelByType = Object.fromEntries(
     allNodes.map((a) => [a.type, a.text]),
   );

--- a/apps/roam/src/utils/getRelationData.ts
+++ b/apps/roam/src/utils/getRelationData.ts
@@ -68,7 +68,7 @@ export const getRelationDataUtil = async ({
 
 const getRelationData = async (local?: boolean) => {
   const allRelations = getDiscourseRelations();
-  const allNodes = getDiscourseNodes(allRelations);
+  const allNodes = getDiscourseNodes();
   const nodeLabelByType = Object.fromEntries(
     allNodes.map((a) => [a.type, a.text]),
   );

--- a/apps/roam/src/utils/initializeDiscourseNodes.ts
+++ b/apps/roam/src/utils/initializeDiscourseNodes.ts
@@ -7,9 +7,7 @@ import type { SettingsSnapshot } from "~/components/settings/utils/accessors";
 const initializeDiscourseNodes = async (
   snapshot: SettingsSnapshot,
 ): Promise<boolean> => {
-  const nodes = getDiscourseNodes(undefined, snapshot).filter(
-    excludeDefaultNodes,
-  );
+  const nodes = getDiscourseNodes(snapshot).filter(excludeDefaultNodes);
   if (nodes.length === 0) {
     await Promise.all(
       INITIAL_NODE_VALUES.map(

--- a/apps/roam/src/utils/initializeObserversAndListeners.ts
+++ b/apps/roam/src/utils/initializeObserversAndListeners.ts
@@ -158,7 +158,7 @@ export const initObservers = ({
   const getNodesForTagBatch = (): DiscourseNode[] => {
     if (batchedTagNodes === null) {
       const settings = bulkReadSettings();
-      batchedTagNodes = getDiscourseNodes(undefined, settings);
+      batchedTagNodes = getDiscourseNodes(settings);
       queueMicrotask(() => {
         batchedTagNodes = null;
       });
@@ -253,9 +253,7 @@ export const initObservers = ({
     // doesn't work if they update via sidebar
     if (
       (configPageUid && evt.oldURL.endsWith(configPageUid)) ||
-      getDiscourseNodes(undefined, settings).some(({ type }) =>
-        evt.oldURL.endsWith(type),
-      )
+      getDiscourseNodes(settings).some(({ type }) => evt.oldURL.endsWith(type))
     ) {
       refreshConfigTree(settings);
     }

--- a/apps/roam/src/utils/pageRefObserverHandlers.ts
+++ b/apps/roam/src/utils/pageRefObserverHandlers.ts
@@ -56,10 +56,7 @@ const getBatchSettingsSnapshot = (): SettingsSnapshot => {
 const getBatchDiscourseNodes = (): DiscourseNode[] => {
   if (batchDiscourseNodes) return batchDiscourseNodes;
 
-  batchDiscourseNodes = getDiscourseNodes(
-    undefined,
-    getBatchSettingsSnapshot(),
-  );
+  batchDiscourseNodes = getDiscourseNodes(getBatchSettingsSnapshot());
   queueBatchCacheClear();
   return batchDiscourseNodes;
 };

--- a/apps/roam/src/utils/registerDiscourseDatalogTranslators.ts
+++ b/apps/roam/src/utils/registerDiscourseDatalogTranslators.ts
@@ -90,7 +90,7 @@ const ANY_DISCOURSE_NODE = "Any discourse node";
 
 const registerDiscourseDatalogTranslators = (snapshot?: SettingsSnapshot) => {
   const discourseRelations = getDiscourseRelations(snapshot);
-  const discourseNodes = getDiscourseNodes(discourseRelations, snapshot);
+  const discourseNodes = getDiscourseNodes(snapshot);
 
   const isACallback: Parameters<
     typeof registerDatalogTranslator


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR removes legacy `anchor`-backed discourse node type support from the canvas node type migration path, as requested in Linear issue DIS-608.

## Changes

- **Removed anchor-backed discourse node creation** from `getDiscourseNodes()`:
  - Removed logic that filtered relations with `anchor` in their triples
  - Removed code that generated discourse nodes from these anchor-backed relations
  
- **Removed anchor selection logic** from `getDiscourseContextResults()`:
  - Removed the conditional branch that checked for `anchor` in relation triples
  - Removed anchor selection creation in the `buildSelections()` function

- **Preserved existing functionality**:
  - Context selection behavior remains intact
  - All other discourse node types and relation handling continue to work as before

## Context

Per Joel's explanation, `anchor` was a special keyword for choosing the block displayed as context for a given relation/edge between nodes. However, there is currently no place for this to show up in the discourse context UI, making this functionality unused and unsupported.

The removal simplifies the canvas node type migration flow without affecting any active features.

## Testing

- ✅ TypeScript type checking passes (`pnpm run check-types`)
- ✅ ESLint linting passes (`pnpm run lint`)
- ✅ Verified no remaining anchor references in discourse-related code
- ✅ Code compiles successfully

## Related Issue

Closes DIS-608
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-1896](https://linear.app/discourse-graphs/issue/ENG-1896/remove-legacy-anchor-backed-discourse-node-type-support)

<div><a href="https://cursor.com/agents/bc-2014ca76-ec13-4155-b9f3-0f83b311a423"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2014ca76-ec13-4155-b9f3-0f83b311a423"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

