### PR TITLE
[ENG-1855] Add Roam shared-node import discovery

### DIFF
--- a/apps/roam/src/components/DiscoverSharedNodesDialog.tsx
+++ b/apps/roam/src/components/DiscoverSharedNodesDialog.tsx
@@ -1,0 +1,197 @@
+import React, { useEffect, useState } from "react";
+import {
+  Button,
+  Callout,
+  Classes,
+  Dialog,
+  Spinner,
+  Tag,
+} from "@blueprintjs/core";
+import renderOverlay, {
+  RoamOverlayProps,
+} from "roamjs-components/util/renderOverlay";
+import { getLoggedInClient, getSupabaseContext } from "~/utils/supabaseContext";
+import {
+  discoverSharedNodes,
+  getMyGroups,
+  type DiscoverableGroup,
+  type DiscoveredSharedNode,
+} from "~/utils/discoverSharedNodes";
+
+/**
+ * Source RIDs of shared nodes already imported into this Roam graph. ENG-1855 ships this
+ * as an empty seam: Roam has no imported-node store yet (that is ENG-1856), so nothing is
+ * marked as imported. ENG-1859 points this at the real reader once ENG-1856 persists
+ * imported source identity. See ENG-1855 Decisions in the project worklog.
+ */
+const getImportedSourceRids = (): Set<string> => new Set<string>();
+
+type LoadState =
+  | { status: "loading" }
+  | { status: "error"; message: string }
+  | {
+      status: "ready";
+      groups: DiscoverableGroup[];
+      nodes: DiscoveredSharedNode[];
+    };
+
+const formatModified = (iso: string): string => {
+  const ms = new Date(iso).valueOf();
+  if (Number.isNaN(ms) || ms === 0) return "Unknown";
+  return new Date(ms).toLocaleString();
+};
+
+const SharedNodeList = ({ nodes }: { nodes: DiscoveredSharedNode[] }) => {
+  const bySpace = new Map<
+    string,
+    {
+      sourceApp: DiscoveredSharedNode["sourceApp"];
+      nodes: DiscoveredSharedNode[];
+    }
+  >();
+  for (const node of nodes) {
+    const existing = bySpace.get(node.sourceSpaceName);
+    if (existing) existing.nodes.push(node);
+    else
+      bySpace.set(node.sourceSpaceName, {
+        sourceApp: node.sourceApp,
+        nodes: [node],
+      });
+  }
+
+  return (
+    <div className="flex max-h-96 flex-col gap-4 overflow-y-auto">
+      {[...bySpace.entries()].map(([spaceName, group]) => (
+        <div key={spaceName}>
+          <div className="mb-1 flex items-center gap-2">
+            <Tag minimal>{group.sourceApp}</Tag>
+            <strong>{spaceName}</strong>
+          </div>
+          <ul className="m-0 list-none p-0">
+            {group.nodes.map((node) => (
+              <li
+                key={node.sourceNodeRid}
+                className="flex items-center justify-between gap-2 py-1"
+              >
+                <span className="truncate">{node.title}</span>
+                <span className="flex flex-shrink-0 items-center gap-2">
+                  {node.alreadyImported && (
+                    <Tag intent="success" minimal>
+                      Imported
+                    </Tag>
+                  )}
+                  <span className="text-xs opacity-60">
+                    {formatModified(node.sourceModifiedAt)}
+                  </span>
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+const DiscoverSharedNodesDialog = ({
+  isOpen,
+  onClose,
+}: RoamOverlayProps<Record<string, never>>) => {
+  const [state, setState] = useState<LoadState>({ status: "loading" });
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      try {
+        const client = await getLoggedInClient();
+        if (!client) {
+          if (!cancelled)
+            setState({
+              status: "error",
+              message: "Could not access the Discourse Graph database.",
+            });
+          return;
+        }
+        const context = await getSupabaseContext();
+        if (!context) {
+          if (!cancelled)
+            setState({
+              status: "error",
+              message: "Could not load this graph's workspace context.",
+            });
+          return;
+        }
+        const [groups, nodes] = await Promise.all([
+          getMyGroups(client),
+          discoverSharedNodes({
+            client,
+            currentSpaceId: context.spaceId,
+            importedRids: getImportedSourceRids(),
+          }),
+        ]);
+        if (!cancelled) setState({ status: "ready", groups, nodes });
+      } catch (error) {
+        if (!cancelled)
+          setState({
+            status: "error",
+            message:
+              error instanceof Error
+                ? error.message
+                : "Unexpected error loading shared nodes.",
+          });
+      }
+    };
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <Dialog isOpen={isOpen} onClose={onClose} title="Discover shared nodes">
+      <div className={Classes.DIALOG_BODY}>
+        {state.status === "loading" && (
+          <div className="flex items-center gap-2">
+            <Spinner size={20} />
+            <span>Loading shared nodes…</span>
+          </div>
+        )}
+        {state.status === "error" && (
+          <Callout intent="danger" title="Could not load shared nodes">
+            {state.message}
+          </Callout>
+        )}
+        {state.status === "ready" &&
+          state.groups.length === 0 &&
+          state.nodes.length === 0 && (
+            <Callout intent="primary" title="No sharing groups">
+              You are not a member of any sharing group yet, so there are no
+              shared nodes to import.
+            </Callout>
+          )}
+        {state.status === "ready" &&
+          state.groups.length > 0 &&
+          state.nodes.length === 0 && (
+            <Callout intent="primary" title="No shared nodes">
+              No shared nodes from other spaces are available to import yet.
+            </Callout>
+          )}
+        {state.status === "ready" && state.nodes.length > 0 && (
+          <SharedNodeList nodes={state.nodes} />
+        )}
+      </div>
+      <div className={Classes.DIALOG_FOOTER}>
+        <div className={Classes.DIALOG_FOOTER_ACTIONS}>
+          <Button onClick={onClose}>Close</Button>
+        </div>
+      </div>
+    </Dialog>
+  );
+};
+
+export const renderDiscoverSharedNodesDialog = (): void => {
+  renderOverlay({
+    id: "discover-shared-nodes",
+    Overlay: DiscoverSharedNodesDialog,
+  });
+};

--- a/apps/roam/src/components/settings/AdminPanel.tsx
+++ b/apps/roam/src/components/settings/AdminPanel.tsx
@@ -273,6 +273,9 @@ const FeatureFlagsTab = (): React.ReactElement => {
   const [advancedNodeSearchValue, setAdvancedNodeSearchValue] = useState(
     getFeatureFlag("Advanced node search enabled"),
   );
+  const [crossAppImportValue, setCrossAppImportValue] = useState(
+    getFeatureFlag("Cross-app node import enabled"),
+  );
   const syncAlreadyEnabled = duplicateNodeAlertValue || suggestiveOverlayValue;
 
   const ensureSyncEnabled = (
@@ -368,6 +371,14 @@ const FeatureFlagsTab = (): React.ReactElement => {
         featureKey="Advanced node search enabled"
         value={advancedNodeSearchValue}
         onAfterChange={(checked) => setAdvancedNodeSearchValue(checked)}
+      />
+
+      <FeatureFlagPanel
+        title="Cross-app node import"
+        description="Show the DG: Import - Discover shared nodes command for importing nodes shared from other graphs (Obsidian/Roam). Reload the graph after toggling."
+        featureKey="Cross-app node import enabled"
+        value={crossAppImportValue}
+        onAfterChange={(checked) => setCrossAppImportValue(checked)}
       />
 
       <Alert

--- a/apps/roam/src/components/settings/utils/zodSchema.example.ts
+++ b/apps/roam/src/components/settings/utils/zodSchema.example.ts
@@ -89,6 +89,7 @@ const featureFlags: FeatureFlags = {
   "Enable left sidebar": true,
   "Duplicate node alert enabled": true,
   "Suggestive mode overlay enabled": true,
+  "Cross-app node import enabled": true,
   "Use new settings store": false,
 };
 
@@ -97,6 +98,7 @@ const defaultFeatureFlags: FeatureFlags = {
   "Enable left sidebar": false,
   "Duplicate node alert enabled": false,
   "Suggestive mode overlay enabled": false,
+  "Cross-app node import enabled": false,
   "Use new settings store": false,
 };
 

--- a/apps/roam/src/components/settings/utils/zodSchema.ts
+++ b/apps/roam/src/components/settings/utils/zodSchema.ts
@@ -159,6 +159,7 @@ export const FeatureFlagsSchema = z.object({
   "Enable left sidebar": z.boolean().default(false),
   "Duplicate node alert enabled": z.boolean().default(false),
   "Suggestive mode overlay enabled": z.boolean().default(false),
+  "Cross-app node import enabled": z.boolean().default(false),
   "Use new settings store": z.boolean().default(false),
 });
 

--- a/apps/roam/src/utils/__tests__/discoverSharedNodes.test.ts
+++ b/apps/roam/src/utils/__tests__/discoverSharedNodes.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import {
+  ridToSpaceUriAndLocalId,
+  spaceUriAndLocalIdToRid,
+} from "@repo/database/lib/rid";
+import { assembleDiscoveredNodes } from "~/utils/discoverSharedNodes";
+
+const ROAM_URL = "https://roamresearch.com/#/app/MAPLab";
+const OBSIDIAN_URL = "obsidian:9a8b7c6d5e4f3210";
+
+const spaceMeta: Map<
+  number,
+  { url: string; name: string | null; platform: string | null }
+> = new Map([
+  [1, { url: ROAM_URL, name: "MAP Lab", platform: "Roam" }],
+  [2, { url: OBSIDIAN_URL, name: "Field Vault", platform: "Obsidian" }],
+]);
+
+const row = (
+  space_id: number,
+  source_local_id: string,
+  variant: string,
+  text: string | null,
+  last_modified: string | null,
+) => ({ space_id, source_local_id, variant, text, last_modified });
+
+describe("assembleDiscoveredNodes", () => {
+  it("merges direct + full into one node, preferring direct for the title", () => {
+    const result = assembleDiscoveredNodes({
+      contentRows: [
+        row(1, "abc", "direct", "Sleep improves memory", "2026-06-12T10:00:00"),
+        row(
+          1,
+          "abc",
+          "full",
+          "# Sleep improves memory\n\nbody",
+          "2026-06-12T12:00:00",
+        ),
+      ],
+      spaceMetaById: spaceMeta,
+      importedRids: new Set(),
+    });
+
+    expect(result).toHaveLength(1);
+    const node = result[0]!;
+    expect(node.title).toBe("Sleep improves memory");
+    expect(node.sourceApp).toBe("roam");
+    expect(node.sourceSpaceId).toBe(ROAM_URL);
+    expect(node.sourceSpaceName).toBe("MAP Lab");
+    expect(node.sourceNodeId).toBe("abc");
+    expect(node.alreadyImported).toBe(false);
+    expect(node.sourceModifiedAt).toBe(
+      new Date("2026-06-12T12:00:00Z").toISOString(),
+    );
+    expect(node.sourceNodeRid).toBe(spaceUriAndLocalIdToRid(ROAM_URL, "abc"));
+    expect(ridToSpaceUriAndLocalId(node.sourceNodeRid)).toEqual({
+      spaceUri: ROAM_URL,
+      sourceLocalId: "abc",
+    });
+  });
+
+  it("skips title-only nodes that have no full variant (not actually shared)", () => {
+    const result = assembleDiscoveredNodes({
+      contentRows: [
+        row(1, "title-only", "direct", "Just a title", "2026-06-12T10:00:00"),
+      ],
+      spaceMetaById: spaceMeta,
+      importedRids: new Set(),
+    });
+    expect(result).toHaveLength(0);
+  });
+
+  it("skips nodes whose source space metadata is missing", () => {
+    const result = assembleDiscoveredNodes({
+      contentRows: [
+        row(99, "x", "direct", "Title", "2026-06-12T10:00:00"),
+        row(99, "x", "full", "body", "2026-06-12T10:00:00"),
+      ],
+      spaceMetaById: spaceMeta,
+      importedRids: new Set(),
+    });
+    expect(result).toHaveLength(0);
+  });
+
+  it("marks already-imported nodes by source RID", () => {
+    const contentRows = [
+      row(2, "node-1", "direct", "Field note", "2026-06-12T10:00:00"),
+      row(2, "node-1", "full", "body", "2026-06-12T10:00:00"),
+    ];
+    const rid = spaceUriAndLocalIdToRid(OBSIDIAN_URL, "node-1");
+    const result = assembleDiscoveredNodes({
+      contentRows,
+      spaceMetaById: spaceMeta,
+      importedRids: new Set([rid]),
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0]!.sourceApp).toBe("obsidian");
+    expect(result[0]!.alreadyImported).toBe(true);
+  });
+
+  it("sorts nodes by source space name", () => {
+    const result = assembleDiscoveredNodes({
+      contentRows: [
+        row(2, "o1", "direct", "Obsidian node", "2026-06-12T10:00:00"),
+        row(2, "o1", "full", "body", "2026-06-12T10:00:00"),
+        row(1, "r1", "direct", "Roam node", "2026-06-12T10:00:00"),
+        row(1, "r1", "full", "body", "2026-06-12T10:00:00"),
+      ],
+      spaceMetaById: spaceMeta,
+      importedRids: new Set(),
+    });
+    expect(result.map((n) => n.sourceSpaceName)).toEqual([
+      "Field Vault",
+      "MAP Lab",
+    ]);
+  });
+});

--- a/apps/roam/src/utils/discoverSharedNodes.ts
+++ b/apps/roam/src/utils/discoverSharedNodes.ts
@@ -1,0 +1,192 @@
+import { spaceUriAndLocalIdToRid } from "@repo/database/lib/rid";
+import type { DGSupabaseClient } from "@repo/database/lib/client";
+
+export type DiscoveredSharedNode = {
+  sourceApp: "roam" | "obsidian";
+  sourceSpaceId: string;
+  sourceSpaceName: string;
+  sourceNodeId: string;
+  sourceNodeRid: string;
+  title: string;
+  sourceModifiedAt: string;
+  alreadyImported: boolean;
+};
+
+export type DiscoverableGroup = {
+  id: string;
+  name: string;
+};
+
+type DiscoveryContentRow = {
+  source_local_id: string | null;
+  space_id: number | null;
+  text: string | null;
+  last_modified: string | null;
+  variant: string | null;
+};
+
+type SpaceMeta = {
+  url: string;
+  name: string | null;
+  platform: string | null;
+};
+
+const platformToSourceApp = (
+  platform: string | null,
+): DiscoveredSharedNode["sourceApp"] | null => {
+  if (platform === "Roam") return "roam";
+  if (platform === "Obsidian") return "obsidian";
+  return null;
+};
+
+const dbTimestampToIso = (value: string | null): string | null => {
+  if (!value) return null;
+  const ms = new Date(`${value}Z`).valueOf();
+  return Number.isNaN(ms) ? null : new Date(ms).toISOString();
+};
+
+const latestModifiedIso = (rows: DiscoveryContentRow[]): string | null => {
+  const stamps = rows
+    .map((row) => row.last_modified)
+    .filter((value): value is string => value != null);
+  if (stamps.length === 0) return null;
+  const latest = stamps.reduce((a, b) => (a >= b ? a : b));
+  return dbTimestampToIso(latest);
+};
+
+/**
+ * Assembles raw `my_contents` rows into app-neutral discovered nodes. Pure (no Supabase
+ * or Roam access) so it can be unit-tested directly. A node is discoverable only when it
+ * has a `full` markdown variant — the marker that the source app actually shared it
+ * (ENG-1848) and therefore that it matches the shared cross-app contract.
+ */
+export const assembleDiscoveredNodes = ({
+  contentRows,
+  spaceMetaById,
+  importedRids,
+}: {
+  contentRows: DiscoveryContentRow[];
+  spaceMetaById: Map<number, SpaceMeta>;
+  importedRids: Set<string>;
+}): DiscoveredSharedNode[] => {
+  const byNode = new Map<
+    string,
+    { spaceId: number; sourceNodeId: string; rows: DiscoveryContentRow[] }
+  >();
+  for (const row of contentRows) {
+    if (row.source_local_id == null || row.space_id == null) continue;
+    const key = `${row.space_id}\t${row.source_local_id}`;
+    const existing = byNode.get(key);
+    if (existing) existing.rows.push(row);
+    else
+      byNode.set(key, {
+        spaceId: row.space_id,
+        sourceNodeId: row.source_local_id,
+        rows: [row],
+      });
+  }
+
+  const nodes: DiscoveredSharedNode[] = [];
+  for (const { spaceId, sourceNodeId, rows } of byNode.values()) {
+    if (!rows.some((row) => row.variant === "full")) continue;
+
+    const meta = spaceMetaById.get(spaceId);
+    if (!meta) continue;
+    const sourceApp = platformToSourceApp(meta.platform);
+    if (!sourceApp) continue;
+
+    const direct = rows.find((row) => row.variant === "direct");
+    const full = rows.find((row) => row.variant === "full");
+    const title = (direct?.text ?? full?.text ?? "").trim();
+    if (!title) continue;
+
+    const sourceNodeRid = spaceUriAndLocalIdToRid(meta.url, sourceNodeId);
+    nodes.push({
+      sourceApp,
+      sourceSpaceId: meta.url,
+      sourceSpaceName: meta.name ?? meta.url,
+      sourceNodeId,
+      sourceNodeRid,
+      title,
+      sourceModifiedAt: latestModifiedIso(rows) ?? new Date(0).toISOString(),
+      alreadyImported: importedRids.has(sourceNodeRid),
+    });
+  }
+
+  nodes.sort(
+    (a, b) =>
+      a.sourceSpaceName.localeCompare(b.sourceSpaceName) ||
+      b.sourceModifiedAt.localeCompare(a.sourceModifiedAt) ||
+      a.title.localeCompare(b.title),
+  );
+  return nodes;
+};
+
+const fetchSpaceMetaById = async (
+  client: DGSupabaseClient,
+  spaceIds: number[],
+): Promise<Map<number, SpaceMeta>> => {
+  const metaById = new Map<number, SpaceMeta>();
+  if (spaceIds.length === 0) return metaById;
+
+  const { data, error } = await client
+    .from("my_spaces")
+    .select("id, name, url, platform")
+    .in("id", spaceIds);
+  if (error) {
+    throw new Error(`Failed to load source spaces: ${error.message}`);
+  }
+
+  for (const row of data ?? []) {
+    if (row.id == null || row.url == null) continue;
+    metaById.set(row.id, {
+      url: row.url,
+      name: row.name,
+      platform: row.platform,
+    });
+  }
+  return metaById;
+};
+
+export const discoverSharedNodes = async ({
+  client,
+  currentSpaceId,
+  importedRids = new Set<string>(),
+}: {
+  client: DGSupabaseClient;
+  currentSpaceId: number;
+  importedRids?: Set<string>;
+}): Promise<DiscoveredSharedNode[]> => {
+  const { data, error } = await client
+    .from("my_contents")
+    .select("source_local_id, space_id, text, last_modified, variant")
+    .neq("space_id", currentSpaceId);
+  if (error) {
+    throw new Error(`Failed to load shared nodes: ${error.message}`);
+  }
+
+  const contentRows = data ?? [];
+  if (contentRows.length === 0) return [];
+
+  const spaceIds = [
+    ...new Set(
+      contentRows
+        .map((row) => row.space_id)
+        .filter((value): value is number => value != null),
+    ),
+  ];
+  const spaceMetaById = await fetchSpaceMetaById(client, spaceIds);
+  return assembleDiscoveredNodes({ contentRows, spaceMetaById, importedRids });
+};
+
+export const getMyGroups = async (
+  client: DGSupabaseClient,
+): Promise<DiscoverableGroup[]> => {
+  const { data, error } = await client.from("my_groups").select("id, name");
+  if (error) {
+    throw new Error(`Failed to load sharing groups: ${error.message}`);
+  }
+  return (data ?? []).flatMap((row) =>
+    row.id == null ? [] : [{ id: row.id, name: row.name ?? row.id }],
+  );
+};

--- a/apps/roam/src/utils/registerCommandPaletteCommands.ts
+++ b/apps/roam/src/utils/registerCommandPaletteCommands.ts
@@ -13,6 +13,7 @@ import fireQuery from "./fireQuery";
 import { excludeDefaultNodes } from "~/utils/getDiscourseNodes";
 import { render as renderSettings } from "~/components/settings/Settings";
 import { renderModifyNodeDialog } from "~/components/ModifyNodeDialog";
+import { renderDiscoverSharedNodesDialog } from "~/components/DiscoverSharedNodesDialog";
 import getTextByBlockUid from "roamjs-components/queries/getTextByBlockUid";
 import {
   getOverlayHandler,
@@ -363,6 +364,11 @@ export const registerCommandPaletteCommands = (onloadArgs: OnloadArgs) => {
   );
   void addCommand("DG: Export - Current page", exportCurrentPage);
   void addCommand("DG: Export - Discourse graph", exportDiscourseGraph);
+  if (getFeatureFlag("Cross-app node import enabled")) {
+    void addCommand("DG: Import - Discover shared nodes", () =>
+      renderDiscoverSharedNodesDialog(),
+    );
+  }
   void addCommand("DG: Open - Discourse settings", renderSettingsPopup);
   if (getFeatureFlag("Advanced node search enabled")) {
     void addCommand("DG: Open Node Search", () => {


### PR DESCRIPTION
## Summary

Adds a read-only Roam command **DG: Import - Discover shared nodes** that lists group-visible shared nodes from *other* spaces — source app, source space, title, and upstream modified time — so a Roam user can see what's available to import from Obsidian/Roam. **Discovery only; the import action itself is ENG-1859.**

Part of the Roam↔Obsidian push-pull project, Milestone 2 (Bidirectional node import). Extends the existing Obsidian↔Obsidian discovery reference rather than building a new path.

## What it does

- `discoverSharedNodes` reads the RLS-scoped `my_contents` view, excludes the current space, groups by `(space_id, source_local_id)`, prefers the `direct` variant for the title, and resolves space metadata via `my_spaces`.
- Maps to an app-neutral shape aligned to the ENG-1847 `CrossAppNode` contract (`sourceApp`, `sourceSpaceId`/`Name`, `sourceNodeId`, `sourceNodeRid`, `title`, `sourceModifiedAt`, `alreadyImported`).
- Read-only Blueprint modal with loading / error / empty / list states.

## Design notes (the why)

- **Discovery requires a `full` variant** (the ENG-1848 shared/published marker) so the list shows genuinely importable nodes, not every synced title — a deliberate scoping choice (diverges slightly from Obsidian's list-all discovery).
- **`alreadyImported` flows through an empty `getImportedSourceRids()` seam.** Roam has no imported-node store yet (that's ENG-1856), so nothing is imported and nothing is marked; ENG-1859 wires this to ENG-1856's reader. Keys on source RID.
- **Visibility comes from the RLS `my_*` views + own-space exclusion**, not app-side access logic.
- **Roam-local mirror** of Obsidian's `getPublishedNodesForGroups` / `getMyGroups` (app-specific client + return shape); not promoted to a shared package yet (future-extraction candidate).
- **Gated behind a new `Cross-app node import enabled` feature flag** (off by default; AdminPanel toggle "Cross-app node import"), mirroring `Advanced node search enabled` — the feature is incomplete (no import until ENG-1859), so it stays hidden from users by default. Later M2 commands reuse the same flag.

## Testing

- Unit tests for the pure `assembleDiscoveredNodes` (variant merge, full-variant filter, RID round-trip, already-imported marking, sorting).
- vitest isn't installed in the local worktree (affects all existing tests) → it runs in CI; locally proven via a `tsx` harness (all cases pass). eslint / prettier / tsc green.

## ⚠️ Pending before merge

- **Runtime proof** against a real group-member Roam graph with another space's shared nodes in Supabase (enable the flag → run the command → confirm the list, own-space exclusion, and empty states).
- **Loom** walkthrough.

Linear: ENG-1855

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/1162" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->