### PR TITLE
ENG-1950 Remember canvas viewport session state

### DIFF
--- a/apps/roam/src/components/canvas/Tldraw.tsx
+++ b/apps/roam/src/components/canvas/Tldraw.tsx
@@ -95,6 +95,7 @@ import { CanvasDrawerPanel } from "./CanvasDrawer";
 import { ClipboardPanel, ClipboardProvider } from "./Clipboard";
 import internalError from "~/utils/internalError";
 import { syncCanvasNodeTitlesOnLoad } from "~/utils/syncCanvasNodeTitlesOnLoad";
+import { registerCanvasSessionStatePersistence } from "~/utils/canvasSessionState";
 import { isPluginTimerReady, waitForPluginTimer } from "~/utils/pluginTimer";
 import { HistoryEntry } from "@tldraw/store";
 import { TLRecord } from "@tldraw/tlschema";
@@ -1039,6 +1040,14 @@ const TldrawCanvasShared = ({
             components={editorComponents}
             store={store}
             onMount={(app) => {
+              const unregisterCanvasSessionStatePersistence =
+                registerCanvasSessionStatePersistence({
+                  editor: app,
+                  graphName: window.roamAlphaAPI.graph.name,
+                  userUid: window.roamAlphaAPI.user.uid() || "",
+                  pageUid,
+                });
+
               if (process.env.NODE_ENV !== "production") {
                 if (!window.tldrawApps) window.tldrawApps = {};
                 const { tldrawApps } = window;
@@ -1125,6 +1134,10 @@ const TldrawCanvasShared = ({
                   }
                 }
               });
+
+              return () => {
+                unregisterCanvasSessionStatePersistence();
+              };
             }}
           >
             <ClipboardProvider canvasPageTitle={title}>

--- a/apps/roam/src/utils/__tests__/canvasSessionState.test.ts
+++ b/apps/roam/src/utils/__tests__/canvasSessionState.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it, vi } from "vitest";
+import type {
+  TLRecord,
+  TLSessionStateSnapshot,
+  TLStoreEventInfo,
+} from "tldraw";
+import {
+  getCanvasSessionStorageKey,
+  getValidCanvasSessionState,
+  hasCameraRecordChange,
+  readCanvasSessionState,
+} from "~/utils/canvasSessionState";
+
+type TestStorage = Pick<Storage, "getItem" | "setItem" | "removeItem"> & {
+  values: Map<string, string>;
+};
+
+const createStorage = (initialValues: Record<string, string> = {}) => {
+  const values = new Map(Object.entries(initialValues));
+  return {
+    values,
+    getItem: vi.fn((key: string) => values.get(key) ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      values.set(key, value);
+    }),
+    removeItem: vi.fn((key: string) => {
+      values.delete(key);
+    }),
+  } satisfies TestStorage;
+};
+
+const createSession = ({
+  currentPageId = "page:current",
+  pageId = currentPageId,
+}: {
+  currentPageId?: string;
+  pageId?: string;
+} = {}): TLSessionStateSnapshot =>
+  ({
+    version: 0,
+    currentPageId,
+    isFocusMode: false,
+    exportBackground: true,
+    isDebugMode: false,
+    isToolLocked: false,
+    isGridMode: false,
+    pageStates: [
+      {
+        pageId,
+        camera: {
+          x: 120,
+          y: -40,
+          z: 1.5,
+        },
+        selectedShapeIds: ["shape:selected"],
+        focusedGroupId: "shape:focused",
+      },
+    ],
+  }) as TLSessionStateSnapshot;
+
+const createCameraRecord = (z: number): TLRecord =>
+  ({
+    id: "camera:page",
+    typeName: "camera",
+    x: 0,
+    y: 0,
+    z,
+    meta: {},
+  }) as TLRecord;
+
+describe("getCanvasSessionStorageKey", () => {
+  it("scopes viewport state by graph, user, and canvas page", () => {
+    expect(
+      getCanvasSessionStorageKey({
+        graphName: "graph/name",
+        userUid: "user:1",
+        pageUid: "abc 123",
+      }),
+    ).toBe("dg:tldraw-session:v1:graph%2Fname:user%3A1:abc%20123");
+  });
+});
+
+describe("readCanvasSessionState", () => {
+  it("reads a valid stored tldraw session snapshot", () => {
+    const session = createSession();
+    const storage = createStorage({
+      canvas: JSON.stringify({
+        version: 1,
+        savedAt: 1,
+        session,
+      }),
+    });
+
+    expect(readCanvasSessionState({ storage, storageKey: "canvas" })).toEqual(
+      session,
+    );
+    expect(storage.removeItem).not.toHaveBeenCalled();
+  });
+
+  it("removes malformed stored session state", () => {
+    const storage = createStorage({ canvas: "{not-json" });
+
+    expect(
+      readCanvasSessionState({ storage, storageKey: "canvas" }),
+    ).toBeNull();
+    expect(storage.removeItem).toHaveBeenCalledWith("canvas");
+    expect(storage.values.has("canvas")).toBe(false);
+  });
+});
+
+describe("getValidCanvasSessionState", () => {
+  it("keeps a session snapshot when the saved page still exists", () => {
+    const session = createSession();
+
+    const result = getValidCanvasSessionState({
+      session,
+      pageIds: ["page:current"],
+      currentPageId: "page:current" as TLSessionStateSnapshot["currentPageId"],
+    });
+
+    expect(result).toEqual(session);
+  });
+
+  it("remaps a one-page canvas session to the current page id", () => {
+    const session = createSession({
+      currentPageId: "page:old",
+      pageId: "page:old",
+    });
+
+    const result = getValidCanvasSessionState({
+      session,
+      pageIds: ["page:new"],
+      currentPageId: "page:new" as TLSessionStateSnapshot["currentPageId"],
+    });
+
+    expect(result?.currentPageId).toBe("page:new");
+    expect(result?.pageStates[0]?.pageId).toBe("page:new");
+    expect(result?.pageStates[0]?.camera).toEqual({
+      x: 120,
+      y: -40,
+      z: 1.5,
+    });
+    expect(result?.pageStates[0]?.selectedShapeIds).toEqual([]);
+    expect(result?.pageStates[0]?.focusedGroupId).toBeNull();
+  });
+
+  it("drops a stale session when a multipage document cannot be matched", () => {
+    const session = createSession({
+      currentPageId: "page:old",
+      pageId: "page:old",
+    });
+
+    expect(
+      getValidCanvasSessionState({
+        session,
+        pageIds: ["page:a", "page:b"],
+        currentPageId: "page:a" as TLSessionStateSnapshot["currentPageId"],
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("hasCameraRecordChange", () => {
+  it("detects camera records in session changes", () => {
+    expect(
+      hasCameraRecordChange({
+        source: "user",
+        changes: {
+          added: {},
+          removed: {},
+          updated: {
+            "camera:page": [createCameraRecord(1), createCameraRecord(2)],
+          },
+        },
+      } as TLStoreEventInfo),
+    ).toBe(true);
+  });
+
+  it("ignores non-camera session changes", () => {
+    expect(
+      hasCameraRecordChange({
+        source: "user",
+        changes: {
+          added: {
+            "instance:page": {
+              id: "instance:page",
+              typeName: "instance_page_state",
+            } as TLRecord,
+          },
+          removed: {},
+          updated: {},
+        },
+      } as TLStoreEventInfo),
+    ).toBe(false);
+  });
+});

--- a/apps/roam/src/utils/canvasSessionState.ts
+++ b/apps/roam/src/utils/canvasSessionState.ts
@@ -1,0 +1,289 @@
+import type {
+  Editor,
+  TLRecord,
+  TLSessionStateSnapshot,
+  TLStoreEventInfo,
+} from "tldraw";
+
+const CANVAS_SESSION_STORAGE_VERSION = 1;
+const CANVAS_SESSION_STORAGE_PREFIX = "dg:tldraw-session";
+const CANVAS_SESSION_SAVE_DELAY_MS = 750;
+
+type CanvasSessionStorage = Pick<Storage, "getItem" | "setItem" | "removeItem">;
+
+type StoredCanvasSessionState = {
+  version: typeof CANVAS_SESSION_STORAGE_VERSION;
+  savedAt: number;
+  session: TLSessionStateSnapshot;
+};
+
+type UnknownRecordChange = [TLRecord, TLRecord];
+
+const encodeStoragePart = (value: string): string => encodeURIComponent(value);
+
+const isFiniteNumber = (value: unknown): value is number =>
+  typeof value === "number" && Number.isFinite(value);
+
+const isStringArray = (value: unknown): value is string[] =>
+  Array.isArray(value) && value.every((item) => typeof item === "string");
+
+const isCameraState = (
+  value: unknown,
+): value is TLSessionStateSnapshot["pageStates"][number]["camera"] => {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    isFiniteNumber((value as { x?: unknown }).x) &&
+    isFiniteNumber((value as { y?: unknown }).y) &&
+    isFiniteNumber((value as { z?: unknown }).z)
+  );
+};
+
+const isPageState = (
+  value: unknown,
+): value is TLSessionStateSnapshot["pageStates"][number] => {
+  if (typeof value !== "object" || value === null) return false;
+  const pageState = value as Record<string, unknown>;
+  return (
+    typeof pageState.pageId === "string" &&
+    isCameraState(pageState.camera) &&
+    isStringArray(pageState.selectedShapeIds) &&
+    (pageState.focusedGroupId === null ||
+      typeof pageState.focusedGroupId === "string")
+  );
+};
+
+const isCanvasSessionState = (
+  value: unknown,
+): value is TLSessionStateSnapshot => {
+  if (typeof value !== "object" || value === null) return false;
+  const session = value as Record<string, unknown>;
+  return (
+    isFiniteNumber(session.version) &&
+    typeof session.currentPageId === "string" &&
+    typeof session.isFocusMode === "boolean" &&
+    typeof session.exportBackground === "boolean" &&
+    typeof session.isDebugMode === "boolean" &&
+    typeof session.isToolLocked === "boolean" &&
+    typeof session.isGridMode === "boolean" &&
+    Array.isArray(session.pageStates) &&
+    session.pageStates.every(isPageState)
+  );
+};
+
+const isStoredCanvasSessionState = (
+  value: unknown,
+): value is StoredCanvasSessionState => {
+  if (typeof value !== "object" || value === null) return false;
+  const stored = value as Record<string, unknown>;
+  return (
+    stored.version === CANVAS_SESSION_STORAGE_VERSION &&
+    isFiniteNumber(stored.savedAt) &&
+    isCanvasSessionState(stored.session)
+  );
+};
+
+const isCameraRecord = (record: TLRecord | undefined): boolean =>
+  record?.typeName === "camera";
+
+const getCanvasSessionStorage = (): Storage | null => {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+};
+
+export const getCanvasSessionStorageKey = ({
+  graphName,
+  userUid,
+  pageUid,
+}: {
+  graphName: string;
+  userUid: string;
+  pageUid: string;
+}): string => {
+  return [
+    CANVAS_SESSION_STORAGE_PREFIX,
+    `v${CANVAS_SESSION_STORAGE_VERSION}`,
+    encodeStoragePart(graphName),
+    encodeStoragePart(userUid || "anonymous"),
+    encodeStoragePart(pageUid),
+  ].join(":");
+};
+
+export const readCanvasSessionState = ({
+  storage,
+  storageKey,
+}: {
+  storage: CanvasSessionStorage;
+  storageKey: string;
+}): TLSessionStateSnapshot | null => {
+  const raw = storage.getItem(storageKey);
+  if (!raw) return null;
+
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (isStoredCanvasSessionState(parsed)) return parsed.session;
+  } catch {
+    // Remove invalid stored state below.
+  }
+
+  storage.removeItem(storageKey);
+  return null;
+};
+
+export const getValidCanvasSessionState = ({
+  session,
+  pageIds,
+  currentPageId,
+}: {
+  session: TLSessionStateSnapshot;
+  pageIds: readonly string[];
+  currentPageId: TLSessionStateSnapshot["currentPageId"];
+}): TLSessionStateSnapshot | null => {
+  const pageIdSet = new Set(pageIds);
+  const pageStates = session.pageStates.filter((pageState) =>
+    pageIdSet.has(pageState.pageId),
+  );
+
+  if (
+    pageIdSet.has(session.currentPageId) &&
+    pageStates.some((pageState) => pageState.pageId === session.currentPageId)
+  ) {
+    return {
+      ...session,
+      pageStates,
+    };
+  }
+
+  if (pageIds.length !== 1 || !session.pageStates[0]) return null;
+
+  return {
+    ...session,
+    currentPageId,
+    pageStates: [
+      {
+        ...session.pageStates[0],
+        pageId: currentPageId,
+        selectedShapeIds: [],
+        focusedGroupId: null,
+      },
+    ],
+  };
+};
+
+export const hasCameraRecordChange = (entry: TLStoreEventInfo): boolean => {
+  const changedRecords = [
+    ...Object.values(entry.changes.added),
+    ...Object.values(entry.changes.removed),
+    ...Object.values(entry.changes.updated).flatMap(
+      (change) => change as UnknownRecordChange,
+    ),
+  ];
+  return changedRecords.some(isCameraRecord);
+};
+
+const restoreCanvasSessionState = ({
+  editor,
+  storage,
+  storageKey,
+}: {
+  editor: Editor;
+  storage: CanvasSessionStorage;
+  storageKey: string;
+}): void => {
+  const session = readCanvasSessionState({ storage, storageKey });
+  if (!session) return;
+
+  const validSession = getValidCanvasSessionState({
+    session,
+    pageIds: editor.getPages().map((page) => page.id),
+    currentPageId: editor.getCurrentPageId(),
+  });
+
+  if (!validSession) {
+    storage.removeItem(storageKey);
+    return;
+  }
+
+  try {
+    editor.loadSnapshot({ session: validSession });
+  } catch {
+    storage.removeItem(storageKey);
+  }
+};
+
+const saveCanvasSessionState = ({
+  editor,
+  storage,
+  storageKey,
+}: {
+  editor: Editor;
+  storage: CanvasSessionStorage;
+  storageKey: string;
+}): void => {
+  try {
+    const { session } = editor.getSnapshot();
+    const stored: StoredCanvasSessionState = {
+      version: CANVAS_SESSION_STORAGE_VERSION,
+      savedAt: Date.now(),
+      session,
+    };
+    storage.setItem(storageKey, JSON.stringify(stored));
+  } catch {
+    // Session persistence should never block normal canvas interaction.
+  }
+};
+
+export const registerCanvasSessionStatePersistence = ({
+  editor,
+  graphName,
+  userUid,
+  pageUid,
+  storage = getCanvasSessionStorage(),
+  saveDelayMs = CANVAS_SESSION_SAVE_DELAY_MS,
+}: {
+  editor: Editor;
+  graphName: string;
+  userUid: string;
+  pageUid: string;
+  storage?: CanvasSessionStorage | null;
+  saveDelayMs?: number;
+}): (() => void) => {
+  if (!storage) return () => {};
+
+  const storageKey = getCanvasSessionStorageKey({
+    graphName,
+    userUid,
+    pageUid,
+  });
+  let saveTimeout: ReturnType<typeof setTimeout> | null = null;
+
+  const flushPendingSave = (): void => {
+    if (!saveTimeout) return;
+    clearTimeout(saveTimeout);
+    saveTimeout = null;
+    saveCanvasSessionState({ editor, storage, storageKey });
+  };
+
+  restoreCanvasSessionState({ editor, storage, storageKey });
+
+  const stopListening = editor.store.listen(
+    (entry) => {
+      if (!hasCameraRecordChange(entry)) return;
+      if (saveTimeout) clearTimeout(saveTimeout);
+      saveTimeout = setTimeout(() => {
+        saveTimeout = null;
+        saveCanvasSessionState({ editor, storage, storageKey });
+      }, saveDelayMs);
+    },
+    { source: "user", scope: "session" },
+  );
+
+  return () => {
+    stopListening();
+    flushPendingSave();
+  };
+};


### PR DESCRIPTION
## Intent

Remember a user's tldraw canvas viewport when they navigate away from a canvas and come back, without turning camera movement into shared canvas document writes.

The code intentionally treats the viewport as tldraw session state rather than document state. tldraw's camera lives in the session snapshot, and tldraw sync only pushes document-scope records to the shared room. This keeps pan/zoom personal to the browser profile, Roam user, and canvas page, instead of making one user's last viewport become everyone else's default.

## What changed

- Added a canvas session persistence helper that stores tldraw `session` snapshots in browser `localStorage` under a graph/user/page scoped key.
- Restores that session snapshot on canvas mount with `editor.loadSnapshot({ session })` after validating/remapping page IDs.
- Listens only for user-originated session-scope `camera` record changes and debounces saves.
- Wires the helper into the Roam tldraw canvas mount/unmount lifecycle.
- Adds unit tests for storage key scoping, malformed state cleanup, stale page handling, and camera-change detection.

## Impact

Users returning to a canvas on the same browser profile should see the last pan/zoom they used instead of always reopening at 100% zoom in the middle of the canvas.

This does not write camera changes into Roam block props and does not push camera changes into the Cloudflare tldraw room. Shared canvas document sync remains limited to document records like shapes, bindings, pages, and assets.

## Validation

- `npm test`
- `npm run check-types`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Canvas sessions now persist automatically, so your tldraw view can restore after reloads or revisits.
  * Saved canvas state is scoped to your graph, user, and page for more consistent restoration.

* **Bug Fixes**
  * Improved recovery from invalid saved session data by ignoring corrupted entries.
  * Better handling of page changes and multi-page canvases to avoid restoring stale state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->