### PR TITLE
ENG-1966 Add branch and PR naming conventions to root AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,25 @@ This repository uses Turborepo.
 - packages/eslint-config: ESLint preset
 - packages/ui: Core React components
 
+## Git & Publishing Conventions
+
+### Branch Naming
+
+When working on Linear issues, prefer using the Linear-provided branch name when available. Linear automatically generates branch names in the format `eng-####-descriptive-name` (e.g., `eng-1912-scaffold-repocontent-model`).
+
+- Use Linear's generated branch name for consistency and traceability
+- Branch names should be lowercase with hyphens separating words
+- Include the Linear ticket ID at the start of the branch name
+
+### Pull Request Titles
+
+PR titles for Linear-backed work should follow this format:
+
+- Format: `ENG-#### Ticket title`
+- The ticket ID must be uppercased (e.g., `ENG-1912` not `eng-1912`)
+- Follow the ticket ID with the exact Linear ticket title
+- Example: `ENG-1912 Scaffold @repo/content-model`
+
 ## Style Guide
 
 ### UI Guidelines


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR adds Git and publishing conventions to the repository root `AGENTS.md` to document standards for Linear-backed work.

## Changes

- Added new "Git & Publishing Conventions" section to `AGENTS.md`
- Documented branch naming convention: prefer Linear-provided branch names (format: `eng-####-descriptive-name`)
- Documented PR title convention: `ENG-#### Ticket title` with uppercased ticket ID
- Included clear examples for both conventions

## Done When Checklist

- [x] Root `AGENTS.md` includes the branch naming convention
- [x] Root `AGENTS.md` includes the PR title convention
- [x] The instructions make clear to prefer Linear's generated branch name when available

Fixes ENG-1966
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-1966](https://linear.app/discourse-graphs/issue/ENG-1966/add-branch-and-pr-naming-conventions-to-root-agentsmd)

<div><a href="https://cursor.com/agents/bc-a95a2d9a-0038-4b0d-a23c-0d76eeaca766"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a95a2d9a-0038-4b0d-a23c-0d76eeaca766"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

