### PR TITLE
Bump roam package to 0.21.0 [ENG-1904]

### DIFF
--- a/apps/roam/CHANGELOG.md
+++ b/apps/roam/CHANGELOG.md
@@ -9,14 +9,6 @@ and this project does not follow [Semantic Versioning](https://semver.org/), her
 - Minor version bumps are released on a regular cadence.
 - Patch version bumps are for bugfixes and hotfixes.
 
-## [0.21.0] - 2026-06-21
-
-### Added
-
-### Changed
-
-### Fixed
-
 ## [0.20.0] - 2026-06-21
 
 ### Added

--- a/apps/roam/CHANGELOG.md
+++ b/apps/roam/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project does not follow [Semantic Versioning](https://semver.org/), her
 - Minor version bumps are released on a regular cadence.
 - Patch version bumps are for bugfixes and hotfixes.
 
+## [0.21.0] - 2026-06-21
+
+### Added
+
+### Changed
+
+### Fixed
+
 ## [0.20.0] - 2026-06-21
 
 ### Added

--- a/apps/roam/package.json
+++ b/apps/roam/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roam",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Discourse Graph Plugin for roamresearch.com",
   "scripts": {
     "dev": "tsx scripts/dev.ts",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR bumps the Roam package version from `0.20.0` to `0.21.0`.

## Changes

- Updated `apps/roam/package.json` version to `0.21.0`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-1904](https://linear.app/discourse-graphs/issue/ENG-1904/bump-roam-package-0210)

<div><a href="https://cursor.com/agents/bc-a15b4fae-6663-4d77-8e69-4bdc730079c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a15b4fae-6663-4d77-8e69-4bdc730079c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

