### PR TITLE
ENG-1900 Update Roam changelog for 0.20.0 release

### DIFF
--- a/apps/roam/CHANGELOG.md
+++ b/apps/roam/CHANGELOG.md
@@ -13,27 +13,27 @@ and this project does not follow [Semantic Versioning](https://semver.org/), her
 
 ### Added
 
-* **Advanced search (BETA, behind admin flag)** - New node search dialog with filtering, sorting, preview, result insertion, and opening results in the main panel or right sidebar.
-* **Canvas sharing** - Share Data now appears in the canvas selection menu for selected discourse nodes.
-* **Convert existing page to node** - Command palette action to turn an existing page into a discourse node.
+- **Advanced search (BETA, behind admin flag)** - New node search dialog with filtering, sorting, preview, result insertion, and opening results in the main panel or right sidebar.
+- **Canvas sharing** - Share Data now appears in the canvas selection menu for selected discourse nodes.
+- **Convert existing page to node** - Command palette action to turn an existing page into a discourse node.
 
 ### Changed
 
-* **Custom favorites in sidebar** - Query sections render in the sidebar, and drag reorders now persist.
-* **Custom favorites in sidebar** - Global and personal settings tabs stay hidden when the left sidebar feature is off, and the global section starts open when it has children.
-* **SmartBlocks in Custom favorites in sidebar** - SmartBlocks render as clickable items in the left sidebar.
-* **Canvas shortcuts** - Per-user canvas keyboard shortcuts now work with the new settings flow.
-* **Canvas embed** - Embedded canvas selection now works with the mouse, and duplicate node-type shortcuts are no longer assigned.
+- **Custom favorites in sidebar** - Query sections render in the sidebar, and drag reorders now persist.
+- **Custom favorites in sidebar** - Global and personal settings tabs stay hidden when the left sidebar feature is off, and the global section starts open when it has children.
+- **SmartBlocks in Custom favorites in sidebar** - SmartBlocks render as clickable items in the left sidebar.
+- **Canvas shortcuts** - Per-user canvas keyboard shortcuts now work with the new settings flow.
+- **Canvas embed** - Embedded canvas selection now works with the mouse, and duplicate node-type shortcuts are no longer assigned.
 
 ### Fixed
 
-* **Image resizing** - Image controls no longer overlap the resize handle.
-* **Suggestion mode** - Reflow on first load is corrected, and searching from all pages works again.
-* **Node type menu** - The node type menu now scrolls when there are many node types.
-* **Create relation flow** - The relation dialog no longer closes when there is no match, and incomplete relation types no longer crash the canvas.
-* **Template editing** - Changing a node template no longer fails with a duplicate block error.
-* **Search result tags** - Search result tags no longer show a leading `#`.
-* **Roam sync** - Missing concepts are recovered during sync, and page-load observer paths no longer repeat settings reads as often.
+- **Image resizing** - Image controls no longer overlap the resize handle.
+- **Suggestion mode** - Reflow on first load is corrected, and searching from all pages works again.
+- **Node type menu** - The node type menu now scrolls when there are many node types.
+- **Create relation flow** - The relation dialog no longer closes when there is no match, and incomplete relation types no longer crash the canvas.
+- **Template editing** - Changing a node template no longer fails with a duplicate block error.
+- **Search result tags** - Search result tags no longer show a leading `#`.
+- **Roam sync** - Missing concepts are recovered during sync, and page-load observer paths no longer repeat settings reads as often.
 
 ## [0.19.0] - 2026-05-11
 

--- a/apps/roam/CHANGELOG.md
+++ b/apps/roam/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project does not follow [Semantic Versioning](https://semver.org/), her
 - Minor version bumps are released on a regular cadence.
 - Patch version bumps are for bugfixes and hotfixes.
 
-## [0.20.0] - 2026-06-01
+## [0.20.0] - 2026-06-21
 
 ### Added
 

--- a/apps/roam/CHANGELOG.md
+++ b/apps/roam/CHANGELOG.md
@@ -9,6 +9,32 @@ and this project does not follow [Semantic Versioning](https://semver.org/), her
 - Minor version bumps are released on a regular cadence.
 - Patch version bumps are for bugfixes and hotfixes.
 
+## [0.20.0] - 2026-06-01
+
+### Added
+
+* **Advanced search (BETA, behind admin flag)** - New node search dialog with filtering, sorting, preview, result insertion, and opening results in the main panel or right sidebar.
+* **Canvas sharing** - Share Data now appears in the canvas selection menu for selected discourse nodes.
+* **Convert existing page to node** - Command palette action to turn an existing page into a discourse node.
+
+### Changed
+
+* **Custom favorites in sidebar** - Query sections render in the sidebar, and drag reorders now persist.
+* **Custom favorites in sidebar** - Global and personal settings tabs stay hidden when the left sidebar feature is off, and the global section starts open when it has children.
+* **SmartBlocks in Custom favorites in sidebar** - SmartBlocks render as clickable items in the left sidebar.
+* **Canvas shortcuts** - Per-user canvas keyboard shortcuts now work with the new settings flow.
+* **Canvas embed** - Embedded canvas selection now works with the mouse, and duplicate node-type shortcuts are no longer assigned.
+
+### Fixed
+
+* **Image resizing** - Image controls no longer overlap the resize handle.
+* **Suggestion mode** - Reflow on first load is corrected, and searching from all pages works again.
+* **Node type menu** - The node type menu now scrolls when there are many node types.
+* **Create relation flow** - The relation dialog no longer closes when there is no match, and incomplete relation types no longer crash the canvas.
+* **Template editing** - Changing a node template no longer fails with a duplicate block error.
+* **Search result tags** - Search result tags no longer show a leading `#`.
+* **Roam sync** - Missing concepts are recovered during sync, and page-load observer paths no longer repeat settings reads as often.
+
 ## [0.19.0] - 2026-05-11
 
 ### Added


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Updates the Roam Research extension changelog with version 0.20.0 release notes.

## Changes

Added changelog entry for version 0.20.0 (2026-06-01) including:

### Added
- Advanced search (BETA, behind admin flag) with filtering, sorting, preview, and result insertion
- Canvas sharing with Share Data in canvas selection menu
- Convert existing page to node command palette action

### Changed
- Custom favorites in sidebar improvements (query sections, drag reorder persistence)
- SmartBlocks render as clickable items in left sidebar
- Canvas shortcuts and embed improvements

### Fixed
- Image resizing controls overlap
- Suggestion mode reflow and search issues
- Node type menu scrolling
- Create relation flow and template editing bugs
- Search result tags and Roam sync improvements

All Linear issue links have been removed from the changelog as requested.

Resolves ENG-1900
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-1900](https://linear.app/discourse-graphs/issue/ENG-1900/roam-release-0200-update-changelog)

<div><a href="https://cursor.com/agents/bc-156a3c1f-b4bd-40ae-ab3e-198d4786d89e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-156a3c1f-b4bd-40ae-ab3e-198d4786d89e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

