### PR TITLE
FEE-840 Add schema import for Obsidian

### DIFF
--- a/apps/obsidian/src/components/GeneralSettings.tsx
+++ b/apps/obsidian/src/components/GeneralSettings.tsx
@@ -4,6 +4,7 @@ import { setIcon } from "obsidian";
 import SuggestInput from "./SuggestInput";
 import { DiscourseGraphLogoIcon, SlackLogoIcon } from "./Icons";
 import { openExportSpecsModal } from "./ExportSpecsModal";
+import { openImportSpecsModal } from "./ImportSpecsModal";
 import { getDgSchemaFileName } from "~/utils/specValidation";
 
 const DOCS_URL = "https://discoursegraphs.com/docs/obsidian";
@@ -270,6 +271,26 @@ const GeneralSettings = () => {
             onChange={handleCanvasAttachmentsFolderPathChange}
             placeholder="Example: attachments"
           />
+        </div>
+      </div>
+
+      <div className="setting-item">
+        <div className="setting-item-info">
+          <div className="setting-item-name">Import discourse graph schema</div>
+          <div className="setting-item-description">
+            Choose a schema JSON file from your computer and preview how it maps
+            to your existing node types, relation types, relation triples, and
+            templates.
+          </div>
+        </div>
+        <div className="setting-item-control">
+          <button
+            type="button"
+            className="rounded border px-3 py-1.5 text-sm"
+            onClick={() => openImportSpecsModal(plugin)}
+          >
+            Open import modal
+          </button>
         </div>
       </div>
 

--- a/apps/obsidian/src/components/ImportSchemaPreviewSummary.tsx
+++ b/apps/obsidian/src/components/ImportSchemaPreviewSummary.tsx
@@ -1,0 +1,59 @@
+import type { ImportPreviewStats, LoadedSchemaFile } from "~/utils/specImport";
+
+export const ImportSchemaPreviewSummary = ({
+  loadedSchemaFile,
+  previewStats,
+}: {
+  loadedSchemaFile: LoadedSchemaFile;
+  previewStats: ImportPreviewStats;
+}) => {
+  return (
+    <>
+      <div className="mb-4 rounded border p-3 text-sm">
+        <div className="font-medium">Schema file metadata</div>
+        <div className="text-muted mt-1">
+          Vault:{" "}
+          <span className="font-medium">
+            {loadedSchemaFile.schemaFile.vaultName}
+          </span>
+        </div>
+        <div className="text-muted">
+          Exported at:{" "}
+          <span className="font-medium">
+            {loadedSchemaFile.schemaFile.exportedAt}
+          </span>
+        </div>
+        <div className="text-muted">
+          Plugin version:{" "}
+          <span className="font-medium">
+            {loadedSchemaFile.schemaFile.pluginVersion}
+          </span>
+        </div>
+      </div>
+
+      <div className="mb-4 rounded border p-3 text-sm">
+        <div className="font-medium">Preview (full schema file)</div>
+        <div className="text-muted mt-1">
+          Node types: {previewStats.nodeTypes.total} total (
+          {previewStats.nodeTypes.new} new, {previewStats.nodeTypes.existing}{" "}
+          existing)
+        </div>
+        <div className="text-muted">
+          Relation types: {previewStats.relationTypes.total} total (
+          {previewStats.relationTypes.new} new,{" "}
+          {previewStats.relationTypes.existing} existing)
+        </div>
+        <div className="text-muted">
+          Relation triples: {previewStats.discourseRelations.total} total (
+          {previewStats.discourseRelations.new} new,{" "}
+          {previewStats.discourseRelations.existing} existing)
+        </div>
+        <div className="text-muted">
+          Templates: {previewStats.templates.total} total (
+          {previewStats.templates.new} new, {previewStats.templates.existing}{" "}
+          existing)
+        </div>
+      </div>
+    </>
+  );
+};

--- a/apps/obsidian/src/components/ImportSpecsModal.tsx
+++ b/apps/obsidian/src/components/ImportSpecsModal.tsx
@@ -1,0 +1,213 @@
+import { App, Notice } from "obsidian";
+import { useMemo, useState } from "react";
+import type DiscourseGraphPlugin from "~/index";
+import {
+  applySchemaImportSelection,
+  pickAndPreviewSchemaImport,
+  type ImportPreviewStats,
+  type LoadedSchemaFile,
+  type SpecImportPreview,
+} from "~/utils/specImport";
+import { NativeFileDialogCancelledError } from "~/utils/nativeJsonFileDialogs";
+import {
+  useSchemaSelection,
+  type SchemaSelectionSource,
+} from "~/components/useSchemaSelection";
+import { SchemaSelectionModalBody } from "~/components/SchemaSelectionModalBody";
+import { ImportSchemaPreviewSummary } from "~/components/ImportSchemaPreviewSummary";
+import { ReactRootModal } from "~/components/ReactRootModal";
+
+type ImportSpecsModalProps = {
+  plugin: DiscourseGraphPlugin;
+  onClose: () => void;
+};
+
+export const openImportSpecsModal = (plugin: DiscourseGraphPlugin): void => {
+  new ImportSpecsModal(plugin.app, plugin).open();
+};
+
+const ImportPreviewSelection = ({
+  plugin,
+  loadedSchemaFile,
+  previewStats,
+  isApplyingImport,
+  setIsApplyingImport,
+  onResetPreview,
+  onClose,
+}: {
+  plugin: DiscourseGraphPlugin;
+  loadedSchemaFile: LoadedSchemaFile;
+  previewStats: ImportPreviewStats;
+  isApplyingImport: boolean;
+  setIsApplyingImport: (value: boolean) => void;
+  onResetPreview: () => void;
+  onClose: () => void;
+}) => {
+  const source = useMemo<SchemaSelectionSource>(() => {
+    const schemaFile = loadedSchemaFile.schemaFile;
+    return {
+      nodeTypes: schemaFile.nodeTypes,
+      relationTypes: schemaFile.relationTypes,
+      relationTriples: schemaFile.discourseRelations,
+      templateNames: schemaFile.templates.map((template) => template.name),
+    };
+  }, [loadedSchemaFile]);
+
+  const selection = useSchemaSelection({
+    source,
+    resetKey: loadedSchemaFile.sourcePath,
+  });
+
+  const handleApplyImport = async (): Promise<void> => {
+    const selected = selection.asSelectionPayload();
+    const hasAnySelection =
+      selected.nodeTypeIds.length > 0 ||
+      selected.relationTypeIds.length > 0 ||
+      selected.relationIds.length > 0 ||
+      selected.templateNames.length > 0;
+    if (!hasAnySelection) {
+      new Notice("Select at least one item to import.");
+      return;
+    }
+
+    setIsApplyingImport(true);
+    try {
+      const result = await applySchemaImportSelection({
+        plugin,
+        loadedSchemaFile,
+        selection: {
+          nodeTypeIds: selected.nodeTypeIds,
+          relationTypeIds: selected.relationTypeIds,
+          discourseRelationIds: selected.relationIds,
+          templateNames: selected.templateNames,
+        },
+      });
+
+      const { created } = result;
+      new Notice(
+        `Import complete: ${created.nodeTypes} node type(s), ${created.relationTypes} relation type(s), ${created.discourseRelations} relation triple(s), and ${created.templates} template(s) created.`,
+        7000,
+      );
+
+      if (result.warnings.length > 0) {
+        new Notice(
+          `Import completed with ${result.warnings.length} warning(s).`,
+          6000,
+        );
+        for (const warning of result.warnings) {
+          new Notice(warning, 6000);
+        }
+      }
+      onClose();
+    } catch (error) {
+      console.error("Failed to apply schema import:", error);
+      const message = error instanceof Error ? error.message : String(error);
+      new Notice(`Failed to import schema: ${message}`, 6000);
+    } finally {
+      setIsApplyingImport(false);
+    }
+  };
+
+  return (
+    <SchemaSelectionModalBody
+      title="Import schema preview"
+      description={`Source file: ${loadedSchemaFile.sourcePath}`}
+      source={source}
+      selection={selection}
+      emptyTemplateText="No templates found in this schema file."
+      onDependencyViolation={(message) => new Notice(message)}
+      beforePanel={
+        <ImportSchemaPreviewSummary
+          loadedSchemaFile={loadedSchemaFile}
+          previewStats={previewStats}
+        />
+      }
+      footerSecondaryLabel="Choose another file"
+      onFooterSecondaryClick={onResetPreview}
+      footerPrimaryLabel={isApplyingImport ? "Importing..." : "Import selected"}
+      onFooterPrimaryClick={() => void handleApplyImport()}
+      isFooterSecondaryDisabled={isApplyingImport}
+      isFooterPrimaryDisabled={isApplyingImport}
+    />
+  );
+};
+
+const ImportSpecsContent = ({ plugin, onClose }: ImportSpecsModalProps) => {
+  const [preview, setPreview] = useState<SpecImportPreview | null>(null);
+  const [isSelectingFile, setIsSelectingFile] = useState(false);
+  const [isApplyingImport, setIsApplyingImport] = useState(false);
+
+  const handleSelectSchemaFile = async (): Promise<void> => {
+    setIsSelectingFile(true);
+    try {
+      const nextPreview = await pickAndPreviewSchemaImport({ plugin });
+      setPreview(nextPreview);
+    } catch (error) {
+      if (error instanceof NativeFileDialogCancelledError) {
+        return;
+      }
+      console.error("Failed to load schema import file:", error);
+      const message = error instanceof Error ? error.message : String(error);
+      new Notice(`Failed to load schema file: ${message}`, 6000);
+    } finally {
+      setIsSelectingFile(false);
+    }
+  };
+
+  if (!preview) {
+    return (
+      <div>
+        <h3 className="mb-2">Import discourse graph schema</h3>
+        <p className="text-muted mb-4 text-sm">
+          Pick a <code>dg-schema-*.json</code> file from your computer to
+          preview and choose exactly what to import.
+        </p>
+
+        <div className="mb-4 rounded border p-3 text-sm">
+          Same dependency rules as export apply here during selection.
+        </div>
+
+        <div className="flex justify-between">
+          <button type="button" className="px-4 py-2" onClick={onClose}>
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="!bg-accent !text-on-accent rounded px-4 py-2"
+            onClick={() => void handleSelectSchemaFile()}
+            disabled={isSelectingFile}
+          >
+            {isSelectingFile ? "Opening..." : "Choose schema file"}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <ImportPreviewSelection
+      plugin={plugin}
+      loadedSchemaFile={preview.loadedSchemaFile}
+      previewStats={preview.previewStats}
+      isApplyingImport={isApplyingImport}
+      setIsApplyingImport={setIsApplyingImport}
+      onResetPreview={() => setPreview(null)}
+      onClose={onClose}
+    />
+  );
+};
+
+export class ImportSpecsModal extends ReactRootModal {
+  private plugin: DiscourseGraphPlugin;
+
+  constructor(app: App, plugin: DiscourseGraphPlugin) {
+    super(app);
+    this.plugin = plugin;
+  }
+
+  protected renderContent() {
+    return (
+      <ImportSpecsContent plugin={this.plugin} onClose={() => this.close()} />
+    );
+  }
+}

--- a/apps/obsidian/src/utils/registerCommands.ts
+++ b/apps/obsidian/src/utils/registerCommands.ts
@@ -15,6 +15,7 @@ import { addRelationIfRequested } from "~/components/canvas/utils/relationJsonUt
 import type { DiscourseNode } from "~/types";
 import { TldrawView } from "~/components/canvas/TldrawView";
 import { createBaseForNodeType } from "./baseForNodeType";
+import { openImportSpecsModal } from "~/components/ImportSpecsModal";
 
 type ModifyNodeSubmitParams = {
   nodeType: DiscourseNode;
@@ -200,6 +201,14 @@ export const registerCommands = (plugin: DiscourseGraphPlugin) => {
     name: "Export discourse graph schema",
     callback: () => {
       openExportSpecsModal(plugin);
+    },
+  });
+
+  plugin.addCommand({
+    id: "import-dg-schema",
+    name: "Import discourse graph schema",
+    callback: () => {
+      openImportSpecsModal(plugin);
     },
   });
 

--- a/apps/obsidian/src/utils/specImport.ts
+++ b/apps/obsidian/src/utils/specImport.ts
@@ -332,7 +332,8 @@ export const applySchemaImportSelection = async ({
       ...importedNodeType,
       template:
         importedNodeType.template &&
-        selectedTemplateNames.has(importedNodeType.template)
+        (selectedTemplateNames.has(importedNodeType.template) ||
+          matchPlan.existingTemplateNames.has(importedNodeType.template))
           ? importedNodeType.template
           : undefined,
       modified: Date.now(),

--- a/apps/obsidian/src/utils/specImport.ts
+++ b/apps/obsidian/src/utils/specImport.ts
@@ -1,0 +1,416 @@
+import type DiscourseGraphPlugin from "~/index";
+import { uuidv7 } from "uuidv7";
+import { parseDgSchemaFile } from "~/utils/specValidation";
+import { createTemplateFile, getTemplateFiles } from "~/utils/templates";
+import { openJsonFromUserLocation } from "~/utils/nativeJsonFileDialogs";
+import type {
+  DiscourseNode,
+  DiscourseRelation,
+  DiscourseRelationType,
+  DiscourseSchemaFile,
+} from "~/types";
+import { toTldrawColor } from "~/utils/tldrawColors";
+
+export type SchemaImportMatchPlan = {
+  nodeTypeIdMapping: Map<string, string>;
+  relationTypeIdMapping: Map<string, string>;
+  existingNodeTypeIds: Set<string>;
+  existingRelationTypeIds: Set<string>;
+  existingDiscourseRelationIds: Set<string>;
+  existingTemplateNames: Set<string>;
+};
+
+export type LoadedSchemaFile = {
+  sourcePath: string;
+  schemaFile: DiscourseSchemaFile;
+  matchPlan: SchemaImportMatchPlan;
+};
+
+export type ImportPreviewStats = {
+  nodeTypes: { total: number; new: number; existing: number };
+  relationTypes: { total: number; new: number; existing: number };
+  discourseRelations: { total: number; new: number; existing: number };
+  templates: { total: number; new: number; existing: number };
+};
+
+export type SpecImportPreview = {
+  loadedSchemaFile: LoadedSchemaFile;
+  previewStats: ImportPreviewStats;
+};
+
+export type SpecImportSelection = {
+  nodeTypeIds: string[];
+  relationTypeIds: string[];
+  discourseRelationIds: string[];
+  templateNames: string[];
+};
+
+export type SpecImportApplyResult = {
+  created: {
+    nodeTypes: number;
+    relationTypes: number;
+    discourseRelations: number;
+    templates: number;
+  };
+  warnings: string[];
+};
+
+const normalizeLabel = (value: string): string => {
+  return value.trim().toLowerCase();
+};
+
+const buildTripleKey = ({
+  sourceId,
+  relationshipTypeId,
+  destinationId,
+}: {
+  sourceId: string;
+  relationshipTypeId: string;
+  destinationId: string;
+}): string => {
+  return `${sourceId}::${relationshipTypeId}::${destinationId}`;
+};
+
+const buildSchemaImportMatchPlan = ({
+  schemaFile,
+  localNodeTypes,
+  localRelationTypes,
+  localDiscourseRelations,
+  localTemplateNames,
+}: {
+  schemaFile: DiscourseSchemaFile;
+  localNodeTypes: DiscourseNode[];
+  localRelationTypes: DiscourseRelationType[];
+  localDiscourseRelations: DiscourseRelation[];
+  localTemplateNames: Set<string>;
+}): SchemaImportMatchPlan => {
+  const localNodeTypeById = new Map(
+    localNodeTypes.map((nodeType) => [nodeType.id, nodeType]),
+  );
+  const localNodeTypeByName = new Map(
+    localNodeTypes.map((nodeType) => [normalizeLabel(nodeType.name), nodeType]),
+  );
+  const localRelationTypeById = new Map(
+    localRelationTypes.map((relationType) => [relationType.id, relationType]),
+  );
+  const localRelationTypeByLabel = new Map(
+    localRelationTypes.map((relationType) => [
+      normalizeLabel(relationType.label),
+      relationType,
+    ]),
+  );
+
+  const nodeTypeIdMapping = new Map<string, string>();
+  const existingNodeTypeIds = new Set<string>();
+
+  for (const nodeType of schemaFile.nodeTypes) {
+    const matchById = localNodeTypeById.get(nodeType.id);
+    if (matchById) {
+      nodeTypeIdMapping.set(nodeType.id, matchById.id);
+      existingNodeTypeIds.add(nodeType.id);
+      continue;
+    }
+
+    const matchByName = localNodeTypeByName.get(normalizeLabel(nodeType.name));
+    if (matchByName) {
+      nodeTypeIdMapping.set(nodeType.id, matchByName.id);
+      existingNodeTypeIds.add(nodeType.id);
+      continue;
+    }
+
+    nodeTypeIdMapping.set(nodeType.id, nodeType.id);
+  }
+
+  const relationTypeIdMapping = new Map<string, string>();
+  const existingRelationTypeIds = new Set<string>();
+
+  for (const relationType of schemaFile.relationTypes) {
+    const matchById = localRelationTypeById.get(relationType.id);
+    if (matchById) {
+      relationTypeIdMapping.set(relationType.id, matchById.id);
+      existingRelationTypeIds.add(relationType.id);
+      continue;
+    }
+
+    const matchByLabel = localRelationTypeByLabel.get(
+      normalizeLabel(relationType.label),
+    );
+    if (matchByLabel) {
+      relationTypeIdMapping.set(relationType.id, matchByLabel.id);
+      existingRelationTypeIds.add(relationType.id);
+      continue;
+    }
+
+    relationTypeIdMapping.set(relationType.id, relationType.id);
+  }
+
+  const localTripleKeys = new Set(
+    localDiscourseRelations.map((relation) =>
+      buildTripleKey({
+        sourceId: relation.sourceId,
+        relationshipTypeId: relation.relationshipTypeId,
+        destinationId: relation.destinationId,
+      }),
+    ),
+  );
+
+  const existingDiscourseRelationIds = new Set<string>();
+  for (const relation of schemaFile.discourseRelations) {
+    const mappedSourceId =
+      nodeTypeIdMapping.get(relation.sourceId) ?? relation.sourceId;
+    const mappedDestinationId =
+      nodeTypeIdMapping.get(relation.destinationId) ?? relation.destinationId;
+    const mappedRelationTypeId =
+      relationTypeIdMapping.get(relation.relationshipTypeId) ??
+      relation.relationshipTypeId;
+    const key = buildTripleKey({
+      sourceId: mappedSourceId,
+      relationshipTypeId: mappedRelationTypeId,
+      destinationId: mappedDestinationId,
+    });
+    if (localTripleKeys.has(key)) {
+      existingDiscourseRelationIds.add(relation.id);
+    }
+  }
+
+  const existingTemplateNames = new Set<string>();
+  for (const template of schemaFile.templates) {
+    if (localTemplateNames.has(template.name)) {
+      existingTemplateNames.add(template.name);
+    }
+  }
+
+  return {
+    nodeTypeIdMapping,
+    relationTypeIdMapping,
+    existingNodeTypeIds,
+    existingRelationTypeIds,
+    existingDiscourseRelationIds,
+    existingTemplateNames,
+  };
+};
+
+const buildPreviewStats = ({
+  schemaFile,
+  matchPlan,
+}: {
+  schemaFile: DiscourseSchemaFile;
+  matchPlan: SchemaImportMatchPlan;
+}): ImportPreviewStats => {
+  return {
+    nodeTypes: {
+      total: schemaFile.nodeTypes.length,
+      existing: matchPlan.existingNodeTypeIds.size,
+      new: schemaFile.nodeTypes.length - matchPlan.existingNodeTypeIds.size,
+    },
+    relationTypes: {
+      total: schemaFile.relationTypes.length,
+      existing: matchPlan.existingRelationTypeIds.size,
+      new:
+        schemaFile.relationTypes.length -
+        matchPlan.existingRelationTypeIds.size,
+    },
+    discourseRelations: {
+      total: schemaFile.discourseRelations.length,
+      existing: matchPlan.existingDiscourseRelationIds.size,
+      new:
+        schemaFile.discourseRelations.length -
+        matchPlan.existingDiscourseRelationIds.size,
+    },
+    templates: {
+      total: schemaFile.templates.length,
+      existing: matchPlan.existingTemplateNames.size,
+      new: schemaFile.templates.length - matchPlan.existingTemplateNames.size,
+    },
+  };
+};
+
+export const pickAndPreviewSchemaImport = async ({
+  plugin,
+}: {
+  plugin: DiscourseGraphPlugin;
+}): Promise<SpecImportPreview> => {
+  const file = await openJsonFromUserLocation({
+    title: "Import discourse graph schema",
+  });
+  const schemaFile = parseDgSchemaFile(JSON.parse(file.content) as unknown);
+  const localTemplateNames = new Set(getTemplateFiles(plugin.app));
+  const matchPlan = buildSchemaImportMatchPlan({
+    schemaFile,
+    localNodeTypes: plugin.settings.nodeTypes,
+    localRelationTypes: plugin.settings.relationTypes,
+    localDiscourseRelations: plugin.settings.discourseRelations,
+    localTemplateNames,
+  });
+
+  const loadedSchemaFile: LoadedSchemaFile = {
+    sourcePath: file.sourcePath,
+    schemaFile,
+    matchPlan,
+  };
+
+  return {
+    loadedSchemaFile,
+    previewStats: buildPreviewStats({ schemaFile, matchPlan }),
+  };
+};
+
+export const applySchemaImportSelection = async ({
+  plugin,
+  loadedSchemaFile,
+  selection,
+}: {
+  plugin: DiscourseGraphPlugin;
+  loadedSchemaFile: LoadedSchemaFile;
+  selection: SpecImportSelection;
+}): Promise<SpecImportApplyResult> => {
+  const warnings: string[] = [];
+  const { schemaFile, matchPlan } = loadedSchemaFile;
+  const selectedTemplateNames = new Set(selection.templateNames);
+  const selectedNodeTypeIds = new Set(selection.nodeTypeIds);
+  const selectedRelationTypeIds = new Set(selection.relationTypeIds);
+  const selectedRelationIds = new Set(selection.discourseRelationIds);
+
+  let templatesCreated = 0;
+  const templatesByName = new Map(
+    schemaFile.templates.map((template) => [template.name, template]),
+  );
+  for (const templateName of selectedTemplateNames) {
+    if (matchPlan.existingTemplateNames.has(templateName)) {
+      continue;
+    }
+
+    const template = templatesByName.get(templateName);
+    if (!template) {
+      warnings.push(
+        `Template "${templateName}" was selected but not found in schema file.`,
+      );
+      continue;
+    }
+
+    const result = await createTemplateFile({
+      app: plugin.app,
+      templateName: template.name,
+      content: template.content,
+    });
+
+    if (result.created) {
+      templatesCreated += 1;
+      continue;
+    }
+
+    if (result.reason !== "template already exists") {
+      warnings.push(`Template "${template.name}" skipped: ${result.reason}.`);
+    }
+  }
+
+  const schemaNodeTypesById = new Map(
+    schemaFile.nodeTypes.map((nodeType) => [nodeType.id, nodeType]),
+  );
+  const schemaRelationTypesById = new Map(
+    schemaFile.relationTypes.map((relationType) => [
+      relationType.id,
+      relationType,
+    ]),
+  );
+
+  let nodeTypesCreated = 0;
+  for (const nodeTypeId of selectedNodeTypeIds) {
+    if (matchPlan.existingNodeTypeIds.has(nodeTypeId)) {
+      continue;
+    }
+
+    const importedNodeType = schemaNodeTypesById.get(nodeTypeId);
+    if (!importedNodeType) {
+      warnings.push(
+        `Node type "${nodeTypeId}" was selected but missing from schema file.`,
+      );
+      continue;
+    }
+
+    const newNodeType: DiscourseNode = {
+      ...importedNodeType,
+      template:
+        importedNodeType.template &&
+        selectedTemplateNames.has(importedNodeType.template)
+          ? importedNodeType.template
+          : undefined,
+      modified: Date.now(),
+    };
+    plugin.settings.nodeTypes = [...plugin.settings.nodeTypes, newNodeType];
+    nodeTypesCreated += 1;
+  }
+
+  let relationTypesCreated = 0;
+  for (const relationTypeId of selectedRelationTypeIds) {
+    if (matchPlan.existingRelationTypeIds.has(relationTypeId)) {
+      continue;
+    }
+
+    const importedRelationType = schemaRelationTypesById.get(relationTypeId);
+    if (!importedRelationType) {
+      warnings.push(
+        `Relation type "${relationTypeId}" was selected but missing from schema file.`,
+      );
+      continue;
+    }
+
+    const newRelationType: DiscourseRelationType = {
+      ...importedRelationType,
+      color: toTldrawColor(importedRelationType.color),
+      status: "provisional",
+      modified: Date.now(),
+    };
+    plugin.settings.relationTypes = [
+      ...plugin.settings.relationTypes,
+      newRelationType,
+    ];
+    relationTypesCreated += 1;
+  }
+
+  let discourseRelationsCreated = 0;
+  for (const relation of schemaFile.discourseRelations) {
+    if (!selectedRelationIds.has(relation.id)) {
+      continue;
+    }
+    if (matchPlan.existingDiscourseRelationIds.has(relation.id)) {
+      continue;
+    }
+
+    const mappedSourceId =
+      matchPlan.nodeTypeIdMapping.get(relation.sourceId) ?? relation.sourceId;
+    const mappedDestinationId =
+      matchPlan.nodeTypeIdMapping.get(relation.destinationId) ??
+      relation.destinationId;
+    const mappedRelationTypeId =
+      matchPlan.relationTypeIdMapping.get(relation.relationshipTypeId) ??
+      relation.relationshipTypeId;
+
+    const newRelation: DiscourseRelation = {
+      ...relation,
+      id: uuidv7(),
+      sourceId: mappedSourceId,
+      destinationId: mappedDestinationId,
+      relationshipTypeId: mappedRelationTypeId,
+      status: "provisional",
+      modified: Date.now(),
+    };
+    plugin.settings.discourseRelations = [
+      ...plugin.settings.discourseRelations,
+      newRelation,
+    ];
+    discourseRelationsCreated += 1;
+  }
+
+  await plugin.saveSettings();
+
+  return {
+    created: {
+      nodeTypes: nodeTypesCreated,
+      relationTypes: relationTypesCreated,
+      discourseRelations: discourseRelationsCreated,
+      templates: templatesCreated,
+    },
+    warnings,
+  };
+};


### PR DESCRIPTION
## Summary

- Adds an **Import discourse graph schema** command and settings entry point
- Users pick a `dg-schema-*.json` file via the Electron native open dialog
- Preview step computes a match plan (id match, then name/label fallback) and shows per-category stats (new vs existing) for the full file before any changes are made
- On apply, new items are created as `provisional`; existing matches are skipped (no destructive merges)
- Relation triples, node types, and relation types in the selection panel enforce the same dependency constraints as export

## Test plan

- [ ] `pnpm --filter @discourse-graphs/obsidian check-types`
- [ ] Open Import schema modal from command palette
- [ ] Open Import schema modal from Settings
- [ ] Pick an exported `dg-schema-*.json` file; verify preview stats are correct
- [ ] Verify id-matched items show as existing; name/label-matched items show as existing
- [ ] Import selected items; confirm new node types, relation types, triples created as `provisional`
- [ ] Re-import the same file; confirm no duplicates created

## Stack

Stacked on #1163 (export PR). Base branch: `fee-840-export-schema`.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/1164" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->