### PR TITLE
FEE-840 Add schema export for Obsidian

### DIFF
--- a/apps/obsidian/src/components/ExportSpecsModal.tsx
+++ b/apps/obsidian/src/components/ExportSpecsModal.tsx
@@ -43,7 +43,9 @@ const ExportSpecsContent = ({ plugin, onClose }: ExportSpecsModalProps) => {
   const selection = useSchemaSelection({
     source,
     resetKey: "export",
-    initialTemplateNames: [...getReferencedTemplateNames(source.nodeTypes)],
+    initialTemplateNames: [
+      ...getReferencedTemplateNames(source.nodeTypes),
+    ].filter((name) => source.templateNames.includes(name)),
   });
 
   const handleExport = async (): Promise<void> => {

--- a/apps/obsidian/src/components/ExportSpecsModal.tsx
+++ b/apps/obsidian/src/components/ExportSpecsModal.tsx
@@ -1,0 +1,132 @@
+import { App, Notice } from "obsidian";
+import { useMemo, useState } from "react";
+import type DiscourseGraphPlugin from "~/index";
+import { exportSchemaSelection } from "~/utils/specExport";
+import { NativeFileDialogCancelledError } from "~/utils/nativeJsonFileDialogs";
+import { getDgSchemaFileName } from "~/utils/specValidation";
+import { getTemplateFiles } from "~/utils/templates";
+import {
+  getReferencedTemplateNames,
+  useSchemaSelection,
+  type SchemaSelectionSource,
+} from "~/components/useSchemaSelection";
+import { SchemaSelectionModalBody } from "~/components/SchemaSelectionModalBody";
+import { ReactRootModal } from "~/components/ReactRootModal";
+
+type ExportSpecsModalProps = {
+  plugin: DiscourseGraphPlugin;
+  onClose: () => void;
+};
+
+export const openExportSpecsModal = (plugin: DiscourseGraphPlugin): void => {
+  new ExportSpecsModal(plugin.app, plugin).open();
+};
+
+const ExportSpecsContent = ({ plugin, onClose }: ExportSpecsModalProps) => {
+  const [isExporting, setIsExporting] = useState(false);
+  const outputFileName = getDgSchemaFileName(plugin.app.vault.getName());
+
+  const source = useMemo<SchemaSelectionSource>(() => {
+    return {
+      nodeTypes: plugin.settings.nodeTypes,
+      relationTypes: plugin.settings.relationTypes,
+      relationTriples: plugin.settings.discourseRelations,
+      templateNames: getTemplateFiles(plugin.app),
+    };
+  }, [
+    plugin.app,
+    plugin.settings.discourseRelations,
+    plugin.settings.nodeTypes,
+    plugin.settings.relationTypes,
+  ]);
+
+  const selection = useSchemaSelection({
+    source,
+    resetKey: "export",
+    initialTemplateNames: [...getReferencedTemplateNames(source.nodeTypes)],
+  });
+
+  const handleExport = async (): Promise<void> => {
+    const payload = selection.asSelectionPayload();
+    const hasSelection =
+      payload.nodeTypeIds.length > 0 ||
+      payload.relationTypeIds.length > 0 ||
+      payload.relationIds.length > 0 ||
+      payload.templateNames.length > 0;
+    if (!hasSelection) {
+      new Notice("Select at least one schema item or template to export.");
+      return;
+    }
+
+    setIsExporting(true);
+    try {
+      const result = await exportSchemaSelection({
+        plugin,
+        selection: {
+          nodeTypeIds: payload.nodeTypeIds,
+          relationTypeIds: payload.relationTypeIds,
+          discourseRelationIds: payload.relationIds,
+          templateNames: payload.templateNames,
+        },
+      });
+
+      const warningSuffix =
+        result.warnings.length > 0
+          ? ` (${result.warnings.length} warning${result.warnings.length === 1 ? "" : "s"})`
+          : "";
+
+      new Notice(
+        `Exported schema to ${result.filePath}${warningSuffix}.`,
+        6000,
+      );
+
+      if (result.warnings.length > 0) {
+        for (const warning of result.warnings) {
+          new Notice(warning, 6000);
+        }
+      }
+
+      onClose();
+    } catch (error) {
+      if (error instanceof NativeFileDialogCancelledError) {
+        return;
+      }
+      console.error("Failed to export schema:", error);
+      const message = error instanceof Error ? error.message : String(error);
+      new Notice(`Schema export failed: ${message}`, 6000);
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  return (
+    <SchemaSelectionModalBody
+      title="Export discourse graph schema"
+      description={`Select the node types, relation types, relation triples, and templates to include in ${outputFileName}.`}
+      source={source}
+      selection={selection}
+      emptyTemplateText="No templates found in your Templates folder."
+      onDependencyViolation={(message) => new Notice(message)}
+      footerSecondaryLabel="Cancel"
+      onFooterSecondaryClick={onClose}
+      footerPrimaryLabel={isExporting ? "Exporting..." : "Export schema"}
+      onFooterPrimaryClick={() => void handleExport()}
+      isFooterPrimaryDisabled={isExporting}
+    />
+  );
+};
+
+export class ExportSpecsModal extends ReactRootModal {
+  private plugin: DiscourseGraphPlugin;
+
+  constructor(app: App, plugin: DiscourseGraphPlugin) {
+    super(app);
+    this.plugin = plugin;
+  }
+
+  protected renderContent() {
+    return (
+      <ExportSpecsContent plugin={this.plugin} onClose={() => this.close()} />
+    );
+  }
+}

--- a/apps/obsidian/src/components/GeneralSettings.tsx
+++ b/apps/obsidian/src/components/GeneralSettings.tsx
@@ -3,6 +3,8 @@ import { usePlugin } from "./PluginContext";
 import { setIcon } from "obsidian";
 import SuggestInput from "./SuggestInput";
 import { DiscourseGraphLogoIcon, SlackLogoIcon } from "./Icons";
+import { openExportSpecsModal } from "./ExportSpecsModal";
+import { getDgSchemaFileName } from "~/utils/specValidation";
 
 const DOCS_URL = "https://discoursegraphs.com/docs/obsidian";
 const COMMUNITY_URL =
@@ -148,6 +150,7 @@ const GeneralSettings = () => {
   const [nodeTagHotkey, setNodeTagHotkey] = useState<string>(
     plugin.settings.nodeTagHotkey,
   );
+  const schemaFileName = getDgSchemaFileName(plugin.app.vault.getName());
 
   const handleToggleChange = (newValue: boolean) => {
     setShowIdsInFrontmatter(newValue);
@@ -295,6 +298,25 @@ const GeneralSettings = () => {
             placeholder="\"
             maxLength={1}
           />
+        </div>
+      </div>
+
+      <div className="setting-item">
+        <div className="setting-item-info">
+          <div className="setting-item-name">Export discourse graph schema</div>
+          <div className="setting-item-description">
+            Export selected node types, relation types, relation triples, and
+            templates to a JSON file named <code>{schemaFileName}</code>.
+          </div>
+        </div>
+        <div className="setting-item-control">
+          <button
+            type="button"
+            className="rounded border px-3 py-1.5 text-sm"
+            onClick={() => void openExportSpecsModal(plugin)}
+          >
+            Open export modal
+          </button>
         </div>
       </div>
 

--- a/apps/obsidian/src/components/ReactRootModal.tsx
+++ b/apps/obsidian/src/components/ReactRootModal.tsx
@@ -1,0 +1,27 @@
+import { App, Modal } from "obsidian";
+import { StrictMode, type ReactNode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+export abstract class ReactRootModal extends Modal {
+  private root: Root | null = null;
+
+  constructor(app: App) {
+    super(app);
+  }
+
+  protected abstract renderContent(): ReactNode;
+
+  onOpen(): void {
+    const { contentEl } = this;
+    contentEl.empty();
+    this.root = createRoot(contentEl);
+    this.root.render(<StrictMode>{this.renderContent()}</StrictMode>);
+  }
+
+  onClose(): void {
+    if (this.root) {
+      this.root.unmount();
+      this.root = null;
+    }
+  }
+}

--- a/apps/obsidian/src/components/SchemaSelectionModalBody.tsx
+++ b/apps/obsidian/src/components/SchemaSelectionModalBody.tsx
@@ -1,0 +1,77 @@
+import { SchemaSelectionPanel } from "~/components/SchemaSelectionPanel";
+import type { ReactNode } from "react";
+import type {
+  SchemaSelectionSource,
+  SchemaSelectionState,
+} from "~/components/useSchemaSelection";
+
+type SchemaSelectionModalBodyProps = {
+  title: string;
+  description: string;
+  source: SchemaSelectionSource;
+  selection: SchemaSelectionState;
+  emptyTemplateText: string;
+  onDependencyViolation?: (message: string) => void;
+  beforePanel?: ReactNode;
+  afterPanel?: ReactNode;
+  footerSecondaryLabel: string;
+  onFooterSecondaryClick: () => void;
+  footerPrimaryLabel: string;
+  onFooterPrimaryClick: () => void;
+  isFooterPrimaryDisabled?: boolean;
+  isFooterSecondaryDisabled?: boolean;
+};
+
+export const SchemaSelectionModalBody = ({
+  title,
+  description,
+  source,
+  selection,
+  emptyTemplateText,
+  onDependencyViolation,
+  beforePanel,
+  afterPanel,
+  footerSecondaryLabel,
+  onFooterSecondaryClick,
+  footerPrimaryLabel,
+  onFooterPrimaryClick,
+  isFooterPrimaryDisabled = false,
+  isFooterSecondaryDisabled = false,
+}: SchemaSelectionModalBodyProps) => {
+  return (
+    <div>
+      <h3 className="mb-2">{title}</h3>
+      <p className="text-muted mb-4 text-sm">{description}</p>
+
+      {beforePanel}
+
+      <SchemaSelectionPanel
+        source={source}
+        selection={selection}
+        emptyTemplateText={emptyTemplateText}
+        onDependencyViolation={onDependencyViolation}
+      />
+
+      {afterPanel}
+
+      <div className="mt-6 flex justify-between">
+        <button
+          type="button"
+          className="px-4 py-2"
+          onClick={onFooterSecondaryClick}
+          disabled={isFooterSecondaryDisabled}
+        >
+          {footerSecondaryLabel}
+        </button>
+        <button
+          type="button"
+          className="!bg-accent !text-on-accent rounded px-4 py-2"
+          onClick={onFooterPrimaryClick}
+          disabled={isFooterPrimaryDisabled}
+        >
+          {footerPrimaryLabel}
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/apps/obsidian/src/components/SchemaSelectionPanel.tsx
+++ b/apps/obsidian/src/components/SchemaSelectionPanel.tsx
@@ -1,0 +1,307 @@
+import type {
+  SchemaSelectionSource,
+  SchemaSelectionState,
+} from "~/components/useSchemaSelection";
+
+type SchemaSelectionPanelProps = {
+  source: SchemaSelectionSource;
+  selection: SchemaSelectionState;
+  emptyTemplateText: string;
+  onDependencyViolation?: (message: string) => void;
+};
+
+export const SchemaSelectionPanel = ({
+  source,
+  selection,
+  emptyTemplateText,
+  onDependencyViolation,
+}: SchemaSelectionPanelProps) => {
+  const {
+    selectedNodeTypeIds,
+    selectedRelationTypeIds,
+    selectedRelationIds,
+    selectedTemplateNames,
+    requiredNodeTypeIds,
+    requiredRelationTypeIds,
+    selectAllNodeTypes,
+    deselectOptionalNodeTypes,
+    toggleNodeType,
+    selectAllRelationTypes,
+    deselectOptionalRelationTypes,
+    toggleRelationType,
+    selectAllRelationTriples,
+    deselectAllRelationTriples,
+    toggleRelationTriple,
+    selectAllTemplates,
+    deselectAllTemplates,
+    toggleTemplate,
+  } = selection;
+
+  const nodeTypeById = new Map(
+    source.nodeTypes.map((nodeType) => [nodeType.id, nodeType]),
+  );
+  const relationTypeById = new Map(
+    source.relationTypes.map((relationType) => [relationType.id, relationType]),
+  );
+  const templateToNodeTypeNames = new Map<string, string[]>();
+  for (const nodeType of source.nodeTypes) {
+    if (!nodeType.template) continue;
+    const current = templateToNodeTypeNames.get(nodeType.template) ?? [];
+    current.push(nodeType.name);
+    templateToNodeTypeNames.set(nodeType.template, current);
+  }
+  for (const [
+    templateName,
+    nodeTypeNames,
+  ] of templateToNodeTypeNames.entries()) {
+    templateToNodeTypeNames.set(
+      templateName,
+      [...new Set(nodeTypeNames)].sort((left, right) =>
+        left.localeCompare(right),
+      ),
+    );
+  }
+  const referencedTemplateNames = new Set(templateToNodeTypeNames.keys());
+
+  return (
+    <>
+      <div className="mb-4 rounded border p-3 text-sm">
+        <div className="font-medium">Selection summary</div>
+        <div className="text-muted mt-1 flex flex-wrap gap-4">
+          <span>{selectedNodeTypeIds.size} node type(s)</span>
+          <span>{selectedRelationTypeIds.size} relation type(s)</span>
+          <span>{selectedRelationIds.size} relation triple(s)</span>
+          <span>{selectedTemplateNames.size} template(s)</span>
+        </div>
+      </div>
+
+      <div className="max-h-96 space-y-4 overflow-y-auto">
+        <section className="rounded border p-3">
+          <div className="mb-2 flex items-center justify-between">
+            <h4 className="font-medium">Node types</h4>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                className="rounded border px-2 py-1 text-xs"
+                onClick={selectAllNodeTypes}
+              >
+                Select all
+              </button>
+              <button
+                type="button"
+                className="rounded border px-2 py-1 text-xs"
+                onClick={deselectOptionalNodeTypes}
+              >
+                Deselect optional
+              </button>
+            </div>
+          </div>
+          <div className="space-y-1">
+            {source.nodeTypes.map((nodeType) => {
+              const isRequired = requiredNodeTypeIds.has(nodeType.id);
+              return (
+                <label
+                  key={nodeType.id}
+                  className="flex items-center gap-2 text-sm"
+                >
+                  <input
+                    type="checkbox"
+                    checked={selectedNodeTypeIds.has(nodeType.id)}
+                    onChange={(event) => {
+                      const result = toggleNodeType(
+                        nodeType.id,
+                        event.target.checked,
+                      );
+                      if (
+                        !result.ok &&
+                        result.reason &&
+                        onDependencyViolation
+                      ) {
+                        onDependencyViolation(result.reason);
+                      }
+                    }}
+                    disabled={isRequired}
+                  />
+                  <span>{nodeType.name}</span>
+                  {isRequired && (
+                    <span className="text-muted text-xs">
+                      required by selected triple
+                    </span>
+                  )}
+                </label>
+              );
+            })}
+          </div>
+        </section>
+
+        <section className="rounded border p-3">
+          <div className="mb-2 flex items-center justify-between">
+            <h4 className="font-medium">Relation types</h4>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                className="rounded border px-2 py-1 text-xs"
+                onClick={selectAllRelationTypes}
+              >
+                Select all
+              </button>
+              <button
+                type="button"
+                className="rounded border px-2 py-1 text-xs"
+                onClick={deselectOptionalRelationTypes}
+              >
+                Deselect optional
+              </button>
+            </div>
+          </div>
+          <div className="space-y-1">
+            {source.relationTypes.map((relationType) => {
+              const isRequired = requiredRelationTypeIds.has(relationType.id);
+              return (
+                <label
+                  key={relationType.id}
+                  className="flex items-center gap-2 text-sm"
+                >
+                  <input
+                    type="checkbox"
+                    checked={selectedRelationTypeIds.has(relationType.id)}
+                    onChange={(event) => {
+                      const result = toggleRelationType(
+                        relationType.id,
+                        event.target.checked,
+                      );
+                      if (
+                        !result.ok &&
+                        result.reason &&
+                        onDependencyViolation
+                      ) {
+                        onDependencyViolation(result.reason);
+                      }
+                    }}
+                    disabled={isRequired}
+                  />
+                  <span>{relationType.label}</span>
+                  {isRequired && (
+                    <span className="text-muted text-xs">
+                      required by selected triple
+                    </span>
+                  )}
+                </label>
+              );
+            })}
+          </div>
+        </section>
+
+        <section className="rounded border p-3">
+          <div className="mb-2 flex items-center justify-between">
+            <h4 className="font-medium">Relation triples</h4>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                className="rounded border px-2 py-1 text-xs"
+                onClick={selectAllRelationTriples}
+              >
+                Select all
+              </button>
+              <button
+                type="button"
+                className="rounded border px-2 py-1 text-xs"
+                onClick={deselectAllRelationTriples}
+              >
+                Deselect all
+              </button>
+            </div>
+          </div>
+          <div className="space-y-1">
+            {source.relationTriples.map((relation) => {
+              const sourceName =
+                nodeTypeById.get(relation.sourceId)?.name ?? relation.sourceId;
+              const destinationName =
+                nodeTypeById.get(relation.destinationId)?.name ??
+                relation.destinationId;
+              const relationTypeLabel =
+                relationTypeById.get(relation.relationshipTypeId)?.label ??
+                relation.relationshipTypeId;
+
+              return (
+                <label
+                  key={relation.id}
+                  className="flex items-center gap-2 text-sm"
+                >
+                  <input
+                    type="checkbox"
+                    checked={selectedRelationIds.has(relation.id)}
+                    onChange={(event) =>
+                      toggleRelationTriple(relation.id, event.target.checked)
+                    }
+                  />
+                  <span className="rounded bg-secondary px-1.5 py-0.5 text-xs">
+                    {sourceName}
+                  </span>
+                  <span className="text-accent text-xs font-medium">
+                    {relationTypeLabel}
+                  </span>
+                  <span className="rounded bg-secondary px-1.5 py-0.5 text-xs">
+                    {destinationName}
+                  </span>
+                </label>
+              );
+            })}
+          </div>
+        </section>
+
+        <section className="rounded border p-3">
+          <div className="mb-2 flex items-center justify-between">
+            <h4 className="font-medium">Templates</h4>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                className="rounded border px-2 py-1 text-xs"
+                onClick={selectAllTemplates}
+              >
+                Select all
+              </button>
+              <button
+                type="button"
+                className="rounded border px-2 py-1 text-xs"
+                onClick={deselectAllTemplates}
+              >
+                Deselect all
+              </button>
+            </div>
+          </div>
+          {source.templateNames.length === 0 ? (
+            <p className="text-muted text-sm">{emptyTemplateText}</p>
+          ) : (
+            <div className="space-y-1">
+              {source.templateNames.map((templateName) => (
+                <label
+                  key={templateName}
+                  className="flex items-center gap-2 text-sm"
+                >
+                  <input
+                    type="checkbox"
+                    checked={selectedTemplateNames.has(templateName)}
+                    onChange={(event) =>
+                      toggleTemplate(templateName, event.target.checked)
+                    }
+                  />
+                  <span>{templateName}.md</span>
+                  {referencedTemplateNames.has(templateName) && (
+                    <span className="text-muted rounded bg-secondary px-1.5 py-0.5 text-xs">
+                      used by{" "}
+                      {(templateToNodeTypeNames.get(templateName) ?? []).join(
+                        ", ",
+                      )}{" "}
+                      type
+                    </span>
+                  )}
+                </label>
+              ))}
+            </div>
+          )}
+        </section>
+      </div>
+    </>
+  );
+};

--- a/apps/obsidian/src/components/useSchemaSelection.ts
+++ b/apps/obsidian/src/components/useSchemaSelection.ts
@@ -1,0 +1,242 @@
+import { useEffect, useMemo, useState } from "react";
+import type {
+  DiscourseNode,
+  DiscourseRelation,
+  DiscourseRelationType,
+} from "~/types";
+
+export type SchemaSelectionSource = {
+  nodeTypes: Pick<DiscourseNode, "id" | "name" | "template">[];
+  relationTypes: Pick<DiscourseRelationType, "id" | "label">[];
+  relationTriples: Pick<
+    DiscourseRelation,
+    "id" | "sourceId" | "destinationId" | "relationshipTypeId"
+  >[];
+  templateNames: string[];
+};
+
+type SelectionToggleResult = {
+  ok: boolean;
+  reason?: string;
+};
+
+export type SchemaSelectionState = {
+  selectedNodeTypeIds: Set<string>;
+  selectedRelationTypeIds: Set<string>;
+  selectedRelationIds: Set<string>;
+  selectedTemplateNames: Set<string>;
+  requiredNodeTypeIds: Set<string>;
+  requiredRelationTypeIds: Set<string>;
+  selectAllNodeTypes: () => void;
+  deselectOptionalNodeTypes: () => void;
+  toggleNodeType: (
+    nodeTypeId: string,
+    shouldSelect: boolean,
+  ) => SelectionToggleResult;
+  selectAllRelationTypes: () => void;
+  deselectOptionalRelationTypes: () => void;
+  toggleRelationType: (
+    relationTypeId: string,
+    shouldSelect: boolean,
+  ) => SelectionToggleResult;
+  selectAllRelationTriples: () => void;
+  deselectAllRelationTriples: () => void;
+  toggleRelationTriple: (relationId: string, shouldSelect: boolean) => void;
+  selectAllTemplates: () => void;
+  deselectAllTemplates: () => void;
+  toggleTemplate: (templateName: string, shouldSelect: boolean) => void;
+  asSelectionPayload: () => {
+    nodeTypeIds: string[];
+    relationTypeIds: string[];
+    relationIds: string[];
+    templateNames: string[];
+  };
+};
+
+const updateSet = (
+  previousSet: Set<string>,
+  id: string,
+  shouldSelect: boolean,
+): Set<string> => {
+  const nextSet = new Set(previousSet);
+  if (shouldSelect) {
+    nextSet.add(id);
+  } else {
+    nextSet.delete(id);
+  }
+  return nextSet;
+};
+
+export const getReferencedTemplateNames = (
+  nodeTypes: SchemaSelectionSource["nodeTypes"],
+): Set<string> => {
+  return new Set(
+    nodeTypes
+      .map((nodeType) => nodeType.template)
+      .filter((template): template is string => !!template),
+  );
+};
+
+export const useSchemaSelection = ({
+  source,
+  initialTemplateNames,
+  resetKey,
+}: {
+  source: SchemaSelectionSource;
+  /**
+   * Template names to pre-select on mount and on reset. Defaults to all
+   * templates in source when not provided.
+   */
+  initialTemplateNames?: string[];
+  resetKey: string;
+}): SchemaSelectionState => {
+  const [selectedNodeTypeIds, setSelectedNodeTypeIds] = useState<Set<string>>(
+    () => new Set(source.nodeTypes.map((nodeType) => nodeType.id)),
+  );
+  const [selectedRelationTypeIds, setSelectedRelationTypeIds] = useState<
+    Set<string>
+  >(() => new Set(source.relationTypes.map((relationType) => relationType.id)));
+  const [selectedRelationIds, setSelectedRelationIds] = useState<Set<string>>(
+    () => new Set(source.relationTriples.map((relation) => relation.id)),
+  );
+  const [selectedTemplateNames, setSelectedTemplateNames] = useState<
+    Set<string>
+  >(() => new Set(initialTemplateNames ?? source.templateNames));
+
+  // resetKey is the only trigger; source and initialTemplateNames are read
+  // from the current render's closure when resetKey changes.
+  useEffect(() => {
+    setSelectedNodeTypeIds(
+      new Set(source.nodeTypes.map((nodeType) => nodeType.id)),
+    );
+    setSelectedRelationTypeIds(
+      new Set(source.relationTypes.map((relationType) => relationType.id)),
+    );
+    setSelectedRelationIds(
+      new Set(source.relationTriples.map((relation) => relation.id)),
+    );
+    setSelectedTemplateNames(
+      new Set(initialTemplateNames ?? source.templateNames),
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [resetKey]);
+
+  const requiredRelationTypeIds = useMemo(() => {
+    const requiredIds = new Set<string>();
+    for (const relation of source.relationTriples) {
+      if (selectedRelationIds.has(relation.id)) {
+        requiredIds.add(relation.relationshipTypeId);
+      }
+    }
+    return requiredIds;
+  }, [source.relationTriples, selectedRelationIds]);
+
+  const requiredNodeTypeIds = useMemo(() => {
+    const requiredIds = new Set<string>();
+    for (const relation of source.relationTriples) {
+      if (!selectedRelationIds.has(relation.id)) {
+        continue;
+      }
+      requiredIds.add(relation.sourceId);
+      requiredIds.add(relation.destinationId);
+    }
+    return requiredIds;
+  }, [source.relationTriples, selectedRelationIds]);
+
+  useEffect(() => {
+    setSelectedRelationTypeIds((previousSet) => {
+      const nextSet = new Set(previousSet);
+      let didChange = false;
+      for (const relationTypeId of requiredRelationTypeIds) {
+        if (!nextSet.has(relationTypeId)) {
+          nextSet.add(relationTypeId);
+          didChange = true;
+        }
+      }
+      return didChange ? nextSet : previousSet;
+    });
+  }, [requiredRelationTypeIds]);
+
+  useEffect(() => {
+    setSelectedNodeTypeIds((previousSet) => {
+      const nextSet = new Set(previousSet);
+      let didChange = false;
+      for (const nodeTypeId of requiredNodeTypeIds) {
+        if (!nextSet.has(nodeTypeId)) {
+          nextSet.add(nodeTypeId);
+          didChange = true;
+        }
+      }
+      return didChange ? nextSet : previousSet;
+    });
+  }, [requiredNodeTypeIds]);
+
+  return {
+    selectedNodeTypeIds,
+    selectedRelationTypeIds,
+    selectedRelationIds,
+    selectedTemplateNames,
+    requiredNodeTypeIds,
+    requiredRelationTypeIds,
+    selectAllNodeTypes: () =>
+      setSelectedNodeTypeIds(
+        new Set(source.nodeTypes.map((nodeType) => nodeType.id)),
+      ),
+    deselectOptionalNodeTypes: () =>
+      setSelectedNodeTypeIds(new Set([...requiredNodeTypeIds])),
+    toggleNodeType: (nodeTypeId, shouldSelect) => {
+      if (!shouldSelect && requiredNodeTypeIds.has(nodeTypeId)) {
+        return {
+          ok: false,
+          reason:
+            "This node type is required by a selected relation triple. Remove the triple first.",
+        };
+      }
+      setSelectedNodeTypeIds((previousSet) =>
+        updateSet(previousSet, nodeTypeId, shouldSelect),
+      );
+      return { ok: true };
+    },
+    selectAllRelationTypes: () =>
+      setSelectedRelationTypeIds(
+        new Set(source.relationTypes.map((relationType) => relationType.id)),
+      ),
+    deselectOptionalRelationTypes: () =>
+      setSelectedRelationTypeIds(new Set([...requiredRelationTypeIds])),
+    toggleRelationType: (relationTypeId, shouldSelect) => {
+      if (!shouldSelect && requiredRelationTypeIds.has(relationTypeId)) {
+        return {
+          ok: false,
+          reason:
+            "This relation type is required by a selected relation triple. Remove the triple first.",
+        };
+      }
+      setSelectedRelationTypeIds((previousSet) =>
+        updateSet(previousSet, relationTypeId, shouldSelect),
+      );
+      return { ok: true };
+    },
+    selectAllRelationTriples: () =>
+      setSelectedRelationIds(
+        new Set(source.relationTriples.map((relation) => relation.id)),
+      ),
+    deselectAllRelationTriples: () => setSelectedRelationIds(new Set()),
+    toggleRelationTriple: (relationId, shouldSelect) =>
+      setSelectedRelationIds((previousSet) =>
+        updateSet(previousSet, relationId, shouldSelect),
+      ),
+    selectAllTemplates: () =>
+      setSelectedTemplateNames(new Set(source.templateNames)),
+    deselectAllTemplates: () => setSelectedTemplateNames(new Set()),
+    toggleTemplate: (templateName, shouldSelect) =>
+      setSelectedTemplateNames((previousSet) =>
+        updateSet(previousSet, templateName, shouldSelect),
+      ),
+    asSelectionPayload: () => ({
+      nodeTypeIds: [...selectedNodeTypeIds],
+      relationTypeIds: [...selectedRelationTypeIds],
+      relationIds: [...selectedRelationIds],
+      templateNames: [...selectedTemplateNames],
+    }),
+  };
+};

--- a/apps/obsidian/src/types.ts
+++ b/apps/obsidian/src/types.ts
@@ -117,4 +117,20 @@ export type ImportFolderMetadata = {
   userName?: string;
 };
 
+export type DiscourseSchemaTemplate = {
+  name: string;
+  content: string;
+};
+
+export type DiscourseSchemaFile = {
+  version: number;
+  exportedAt: string;
+  pluginVersion: string;
+  vaultName: string;
+  nodeTypes: DiscourseNode[];
+  relationTypes: DiscourseRelationType[];
+  discourseRelations: DiscourseRelation[];
+  templates: DiscourseSchemaTemplate[];
+};
+
 export const VIEW_TYPE_DISCOURSE_CONTEXT = "discourse-context-view";

--- a/apps/obsidian/src/utils/nativeJsonFileDialogs.ts
+++ b/apps/obsidian/src/utils/nativeJsonFileDialogs.ts
@@ -1,0 +1,121 @@
+type SaveDialogResult = {
+  canceled: boolean;
+  filePath?: string;
+};
+
+type OpenDialogResult = {
+  canceled: boolean;
+  filePaths: string[];
+};
+
+type ElectronDialog = {
+  showSaveDialog: (options: {
+    title: string;
+    defaultPath: string;
+    filters: Array<{ name: string; extensions: string[] }>;
+  }) => Promise<SaveDialogResult>;
+  showOpenDialog: (options: {
+    title: string;
+    properties: string[];
+    filters: Array<{ name: string; extensions: string[] }>;
+  }) => Promise<OpenDialogResult>;
+};
+
+type ElectronLike = {
+  dialog?: ElectronDialog;
+  remote?: {
+    dialog?: ElectronDialog;
+  };
+};
+
+type FsPromisesLike = {
+  readFile: (path: string, encoding: string) => Promise<string>;
+  writeFile: (path: string, data: string, encoding: string) => Promise<void>;
+};
+
+type ElectronWindow = Window & {
+  require: (name: string) => unknown;
+};
+
+export class NativeFileDialogCancelledError extends Error {
+  constructor() {
+    super("File dialog cancelled");
+    this.name = "NativeFileDialogCancelledError";
+  }
+}
+
+const getElectronWindow = (): ElectronWindow => {
+  if (typeof window === "undefined" || !("require" in window)) {
+    throw new Error(
+      "Schema export/import requires Obsidian desktop (Electron).",
+    );
+  }
+  return window as ElectronWindow;
+};
+
+const getFsPromises = (electronWindow: ElectronWindow): FsPromisesLike => {
+  const fsPromises = electronWindow.require("fs/promises");
+  if (
+    typeof fsPromises !== "object" ||
+    fsPromises === null ||
+    !("readFile" in fsPromises) ||
+    !("writeFile" in fsPromises)
+  ) {
+    throw new Error("Unable to access filesystem read/write APIs.");
+  }
+  return fsPromises as FsPromisesLike;
+};
+
+const getElectronDialog = (electronWindow: ElectronWindow): ElectronDialog => {
+  const electron = electronWindow.require("electron") as ElectronLike;
+  const dialog = electron.dialog ?? electron.remote?.dialog;
+  if (!dialog?.showSaveDialog || !dialog.showOpenDialog) {
+    throw new Error("Unable to access Electron file dialogs.");
+  }
+  return dialog;
+};
+
+export const saveJsonToUserLocation = async ({
+  title,
+  fileName,
+  content,
+}: {
+  title: string;
+  fileName: string;
+  content: string;
+}): Promise<string> => {
+  const electronWindow = getElectronWindow();
+  const dialog = getElectronDialog(electronWindow);
+  const result = await dialog.showSaveDialog({
+    title,
+    defaultPath: fileName,
+    filters: [{ name: "JSON files", extensions: ["json"] }],
+  });
+  if (result.canceled || !result.filePath) {
+    throw new NativeFileDialogCancelledError();
+  }
+  const fsPromises = getFsPromises(electronWindow);
+  await fsPromises.writeFile(result.filePath, content, "utf8");
+  return result.filePath;
+};
+
+export const openJsonFromUserLocation = async ({
+  title,
+}: {
+  title: string;
+}): Promise<{ content: string; sourcePath: string }> => {
+  const electronWindow = getElectronWindow();
+  const dialog = getElectronDialog(electronWindow);
+  const result = await dialog.showOpenDialog({
+    title,
+    properties: ["openFile"],
+    filters: [{ name: "JSON files", extensions: ["json"] }],
+  });
+  if (result.canceled || !result.filePaths[0]) {
+    throw new NativeFileDialogCancelledError();
+  }
+  const fsPromises = getFsPromises(electronWindow);
+  const sourcePath = result.filePaths[0];
+  const content = await fsPromises.readFile(sourcePath, "utf8");
+  return { content, sourcePath };
+};

--- a/apps/obsidian/src/utils/registerCommands.ts
+++ b/apps/obsidian/src/utils/registerCommands.ts
@@ -4,6 +4,7 @@ import { NodeTypeModal } from "~/components/NodeTypeModal";
 import ModifyNodeModal from "~/components/ModifyNodeModal";
 import { BulkIdentifyDiscourseNodesModal } from "~/components/BulkIdentifyDiscourseNodesModal";
 import { ImportNodesModal } from "~/components/ImportNodesModal";
+import { openExportSpecsModal } from "~/components/ExportSpecsModal";
 import { convertPageToDiscourseNode, createDiscourseNode } from "./createNode";
 import { refreshAllImportedFiles } from "./importNodes";
 import { VIEW_TYPE_MARKDOWN, VIEW_TYPE_TLDRAW_DG_PREVIEW } from "~/constants";
@@ -191,6 +192,14 @@ export const registerCommands = (plugin: DiscourseGraphPlugin) => {
           });
       }
       return true;
+    },
+  });
+
+  plugin.addCommand({
+    id: "export-dg-schema",
+    name: "Export discourse graph schema",
+    callback: () => {
+      openExportSpecsModal(plugin);
     },
   });
 

--- a/apps/obsidian/src/utils/specExport.ts
+++ b/apps/obsidian/src/utils/specExport.ts
@@ -1,0 +1,131 @@
+import { TFile } from "obsidian";
+import type DiscourseGraphPlugin from "~/index";
+import type {
+  DiscourseNode,
+  DiscourseRelation,
+  DiscourseSchemaFile,
+  DiscourseSchemaTemplate,
+} from "~/types";
+import {
+  DG_SCHEMA_EXPORT_VERSION,
+  getDgSchemaFileName,
+} from "~/utils/specValidation";
+import { getTemplatePluginInfo } from "~/utils/templates";
+import { saveJsonToUserLocation } from "~/utils/nativeJsonFileDialogs";
+
+export type SpecExportSelection = {
+  nodeTypeIds: string[];
+  relationTypeIds: string[];
+  discourseRelationIds: string[];
+  templateNames: string[];
+};
+
+export type SpecExportResult = {
+  filePath: string;
+  warnings: string[];
+};
+
+const asMap = <T extends { id: string }>(items: T[]): Map<string, T> => {
+  return new Map(items.map((item) => [item.id, item]));
+};
+
+const getTemplateContents = async ({
+  plugin,
+  templateNames,
+}: {
+  plugin: DiscourseGraphPlugin;
+  templateNames: string[];
+}): Promise<{ templates: DiscourseSchemaTemplate[]; warnings: string[] }> => {
+  const warnings: string[] = [];
+  const templates: DiscourseSchemaTemplate[] = [];
+  const { isEnabled, folderPath } = getTemplatePluginInfo(plugin.app);
+
+  if (!isEnabled || !folderPath) {
+    if (templateNames.length > 0) {
+      warnings.push(
+        "Templates plugin is not enabled or folder is not configured; template content was skipped.",
+      );
+    }
+    return { templates, warnings };
+  }
+
+  for (const templateName of templateNames) {
+    const templatePath = `${folderPath}/${templateName}.md`;
+    const templateFile = plugin.app.vault.getAbstractFileByPath(templatePath);
+
+    if (!(templateFile instanceof TFile)) {
+      warnings.push(`Template file not found: ${templateName}.md`);
+      continue;
+    }
+
+    const content = await plugin.app.vault.read(templateFile);
+    templates.push({ name: templateName, content });
+  }
+
+  return { templates, warnings };
+};
+
+const buildSchemaExportPayload = async ({
+  plugin,
+  selection,
+}: {
+  plugin: DiscourseGraphPlugin;
+  selection: SpecExportSelection;
+}): Promise<{ payload: DiscourseSchemaFile; warnings: string[] }> => {
+  const nodeTypeMap = asMap(plugin.settings.nodeTypes);
+  const relationTypeMap = asMap(plugin.settings.relationTypes);
+  const discourseRelationMap = asMap(plugin.settings.discourseRelations);
+
+  const selectedNodeTypes: DiscourseNode[] = selection.nodeTypeIds
+    .map((id) => nodeTypeMap.get(id))
+    .filter((nodeType): nodeType is DiscourseNode => !!nodeType);
+
+  const selectedRelationTypes = selection.relationTypeIds
+    .map((id) => relationTypeMap.get(id))
+    .filter((relationType) => !!relationType);
+
+  const selectedDiscourseRelations: DiscourseRelation[] =
+    selection.discourseRelationIds
+      .map((id) => discourseRelationMap.get(id))
+      .filter((relation): relation is DiscourseRelation => !!relation);
+
+  const { templates, warnings } = await getTemplateContents({
+    plugin,
+    templateNames: selection.templateNames,
+  });
+
+  const payload: DiscourseSchemaFile = {
+    version: DG_SCHEMA_EXPORT_VERSION,
+    exportedAt: new Date().toISOString(),
+    pluginVersion: plugin.manifest.version,
+    vaultName: plugin.app.vault.getName(),
+    nodeTypes: selectedNodeTypes,
+    relationTypes: selectedRelationTypes,
+    discourseRelations: selectedDiscourseRelations,
+    templates,
+  };
+
+  return { payload, warnings };
+};
+
+export const exportSchemaSelection = async ({
+  plugin,
+  selection,
+}: {
+  plugin: DiscourseGraphPlugin;
+  selection: SpecExportSelection;
+}): Promise<SpecExportResult> => {
+  const { payload, warnings } = await buildSchemaExportPayload({
+    plugin,
+    selection,
+  });
+  const serializedPayload = JSON.stringify(payload, null, 2);
+  const fileName = getDgSchemaFileName(plugin.app.vault.getName());
+  const filePath = await saveJsonToUserLocation({
+    title: "Export discourse graph schema",
+    fileName,
+    content: serializedPayload,
+  });
+
+  return { filePath, warnings };
+};

--- a/apps/obsidian/src/utils/specValidation.ts
+++ b/apps/obsidian/src/utils/specValidation.ts
@@ -1,0 +1,83 @@
+import { z } from "zod";
+import type { DiscourseSchemaFile } from "~/types";
+
+export const DG_SCHEMA_EXPORT_VERSION = 1;
+
+const discourseNodeSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  format: z.string(),
+  template: z.string().optional(),
+  description: z.string().optional(),
+  shortcut: z.string().optional(),
+  color: z.string().optional(),
+  tag: z.string().optional(),
+  keyImage: z.boolean().optional(),
+  folderPath: z.string().optional(),
+  created: z.number(),
+  modified: z.number(),
+  importedFromRid: z.string().optional(),
+  authorId: z.number().optional(),
+});
+
+const relationImportStatusSchema = z.enum(["provisional", "accepted"]);
+
+const discourseRelationTypeSchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  complement: z.string(),
+  color: z.string(),
+  created: z.number(),
+  modified: z.number(),
+  importedFromRid: z.string().optional(),
+  status: relationImportStatusSchema.optional(),
+  authorId: z.number().optional(),
+});
+
+const discourseRelationSchema = z.object({
+  id: z.string(),
+  sourceId: z.string(),
+  destinationId: z.string(),
+  relationshipTypeId: z.string(),
+  created: z.number(),
+  modified: z.number(),
+  importedFromRid: z.string().optional(),
+  status: relationImportStatusSchema.optional(),
+  authorId: z.number().optional(),
+});
+
+const templateExportSchema = z.object({
+  name: z.string(),
+  content: z.string(),
+});
+
+export const dgSchemaFileSchema = z.object({
+  version: z.literal(DG_SCHEMA_EXPORT_VERSION),
+  exportedAt: z.string(),
+  pluginVersion: z.string(),
+  vaultName: z.string(),
+  nodeTypes: z.array(discourseNodeSchema),
+  relationTypes: z.array(discourseRelationTypeSchema),
+  discourseRelations: z.array(discourseRelationSchema),
+  templates: z.array(templateExportSchema),
+});
+
+const normalizeToKebabCase = (value: string): string => {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .replace(/-{2,}/g, "-");
+};
+
+export const getDgSchemaFileName = (vaultName?: string): string => {
+  const normalizedVaultName = vaultName ? normalizeToKebabCase(vaultName) : "";
+  const safeVaultName =
+    normalizedVaultName.length > 0 ? normalizedVaultName : "vault";
+  return `dg-schema-${safeVaultName}.json`;
+};
+
+export const parseDgSchemaFile = (value: unknown): DiscourseSchemaFile => {
+  return dgSchemaFileSchema.parse(value) as DiscourseSchemaFile;
+};


### PR DESCRIPTION
https://www.loom.com/share/4510e9ed157a4b3395dc8083aae30770

Another export entry point I forgot to mention:
<img width="826" height="840" alt="image" src="https://github.com/user-attachments/assets/d1e7d845-dc71-42de-9647-d97de398d81d" />

## Summary

- Adds an **Export discourse graph schema** command and settings entry point
- Users can select node types, relation types, relation triples, and templates to include; the selection panel enforces dependency constraints (selecting a relation triple locks in its source/destination node types and relation type)
- Saves the selection to a `dg-schema-<vault>.json` file via the Electron native save dialog
- Includes the shared foundation that the import PR builds on: `ReactRootModal`, `useSchemaSelection`, `SchemaSelectionPanel`, `SchemaSelectionModalBody`, `specValidation`, and `nativeJsonFileDialogs`

## Test plan

- [x] `pnpm --filter @discourse-graphs/obsidian check-types`
- [x] Open Export schema modal from command palette
- [x] Open Export schema modal from Settings
- [x] Verify dependency enforcement: selecting a relation triple locks the related node/relation types
- [x] Export to a custom filesystem location via native save dialog
- [x] Verify the saved JSON contains the expected `dg-schema-<vault>.json` structure

## Stack

This is PR 1 of 2. PR 2 (import) will be stacked on this branch.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/1163" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->