### PR TITLE
ENG-1711 Reciprocal stored relations not updating after being added

### DIFF
--- a/apps/roam/src/components/CreateRelationDialog.tsx
+++ b/apps/roam/src/components/CreateRelationDialog.tsx
@@ -24,9 +24,10 @@ import type { Result } from "~/utils/types";
 import internalError from "~/utils/internalError";
 import getDiscourseNodes from "~/utils/getDiscourseNodes";
 import posthog from "posthog-js";
+import { refreshDiscourseContextsForMutatedUids } from "~/utils/discourseContextMutationRefresh";
 
 export type CreateRelationDialogProps = {
-  onClose: () => void;
+  onClose: (created?: boolean) => void;
   sourceNodeUid: string;
 };
 
@@ -159,12 +160,18 @@ const CreateRelationDialog = ({
     if (selectedTargetUid === "") return false;
     const relation = identifyRelationMatch(selectedTargetText);
     if (relation === null) return false;
+    const sourceUid = relation.forward ? sourceNodeUid : selectedTargetUid;
+    const destinationUid = relation.forward ? selectedTargetUid : sourceNodeUid;
     const result = await createReifiedRelation({
       relationBlockUid: relation.id,
-      sourceUid: relation.forward ? sourceNodeUid : selectedTargetUid,
-      destinationUid: relation.forward ? selectedTargetUid : sourceNodeUid,
+      sourceUid,
+      destinationUid,
     });
-    return result !== undefined;
+    if (result === undefined) return false;
+    refreshDiscourseContextsForMutatedUids({
+      uids: [sourceNodeUid, selectedTargetUid],
+    });
+    return true;
   };
 
   const onCreateSync = (): void => {
@@ -173,8 +180,8 @@ const CreateRelationDialog = ({
       hasTarget: !!selectedTargetUid,
     });
     onCreate()
-      .then((result: boolean) => {
-        if (result) {
+      .then((created) => {
+        if (created) {
           renderToast({
             id: `discourse-relation-created-${Date.now()}`,
             intent: "success",
@@ -188,7 +195,7 @@ const CreateRelationDialog = ({
             content: <span>Failed to create relation</span>,
           });
         }
-        onClose();
+        onClose(created);
       })
       .catch(() => {
         renderToast({
@@ -196,7 +203,7 @@ const CreateRelationDialog = ({
           intent: "danger",
           content: <span>Failed to create relation</span>,
         });
-        onClose();
+        onClose(false);
       });
   };
 
@@ -227,7 +234,7 @@ const CreateRelationDialog = ({
   return (
     <Dialog
       isOpen={true}
-      onClose={onClose}
+      onClose={() => onClose(false)}
       autoFocus={false}
       className="roamjs-canvas-dialog"
     >
@@ -264,7 +271,7 @@ const CreateRelationDialog = ({
       </div>
       <div className={Classes.DIALOG_FOOTER}>
         <div className={Classes.DIALOG_FOOTER_ACTIONS}>
-          <Button minimal onClick={onClose}>
+          <Button minimal onClick={() => onClose(false)}>
             Cancel
           </Button>
           <Button

--- a/apps/roam/src/components/CreateRelationDialog.tsx
+++ b/apps/roam/src/components/CreateRelationDialog.tsx
@@ -27,7 +27,10 @@ import posthog from "posthog-js";
 import { refreshDiscourseContextsForMutatedUids } from "~/utils/discourseContextMutationRefresh";
 
 export type CreateRelationDialogProps = {
-  onClose: (created?: boolean) => void;
+  // `renderOverlay` replaces `onClose` with its own zero-argument wrapper, so a
+  // create result can only reach callers through a separate prop.
+  onClose?: () => void;
+  onCreated?: () => void;
   sourceNodeUid: string;
 };
 
@@ -43,6 +46,7 @@ type ExtendedCreateRelationDialogProps = CreateRelationDialogProps & {
 
 const CreateRelationDialog = ({
   onClose,
+  onCreated,
   sourceNodeUid,
   relData,
   sourceNodeTitle,
@@ -188,6 +192,7 @@ const CreateRelationDialog = ({
             timeout: 10000,
             content: <span>Created relation</span>,
           });
+          onCreated?.();
         } else {
           renderToast({
             id: `discourse-relation-error-${Date.now()}`,
@@ -195,7 +200,7 @@ const CreateRelationDialog = ({
             content: <span>Failed to create relation</span>,
           });
         }
-        onClose(created);
+        onClose?.();
       })
       .catch(() => {
         renderToast({
@@ -203,7 +208,7 @@ const CreateRelationDialog = ({
           intent: "danger",
           content: <span>Failed to create relation</span>,
         });
-        onClose(false);
+        onClose?.();
       });
   };
 
@@ -234,7 +239,7 @@ const CreateRelationDialog = ({
   return (
     <Dialog
       isOpen={true}
-      onClose={() => onClose(false)}
+      onClose={onClose}
       autoFocus={false}
       className="roamjs-canvas-dialog"
     >
@@ -271,7 +276,7 @@ const CreateRelationDialog = ({
       </div>
       <div className={Classes.DIALOG_FOOTER}>
         <div className={Classes.DIALOG_FOOTER_ACTIONS}>
-          <Button minimal onClick={() => onClose(false)}>
+          <Button minimal onClick={onClose}>
             Cancel
           </Button>
           <Button
@@ -330,6 +335,7 @@ const prepareRelData = (
 const extendProps = ({
   sourceNodeUid,
   onClose,
+  onCreated,
 }: CreateRelationDialogProps): ExtendedCreateRelationDialogProps | null => {
   const nodeTitle = getPageTitleByPageUid(sourceNodeUid).trim();
   const relData = prepareRelData(sourceNodeUid, nodeTitle);
@@ -347,6 +353,7 @@ const extendProps = ({
   return {
     sourceNodeUid,
     onClose,
+    onCreated,
     relData,
     sourceNodeTitle: nodeTitle,
     selectedSourceType,

--- a/apps/roam/src/components/DiscourseContext.tsx
+++ b/apps/roam/src/components/DiscourseContext.tsx
@@ -5,6 +5,10 @@ import getDiscourseContextResults from "~/utils/getDiscourseContextResults";
 import ResultsView from "./results-view/ResultsView";
 import posthog from "posthog-js";
 import { CreateRelationButton } from "./CreateRelationDialog";
+import {
+  DISCOURSE_CONTEXT_MUTATION_REFRESH_EVENT,
+  type DiscourseContextMutationRefreshDetail,
+} from "~/utils/discourseContextMutationRefresh";
 
 export type DiscourseContextResults = Awaited<
   ReturnType<typeof getDiscourseContextResults>
@@ -13,7 +17,7 @@ export type DiscourseContextResults = Awaited<
 type Props = {
   uid: string;
   results?: DiscourseContextResults;
-  overlayRefresh?: () => void;
+  overlayRefresh?: (ignoreCache?: boolean) => void;
 };
 
 const removeTargetFromResult = (
@@ -85,7 +89,8 @@ const ContextTab = ({
           <span style={{ display: "flex", alignItems: "center" }}>
             <CreateRelationButton
               sourceNodeUid={parentUid}
-              onClose={() => {
+              onClose={(created) => {
+                if (!created) return;
                 window.setTimeout(onRefresh, 150, true);
               }}
             />
@@ -158,7 +163,7 @@ export const ContextContent = ({ uid, results, overlayRefresh }: Props) => {
         onResult: addLabels,
         ignoreCache,
       }).finally(() => {
-        if (overlayRefresh) overlayRefresh();
+        if (overlayRefresh) overlayRefresh(ignoreCache);
         setLoading(false);
       });
     },
@@ -177,6 +182,27 @@ export const ContextContent = ({ uid, results, overlayRefresh }: Props) => {
       setLoading(false);
     }
   }, [onRefresh, results, setLoading, loading, addLabels]);
+
+  useEffect(() => {
+    const onMutationRefresh = (event: Event) => {
+      const detail = (
+        event as CustomEvent<DiscourseContextMutationRefreshDetail>
+      ).detail;
+      if (!detail?.uids.includes(uid)) return;
+      onRefresh(true);
+    };
+
+    document.body.addEventListener(
+      DISCOURSE_CONTEXT_MUTATION_REFRESH_EVENT,
+      onMutationRefresh,
+    );
+    return () => {
+      document.body.removeEventListener(
+        DISCOURSE_CONTEXT_MUTATION_REFRESH_EVENT,
+        onMutationRefresh,
+      );
+    };
+  }, [uid, onRefresh]);
   const [tabId, setTabId] = useState(0);
   const [groupByTarget, setGroupByTarget] = useState(false);
   return queryResults.length ? (
@@ -235,7 +261,13 @@ export const ContextContent = ({ uid, results, overlayRefresh }: Props) => {
   ) : (
     <div className="text-center">
       No discourse relations found.
-      <CreateRelationButton sourceNodeUid={uid} onClose={delayedRefresh} />
+      <CreateRelationButton
+        sourceNodeUid={uid}
+        onClose={(created) => {
+          if (!created) return;
+          delayedRefresh();
+        }}
+      />
     </div>
   );
 };

--- a/apps/roam/src/components/DiscourseContext.tsx
+++ b/apps/roam/src/components/DiscourseContext.tsx
@@ -5,10 +5,7 @@ import getDiscourseContextResults from "~/utils/getDiscourseContextResults";
 import ResultsView from "./results-view/ResultsView";
 import posthog from "posthog-js";
 import { CreateRelationButton } from "./CreateRelationDialog";
-import {
-  DISCOURSE_CONTEXT_MUTATION_REFRESH_EVENT,
-  type DiscourseContextMutationRefreshDetail,
-} from "~/utils/discourseContextMutationRefresh";
+import { useDiscourseContextMutationRefresh } from "~/utils/discourseContextMutationRefresh";
 
 export type DiscourseContextResults = Awaited<
   ReturnType<typeof getDiscourseContextResults>
@@ -155,14 +152,17 @@ export const ContextContent = ({ uid, results, overlayRefresh }: Props) => {
   }, []);
 
   const onRefresh = useCallback(
-    (ignoreCache = true) => {
+    (
+      ignoreCache = true,
+      { skipOverlayRefresh = false }: { skipOverlayRefresh?: boolean } = {},
+    ) => {
       setRawQueryResults({});
       void getDiscourseContextResults({
         uid,
         onResult: addLabels,
         ignoreCache,
       }).finally(() => {
-        if (overlayRefresh) overlayRefresh(ignoreCache);
+        if (overlayRefresh && !skipOverlayRefresh) overlayRefresh(ignoreCache);
         setLoading(false);
       });
     },
@@ -182,26 +182,16 @@ export const ContextContent = ({ uid, results, overlayRefresh }: Props) => {
     }
   }, [onRefresh, results, setLoading, loading, addLabels]);
 
-  useEffect(() => {
-    const onMutationRefresh = (event: Event) => {
-      const detail = (
-        event as CustomEvent<DiscourseContextMutationRefreshDetail>
-      ).detail;
-      if (!detail?.uids.includes(uid)) return;
-      onRefresh(true);
-    };
-
-    document.body.addEventListener(
-      DISCOURSE_CONTEXT_MUTATION_REFRESH_EVENT,
-      onMutationRefresh,
-    );
-    return () => {
-      document.body.removeEventListener(
-        DISCOURSE_CONTEXT_MUTATION_REFRESH_EVENT,
-        onMutationRefresh,
-      );
-    };
-  }, [uid, onRefresh]);
+  // Any enclosing overlay subscribes to the same event, so let it refresh itself
+  // rather than triggering a second overlay query from here.
+  const refreshForMutation = useCallback(
+    () => onRefresh(true, { skipOverlayRefresh: true }),
+    [onRefresh],
+  );
+  useDiscourseContextMutationRefresh({
+    uid,
+    onMutationRefresh: refreshForMutation,
+  });
   const [tabId, setTabId] = useState(0);
   const [groupByTarget, setGroupByTarget] = useState(false);
   return queryResults.length ? (

--- a/apps/roam/src/components/DiscourseContext.tsx
+++ b/apps/roam/src/components/DiscourseContext.tsx
@@ -89,8 +89,7 @@ const ContextTab = ({
           <span style={{ display: "flex", alignItems: "center" }}>
             <CreateRelationButton
               sourceNodeUid={parentUid}
-              onClose={(created) => {
-                if (!created) return;
+              onCreated={() => {
                 window.setTimeout(onRefresh, 150, true);
               }}
             />
@@ -261,13 +260,7 @@ export const ContextContent = ({ uid, results, overlayRefresh }: Props) => {
   ) : (
     <div className="text-center">
       No discourse relations found.
-      <CreateRelationButton
-        sourceNodeUid={uid}
-        onClose={(created) => {
-          if (!created) return;
-          delayedRefresh();
-        }}
-      />
+      <CreateRelationButton sourceNodeUid={uid} onCreated={delayedRefresh} />
     </div>
   );
 };

--- a/apps/roam/src/components/DiscourseContextOverlay.tsx
+++ b/apps/roam/src/components/DiscourseContextOverlay.tsx
@@ -7,7 +7,6 @@ import {
   Card,
 } from "@blueprintjs/core";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
-import ReactDOM from "react-dom";
 import renderWithUnmount from "roamjs-components/util/renderWithUnmount";
 import { ContextContent } from "./DiscourseContext";
 import useInViewport from "react-in-viewport/dist/es/lib/useInViewport";
@@ -22,7 +21,6 @@ import getDiscourseContextResults from "~/utils/getDiscourseContextResults";
 import findDiscourseNode from "~/utils/findDiscourseNode";
 import getDiscourseNodes from "~/utils/getDiscourseNodes";
 import getDiscourseRelations from "~/utils/getDiscourseRelations";
-import ExtensionApiContextProvider from "roamjs-components/components/ExtensionApiContext";
 import { OnloadArgs } from "roamjs-components/types/native";
 import getPageTitleByPageUid from "roamjs-components/queries/getPageTitleByPageUid";
 import internalError from "~/utils/internalError";

--- a/apps/roam/src/components/DiscourseContextOverlay.tsx
+++ b/apps/roam/src/components/DiscourseContextOverlay.tsx
@@ -15,6 +15,7 @@ import deriveDiscourseNodeAttribute from "~/utils/deriveDiscourseNodeAttribute";
 import { getDiscourseNodeSetting } from "~/components/settings/utils/accessors";
 import { DISCOURSE_NODE_KEYS } from "~/components/settings/utils/settingKeys";
 import { getStoredRelationsEnabled } from "~/utils/storedRelations";
+import { useDiscourseContextMutationRefresh } from "~/utils/discourseContextMutationRefresh";
 import nanoid from "nanoid";
 import getPageUidByPageTitle from "roamjs-components/queries/getPageUidByPageTitle";
 import getDiscourseContextResults from "~/utils/getDiscourseContextResults";
@@ -231,6 +232,10 @@ const useDiscourseContext = (uid: string, tag: string) => {
   useEffect(() => {
     void getInfo();
   }, [getInfo]);
+
+  // The popover unmounts `ContextContent` while closed, so the overlay button's
+  // score/refs would otherwise stay stale after a relation mutation.
+  useDiscourseContextMutationRefresh({ uid, onMutationRefresh: refresh });
 
   return { loading, results, refs, score, refresh };
 };

--- a/apps/roam/src/components/results-view/ResultsTable.tsx
+++ b/apps/roam/src/components/results-view/ResultsTable.tsx
@@ -23,6 +23,7 @@ import { ContextContent } from "~/components/DiscourseContext";
 import DiscourseContextOverlay from "~/components/DiscourseContextOverlay";
 import { CONTEXT_OVERLAY_SUGGESTION } from "~/utils/predefinedSelections";
 import { strictQueryForReifiedBlocks } from "~/utils/createReifiedBlock";
+import { refreshDiscourseContextsForMutatedUids } from "~/utils/discourseContextMutationRefresh";
 import { getStoredRelationsEnabled } from "~/utils/storedRelations";
 import {
   RenderRoamBlock,
@@ -286,7 +287,9 @@ const ResultRow = ({
               content: "Relation deleted",
               intent: "success",
             });
-            onRefresh(true);
+            refreshDiscourseContextsForMutatedUids({
+              uids: [data.sourceUid, data.destinationUid],
+            });
           })
           .catch((e) => {
             // this one should be an internalError

--- a/apps/roam/src/utils/discourseContextMutationRefresh.ts
+++ b/apps/roam/src/utils/discourseContextMutationRefresh.ts
@@ -1,0 +1,25 @@
+export const DISCOURSE_CONTEXT_MUTATION_REFRESH_EVENT =
+  "roamjs:discourse-context:mutation-refresh";
+
+export type DiscourseContextMutationRefreshDetail = {
+  uids: string[];
+};
+
+export const refreshDiscourseContextsForMutatedUids = ({
+  uids,
+}: DiscourseContextMutationRefreshDetail): void => {
+  const uniqueUids = Array.from(
+    new Set(uids.map((uid) => uid?.trim()).filter(Boolean)),
+  );
+  if (!uniqueUids.length) return;
+  document.body.dispatchEvent(
+    new CustomEvent<DiscourseContextMutationRefreshDetail>(
+      DISCOURSE_CONTEXT_MUTATION_REFRESH_EVENT,
+      {
+        detail: {
+          uids: uniqueUids,
+        },
+      },
+    ),
+  );
+};

--- a/apps/roam/src/utils/discourseContextMutationRefresh.ts
+++ b/apps/roam/src/utils/discourseContextMutationRefresh.ts
@@ -1,3 +1,5 @@
+import { useEffect } from "react";
+
 export const DISCOURSE_CONTEXT_MUTATION_REFRESH_EVENT =
   "roamjs:discourse-context:mutation-refresh";
 
@@ -22,4 +24,34 @@ export const refreshDiscourseContextsForMutatedUids = ({
       },
     ),
   );
+};
+
+// Both the always-mounted overlay button state and the (sometimes unmounted)
+// context body need to react to the same event, so the subscription lives here.
+export const useDiscourseContextMutationRefresh = ({
+  uid,
+  onMutationRefresh,
+}: {
+  uid: string;
+  onMutationRefresh: () => void;
+}): void => {
+  useEffect(() => {
+    const handleMutationRefresh = (event: Event) => {
+      const { detail } =
+        event as CustomEvent<DiscourseContextMutationRefreshDetail>;
+      if (!detail?.uids.includes(uid)) return;
+      onMutationRefresh();
+    };
+
+    document.body.addEventListener(
+      DISCOURSE_CONTEXT_MUTATION_REFRESH_EVENT,
+      handleMutationRefresh,
+    );
+    return () => {
+      document.body.removeEventListener(
+        DISCOURSE_CONTEXT_MUTATION_REFRESH_EVENT,
+        handleMutationRefresh,
+      );
+    };
+  }, [uid, onMutationRefresh]);
 };

--- a/apps/roam/src/utils/matchDiscourseNode.ts
+++ b/apps/roam/src/utils/matchDiscourseNode.ts
@@ -20,9 +20,10 @@ const matchDiscourseNode = ({
   )) => {
   // Handle specification with single "has title" clause
   if (
-    specification.length === 1 &&
-    specification[0].type === "clause" &&
-    specification[0].relation === "has title"
+    specification?.length === 1 &&
+    specification[0]?.type === "clause" &&
+    specification[0]?.relation === "has title" &&
+    specification[0]?.target
   ) {
     const title =
       "title" in rest ? rest.title : getPageTitleByPageUid(rest.uid);


### PR DESCRIPTION
Bug analysis:
https://www.loom.com/share/90f39d46cf4b49cf94c47ebb98645ba3

Bug fix test:
https://www.loom.com/share/1dbd7a00ab224f79903ee7e2af945e1a

## Summary
- Guard `matchDiscourseNode` against missing or malformed `specification` values to avoid discourse context query crashes.
- Add mutation-targeted discourse context refresh for stored relation create/delete by dispatching affected source/destination UIDs.
- Refresh only mounted contexts whose UID is affected, using `ignoreCache: true` for mutation-triggered refreshes while keeping passive/default loads cached.
- Ensure create dialog close/cancel paths do not trigger mutation refresh behavior.

## Why
Reciprocal stored relations could appear stale in open discourse context UI (especially across sidebar/main workflows) because mutation outcomes were not consistently propagating to mounted context views. This keeps default cached behavior intact and applies cache bypass only where mutation freshness is required.

## Test plan
- [x] Create a stored relation from an open discourse context and verify both affected source/destination contexts refresh if currently open.
- [x] Delete a stored relation from results table and verify affected open contexts refresh immediately.
- [x] Open discourse context passively (no mutation) and verify normal cached behavior remains unchanged.
- [x] Cancel/close the create relation dialog and verify no forced refresh occurs.
- [x] Verify no regression for `has title` specification matching and nodes with missing specifications.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/1146" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->