### PR TITLE
ENG-1949 Update website footer

### DIFF
--- a/apps/website/app/(home)/page.tsx
+++ b/apps/website/app/(home)/page.tsx
@@ -823,14 +823,12 @@ const Home = async () => {
               className="text-secondary transition-colors hover:text-white"
             >
               GitHub
-
             </Link>
             <Link
               href="https://www.youtube.com/@discoursegraphs"
               className="text-secondary transition-colors hover:text-white"
             >
               YouTube
-
             </Link>
             <Link
               href="https://join.slack.com/t/discoursegraphs/shared_invite/zt-37xklatti-cpEjgPQC0YyKYQWPNgAkEg"
@@ -876,7 +874,6 @@ const Home = async () => {
                 Subscribe
               </button>
             </form>
-
           </div>
         </div>
       </footer>

--- a/apps/website/app/(home)/page.tsx
+++ b/apps/website/app/(home)/page.tsx
@@ -806,8 +806,8 @@ const Home = async () => {
         </div>
       </main>
 
-      <footer className="mt-12 border-t border-neutral-light/10 bg-neutral-dark px-6 py-10">
-        <div className="mx-auto grid max-w-6xl grid-cols-1 gap-10 md:grid-cols-3 md:items-start">
+      <footer className="mt-12 border-t border-neutral-light/10 bg-neutral-dark py-10">
+        <div className="mx-auto grid max-w-6xl grid-cols-1 gap-10 px-6 md:grid-cols-3 md:items-start">
           {/* Logo + copyright */}
           <div className="flex flex-col gap-3">
             <Logo textClassName="text-white" linked={false} />

--- a/apps/website/app/(home)/page.tsx
+++ b/apps/website/app/(home)/page.tsx
@@ -822,13 +822,15 @@ const Home = async () => {
               href="https://github.com/DiscourseGraphs"
               className="text-secondary transition-colors hover:text-white"
             >
-              Github
+              GitHub
+
             </Link>
             <Link
               href="https://www.youtube.com/@discoursegraphs"
               className="text-secondary transition-colors hover:text-white"
             >
-              Youtube
+              YouTube
+
             </Link>
             <Link
               href="https://join.slack.com/t/discoursegraphs/shared_invite/zt-37xklatti-cpEjgPQC0YyKYQWPNgAkEg"

--- a/apps/website/app/(home)/page.tsx
+++ b/apps/website/app/(home)/page.tsx
@@ -854,11 +854,13 @@ const Home = async () => {
             <p className="mb-4 text-sm text-secondary">
               Periodic news and info about the Discourse Graphs project.
             </p>
+
             <form
               action="https://buttondown.com/api/emails/embed-subscribe/DiscourseGraphs"
               method="post"
               className="flex gap-2"
             >
+              <input type="hidden" name="embed" value="1" />
               <input
                 type="email"
                 name="email"
@@ -874,6 +876,7 @@ const Home = async () => {
                 Subscribe
               </button>
             </form>
+
           </div>
         </div>
       </footer>

--- a/apps/website/app/(home)/page.tsx
+++ b/apps/website/app/(home)/page.tsx
@@ -9,6 +9,7 @@ import {
 import { ArrowBigDownDash, CircleGauge } from "lucide-react";
 import { getLatestBlogs } from "~/(home)/blog/readBlogs";
 import { TeamPerson } from "~/components/TeamPerson";
+import { Logo } from "~/components/Logo";
 import { TEAM_MEMBERS } from "~/data/constants";
 
 const Home = async () => {
@@ -805,45 +806,73 @@ const Home = async () => {
         </div>
       </main>
 
-      <footer className="mt-12 border-t border-neutral-light/10 bg-neutral-dark px-6 py-6">
-        <div className="mx-auto flex max-w-6xl items-center justify-between">
-          <p className="text-secondary">
-            © 2024-{new Date().getFullYear()} Homeworld Collective
-          </p>
-          <div className="flex items-center space-x-4">
+      <footer className="mt-12 border-t border-neutral-light/10 bg-neutral-dark px-6 py-10">
+        <div className="mx-auto grid max-w-6xl grid-cols-1 gap-10 md:grid-cols-3 md:items-start">
+          {/* Logo + copyright */}
+          <div className="flex flex-col gap-3">
+            <Logo textClassName="text-white" linked={false} />
+            <p className="text-sm text-secondary">
+              © 2024-{new Date().getFullYear()} Homeworld Collective
+            </p>
+          </div>
+
+          {/* Links */}
+          <div className="flex flex-col gap-2">
             <Link
               href="https://github.com/DiscourseGraphs"
-              aria-label="GitHub Repository"
+              className="text-secondary transition-colors hover:text-white"
             >
-              <Image
-                src="/github.svg"
-                alt="GitHub"
-                width={24}
-                height={24}
-                className="opacity-80 transition-opacity hover:opacity-100"
-              />
+              Github
+            </Link>
+            <Link
+              href="https://www.youtube.com/@discoursegraphs"
+              className="text-secondary transition-colors hover:text-white"
+            >
+              Youtube
             </Link>
             <Link
               href="https://join.slack.com/t/discoursegraphs/shared_invite/zt-37xklatti-cpEjgPQC0YyKYQWPNgAkEg"
-              aria-label="Slack"
+              className="text-secondary transition-colors hover:text-white"
             >
-              <Image
-                src="/slack.svg"
-                alt="Slack"
-                width={24}
-                height={24}
-                className="opacity-80 transition-opacity hover:opacity-100"
-              />
+              Slack
+            </Link>
+            <Link
+              href="https://bsky.app/profile/discoursegraphs.bsky.social"
+              className="text-secondary transition-colors hover:text-white"
+            >
+              Bluesky
             </Link>
           </div>
-          {/* <div className="flex space-x-4">
-              <Link href="#" className="text-secondary hover:text-neutral-dark">
-                Privacy Policy
-              </Link>
-              <Link href="#" className="text-secondary hover:text-neutral-dark">
-                Terms of Service
-              </Link>
-            </div> */}
+
+          {/* Email subscription */}
+          <div className="rounded-lg border border-neutral-light/20 p-6">
+            <h3 className="mb-1 text-lg font-semibold text-white">
+              Stay up to date
+            </h3>
+            <p className="mb-4 text-sm text-secondary">
+              Periodic news and info about the Discourse Graphs project.
+            </p>
+            <form
+              action="https://buttondown.com/api/emails/embed-subscribe/DiscourseGraphs"
+              method="post"
+              className="flex gap-2"
+            >
+              <input
+                type="email"
+                name="email"
+                id="bd-email"
+                placeholder="your@email.com"
+                required
+                className="min-w-0 flex-1 rounded border border-neutral-light/30 bg-neutral-dark px-3 py-2 text-sm text-white placeholder-neutral-light/50 focus:outline-none focus:ring-1 focus:ring-white/40"
+              />
+              <button
+                type="submit"
+                className="rounded border border-white px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-white hover:text-neutral-dark"
+              >
+                Subscribe
+              </button>
+            </form>
+          </div>
         </div>
       </footer>
     </div>


### PR DESCRIPTION
## Summary
- Replaced the icon-only footer with a 3-column layout matching the design mockup
- Added the Discourse Graphs logo (using the shared `Logo` component) + copyright on the left
- Added text links for Github, Youtube, Slack, and Bluesky in the center
- Added a Buttondown email subscription form ("Stay up to date") on the right

## Test plan
- [ ] Visit the homepage and scroll to the footer
- [ ] Verify 3 columns align to the top on desktop
- [ ] Verify all 4 social links open the correct URLs
- [ ] Verify the email form submits to Buttondown

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/1153" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->