### PR TITLE
Add Frontiers in Research: Open Science Catalyze Panel to Events

### DIFF
--- a/apps/website/app/(home)/page.tsx
+++ b/apps/website/app/(home)/page.tsx
@@ -441,6 +441,18 @@ const Home = async () => {
               <div className="space-y-6">
                 <div>
                   <h3 className="mb-2 text-xl font-semibold text-neutral-dark">
+                    Frontiers in Research: Open Science Catalyze Panel
+                  </h3>
+                  <p className="mb-2 text-neutral-dark">June 18, 2026 | Zoom</p>
+                  <Link
+                    href="https://discoursegraphs.github.io/panel-qa-site/#panelists"
+                    className="text-primary transition-colors hover:text-primary/80"
+                  >
+                    View panel notes →
+                  </Link>
+                </div>
+                <div>
+                  <h3 className="mb-2 text-xl font-semibold text-neutral-dark">
                     Toward Modular Open Science
                   </h3>
                   <p className="mb-2 text-neutral-dark">


### PR DESCRIPTION
## Summary
- Adds the "Frontiers in Research: Open Science Catalyze Panel" event (June 18, 2026 | Zoom) to the Events section of the homepage
- New event is placed at the top of the list as the most recent entry
- Links to https://discoursegraphs.github.io/panel-qa-site/#panelists with text "View panel notes →"

<img width="1155" height="253" alt="image" src="https://github.com/user-attachments/assets/a1f31285-c636-42eb-92ef-07b009372b3a" />


## Test plan
- [ ] Verify new event appears at the top of the Events section on the homepage
- [ ] Confirm the link opens the panel notes site correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/1158" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->