### PR TITLE
ENG-1929 Multiple additional relations bug

### DIFF
--- a/apps/roam/src/components/canvas/Tldraw.tsx
+++ b/apps/roam/src/components/canvas/Tldraw.tsx
@@ -114,6 +114,7 @@ import {
   CanvasStoreAdapterArgs,
   useCanvasStoreAdapterArgs,
 } from "./useCanvasStoreAdapterArgs";
+import { areAutoCanvasRelationsSuppressed } from "./autoCanvasRelationsSuppression";
 import posthog from "posthog-js";
 import { getPersonalSetting } from "~/components/settings/utils/accessors";
 import { PERSONAL_KEYS } from "~/components/settings/utils/settingKeys";
@@ -1486,6 +1487,8 @@ const InsideEditorAndUiContext = ({
 
       const removeAfterCreateHandler =
         editor.sideEffects.registerAfterCreateHandler("shape", (shape) => {
+          if (areAutoCanvasRelationsSuppressed()) return;
+
           const util = editor.getShapeUtil(shape);
           if (util instanceof DiscourseNodeUtil) {
             const autoCanvasRelations = getPersonalSetting<boolean>([

--- a/apps/roam/src/components/canvas/Tldraw.tsx
+++ b/apps/roam/src/components/canvas/Tldraw.tsx
@@ -114,7 +114,7 @@ import {
   CanvasStoreAdapterArgs,
   useCanvasStoreAdapterArgs,
 } from "./useCanvasStoreAdapterArgs";
-import { areAutoCanvasRelationsSuppressed } from "./autoCanvasRelationsSuppression";
+import { shouldCreateAutoCanvasRelations } from "./autoCanvasRelationsSuppression";
 import posthog from "posthog-js";
 import { getPersonalSetting } from "~/components/settings/utils/accessors";
 import { PERSONAL_KEYS } from "~/components/settings/utils/settingKeys";
@@ -1486,21 +1486,24 @@ const InsideEditorAndUiContext = ({
         );
 
       const removeAfterCreateHandler =
-        editor.sideEffects.registerAfterCreateHandler("shape", (shape) => {
-          if (areAutoCanvasRelationsSuppressed()) return;
+        editor.sideEffects.registerAfterCreateHandler(
+          "shape",
+          (shape, source) => {
+            if (!shouldCreateAutoCanvasRelations({ source })) return;
 
-          const util = editor.getShapeUtil(shape);
-          if (util instanceof DiscourseNodeUtil) {
-            const autoCanvasRelations = getPersonalSetting<boolean>([
-              PERSONAL_KEYS.autoCanvasRelations,
-            ]);
-            if (autoCanvasRelations) {
-              void util.createExistingRelations({
-                shape: shape as DiscourseNodeShape,
-              });
+            const util = editor.getShapeUtil(shape);
+            if (util instanceof DiscourseNodeUtil) {
+              const autoCanvasRelations = getPersonalSetting<boolean>([
+                PERSONAL_KEYS.autoCanvasRelations,
+              ]);
+              if (autoCanvasRelations) {
+                void util.createExistingRelations({
+                  shape: shape as DiscourseNodeShape,
+                });
+              }
             }
-          }
-        });
+          },
+        );
 
       return () => {
         removeBeforeChangeHandler();

--- a/apps/roam/src/components/canvas/autoCanvasRelationsSuppression.ts
+++ b/apps/roam/src/components/canvas/autoCanvasRelationsSuppression.ts
@@ -1,0 +1,13 @@
+let suppressionDepth = 0;
+
+export const areAutoCanvasRelationsSuppressed = (): boolean =>
+  suppressionDepth > 0;
+
+export const withAutoCanvasRelationsSuppressed = <T>(callback: () => T): T => {
+  suppressionDepth += 1;
+  try {
+    return callback();
+  } finally {
+    suppressionDepth -= 1;
+  }
+};

--- a/apps/roam/src/components/canvas/autoCanvasRelationsSuppression.ts
+++ b/apps/roam/src/components/canvas/autoCanvasRelationsSuppression.ts
@@ -1,7 +1,15 @@
 let suppressionDepth = 0;
 
+type CanvasRecordSource = "remote" | "user";
+
 export const areAutoCanvasRelationsSuppressed = (): boolean =>
   suppressionDepth > 0;
+
+export const shouldCreateAutoCanvasRelations = ({
+  source,
+}: {
+  source: CanvasRecordSource;
+}): boolean => source === "user" && !areAutoCanvasRelationsSuppressed();
 
 export const withAutoCanvasRelationsSuppressed = <T>(callback: () => T): T => {
   suppressionDepth += 1;

--- a/apps/roam/src/components/canvas/canvasSyncMode.ts
+++ b/apps/roam/src/components/canvas/canvasSyncMode.ts
@@ -9,6 +9,7 @@ import {
   loadSnapshot,
 } from "tldraw";
 import { getRoamCanvasSnapshot } from "./useRoamStore";
+import { withAutoCanvasRelationsSuppressed } from "./autoCanvasRelationsSuppression";
 
 export type CanvasSyncMode = "local" | "sync";
 export type CanvasSyncMigrationState = "pending" | "done";
@@ -218,7 +219,10 @@ export const migrateLocalCanvasToCloud = ({
     };
   }
 
-  loadSnapshot(store, localSnapshot);
+  // Loading a local snapshot into the cloud store replays shape creation.
+  // Suppress auto-generated relations so migration copies the canvas exactly
+  // instead of creating duplicate relation shapes for imported nodes.
+  withAutoCanvasRelationsSuppressed(() => loadSnapshot(store, localSnapshot));
 
   setCanvasSyncSettings({
     pageUid,

--- a/apps/roam/src/utils/__tests__/autoCanvasRelationsSuppression.test.ts
+++ b/apps/roam/src/utils/__tests__/autoCanvasRelationsSuppression.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import {
+  areAutoCanvasRelationsSuppressed,
+  withAutoCanvasRelationsSuppressed,
+} from "~/components/canvas/autoCanvasRelationsSuppression";
+
+describe("auto canvas relation suppression", () => {
+  it("suppresses auto canvas relations only inside the callback", () => {
+    expect(areAutoCanvasRelationsSuppressed()).toBe(false);
+
+    const value = withAutoCanvasRelationsSuppressed(() => {
+      expect(areAutoCanvasRelationsSuppressed()).toBe(true);
+      return "loaded";
+    });
+
+    expect(value).toBe("loaded");
+    expect(areAutoCanvasRelationsSuppressed()).toBe(false);
+  });
+
+  it("keeps suppression active for nested callbacks", () => {
+    withAutoCanvasRelationsSuppressed(() => {
+      expect(areAutoCanvasRelationsSuppressed()).toBe(true);
+
+      withAutoCanvasRelationsSuppressed(() => {
+        expect(areAutoCanvasRelationsSuppressed()).toBe(true);
+      });
+
+      expect(areAutoCanvasRelationsSuppressed()).toBe(true);
+    });
+
+    expect(areAutoCanvasRelationsSuppressed()).toBe(false);
+  });
+
+  it("restores suppression state when the callback throws", () => {
+    expect(() =>
+      withAutoCanvasRelationsSuppressed(() => {
+        throw new Error("load failed");
+      }),
+    ).toThrow("load failed");
+
+    expect(areAutoCanvasRelationsSuppressed()).toBe(false);
+  });
+});

--- a/apps/roam/src/utils/__tests__/autoCanvasRelationsSuppression.test.ts
+++ b/apps/roam/src/utils/__tests__/autoCanvasRelationsSuppression.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   areAutoCanvasRelationsSuppressed,
+  shouldCreateAutoCanvasRelations,
   withAutoCanvasRelationsSuppressed,
 } from "~/components/canvas/autoCanvasRelationsSuppression";
 
@@ -39,5 +40,19 @@ describe("auto canvas relation suppression", () => {
     ).toThrow("load failed");
 
     expect(areAutoCanvasRelationsSuppressed()).toBe(false);
+  });
+
+  it("allows auto canvas relations for user-created records", () => {
+    expect(shouldCreateAutoCanvasRelations({ source: "user" })).toBe(true);
+  });
+
+  it("skips auto canvas relations for remote-created records", () => {
+    expect(shouldCreateAutoCanvasRelations({ source: "remote" })).toBe(false);
+  });
+
+  it("skips user-created records while suppression is active", () => {
+    withAutoCanvasRelationsSuppressed(() => {
+      expect(shouldCreateAutoCanvasRelations({ source: "user" })).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
https://www.loom.com/share/97c8d205bb8f4301ae06150144429d2b

## Summary
- Add a scoped suppression helper for auto-generated canvas relations
- Skip relation creation while loading local canvases into the cloud store so migrated canvases stay unchanged
- Cover suppression scope, nesting, and error recovery with unit tests

## Testing
- Unit tests added for suppression behavior, including nested callbacks and thrown errors
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/1176" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->