### PR TITLE
ENG-1912 Scaffold @repo/content-model

### DIFF
--- a/packages/content-model/eslint.config.mjs
+++ b/packages/content-model/eslint.config.mjs
@@ -1,0 +1,13 @@
+import { config as base } from "@repo/eslint-config/base";
+
+export default [
+  ...base,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: true,
+        tsconfigRootDir: ".",
+      },
+    },
+  },
+];

--- a/packages/content-model/package.json
+++ b/packages/content-model/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@repo/content-model",
+  "version": "0.0.0",
+  "private": true,
+  "license": "Apache-2.0",
+  "exports": {
+    ".": "./src/index.ts",
+    "./schema": "./src/schema/index.ts",
+    "./validation": "./src/validation/index.ts",
+    "./text": "./src/text/index.ts",
+    "./constants": "./src/constants/index.ts",
+    "./core": "./src/core/index.ts",
+    "./adapters": "./src/adapters/index.ts",
+    "./render": "./src/render/index.ts"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "check-types": "tsc --noEmit --skipLibCheck",
+    "lint": "eslint .",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "@repo/eslint-config": "workspace:*",
+    "@repo/typescript-config": "workspace:*",
+    "@types/node": "catalog:",
+    "eslint": "catalog:",
+    "typescript": "5.5.4",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/content-model/src/__tests__/exports.test.ts
+++ b/packages/content-model/src/__tests__/exports.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  contentTypes,
+  createValidResult,
+  dgDocumentSchemaVersion,
+  isSupportedContentType,
+  isValidTextRange,
+  normalizeLineEndings,
+  supportedContentTypes,
+} from "@repo/content-model";
+
+describe("@repo/content-model", () => {
+  it("exports supported content type constants", () => {
+    expect(supportedContentTypes).toEqual([
+      "text/plain",
+      "text/markdown",
+      "text/roam+markdown",
+      "text/obsidian+markdown",
+      "application/roam+json",
+      "application/vnd.discourse-graph.atjson+json; version=1",
+    ]);
+    expect(contentTypes.markdown).toBe("text/markdown");
+    expect(isSupportedContentType(contentTypes.discourseGraphAtJson)).toBe(
+      true,
+    );
+    expect(isSupportedContentType("application/json")).toBe(false);
+  });
+
+  it("exports scaffold modules for the content model package", () => {
+    expect(dgDocumentSchemaVersion).toBe(1);
+    expect(createValidResult()).toEqual({ success: true, issues: [] });
+    expect(normalizeLineEndings("a\r\nb\rc")).toBe("a\nb\nc");
+    expect(isValidTextRange({ start: 1, end: 2 })).toBe(true);
+  });
+});

--- a/packages/content-model/src/adapters/index.ts
+++ b/packages/content-model/src/adapters/index.ts
@@ -1,0 +1,1 @@
+export type ContentAdapterKind = "obsidian" | "roam";

--- a/packages/content-model/src/constants/index.ts
+++ b/packages/content-model/src/constants/index.ts
@@ -1,0 +1,23 @@
+export const contentTypes = {
+  plainText: "text/plain",
+  markdown: "text/markdown",
+  roamMarkdown: "text/roam+markdown",
+  obsidianMarkdown: "text/obsidian+markdown",
+  roamJson: "application/roam+json",
+  discourseGraphAtJson:
+    "application/vnd.discourse-graph.atjson+json; version=1",
+} as const;
+
+export const supportedContentTypes = [
+  contentTypes.plainText,
+  contentTypes.markdown,
+  contentTypes.roamMarkdown,
+  contentTypes.obsidianMarkdown,
+  contentTypes.roamJson,
+  contentTypes.discourseGraphAtJson,
+] as const;
+
+export type ContentType = (typeof supportedContentTypes)[number];
+
+export const isSupportedContentType = (value: string): value is ContentType =>
+  supportedContentTypes.includes(value as ContentType);

--- a/packages/content-model/src/core/index.ts
+++ b/packages/content-model/src/core/index.ts
@@ -1,0 +1,10 @@
+export type TextRange = {
+  start: number;
+  end: number;
+};
+
+export const isValidTextRange = ({ start, end }: TextRange): boolean =>
+  Number.isInteger(start) &&
+  Number.isInteger(end) &&
+  start >= 0 &&
+  end >= start;

--- a/packages/content-model/src/index.ts
+++ b/packages/content-model/src/index.ts
@@ -1,0 +1,7 @@
+export * from "./adapters/index.js";
+export * from "./constants/index.js";
+export * from "./core/index.js";
+export * from "./render/index.js";
+export * from "./schema/index.js";
+export * from "./text/index.js";
+export * from "./validation/index.js";

--- a/packages/content-model/src/render/index.ts
+++ b/packages/content-model/src/render/index.ts
@@ -1,0 +1,1 @@
+export type RenderFormat = "html";

--- a/packages/content-model/src/schema/index.ts
+++ b/packages/content-model/src/schema/index.ts
@@ -1,0 +1,3 @@
+export const dgDocumentSchemaVersion = 1;
+
+export type DgDocumentSchemaVersion = typeof dgDocumentSchemaVersion;

--- a/packages/content-model/src/text/index.ts
+++ b/packages/content-model/src/text/index.ts
@@ -1,0 +1,2 @@
+export const normalizeLineEndings = (text: string): string =>
+  text.replace(/\r\n?/g, "\n");

--- a/packages/content-model/src/validation/index.ts
+++ b/packages/content-model/src/validation/index.ts
@@ -1,0 +1,19 @@
+export type ValidationIssue = {
+  path: readonly string[];
+  message: string;
+};
+
+export type ValidationResult =
+  | {
+      success: true;
+      issues: readonly [];
+    }
+  | {
+      success: false;
+      issues: readonly ValidationIssue[];
+    };
+
+export const createValidResult = (): ValidationResult => ({
+  success: true,
+  issues: [],
+});

--- a/packages/content-model/tsconfig.build.json
+++ b/packages/content-model/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["./src/**/*.test.ts", "./src/**/__tests__/**"]
+}

--- a/packages/content-model/tsconfig.json
+++ b/packages/content-model/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@repo/typescript-config/base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": ".",
+    "outDir": "dist"
+  },
+  "include": ["./src/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -552,6 +552,27 @@ importers:
         specifier: 'catalog:'
         version: 4.1.6(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.0)(@types/node@22.20.0)(jsdom@20.0.3)(msw@2.11.1(@types/node@22.20.0)(typescript@5.5.4))(vite@7.3.3(@types/node@22.20.0)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2))
 
+  packages/content-model:
+    devDependencies:
+      '@repo/eslint-config':
+        specifier: workspace:*
+        version: link:../eslint-config
+      '@repo/typescript-config':
+        specifier: workspace:*
+        version: link:../typescript-config
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.20.0
+      eslint:
+        specifier: 'catalog:'
+        version: 8.57.1
+      typescript:
+        specifier: 5.5.4
+        version: 5.5.4
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.6(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.0)(@types/node@22.20.0)(jsdom@20.0.3)(msw@2.11.1(@types/node@22.20.0)(typescript@5.5.4))(vite@7.3.3(@types/node@22.20.0)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2))
+
   packages/database:
     dependencies:
       '@repo/utils':


### PR DESCRIPTION
## Summary

- Scaffold `@repo/content-model` as a DG-owned workspace package.
- Add package exports for schema, validation, text, constants, core, adapters, and render modules.
- Add build, type-check, lint, and Vitest setup with scaffold tests that import through the package export path.

## Notes

- Keeps `DgDocument` schema, parser/render core, adapters, and HTML rendering for follow-up tickets.
- Does not include SamePage sync/runtime, networking, Automerge, IPFS, Supabase, or protocol code.

## Validation

- `pnpm --filter @repo/content-model check-types`
- `pnpm --filter @repo/content-model test`
- `pnpm --filter @repo/content-model build`
- `pnpm --filter @repo/content-model lint`
- `pnpm exec prettier --check packages/content-model`
- `git diff --check`

Linear: https://linear.app/discourse-graphs/issue/ENG-1912/scaffold-repocontent-model