### PR TITLE
ENG-1905 Add shared content type constants

### DIFF
--- a/apps/roam/package.json
+++ b/apps/roam/package.json
@@ -46,6 +46,7 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@octokit/auth-app": "^7.1.4",
     "@octokit/core": "^6.1.3",
+    "@repo/content-model": "workspace:*",
     "@repo/database": "workspace:*",
     "@repo/utils": "workspace:*",
     "@supabase/functions-js": "catalog:",

--- a/apps/roam/src/utils/convertRoamNodeToFullContent.example.ts
+++ b/apps/roam/src/utils/convertRoamNodeToFullContent.example.ts
@@ -1,3 +1,4 @@
+import { contentTypes } from "@repo/content-model";
 import type { TreeNode } from "roamjs-components/types";
 import type { CrossAppNode } from "@repo/database/crossAppNodeContract";
 import { buildFullMarkdown } from "./convertRoamNodeToFullContent";
@@ -226,7 +227,7 @@ export const roamClaimFullMarkdownExample: {
   title,
   blocks,
   full: {
-    format: "text/markdown",
+    format: contentTypes.markdown,
     value: buildFullMarkdown({ title, blocks }),
   },
 };

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -44,6 +44,7 @@
     "deploy:functions": "tsx scripts/deploy.ts -f"
   },
   "dependencies": {
+    "@repo/content-model": "workspace:*",
     "@repo/utils": "workspace:*",
     "@supabase/auth-js": "catalog:",
     "@supabase/functions-js": "catalog:",

--- a/packages/database/src/crossAppNodeContract.example.ts
+++ b/packages/database/src/crossAppNodeContract.example.ts
@@ -1,3 +1,4 @@
+import { contentTypes } from "@repo/content-model";
 import type { CrossAppNode } from "./crossAppNodeContract";
 import { spaceUriAndLocalIdToRid } from "./lib/rid";
 
@@ -26,7 +27,7 @@ export const roamOriginNodeExample: CrossAppNode = {
   },
   content: {
     direct: { value: "Sleep improves memory consolidation" },
-    full: { format: "text/markdown", value: roamFullMarkdown },
+    full: { format: contentTypes.markdown, value: roamFullMarkdown },
   },
   sourceModifiedAt: "2026-06-12T14:00:00.000Z",
 };
@@ -61,7 +62,7 @@ export const obsidianOriginNodeExample: CrossAppNode = {
   },
   content: {
     direct: { value: "EVD - REM sleep and recall" },
-    full: { format: "text/markdown", value: obsidianFullMarkdown },
+    full: { format: contentTypes.markdown, value: obsidianFullMarkdown },
   },
   sourceModifiedAt: "2026-06-14T10:30:00.000Z",
 };

--- a/packages/database/src/crossAppNodeContract.ts
+++ b/packages/database/src/crossAppNodeContract.ts
@@ -1,3 +1,5 @@
+import type { contentTypes } from "@repo/content-model";
+
 export type CrossAppNode = {
   sourceApp: "roam" | "obsidian";
   /**
@@ -27,7 +29,7 @@ export type CrossAppNode = {
        * Contract media type for `full.value`; current Content rows store the
        * markdown in `text`, not in a typed media column.
        */
-      format: "text/markdown";
+      format: typeof contentTypes.markdown;
       value: string;
     };
   };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -245,6 +245,9 @@ importers:
       '@octokit/core':
         specifier: ^6.1.3
         version: 6.1.6
+      '@repo/content-model':
+        specifier: workspace:*
+        version: link:../../packages/content-model
       '@repo/database':
         specifier: workspace:*
         version: link:../../packages/database
@@ -575,6 +578,9 @@ importers:
 
   packages/database:
     dependencies:
+      '@repo/content-model':
+        specifier: workspace:*
+        version: link:../content-model
       '@repo/utils':
         specifier: workspace:*
         version: link:../utils


### PR DESCRIPTION
## Summary

- Wire the existing `@repo/content-model` content type constants into the cross-app content contract.
- Replace Markdown representation literals in database and Roam cross-app examples with `contentTypes.markdown`.
- Add the required workspace dependency links for `@repo/database` and `roam`.

## Notes

- Generic HTTP and clipboard `text/plain` usage was left alone because it is not the DG content representation discriminator.
- `ENG-1906` is still separate assigned database migration work; this PR does not duplicate that branch.

## Validation

- `pnpm --filter @repo/content-model test`
- `pnpm exec prettier --check packages/database/src/crossAppNodeContract.ts packages/database/src/crossAppNodeContract.example.ts apps/roam/src/utils/convertRoamNodeToFullContent.example.ts packages/database/package.json apps/roam/package.json pnpm-lock.yaml`
- `pnpm --filter @repo/database check-types`
- `pnpm --filter roam check-types`
- `pnpm --filter @repo/database lint` (warnings only, pre-existing)
- `pnpm --filter roam lint` (warnings only, pre-existing)
- `git diff --check`

Linear: https://linear.app/discourse-graphs/issue/ENG-1905/add-shared-content-type-constants