### PR TITLE
ENG-1927 Debounce canvas color writes and flush pending writes on unmount

### DIFF
--- a/apps/roam/src/components/settings/NodeConfig.tsx
+++ b/apps/roam/src/components/settings/NodeConfig.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useEffect } from "react";
+import React, { useState, useCallback, useEffect, useRef } from "react";
 import getDiscourseNodes, { DiscourseNode } from "~/utils/getDiscourseNodes";
 import DualWriteBlocksPanel from "./components/EphemeralBlocksPanel";
 import { getSubTree } from "roamjs-components/util";
@@ -45,6 +45,31 @@ export const getCleanTagText = (tag: string): string => {
   return tag.replace(/^#+/, "").trim().toUpperCase();
 };
 
+const COLOR_WRITE_DEBOUNCE_MS = 300;
+
+type PendingColorWrite = {
+  blockUid: string;
+  nodeType: string;
+  value: string;
+};
+
+const writeColorSetting = ({
+  blockUid,
+  nodeType,
+  value,
+}: PendingColorWrite): void => {
+  void setInputSetting({
+    blockUid,
+    key: "color",
+    value,
+  });
+  setDiscourseNodeSetting(
+    nodeType,
+    [DISCOURSE_NODE_KEYS.canvasSettings, CANVAS_KEYS.color],
+    value,
+  );
+};
+
 const generateTagPlaceholder = (node: DiscourseNode): string => {
   // Extract first reference from format like [[CLM]], [[QUE]], [[EVD]]
   const referenceMatch = node.format.match(/\[\[([A-Z]+)\]\]/);
@@ -89,6 +114,10 @@ const NodeConfig = ({
   const [color, setColor] = useState<string>(() =>
     formatHexColor(node.canvasSettings?.color ?? ""),
   );
+  const colorWriteTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
+  const pendingColorWriteRef = useRef<PendingColorWrite | null>(null);
 
   const [selectedTabId, setSelectedTabId] = useState<TabId>("general");
   const [tagError, setTagError] = useState("");
@@ -98,6 +127,57 @@ const NodeConfig = ({
   const [tagValue, setTagValue] = useState(node.tag || "");
   const [formatValue, setFormatValue] = useState(node.format || "");
   const [shortcutValue, setShortcutValue] = useState(node.shortcut || "");
+
+  const clearColorWriteTimeout = useCallback((): void => {
+    if (!colorWriteTimeoutRef.current) return;
+
+    clearTimeout(colorWriteTimeoutRef.current);
+    colorWriteTimeoutRef.current = null;
+  }, []);
+
+  const persistColor = useCallback(
+    (colorValue: string): void => {
+      const colorWrite = {
+        blockUid: canvasUid,
+        nodeType: node.type,
+        value: colorValue,
+      };
+
+      pendingColorWriteRef.current = null;
+      writeColorSetting(colorWrite);
+    },
+    [canvasUid, node.type],
+  );
+
+  const persistColorAfterPause = useCallback(
+    (colorValue: string): void => {
+      const colorWrite = {
+        blockUid: canvasUid,
+        nodeType: node.type,
+        value: colorValue,
+      };
+
+      clearColorWriteTimeout();
+      pendingColorWriteRef.current = colorWrite;
+      colorWriteTimeoutRef.current = setTimeout(() => {
+        writeColorSetting(colorWrite);
+        pendingColorWriteRef.current = null;
+        colorWriteTimeoutRef.current = null;
+      }, COLOR_WRITE_DEBOUNCE_MS);
+    },
+    [canvasUid, clearColorWriteTimeout, node.type],
+  );
+
+  useEffect(
+    () => () => {
+      clearColorWriteTimeout();
+      if (!pendingColorWriteRef.current) return;
+
+      writeColorSetting(pendingColorWriteRef.current);
+      pendingColorWriteRef.current = null;
+    },
+    [clearColorWriteTimeout],
+  );
   const validate = useCallback(
     ({
       tag,
@@ -274,21 +354,10 @@ const NodeConfig = ({
                       type={"color"}
                       value={color}
                       onChange={(e) => {
-                        const colorValue = e.target.value.replace("#", ""); // remove hash to not create roam link
-                        setColor(e.target.value);
-                        void setInputSetting({
-                          blockUid: canvasUid,
-                          key: "color",
-                          value: colorValue,
-                        });
-                        setDiscourseNodeSetting(
-                          node.type,
-                          [
-                            DISCOURSE_NODE_KEYS.canvasSettings,
-                            CANVAS_KEYS.color,
-                          ],
-                          colorValue,
-                        );
+                        const nextColor = e.target.value;
+                        const colorValue = nextColor.replace("#", ""); // remove hash to not create roam link
+                        setColor(nextColor);
+                        persistColorAfterPause(colorValue);
                       }}
                     />
                     <Tooltip content={color ? "Unset" : "Color not set"}>
@@ -296,20 +365,9 @@ const NodeConfig = ({
                         className={"ml-2 align-middle opacity-80"}
                         icon={color ? "delete" : "info-sign"}
                         onClick={() => {
+                          clearColorWriteTimeout();
                           setColor("");
-                          void setInputSetting({
-                            blockUid: canvasUid,
-                            key: "color",
-                            value: "",
-                          });
-                          setDiscourseNodeSetting(
-                            node.type,
-                            [
-                              DISCOURSE_NODE_KEYS.canvasSettings,
-                              CANVAS_KEYS.color,
-                            ],
-                            "",
-                          );
+                          persistColor("");
                         }}
                       />
                     </Tooltip>

--- a/apps/roam/src/components/settings/NodeConfig.tsx
+++ b/apps/roam/src/components/settings/NodeConfig.tsx
@@ -70,6 +70,14 @@ const writeColorSetting = ({
   );
 };
 
+const pendingColorWriteFlushers = new Set<() => void>();
+
+export const flushPendingNodeColorWrites = (): void => {
+  pendingColorWriteFlushers.forEach((flushPendingColorWrite) =>
+    flushPendingColorWrite(),
+  );
+};
+
 const generateTagPlaceholder = (node: DiscourseNode): string => {
   // Extract first reference from format like [[CLM]], [[QUE]], [[EVD]]
   const referenceMatch = node.format.match(/\[\[([A-Z]+)\]\]/);
@@ -168,16 +176,21 @@ const NodeConfig = ({
     [canvasUid, clearColorWriteTimeout, node.type],
   );
 
-  useEffect(
-    () => () => {
-      clearColorWriteTimeout();
-      if (!pendingColorWriteRef.current) return;
+  const flushPendingColorWrite = useCallback((): void => {
+    clearColorWriteTimeout();
+    if (!pendingColorWriteRef.current) return;
 
-      writeColorSetting(pendingColorWriteRef.current);
-      pendingColorWriteRef.current = null;
-    },
-    [clearColorWriteTimeout],
-  );
+    writeColorSetting(pendingColorWriteRef.current);
+    pendingColorWriteRef.current = null;
+  }, [clearColorWriteTimeout]);
+
+  useEffect(() => {
+    pendingColorWriteFlushers.add(flushPendingColorWrite);
+    return () => {
+      pendingColorWriteFlushers.delete(flushPendingColorWrite);
+      flushPendingColorWrite();
+    };
+  }, [flushPendingColorWrite]);
   const validate = useCallback(
     ({
       tag,

--- a/apps/roam/src/components/settings/NodeConfig.tsx
+++ b/apps/roam/src/components/settings/NodeConfig.tsx
@@ -45,7 +45,7 @@ export const getCleanTagText = (tag: string): string => {
   return tag.replace(/^#+/, "").trim().toUpperCase();
 };
 
-const COLOR_WRITE_DEBOUNCE_MS = 250;
+const COLOR_WRITE_DEBOUNCE_MS = 150;
 
 type DiscourseNodeColorSettingProps = {
   canvasUid: string;

--- a/apps/roam/src/components/settings/NodeConfig.tsx
+++ b/apps/roam/src/components/settings/NodeConfig.tsx
@@ -45,36 +45,103 @@ export const getCleanTagText = (tag: string): string => {
   return tag.replace(/^#+/, "").trim().toUpperCase();
 };
 
-const COLOR_WRITE_DEBOUNCE_MS = 300;
+const COLOR_WRITE_DEBOUNCE_MS = 250;
 
-type PendingColorWrite = {
-  blockUid: string;
+type DiscourseNodeColorSettingProps = {
+  canvasUid: string;
   nodeType: string;
-  value: string;
+  initialColor?: string;
+  tagValue: string;
 };
 
-const writeColorSetting = ({
-  blockUid,
+const DiscourseNodeColorSetting = ({
+  canvasUid,
   nodeType,
-  value,
-}: PendingColorWrite): void => {
-  void setInputSetting({
-    blockUid,
-    key: "color",
-    value,
-  });
-  setDiscourseNodeSetting(
-    nodeType,
-    [DISCOURSE_NODE_KEYS.canvasSettings, CANVAS_KEYS.color],
-    value,
+  initialColor,
+  tagValue,
+}: DiscourseNodeColorSettingProps): React.ReactElement => {
+  const [color, setColor] = useState<string>(() =>
+    formatHexColor(initialColor ?? ""),
   );
-};
+  const colorWriteTimeoutRef = useRef<number | null>(null);
 
-const pendingColorWriteFlushers = new Set<() => void>();
+  const persistColorValue = useCallback(
+    (colorValue: string): void => {
+      void setInputSetting({
+        blockUid: canvasUid,
+        key: "color",
+        value: colorValue,
+      });
+      setDiscourseNodeSetting(
+        nodeType,
+        [DISCOURSE_NODE_KEYS.canvasSettings, CANVAS_KEYS.color],
+        colorValue,
+      );
+    },
+    [canvasUid, nodeType],
+  );
 
-export const flushPendingNodeColorWrites = (): void => {
-  pendingColorWriteFlushers.forEach((flushPendingColorWrite) =>
-    flushPendingColorWrite(),
+  useEffect(() => {
+    return () => {
+      if (!colorWriteTimeoutRef.current) return;
+
+      window.clearTimeout(colorWriteTimeoutRef.current);
+    };
+  }, []);
+
+  const persistColorAfterPause = (colorValue: string): void => {
+    if (colorWriteTimeoutRef.current) {
+      window.clearTimeout(colorWriteTimeoutRef.current);
+      colorWriteTimeoutRef.current = null;
+    }
+    colorWriteTimeoutRef.current = window.setTimeout(() => {
+      persistColorValue(colorValue);
+      colorWriteTimeoutRef.current = null;
+    }, COLOR_WRITE_DEBOUNCE_MS);
+  };
+
+  return (
+    <>
+      {tagValue && (
+        <div className="flex items-center gap-1.5 pl-1">
+          <span className="text-xs italic text-gray-400">Preview:</span>
+          <span style={color ? getNodeTagStyles(color) : undefined}>
+            #{tagValue.replace(/^#/, "")}
+          </span>
+        </div>
+      )}
+      <Label>
+        Color
+        <Description description="Changes the color of tags and canvas nodes" />
+        <ControlGroup>
+          <InputGroup
+            style={{ width: 120 }}
+            type={"color"}
+            value={color}
+            onChange={(e) => {
+              const nextColor = e.target.value;
+              const colorValue = nextColor.replace("#", ""); // remove hash to not create roam link
+              setColor(nextColor);
+              persistColorAfterPause(colorValue);
+            }}
+          />
+          <Tooltip content={color ? "Unset" : "Color not set"}>
+            <Icon
+              className={"ml-2 align-middle opacity-80"}
+              icon={color ? "delete" : "info-sign"}
+              onClick={() => {
+                if (colorWriteTimeoutRef.current) {
+                  window.clearTimeout(colorWriteTimeoutRef.current);
+                  colorWriteTimeoutRef.current = null;
+                }
+                setColor("");
+                persistColorValue("");
+              }}
+            />
+          </Tooltip>
+        </ControlGroup>
+      </Label>
+    </>
   );
 };
 
@@ -119,14 +186,6 @@ const NodeConfig = ({
     key: "Attributes",
   });
 
-  const [color, setColor] = useState<string>(() =>
-    formatHexColor(node.canvasSettings?.color ?? ""),
-  );
-  const colorWriteTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
-    null,
-  );
-  const pendingColorWriteRef = useRef<PendingColorWrite | null>(null);
-
   const [selectedTabId, setSelectedTabId] = useState<TabId>("general");
   const [tagError, setTagError] = useState("");
   const [formatError, setFormatError] = useState("");
@@ -135,62 +194,6 @@ const NodeConfig = ({
   const [tagValue, setTagValue] = useState(node.tag || "");
   const [formatValue, setFormatValue] = useState(node.format || "");
   const [shortcutValue, setShortcutValue] = useState(node.shortcut || "");
-
-  const clearColorWriteTimeout = useCallback((): void => {
-    if (!colorWriteTimeoutRef.current) return;
-
-    clearTimeout(colorWriteTimeoutRef.current);
-    colorWriteTimeoutRef.current = null;
-  }, []);
-
-  const persistColor = useCallback(
-    (colorValue: string): void => {
-      const colorWrite = {
-        blockUid: canvasUid,
-        nodeType: node.type,
-        value: colorValue,
-      };
-
-      pendingColorWriteRef.current = null;
-      writeColorSetting(colorWrite);
-    },
-    [canvasUid, node.type],
-  );
-
-  const persistColorAfterPause = useCallback(
-    (colorValue: string): void => {
-      const colorWrite = {
-        blockUid: canvasUid,
-        nodeType: node.type,
-        value: colorValue,
-      };
-
-      clearColorWriteTimeout();
-      pendingColorWriteRef.current = colorWrite;
-      colorWriteTimeoutRef.current = setTimeout(() => {
-        writeColorSetting(colorWrite);
-        pendingColorWriteRef.current = null;
-        colorWriteTimeoutRef.current = null;
-      }, COLOR_WRITE_DEBOUNCE_MS);
-    },
-    [canvasUid, clearColorWriteTimeout, node.type],
-  );
-
-  const flushPendingColorWrite = useCallback((): void => {
-    clearColorWriteTimeout();
-    if (!pendingColorWriteRef.current) return;
-
-    writeColorSetting(pendingColorWriteRef.current);
-    pendingColorWriteRef.current = null;
-  }, [clearColorWriteTimeout]);
-
-  useEffect(() => {
-    pendingColorWriteFlushers.add(flushPendingColorWrite);
-    return () => {
-      pendingColorWriteFlushers.delete(flushPendingColorWrite);
-      flushPendingColorWrite();
-    };
-  }, [flushPendingColorWrite]);
   const validate = useCallback(
     ({
       tag,
@@ -346,47 +349,13 @@ const NodeConfig = ({
                   parentUid={node.type}
                   uid={tagUid}
                 />
-                {tagValue && (
-                  <div className="flex items-center gap-1.5 pl-1">
-                    <span className="text-xs italic text-gray-400">
-                      Preview:
-                    </span>
-                    <span style={color ? getNodeTagStyles(color) : undefined}>
-                      #{tagValue.replace(/^#/, "")}
-                    </span>
-                  </div>
-                )}
               </div>
-              <>
-                <Label>
-                  Color
-                  <Description description="Changes the color of tags and canvas nodes" />
-                  <ControlGroup>
-                    <InputGroup
-                      style={{ width: 120 }}
-                      type={"color"}
-                      value={color}
-                      onChange={(e) => {
-                        const nextColor = e.target.value;
-                        const colorValue = nextColor.replace("#", ""); // remove hash to not create roam link
-                        setColor(nextColor);
-                        persistColorAfterPause(colorValue);
-                      }}
-                    />
-                    <Tooltip content={color ? "Unset" : "Color not set"}>
-                      <Icon
-                        className={"ml-2 align-middle opacity-80"}
-                        icon={color ? "delete" : "info-sign"}
-                        onClick={() => {
-                          clearColorWriteTimeout();
-                          setColor("");
-                          persistColor("");
-                        }}
-                      />
-                    </Tooltip>
-                  </ControlGroup>
-                </Label>
-              </>
+              <DiscourseNodeColorSetting
+                canvasUid={canvasUid}
+                nodeType={node.type}
+                initialColor={node.canvasSettings?.color}
+                tagValue={tagValue}
+              />
             </div>
           }
         />

--- a/apps/roam/src/components/settings/Settings.tsx
+++ b/apps/roam/src/components/settings/Settings.tsx
@@ -21,7 +21,7 @@ import DiscourseNodeConfigPanel from "./DiscourseNodeConfigPanel";
 import getDiscourseNodes, {
   excludeDefaultNodes,
 } from "~/utils/getDiscourseNodes";
-import NodeConfig from "./NodeConfig";
+import NodeConfig, { flushPendingNodeColorWrites } from "./NodeConfig";
 import HomePersonalSettings from "./HomePersonalSettings";
 import CanvasShortcutSettings from "./CanvasShortcutSettings";
 import refreshConfigTree from "~/utils/refreshConfigTree";
@@ -148,6 +148,7 @@ export const SettingsDialog = ({
     <Dialog
       isOpen={isOpen}
       onClose={() => {
+        flushPendingNodeColorWrites();
         refreshConfigTree();
         onClose?.();
       }}

--- a/apps/roam/src/components/settings/Settings.tsx
+++ b/apps/roam/src/components/settings/Settings.tsx
@@ -21,7 +21,7 @@ import DiscourseNodeConfigPanel from "./DiscourseNodeConfigPanel";
 import getDiscourseNodes, {
   excludeDefaultNodes,
 } from "~/utils/getDiscourseNodes";
-import NodeConfig, { flushPendingNodeColorWrites } from "./NodeConfig";
+import NodeConfig from "./NodeConfig";
 import HomePersonalSettings from "./HomePersonalSettings";
 import CanvasShortcutSettings from "./CanvasShortcutSettings";
 import refreshConfigTree from "~/utils/refreshConfigTree";
@@ -148,7 +148,6 @@ export const SettingsDialog = ({
     <Dialog
       isOpen={isOpen}
       onClose={() => {
-        flushPendingNodeColorWrites();
         refreshConfigTree();
         onClose?.();
       }}


### PR DESCRIPTION
### Motivation

- Prevent excessive writes when the color input is changed rapidly by debouncing persistence of the canvas color setting.
- Ensure any pending color write is flushed when the settings panel unmounts to avoid losing the last user change.
- Allow immediate persistence when the color is explicitly cleared.

### Description

- Introduced `COLOR_WRITE_DEBOUNCE_MS`, a `PendingColorWrite` type, and a `writeColorSetting` helper to centralize color persistence logic.
- Added `useRef` hooks (`colorWriteTimeoutRef` and `pendingColorWriteRef`) and utility functions `clearColorWriteTimeout`, `persistColor`, and `persistColorAfterPause` to debounce writes and manage pending state.
- Updated the color input handler to call `persistColorAfterPause` and updated the clear (`Icon` click) handler to clear the timeout and call `persistColor` for immediate persistence.
- Added a cleanup `useEffect` to flush any pending color write on unmount.

### Testing

- Ran TypeScript type-check and linting (`tsc` / linter) and they passed.
- Ran the project's unit tests and they passed.
- Performed a development build locally and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38d1fa7f5c83268f7917ff20f3955d)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/1144" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->