### PR TITLE
FEE-848 lightweight website homepage visual refresh

### DIFF
--- a/apps/website/app/(home)/HomeNavigationMenu.tsx
+++ b/apps/website/app/(home)/HomeNavigationMenu.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import Link from "next/link";
+import { Menu } from "lucide-react";
+import { Button } from "@repo/ui/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@repo/ui/components/ui/dropdown-menu";
+
+export type HomeNavigationItem = {
+  href: string;
+  isDocumentNavigation?: boolean;
+  label: string;
+};
+
+type HomeNavigationMenuProps = {
+  items: HomeNavigationItem[];
+};
+
+export const HomeNavigationMenu = ({
+  items,
+}: HomeNavigationMenuProps): React.ReactElement => {
+  return (
+    <>
+      <div className="md:hidden">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              type="button"
+              variant="outline"
+              size="icon"
+              className="border-neutral-dark/15 bg-neutral-light text-neutral-dark hover:border-neutral-dark/15 hover:bg-neutral-light hover:text-neutral-dark focus-visible:ring-neutral-dark/20 active:bg-neutral-light active:text-neutral-dark data-[state=open]:border-neutral-dark/15 data-[state=open]:bg-neutral-light data-[state=open]:text-neutral-dark min-[360px]:w-auto min-[360px]:px-4"
+              aria-label="Open navigation menu"
+            >
+              <Menu className="h-4 w-4" aria-hidden="true" />
+              <span className="hidden min-[360px]:inline">Menu</span>
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            align="end"
+            className="min-w-48 border-neutral-dark/10 bg-white text-neutral-dark"
+          >
+            {items.map((item) => (
+              <DropdownMenuItem key={item.href} asChild>
+                {item.isDocumentNavigation ? (
+                  // Use hard navigation across the marketing/docs boundary because client-side transitions can leak docs CSS.
+                  // eslint-disable-next-line @next/next/no-html-link-for-pages
+                  <a href={item.href}>{item.label}</a>
+                ) : (
+                  <Link href={item.href}>{item.label}</Link>
+                )}
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+
+      <nav aria-label="Primary navigation" className="hidden md:flex md:flex-1">
+        <ul className="flex flex-wrap justify-end gap-x-5 gap-y-2 text-sm font-medium text-neutral-dark/75">
+          {items.map((item) => (
+            <li key={item.href} className="shrink-0">
+              {item.isDocumentNavigation ? (
+                // Use hard navigation across the marketing/docs boundary because client-side transitions can leak docs CSS.
+                // eslint-disable-next-line @next/next/no-html-link-for-pages
+                <a
+                  href={item.href}
+                  className="transition-colors hover:text-neutral-dark"
+                >
+                  {item.label}
+                </a>
+              ) : (
+                <Link
+                  href={item.href}
+                  className="transition-colors hover:text-neutral-dark"
+                >
+                  {item.label}
+                </Link>
+              )}
+            </li>
+          ))}
+        </ul>
+      </nav>
+    </>
+  );
+};

--- a/apps/website/app/(home)/HomeNavigationMenu.tsx
+++ b/apps/website/app/(home)/HomeNavigationMenu.tsx
@@ -25,7 +25,7 @@ export const HomeNavigationMenu = ({
 }: HomeNavigationMenuProps): React.ReactElement => {
   return (
     <>
-      <div className="md:hidden">
+      <div className="lg:hidden">
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button
@@ -58,7 +58,7 @@ export const HomeNavigationMenu = ({
         </DropdownMenu>
       </div>
 
-      <nav aria-label="Primary navigation" className="hidden md:flex md:flex-1">
+      <nav aria-label="Primary navigation" className="hidden lg:flex">
         <ul className="flex flex-wrap justify-end gap-x-5 gap-y-2 text-sm font-medium text-neutral-dark/75">
           {items.map((item) => (
             <li key={item.href} className="shrink-0">

--- a/apps/website/app/(home)/HomeNavigationMenu.tsx
+++ b/apps/website/app/(home)/HomeNavigationMenu.tsx
@@ -23,6 +23,8 @@ type HomeNavigationMenuProps = {
 export const HomeNavigationMenu = ({
   items,
 }: HomeNavigationMenuProps): React.ReactElement => {
+  const desktopItems = items.filter((item) => !item.isDocumentNavigation);
+
   return (
     <>
       <div className="lg:hidden">
@@ -60,7 +62,7 @@ export const HomeNavigationMenu = ({
 
       <nav aria-label="Primary navigation" className="hidden lg:flex">
         <ul className="flex flex-wrap justify-end gap-x-5 gap-y-2 text-sm font-medium text-neutral-dark/75">
-          {items.map((item) => (
+          {desktopItems.map((item) => (
             <li key={item.href} className="shrink-0">
               {item.isDocumentNavigation ? (
                 // Use hard navigation across the marketing/docs boundary because client-side transitions can leak docs CSS.

--- a/apps/website/app/(home)/layout.tsx
+++ b/apps/website/app/(home)/layout.tsx
@@ -1,10 +1,10 @@
 import type { Metadata } from "next";
 import type { ReactElement, ReactNode } from "react";
 import { Inter } from "next/font/google";
-import Link from "next/link";
 import { getAllBlogs } from "~/(home)/blog/readBlogs";
 import { Logo } from "~/components/Logo";
 import { PostHogProvider } from "../providers";
+import { HomeNavigationMenu } from "./HomeNavigationMenu";
 import "~/globals.css";
 
 export const metadata: Metadata = {
@@ -48,6 +48,8 @@ const HomeLayout = async ({
     ...(hasUpdates ? [{ href: "/#updates", label: "Updates" }] : []),
     { href: "/#talks", label: "Talks" },
     { href: "/#team", label: "Team" },
+    { href: "/docs", isDocumentNavigation: true, label: "Docs" },
+    { href: "/#contact", label: "Contact" },
   ];
 
   return (
@@ -56,51 +58,12 @@ const HomeLayout = async ({
         className={`marketing-site flex min-h-screen flex-col bg-neutral-light text-neutral-dark antialiased ${inter.className}`}
       >
         <header className="sticky top-0 z-50 border-b border-neutral-dark/10 bg-neutral-light/95 backdrop-blur">
-          <div className="mx-auto flex max-w-7xl flex-col gap-4 px-5 py-4 md:flex-row md:items-center md:justify-between md:px-6">
+          <div className="mx-auto flex max-w-7xl items-center justify-between gap-2 px-4 py-4 min-[360px]:gap-4 min-[360px]:px-5 md:px-6">
             <div className="flex items-center justify-between gap-4">
               <Logo />
-              {/* Use hard navigation across the marketing/docs boundary because client-side transitions can leak docs CSS. */}
-              {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
-              <a
-                href="/docs"
-                className="rounded-md border border-neutral-dark/15 px-3 py-2 text-sm font-semibold text-neutral-dark transition-colors hover:border-secondary hover:text-secondary md:hidden"
-              >
-                Docs
-              </a>
             </div>
 
-            <nav aria-label="Primary navigation" className="md:flex md:flex-1">
-              <ul className="flex flex-wrap gap-x-4 gap-y-2 text-sm font-medium text-neutral-dark/75 md:justify-end md:gap-x-5">
-                {navigationItems.map((item) => (
-                  <li key={item.href} className="shrink-0">
-                    <Link
-                      href={item.href}
-                      className="transition-colors hover:text-neutral-dark"
-                    >
-                      {item.label}
-                    </Link>
-                  </li>
-                ))}
-                <li className="hidden shrink-0 md:block">
-                  {/* Use hard navigation across the marketing/docs boundary because client-side transitions can leak docs CSS. */}
-                  {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
-                  <a
-                    href="/docs"
-                    className="transition-colors hover:text-neutral-dark"
-                  >
-                    Docs
-                  </a>
-                </li>
-                <li className="shrink-0">
-                  <Link
-                    href="/#contact"
-                    className="transition-colors hover:text-neutral-dark"
-                  >
-                    Contact
-                  </Link>
-                </li>
-              </ul>
-            </nav>
+            <HomeNavigationMenu items={navigationItems} />
 
             <div className="hidden md:block">
               {/* Use hard navigation across the marketing/docs boundary because client-side transitions can leak docs CSS. */}

--- a/apps/website/app/(home)/layout.tsx
+++ b/apps/website/app/(home)/layout.tsx
@@ -1,10 +1,11 @@
 import type { Metadata } from "next";
-import "~/globals.css";
-import { PostHogProvider } from "../providers";
-import Link from "next/link";
+import type { ReactElement, ReactNode } from "react";
 import { Inter } from "next/font/google";
+import Link from "next/link";
 import { getAllBlogs } from "~/(home)/blog/readBlogs";
 import { Logo } from "~/components/Logo";
+import { PostHogProvider } from "../providers";
+import "~/globals.css";
 
 export const metadata: Metadata = {
   title: "Discourse Graphs | A Tool for Collaborative Knowledge Synthesis",
@@ -33,40 +34,85 @@ export const metadata: Metadata = {
 
 const inter = Inter({ subsets: ["latin"] });
 
-const HomeLayout = async ({ children }: { children: React.ReactNode }) => {
+const HomeLayout = async ({
+  children,
+}: {
+  children: ReactNode;
+}): Promise<ReactElement> => {
   const hasUpdates = !!(await getAllBlogs()).length;
+  const navigationItems = [
+    { href: "/#about", label: "About" },
+    { href: "/#plugins", label: "Plugins" },
+    { href: "/#resources", label: "Resources" },
+    { href: "/#events", label: "Events" },
+    ...(hasUpdates ? [{ href: "/#updates", label: "Updates" }] : []),
+    { href: "/#talks", label: "Talks" },
+    { href: "/#team", label: "Team" },
+  ];
+
   return (
     <PostHogProvider>
       <div
-        className={`marketing-site flex min-h-screen flex-col bg-neutral-light antialiased ${inter.className}`}
+        className={`marketing-site flex min-h-screen flex-col bg-neutral-light text-neutral-dark antialiased ${inter.className}`}
       >
-        <header className="flex flex-col items-center justify-between space-y-4 px-6 py-4 md:flex-row md:space-y-0">
-          <Logo />
-          <nav className="w-full md:w-auto">
-            <ul className="flex flex-wrap justify-center space-x-4 md:flex-nowrap md:space-x-8">
-              {[
-                "About",
-                "Resources",
-                "Events",
-                hasUpdates && "Updates",
-                "Talks",
-                "Team",
-                "Supporters",
-                "Contact",
-              ]
-                .filter((item): item is string => Boolean(item))
-                .map((item) => (
-                  <li key={item}>
+        <header className="sticky top-0 z-50 border-b border-neutral-dark/10 bg-neutral-light/95 backdrop-blur">
+          <div className="mx-auto flex max-w-7xl flex-col gap-4 px-5 py-4 md:flex-row md:items-center md:justify-between md:px-6">
+            <div className="flex items-center justify-between gap-4">
+              <Logo />
+              {/* Use hard navigation across the marketing/docs boundary because client-side transitions can leak docs CSS. */}
+              {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
+              <a
+                href="/docs"
+                className="rounded-md border border-neutral-dark/15 px-3 py-2 text-sm font-semibold text-neutral-dark transition-colors hover:border-secondary hover:text-secondary md:hidden"
+              >
+                Docs
+              </a>
+            </div>
+
+            <nav aria-label="Primary navigation" className="md:flex md:flex-1">
+              <ul className="flex flex-wrap gap-x-4 gap-y-2 text-sm font-medium text-neutral-dark/75 md:justify-end md:gap-x-5">
+                {navigationItems.map((item) => (
+                  <li key={item.href} className="shrink-0">
                     <Link
-                      href={`/#${item.toLowerCase()}`} // Ensures absolute path with root `/`
-                      className="text-neutral-dark hover:text-neutral-dark/60"
+                      href={item.href}
+                      className="transition-colors hover:text-neutral-dark"
                     >
-                      {item}
+                      {item.label}
                     </Link>
                   </li>
                 ))}
-            </ul>
-          </nav>
+                <li className="hidden shrink-0 md:block">
+                  {/* Use hard navigation across the marketing/docs boundary because client-side transitions can leak docs CSS. */}
+                  {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
+                  <a
+                    href="/docs"
+                    className="transition-colors hover:text-neutral-dark"
+                  >
+                    Docs
+                  </a>
+                </li>
+                <li className="shrink-0">
+                  <Link
+                    href="/#contact"
+                    className="transition-colors hover:text-neutral-dark"
+                  >
+                    Contact
+                  </Link>
+                </li>
+              </ul>
+            </nav>
+
+            <div className="hidden md:block">
+              {/* Use hard navigation across the marketing/docs boundary because client-side transitions can leak docs CSS. */}
+              {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
+              <a
+                href="/docs"
+                className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-primary/90 hover:text-white"
+              >
+                Open docs
+              </a>
+            </div>
+          </div>
         </header>
         {children}
       </div>

--- a/apps/website/app/(home)/layout.tsx
+++ b/apps/website/app/(home)/layout.tsx
@@ -63,17 +63,19 @@ const HomeLayout = async ({
               <Logo />
             </div>
 
-            <HomeNavigationMenu items={navigationItems} />
+            <div className="flex items-center gap-3">
+              <HomeNavigationMenu items={navigationItems} />
 
-            <div className="hidden md:block">
-              {/* Use hard navigation across the marketing/docs boundary because client-side transitions can leak docs CSS. */}
-              {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
-              <a
-                href="/docs"
-                className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-primary/90 hover:text-white"
-              >
-                Open docs
-              </a>
+              <div className="hidden lg:block">
+                {/* Use hard navigation across the marketing/docs boundary because client-side transitions can leak docs CSS. */}
+                {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
+                <a
+                  href="/docs"
+                  className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-primary/90 hover:text-white"
+                >
+                  Open docs
+                </a>
+              </div>
             </div>
           </div>
         </header>

--- a/apps/website/app/(home)/layout.tsx
+++ b/apps/website/app/(home)/layout.tsx
@@ -63,7 +63,7 @@ const HomeLayout = async ({
               <Logo />
             </div>
 
-            <div className="flex items-center gap-3">
+            <div className="flex items-center gap-6">
               <HomeNavigationMenu items={navigationItems} />
 
               <div className="hidden lg:block">

--- a/apps/website/app/(home)/layout.tsx
+++ b/apps/website/app/(home)/layout.tsx
@@ -48,6 +48,7 @@ const HomeLayout = async ({
     ...(hasUpdates ? [{ href: "/#updates", label: "Updates" }] : []),
     { href: "/#talks", label: "Talks" },
     { href: "/#team", label: "Team" },
+    { href: "/#supporters", label: "Supporters" },
     { href: "/docs", isDocumentNavigation: true, label: "Docs" },
     { href: "/#contact", label: "Contact" },
   ];

--- a/apps/website/app/(home)/page.tsx
+++ b/apps/website/app/(home)/page.tsx
@@ -1,874 +1,930 @@
-import Link from "next/link";
+import type { ReactElement, ReactNode } from "react";
 import Image from "next/image";
+import Link from "next/link";
+import { Card, CardContent } from "@repo/ui/components/ui/card";
 import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-} from "@repo/ui/components/ui/card";
-import { ArrowBigDownDash, CircleGauge } from "lucide-react";
+  ArrowRight,
+  BookOpen,
+  CircleGauge,
+  ExternalLink,
+  GitBranch,
+  Mail,
+  MessageCircle,
+  Network,
+  Puzzle,
+  Sparkles,
+} from "lucide-react";
 import { getLatestBlogs } from "~/(home)/blog/readBlogs";
-import { TeamPerson } from "~/components/TeamPerson";
 import { Logo } from "~/components/Logo";
+import { PlatformBadge } from "~/components/PlatformBadge";
+import { TeamPerson } from "~/components/TeamPerson";
 import { TEAM_MEMBERS } from "~/data/constants";
 
-const Home = async () => {
+const SLACK_URL =
+  "https://join.slack.com/t/discoursegraphs/shared_invite/zt-37xklatti-cpEjgPQC0YyKYQWPNgAkEg";
+
+const FEATURE_CARDS = [
+  {
+    alt: "Structured scientific infrastructure diagram",
+    description:
+      "Map claims, evidence, questions, and projects as modular pieces that can be reused across people, tools, and contexts.",
+    image: "/section1.webp",
+    title: "Make research ideas composable",
+  },
+  {
+    alt: "Discourse graph coordination layer",
+    description:
+      "Turn high-signal findings into shareable graph objects that support attribution, reuse, and decentralized collaboration.",
+    image: "/section4.webp",
+    title: "Liberate findings from static files",
+  },
+  {
+    alt: "Shareable findings workflow",
+    description:
+      "Exchange work in a form that is easier to find, update, and build on than documents locked into one hierarchy.",
+    image: "/section3.webp",
+    title: "Synthesize and update continuously",
+  },
+  {
+    alt: "Knowledge synthesis workflow",
+    description:
+      "Separate observations from interpretations so researchers can compare, remix, and update shared knowledge without flattening disagreement.",
+    image: "/section2.webp",
+    title: "Communicate with better structure",
+  },
+];
+
+const LAB_BENEFITS = [
+  "Identify knowledge gaps and starter projects for new researchers",
+  "Onboard collaborators into active research faster",
+  "Support grassroots knowledge generation between researchers",
+  "Share modular research findings with clearer attribution",
+];
+
+const RESOURCE_LINKS = [
+  {
+    href: "https://research.protocol.ai/blog/2023/discourse-graphs-and-the-future-of-science/",
+    meta: "Matt Akamatsu and Evan Miyazono, in conversation with Tom Kalil",
+    title: "Discourse Graphs and the Future of Science",
+  },
+  {
+    href: "https://experiment.com/projects/sustainable-coordination-in-research-labs-via-graph-enabled-idea-boards/",
+    meta: "Project notes",
+    title: "Discourse Graphs for research lab coordination",
+  },
+  {
+    href: "https://arxiv.org/html/2407.20666v2",
+    meta: "Preprint",
+    title: "Discourse graph plugin design and use cases",
+  },
+  {
+    href: "https://oasislab.pubpub.org/pub/54t0y9mk/release/3",
+    meta: "Conceptual model and practical guide",
+    title: "Knowledge synthesis",
+  },
+  {
+    href: "https://commonplace.knowledgefutures.org/pub/m76tk163/release/1",
+    meta: "Joel Chan",
+    title: "Sustainable authorship models for scholarly communication",
+  },
+] as const;
+
+const EVENTS = [
+  {
+    href: "https://discoursegraphs.github.io/panel-qa-site/#panelists",
+    linkText: "View panel notes",
+    meta: "June 18, 2026 | Zoom",
+    title: "Frontiers in Research: Open Science Catalyze Panel",
+  },
+  {
+    href: "https://bsky.app/profile/atproto.science/post/3mh6kak5agk2z",
+    linkText: "View event post",
+    meta: "March 27, 2026 | ATScience Conference, Vancouver",
+    title: "Toward Modular Open Science",
+  },
+  {
+    href: "https://www.mcgill.ca/qls/channels/event/qls-seminar-series-matthew-akamatsu-371875",
+    linkText: "View seminar details",
+    meta: "March 24, 2026 | Montreal",
+    title: "Seminar: McGill University Quantitative Life Sciences program",
+  },
+  {
+    href: "https://luma.com/jijn0d5k",
+    linkText: "View talk page",
+    meta: "November 19, 2025 | Zoom",
+    title:
+      "Metagov x Future of Science Seminar: Interoperable LLM- and human-centered research with Discourse Graphs",
+  },
+  {
+    href: "https://iosp.io/schedule",
+    linkText: "View full schedule",
+    meta: "February 23-24, 2025 | Denver Museum of Nature and Science",
+    title: "IOSP '25 Winter Workshop: Discourse Graphs",
+  },
+] as const;
+
+type Talk =
+  | {
+      embedUrl: string;
+      kind: "embed";
+      speakers: string;
+      title: string;
+    }
+  | {
+      externalHref: string;
+      kind: "external";
+      speakers: string;
+      title: string;
+    };
+
+const TALKS: Talk[] = [
+  {
+    externalHref:
+      "https://atmosphereconf-vods.wisp.place/videos/keynote-towards-modular-open-science",
+    kind: "external",
+    speakers: "Rowan Cockett, Matt Akamatsu",
+    title: "Keynote: Towards Modular Open Science",
+  },
+  {
+    embedUrl: "https://www.youtube-nocookie.com/embed/JOn_dJ-g3vY",
+    kind: "embed",
+    speakers: "Matt Akamatsu",
+    title: "HCIL Brown Bag Speaker Series: Matt Akamatsu",
+  },
+  {
+    embedUrl: "https://www.youtube-nocookie.com/embed/Fm-lzNhVMKs",
+    kind: "embed",
+    speakers: "Matt Akamatsu, Topos Institute",
+    title: "Discourse Graphs: A New Model for Scientific Communication",
+  },
+  {
+    embedUrl: "https://www.youtube-nocookie.com/embed/2xGQepp-f-8",
+    kind: "embed",
+    speakers: "Matt Akamatsu, Desci Denver 2024",
+    title: "Open Sourcing Scientific Research with Lab Discourse Graphs",
+  },
+  {
+    embedUrl: "https://www.youtube-nocookie.com/embed/53kLyq7PceQ",
+    kind: "embed",
+    speakers: "Joel Chan, Protocol Labs Research Seminar",
+    title: "Accelerating Scientific Discovery with Discourse Graphs",
+  },
+  {
+    embedUrl: "https://www.youtube-nocookie.com/embed/P0KUt2yrUkw",
+    kind: "embed",
+    speakers: "Karola Kirsanow, NYC Protocol Labs Research Seminar",
+    title: "Research roadmapping with Discourse Graphs",
+  },
+];
+
+type Supporter = {
+  alt: string;
+  height: number;
+  href: string;
+  image: string;
+  label?: string;
+  width: number;
+};
+
+const SUPPORTERS: Supporter[] = [
+  {
+    alt: "Protocol Labs Research",
+    href: "https://research.protocol.ai/",
+    image: "/supporter-logos/PL_Research.svg",
+    width: 406,
+    height: 176,
+  },
+  {
+    alt: "Chan Zuckerberg Initiative",
+    href: "https://cziscience.medium.com/request-for-information-pathways-to-ai-enabled-research-55c52124def4",
+    image: "/supporter-logos/Chan_Zuckerberg_Initiative.svg",
+    width: 112,
+    height: 62,
+  },
+  {
+    alt: "Metagov",
+    href: "https://www.metagov.org/",
+    image: "/supporter-logos/Metagov.svg",
+    width: 42,
+    height: 42,
+    label: "Metagov",
+  },
+  {
+    alt: "Schmidt Futures",
+    href: "https://experiment.com/grants/metascience",
+    image: "/supporter-logos/Schmidt_Futures.svg",
+    width: 267,
+    height: 20,
+  },
+  {
+    alt: "The Navigation Fund",
+    href: "https://commons.datacite.org/doi.org/10.71707/cx83-dh41",
+    image: "/supporter-logos/The_Navigation_Fund.svg",
+    width: 546,
+    height: 262,
+  },
+];
+
+type SectionHeaderProps = {
+  description?: string;
+  eyebrow: string;
+  isWide?: boolean;
+  title: string;
+};
+
+const SectionHeader = ({
+  description,
+  eyebrow,
+  isWide = false,
+  title,
+}: SectionHeaderProps): ReactElement => (
+  <div className={isWide ? "max-w-none md:flex-1" : "max-w-3xl"}>
+    <p className="text-sm font-semibold uppercase tracking-[0.18em] text-secondary">
+      {eyebrow}
+    </p>
+    <h2 className="mt-3 text-3xl font-semibold tracking-tight text-primary sm:text-4xl">
+      {title}
+    </h2>
+    {description && (
+      <p className="mt-4 text-lg leading-8 text-neutral-dark/75">
+        {description}
+      </p>
+    )}
+  </div>
+);
+
+const ArrowLink = ({
+  children,
+  href,
+}: {
+  children: ReactNode;
+  href: string;
+}): ReactElement => (
+  <Link
+    href={href}
+    className="inline-flex items-center gap-2 text-sm font-semibold text-secondary transition-colors hover:text-secondary/70"
+  >
+    {children}
+    <ArrowRight className="h-4 w-4" aria-hidden="true" />
+  </Link>
+);
+
+const Home = async (): Promise<ReactElement> => {
   const blogs = await getLatestBlogs();
+
   return (
     <div>
-      {/* Hero */}
-      <section className="relative overflow-hidden bg-neutral-dark px-6 py-24 text-center">
+      <section className="relative isolate flex min-h-[72svh] items-center overflow-hidden bg-neutral-dark px-5 py-16 text-white sm:px-6 lg:py-20">
         <Image
           src="/MATSU_lab_journal_club_graph_view.png"
-          alt="Discourse Graph Network Visualization"
+          alt="Discourse Graph network visualization"
           fill
           priority
-          className="object-cover opacity-20"
-          quality={85}
+          className="object-cover opacity-25"
+          quality={90}
+          sizes="100vw"
         />
-        <div className="relative z-10">
-          <h2 className="mx-auto max-w-5xl text-2xl font-semibold text-white md:text-3xl lg:text-5xl">
-            A tool and ecosystem for collaborative knowledge synthesis
-          </h2>
+        <div className="absolute inset-0 bg-neutral-dark/70" />
+        <div className="relative z-10 mx-auto grid w-full max-w-7xl gap-12 lg:grid-cols-[1.05fr_0.95fr] lg:items-end">
+          <div className="max-w-3xl">
+            <p className="inline-flex rounded-md border border-white/20 bg-white/10 px-3 py-1 text-sm font-semibold text-white/85">
+              Open infrastructure for collaborative knowledge synthesis
+            </p>
+            <h1 className="mt-6 text-5xl font-semibold tracking-tight text-white sm:text-6xl lg:text-7xl">
+              Discourse Graphs
+            </h1>
+            <p className="text-white/82 mt-6 max-w-2xl text-xl leading-8">
+              A tool and ecosystem for turning research claims, evidence, and
+              questions into modular graphs that teams can share, update, and
+              build on.
+            </p>
+            <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+              {/* Use hard navigation across the marketing/docs boundary because client-side transitions can leak docs CSS. */}
+              {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
+              <a
+                href="/docs"
+                className="inline-flex items-center justify-center gap-2 rounded-md bg-primary px-5 py-3 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-primary/90 hover:text-white"
+              >
+                Open docs
+                <BookOpen className="h-4 w-4" aria-hidden="true" />
+              </a>
+              <Link
+                href="/#plugins"
+                className="inline-flex items-center justify-center gap-2 rounded-md border border-white/35 px-5 py-3 text-sm font-semibold text-white transition-colors hover:border-white hover:bg-white/10 hover:text-white"
+              >
+                Explore plugins
+                <Puzzle className="h-4 w-4" aria-hidden="true" />
+              </Link>
+              <Link
+                href={SLACK_URL}
+                className="inline-flex items-center justify-center gap-2 rounded-md border border-white/20 px-5 py-3 text-sm font-semibold text-white/90 transition-colors hover:border-secondary hover:text-white"
+              >
+                Join Slack
+                <MessageCircle className="h-4 w-4" aria-hidden="true" />
+              </Link>
+            </div>
+          </div>
+
+          <div className="grid gap-3 sm:grid-cols-3 lg:grid-cols-1 xl:grid-cols-3">
+            {[
+              ["Protocol", "Client-agnostic model for structured research"],
+              ["Plugins", "Roam Research and Obsidian workflows"],
+              ["Community", "Researchers building shared graph practices"],
+            ].map(([title, description]) => (
+              <div
+                key={title}
+                className="rounded-lg border border-white/15 bg-white/10 p-4 backdrop-blur"
+              >
+                <p className="text-sm font-semibold text-primary">{title}</p>
+                <p className="text-white/78 mt-2 text-sm leading-6">
+                  {description}
+                </p>
+              </div>
+            ))}
+          </div>
         </div>
       </section>
 
-      <main>
-        <div className="mx-auto max-w-6xl space-y-12 px-6 py-12">
-          {/* About */}
-          <div className="space-y-12" id="about">
-            {/* Information Model */}
-            <section className="grid items-center gap-12 md:grid-cols-2">
-              <div>
-                <h3 className="mb-4 text-2xl font-bold text-primary">
-                  Information Model
-                </h3>
-                <p className="mb-4 text-neutral-dark">
-                  Discourse Graphs are an information model that enables
-                  everyone to map their ideas and arguments in a modular,
-                  composable graph format.
-                </p>
-              </div>
-              <div>
-                <Image
-                  src="/section1.webp"
-                  alt="Scientific infrastructure"
-                  width={1555}
-                  height={684}
-                  className="rounded-lg"
-                />
-              </div>
-            </section>
-            <section className="grid items-center gap-12 md:grid-cols-2">
-              <div className="order-1 md:order-2">
-                <h3 className="mb-4 text-2xl font-bold text-primary">
-                  Better Infra for Communication
-                </h3>
-                <p className="mb-4 text-neutral-dark">
-                  Discourse Graphs allow researchers to{" "}
-                  <span className="font-semibold">
-                    break the scientific research process into its atomic
-                    elements
-                  </span>{" "}
-                  in a way that can be shared, remixed, and updated.
-                </p>
-                <p className="mb-4 text-neutral-dark">
-                  Distinguishing evidence (the empirical observation) from claim
-                  (the proposed answer) leaves space for multiple
-                  interpretations.
-                </p>
-              </div>
-              <div className="order-2 md:order-1">
-                <Image
-                  src="/section2.webp"
-                  alt="Synthesize and Update"
-                  width={1682}
-                  height={1020}
-                  className="rounded-lg"
-                />
-              </div>
-            </section>
-            {/* Synthesize and Update */}
-            <section className="grid items-center gap-12 md:grid-cols-2">
-              <div>
-                <h3 className="mb-4 text-2xl font-bold text-primary">
-                  Synthesize and Update
-                </h3>
-                <p className="mb-4 text-neutral-dark">
-                  Discourse Graphs enable researchers to exchange knowledge in a
-                  form that makes it straightforward to construct, update, and
-                  find.
-                </p>
-                <p className="mb-4 text-neutral-dark">
-                  Like Lego™️ bricks, the modular components of the Discourse
-                  Graphs data model make it easy to choose which parts of a
-                  scientific project you wish to share and build upon.
-                </p>
-              </div>
-              <div>
-                <Image
-                  src="/section3.webp"
-                  alt="Liberate your findings"
-                  width={600}
-                  height={800}
-                  className="rounded-lg"
-                  loading="lazy"
-                />
-              </div>
-            </section>
-            {/* Liberate your Findings */}
-            <section className="grid items-center gap-12 md:grid-cols-2">
-              <div className="order-1 md:order-2">
-                <h3 className="mb-4 text-2xl font-bold text-primary">
-                  Liberate your Findings
-                </h3>
-                <p className="mb-4 text-neutral-dark">
-                  Rather than being organized hierarchically, Discourse Graphs
-                  adopt a{" "}
-                  <span className="font-semibold">grassroots organization</span>
-                  , which better matches the
-                  <span className="font-semibold">
-                    {" "}
-                    iterative and nonlinear process
-                  </span>{" "}
-                  of knowledge generation.
-                </p>
-                <p className="mb-4 text-neutral-dark">
-                  The schema adds enough structure for you to revisit{" "}
-                  <span className="font-semibold">
-                    &ldquo;high signal&rdquo; findings
-                  </span>{" "}
-                  as{" "}
-                  <span className="font-semibold">
-                    &ldquo;the minimal shareable insight&rdquo;
-                  </span>{" "}
-                  for others to build on.
-                </p>
-                <p className="mb-4 text-neutral-dark">
-                  As such, Discourse Graphs provide a{" "}
-                  <span className="font-semibold">
-                    needed coordination layer
-                  </span>{" "}
-                  for decentralized science.
-                </p>
-              </div>
-              <div className="order-2 md:order-1">
-                <Image
-                  src="/section4.webp"
-                  alt="Client-Agnostic & Researcher-aligned"
-                  width={2056}
-                  height={874}
-                  className="rounded-lg"
-                />
-              </div>
-            </section>
-          </div>
-          {/* Client-Agnostic & Researcher-Aligned */}
-          <section className="grid items-center gap-12 md:grid-cols-2">
-            <div>
-              <h3 className="mb-4 text-2xl font-bold text-primary">
-                Client-Agnostic & Researcher-Aligned
-              </h3>
-              <p className="mb-4 text-neutral-dark">
-                Discourse Graphs are a decentralized knowledge exchange protocol
-                designed to be implemented and owned by researchers — rather
-                than publishers — to share results at all stages of the
-                scientific process.
-              </p>
-              <p className="mb-4 text-neutral-dark">
-                Discourse Graphs are client-agnostic with decentralized
-                push-pull storage & and can be implemented in any networked
-                notebook software (
-                <Link href="https://roamresearch.com/">Roam</Link>,{" "}
-                <Link href="https://notion.so">Notion</Link>,{" "}
-                <Link href="https://obsidian.md">Obsidian</Link>, etc.),
-                allowing researchers to collaborate widely while using the tool
-                of their choice.
-              </p>
-              <p className="mb-4 text-neutral-dark">
-                Discourse Graphs support and incentivize knowledge sharing by
-                making it easy to push to and pull from a shared knowledge graph
-                — and to claim credit for many more types of contributions.
-              </p>
-              <p className="mb-4 font-bold text-secondary">
-                Discourse Graphs are like GitHub for scientific communication.
-              </p>
-            </div>
-            <Card className="rounded-lg bg-white/50 p-8">
-              <div className="flex flex-col items-center justify-center space-y-4">
-                <Image
-                  src="/section5a.webp"
-                  alt="Client-Agnostic & Researcher-Aligned"
-                  width={400}
-                  height={400}
-                  className="h-52 w-auto rounded-lg object-contain"
-                />
-                <Image
-                  src="/section5b.webp"
-                  alt="Client-Agnostic & Researcher-Aligned"
-                  width={400}
-                  height={400}
-                  className="h-52 w-auto rounded-lg object-contain"
-                />
-              </div>
-            </Card>
-          </section>
-        </div>
-        {/* The Natural OS for a Cloud Laboratory */}
-        <section className="relative isolate overflow-hidden bg-white px-6 py-24 sm:py-32 lg:overflow-visible lg:px-0">
-          <div className="absolute inset-0 -z-10 overflow-hidden">
-            <svg
-              aria-hidden="true"
-              className="absolute left-[max(50%,25rem)] top-0 h-[64rem] w-[128rem] -translate-x-1/2 stroke-gray-200 [mask-image:radial-gradient(64rem_64rem_at_top,white,transparent)]"
-            >
-              <defs>
-                <pattern
-                  x="50%"
-                  y={-1}
-                  id="e813992c-7d03-4cc4-a2bd-151760b470a0"
-                  width={200}
-                  height={200}
-                  patternUnits="userSpaceOnUse"
-                >
-                  <path d="M100 200V.5M.5 .5H200" fill="none" />
-                </pattern>
-              </defs>
-              <svg x="50%" y={-1} className="overflow-visible fill-gray-50">
-                <path
-                  d="M-100.5 0h201v201h-201Z M699.5 0h201v201h-201Z M499.5 400h201v201h-201Z M-300.5 600h201v201h-201Z"
-                  strokeWidth={0}
-                />
-              </svg>
-              <rect
-                fill="url(#e813992c-7d03-4cc4-a2bd-151760b470a0)"
-                width="100%"
-                height="100%"
-                strokeWidth={0}
+      <main className="flex-1">
+        <section
+          id="about"
+          className="scroll-mt-36 px-5 py-16 sm:px-6 md:scroll-mt-24 lg:py-24"
+        >
+          <div className="mx-auto max-w-7xl">
+            <div className="grid gap-10 lg:grid-cols-[0.8fr_1.2fr] lg:items-center">
+              <SectionHeader
+                eyebrow="About"
+                title="A shared structure for research work in motion"
+                description="Discourse Graphs help teams move beyond static documents by representing research as connected claims, evidence, questions, and projects."
               />
-            </svg>
-          </div>
-          <div className="mx-auto grid max-w-2xl grid-cols-1 gap-x-8 gap-y-16 lg:mx-0 lg:max-w-none lg:grid-cols-2 lg:items-start lg:gap-0">
-            <div className="lg:col-span-2 lg:col-start-1 lg:row-start-1 lg:mx-auto lg:grid lg:w-full lg:max-w-7xl lg:grid-cols-2 lg:gap-x-8 lg:px-8">
-              <div className="lg:pr-4">
-                <div className="lg:max-w-lg">
-                  <h2 className="mt-2 text-pretty text-4xl font-semibold tracking-tight text-primary sm:text-5xl">
-                    The Natural OS for a Cloud Laboratory
-                  </h2>
-                  <p className="mt-6 text-xl/8 text-gray-700">
-                    The flexible Discourse Graph framework has been adapted to
-                    coordinate and share active research, helping to lower the
-                    barrier for interdisciplinary collaboration.
+              <div className="grid gap-4 sm:grid-cols-2">
+                <Card className="h-full rounded-lg border-neutral-dark/10 bg-white shadow-sm">
+                  <CardContent className="flex h-full min-h-28 items-center gap-4 p-6">
+                    <Network
+                      className="h-6 w-6 shrink-0 text-primary"
+                      aria-hidden="true"
+                    />
+                    <p className="text-sm leading-6 text-neutral-dark/75">
+                      Compose work into a graph that can be queried, remixed,
+                      and carried across tools.
+                    </p>
+                  </CardContent>
+                </Card>
+                <Card className="h-full rounded-lg border-neutral-dark/10 bg-white shadow-sm">
+                  <CardContent className="flex h-full min-h-28 items-center gap-4 p-6">
+                    <Sparkles
+                      className="h-6 w-6 shrink-0 text-secondary"
+                      aria-hidden="true"
+                    />
+                    <p className="text-sm leading-6 text-neutral-dark/75">
+                      Keep findings live as teams interpret evidence and update
+                      their models.
+                    </p>
+                  </CardContent>
+                </Card>
+              </div>
+            </div>
+
+            <div className="mt-12 grid gap-5 md:grid-cols-2">
+              {FEATURE_CARDS.map((feature) => (
+                <Card
+                  key={feature.title}
+                  className="overflow-hidden rounded-lg border-neutral-dark/10 bg-white shadow-sm"
+                >
+                  <div className="relative aspect-[16/9] bg-neutral-light">
+                    <Image
+                      src={feature.image}
+                      alt={feature.alt}
+                      fill
+                      className="object-cover"
+                      sizes="(min-width: 768px) 50vw, 100vw"
+                    />
+                  </div>
+                  <CardContent className="p-6">
+                    <h3 className="text-xl font-semibold text-neutral-dark">
+                      {feature.title}
+                    </h3>
+                    <p className="mt-3 text-base leading-7 text-neutral-dark/75">
+                      {feature.description}
+                    </p>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+
+            <div className="mt-16 grid gap-8 border-t border-neutral-dark/10 py-12 lg:grid-cols-[0.9fr_1.1fr] lg:items-center">
+              <div>
+                <p className="text-sm font-semibold uppercase tracking-[0.18em] text-secondary">
+                  Tool choice
+                </p>
+                <h3 className="mt-3 text-3xl font-semibold tracking-tight text-primary">
+                  Client-agnostic and researcher-aligned
+                </h3>
+                <div className="mt-5 space-y-4 text-base leading-7 text-neutral-dark/75">
+                  <p>
+                    Discourse Graphs are a decentralized knowledge exchange
+                    protocol designed to be implemented and owned by researchers
+                    rather than publishers.
+                  </p>
+                  <p>
+                    The model can be implemented in networked notebook software
+                    like{" "}
+                    <Link href="https://roamresearch.com/">Roam Research</Link>,{" "}
+                    <Link href="https://obsidian.md">Obsidian</Link>, and other
+                    tools researchers already use.
+                  </p>
+                  <p className="font-semibold text-secondary">
+                    Discourse Graphs are like GitHub for scientific
+                    communication.
                   </p>
                 </div>
               </div>
-            </div>
-            <div className="m-0 p-0 md:-ml-12 md:-mt-12 md:p-12 lg:sticky lg:top-4 lg:col-start-2 lg:row-span-2 lg:row-start-1 lg:overflow-hidden">
-              <Image
-                src="/section6.webp"
-                alt="Cloud Laboratory Workflow"
-                width={1882}
-                height={1918}
-                className="w-full max-w-none rounded-xl bg-gray-900 shadow-xl ring-1 ring-gray-400/10 lg:w-[57rem]"
-              />
-              <p className="w-[48rem] max-w-none text-neutral-dark sm:w-[57rem]">
-                Snapshot of <Link href="https://matsulab.com/">MATSU lab</Link>{" "}
-                Discourse Graph
-              </p>
-            </div>
-            <div className="lg:col-span-2 lg:col-start-1 lg:row-start-2 lg:mx-auto lg:grid lg:w-full lg:max-w-7xl lg:grid-cols-2 lg:gap-x-8 lg:px-8">
-              <div className="lg:pr-4">
-                <div className="max-w-xl text-base/7 text-gray-700 lg:max-w-lg">
-                  <p className="text-xl">
-                    Lab Discourse Graphs can be used to support
-                  </p>
-                  <ul role="list" className="mt-8 space-y-6 text-gray-600">
-                    <li className="flex gap-x-3">
-                      <span>
-                        <strong className="font-semibold text-gray-900">
-                          identifying gaps
-                        </strong>{" "}
-                        in knowledge and tractable &ldquo;starter
-                        projects&rdquo; for new researchers
-                      </span>
-                    </li>
-                    <li className="flex gap-x-3">
-                      <span>
-                        <strong className="font-semibold text-gray-900">
-                          faster onboarding
-                        </strong>{" "}
-                        to existing research projects
-                      </span>
-                    </li>
-                    <li className="flex gap-x-3">
-                      <span>
-                        <strong className="font-semibold text-gray-900">
-                          grassroots generation
-                        </strong>{" "}
-                        of knowledge between researchers
-                      </span>
-                    </li>
-                    <li className="flex gap-x-3">
-                      <span>
-                        <strong className="font-semibold text-gray-900">
-                          modular communication
-                        </strong>{" "}
-                        and attribution of research findings
-                      </span>
-                    </li>
-                  </ul>
-                  <div className="mt-16 flex flex-col gap-4 lg:items-center">
-                    <p className="flex items-center gap-4 text-xl text-neutral-dark sm:gap-2">
-                      <ArrowBigDownDash className="min-w-6 border-2 border-primary text-primary" />
-                      <span>
-                        which leads to{" "}
-                        <span className="font-bold text-secondary">
-                          lower-friction collaboration
-                        </span>
-                      </span>
-                    </p>
-                    <p className="flex items-center gap-4 text-xl text-neutral-dark sm:gap-2">
-                      <CircleGauge className="min-w-6 border-2 border-primary text-primary" />
-                      <span>
-                        and a{" "}
-                        <span className="font-bold text-secondary">
-                          faster discovery & innovation cycle
-                        </span>
-                      </span>
-                    </p>
-                  </div>
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="relative aspect-square overflow-hidden rounded-lg border border-neutral-dark/10 bg-white p-4">
+                  <Image
+                    src="/section5a.webp"
+                    alt="Client-agnostic discourse graph workflow"
+                    fill
+                    className="object-contain p-6"
+                    sizes="(min-width: 640px) 50vw, 100vw"
+                  />
+                </div>
+                <div className="relative aspect-square overflow-hidden rounded-lg border border-neutral-dark/10 bg-white p-4">
+                  <Image
+                    src="/section5b.webp"
+                    alt="Researcher-aligned discourse graph workflow"
+                    fill
+                    className="object-contain p-6"
+                    sizes="(min-width: 640px) 50vw, 100vw"
+                  />
                 </div>
               </div>
             </div>
           </div>
         </section>
-        <div className="mx-auto max-w-6xl space-y-12 px-6 py-12">
-          {/* Resources */}
-          <Card id="resources" className="rounded-xl bg-white/50 p-8 shadow-md">
-            <CardHeader>
-              <CardTitle className="text-4xl font-bold text-primary">
-                Resources
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <ul className="list-inside list-disc space-y-2">
-                <li className="text-neutral-dark">
-                  <Link href="https://research.protocol.ai/blog/2023/discourse-graphs-and-the-future-of-science/">
-                    Discourse Graphs and the Future of Science
-                  </Link>{" "}
-                  by Matt Akamatsu and Evan Miyazono, in conversation with Tom
-                  Kalil
-                </li>
-                <li className="text-neutral-dark">
-                  <Link href="https://experiment.com/projects/sustainable-coordination-in-research-labs-via-graph-enabled-idea-boards/">
-                    Project notes:
-                  </Link>{" "}
-                  Discourse Graphs for research lab coordination
-                </li>
-                <li className="text-neutral-dark">
-                  <Link href="https://arxiv.org/html/2407.20666v2">
-                    Preprint
-                  </Link>{" "}
-                  on discourse graph plugin design and use cases
-                </li>
-                <li className="text-neutral-dark">
-                  <Link href="https://oasislab.pubpub.org/pub/54t0y9mk/release/3">
-                    Knowledge synthesis: A conceptual model and practical guide
-                  </Link>
-                </li>
-                <li className="text-neutral-dark">
-                  Joel Chan on{" "}
-                  <Link href="https://commonplace.knowledgefutures.org/pub/m76tk163/release/1">
-                    Sustainable Authorship Models for a Discourse-Based
-                    Scholarly Communication Infrastructure
-                  </Link>
-                </li>
-              </ul>
 
-              {/* Plugins Subsection */}
-              <div className="mt-8">
-                <h3 className="mb-4 text-2xl font-bold text-primary">
-                  Plugins
-                </h3>
-                <ul className="space-y-4">
-                  <li className="text-neutral-dark">
-                    <span className="text-neutral-dark">
-                      <Link href="https://github.com/DiscourseGraphs/discourse-graph/tree/main/apps/roam">
-                        Roam Research Plugin
-                      </Link>
-                    </span>
-                    <span className="text-neutral-dark">
-                      {" "}
-                      – Available via Roam Depot
-                    </span>
-                    <ul className="ml-6 mt-2 list-inside list-disc space-y-2">
-                      <li className="text-neutral-dark">
-                        {/* Use a hard navigation into docs because client-side transitions can leak marketing CSS into the Nextra docs app. */}
-                        {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
-                        <a href="/docs/roam/">Documentation</a>
-                      </li>
-                    </ul>
-                  </li>
-                  <li className="text-neutral-dark">
-                    <span className="text-neutral-dark">
-                      <Link href="https://github.com/DiscourseGraphs/discourse-graph-obsidian">
-                        Obsidian Plugin
-                      </Link>
-                    </span>
-                    <span className="text-neutral-dark">
-                      {" "}
-                      – Available via BRAT
-                    </span>
-                    <ul className="ml-6 mt-2 list-inside list-disc space-y-2">
-                      <li className="text-neutral-dark">
-                        {/* Use a hard navigation into docs because client-side transitions can leak marketing CSS into the Nextra docs app. */}
-                        {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
-                        <a href="/docs/obsidian/">Documentation</a>
-                      </li>
-                    </ul>
-                  </li>
-                </ul>
-              </div>
-            </CardContent>
-          </Card>
-          {/* Events */}
-          <Card id="events" className="rounded-xl bg-white/50 p-8 shadow-md">
-            <CardHeader>
-              <CardTitle className="text-4xl font-bold text-primary">
-                Events
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="space-y-6">
-                <div>
-                  <h3 className="mb-2 text-xl font-semibold text-neutral-dark">
-                    Frontiers in Research: Open Science Catalyze Panel
-                  </h3>
-                  <p className="mb-2 text-neutral-dark">June 18, 2026 | Zoom</p>
-                  <Link
-                    href="https://discoursegraphs.github.io/panel-qa-site/#panelists"
-                    className="text-primary transition-colors hover:text-primary/80"
-                  >
-                    View panel notes →
-                  </Link>
-                </div>
-                <div>
-                  <h3 className="mb-2 text-xl font-semibold text-neutral-dark">
-                    Toward Modular Open Science
-                  </h3>
-                  <p className="mb-2 text-neutral-dark">
-                    March 27, 2026 | ATScience Conference, Vancouver
-                  </p>
-                  <Link
-                    href="https://bsky.app/profile/atproto.science/post/3mh6kak5agk2z"
-                    className="text-primary transition-colors hover:text-primary/80"
-                  >
-                    View event post →
-                  </Link>
-                </div>
-                <div>
-                  <h3 className="mb-2 text-xl font-semibold text-neutral-dark">
-                    Seminar: McGill University Quantitative Life Sciences
-                    program
-                  </h3>
-                  <p className="mb-2 text-neutral-dark">
-                    March 24, 2026 | Montreal
-                  </p>
-                  <Link
-                    href="https://www.mcgill.ca/qls/channels/event/qls-seminar-series-matthew-akamatsu-371875"
-                    className="text-primary transition-colors hover:text-primary/80"
-                  >
-                    View seminar details →
-                  </Link>
-                </div>
-                <div>
-                  <h3 className="mb-2 text-xl font-semibold text-neutral-dark">
-                    Metagov x Future of Science Seminar: Interoperable LLM - and
-                    Human-Centered Research with Discourse Graphs with Matt
-                    Akamatsu
-                  </h3>
-                  <p className="mb-2 text-neutral-dark">
-                    November 19, 2025 | Zoom
-                  </p>
-                  <Link
-                    href="https://luma.com/jijn0d5k"
-                    className="text-primary transition-colors hover:text-primary/80"
-                  >
-                    Register for the talk →
-                  </Link>
-                </div>
-                <div>
-                  <h3 className="mb-2 text-xl font-semibold text-neutral-dark">
-                    IOSP &apos;25 Winter Workshop: Discourse Graphs
-                  </h3>
-                  <p className="mb-2 text-neutral-dark">
-                    February 23-24, 2025 | Denver Museum of Nature and Science
-                  </p>
-                  <Link
-                    href="https://iosp.io/schedule"
-                    className="text-primary transition-colors hover:text-primary/80"
-                  >
-                    View full schedule →
-                  </Link>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-          {/* Blog Section */}
-          {blogs.length > 0 && (
-            <Card id="updates" className="rounded-xl bg-white/50 p-8 shadow-md">
-              <CardHeader>
-                <CardTitle className="text-4xl font-bold text-primary">
-                  Latest Updates
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="space-y-6">
-                  <ul className="space-y-6">
-                    {blogs.map((blog) => (
-                      <li
-                        key={blog.slug}
-                        className="flex items-start justify-between border-b border-gray-200 pb-4 last:border-b-0"
-                      >
-                        <div className="w-4/5">
-                          <Link
-                            href={`/blog/${blog.slug}`}
-                            className="block text-2xl font-semibold text-blue-600 hover:underline"
-                          >
-                            {blog.title}
-                          </Link>
-                          <p className="mt-2 text-sm italic text-gray-500">
-                            {blog.date}
-                          </p>
-                        </div>
-                        <div className="w-1/5 text-right text-gray-600">
-                          by {blog.author}
-                        </div>
-                      </li>
-                    ))}
-                  </ul>
+        <section
+          id="plugins"
+          className="scroll-mt-36 bg-white px-5 py-16 sm:px-6 md:scroll-mt-24 lg:py-24"
+        >
+          <div className="mx-auto max-w-7xl">
+            <SectionHeader
+              eyebrow="Plugins"
+              isWide
+              title="Start from the tool you already use"
+              description="The project maintains plugin workflows for Roam Research and Obsidian, with docs for installation, graph building, querying, and configuration."
+            />
 
-                  <div className="mt-6 text-center">
-                    <Link
-                      href="/blog"
-                      className="inline-block rounded-md bg-primary px-4 py-2 text-lg font-semibold text-white transition hover:text-white"
-                    >
-                      See All Updates →
-                    </Link>
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
-          )}
-          {/* Talks */}
-          <Card id="talks" className="rounded-xl bg-white/50 p-8 shadow-md">
-            <CardHeader>
-              <CardTitle className="text-4xl font-bold text-primary">
-                Talks
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
-                <div className="space-y-4">
-                  <div className="flex aspect-video items-center justify-center rounded-lg bg-neutral-100 p-6 text-center">
-                    <div className="space-y-3">
-                      <p className="text-sm text-neutral-dark">
-                        Hosted on Atmosphere Conf VODs
+            <div className="mt-10 grid gap-5 md:grid-cols-2">
+              {[
+                {
+                  docsHref: "/docs/roam/",
+                  githubHref:
+                    "https://github.com/DiscourseGraphs/discourse-graph/tree/main/apps/roam",
+                  meta: "Available via Roam Depot",
+                  platform: "roam" as const,
+                  title: "Roam Research plugin",
+                },
+                {
+                  docsHref: "/docs/obsidian/",
+                  githubHref:
+                    "https://github.com/DiscourseGraphs/discourse-graph-obsidian",
+                  meta: "Available via BRAT",
+                  platform: "obsidian" as const,
+                  title: "Obsidian plugin",
+                },
+              ].map((plugin) => (
+                <Card
+                  key={plugin.title}
+                  className="rounded-lg border-neutral-dark/10 bg-neutral-light shadow-sm"
+                >
+                  <CardContent className="flex h-full flex-col gap-8 p-6 sm:p-8">
+                    <div className="flex items-start justify-between gap-4">
+                      <PlatformBadge platform={plugin.platform} />
+                      <Puzzle
+                        className="h-6 w-6 text-neutral-dark/35"
+                        aria-hidden="true"
+                      />
+                    </div>
+                    <div>
+                      <h3 className="text-2xl font-semibold text-primary">
+                        {plugin.title}
+                      </h3>
+                      <p className="mt-3 text-base leading-7 text-neutral-dark/75">
+                        {plugin.meta}. Use the docs to set up the plugin and
+                        learn the core discourse graph workflows.
                       </p>
-                      <Link
-                        href="https://atmosphereconf-vods.wisp.place/videos/keynote-towards-modular-open-science"
-                        className="inline-block rounded-md bg-primary px-4 py-2 text-sm font-semibold text-white transition hover:text-white"
+                    </div>
+                    <div className="mt-auto flex flex-wrap gap-3">
+                      {/* Use hard navigation across the marketing/docs boundary because client-side transitions can leak docs CSS. */}
+                      {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
+                      <a
+                        href={plugin.docsHref}
+                        className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-primary/90 hover:text-white"
                       >
-                        Watch talk →
+                        Read docs
+                        <BookOpen className="h-4 w-4" aria-hidden="true" />
+                      </a>
+                      <Link
+                        href={plugin.githubHref}
+                        className="inline-flex items-center gap-2 rounded-md border border-neutral-dark/15 px-4 py-2 text-sm font-semibold text-neutral-dark transition-colors hover:border-secondary hover:text-secondary"
+                      >
+                        View source
+                        <ExternalLink className="h-4 w-4" aria-hidden="true" />
                       </Link>
                     </div>
-                  </div>
-                  <h3 className="text-xl font-semibold text-neutral-dark">
-                    Keynote: Towards Modular Open Science
-                  </h3>
-                  <p className="text-neutral-dark">
-                    Rowan Cockett, Matt Akamatsu
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="overflow-hidden px-5 py-16 sm:px-6 lg:py-24">
+          <div className="mx-auto grid max-w-7xl gap-10 lg:grid-cols-[0.85fr_1.15fr] lg:items-center">
+            <div>
+              <SectionHeader
+                eyebrow="Cloud laboratory"
+                title="A natural operating layer for active research"
+                description="The flexible framework has been adapted to coordinate and share active research, lowering the barrier for interdisciplinary collaboration."
+              />
+              <ul className="mt-8 space-y-4">
+                {LAB_BENEFITS.map((benefit) => (
+                  <li key={benefit} className="flex gap-3">
+                    <GitBranch
+                      className="mt-1 h-5 w-5 shrink-0 text-primary"
+                      aria-hidden="true"
+                    />
+                    <span className="text-base leading-7 text-neutral-dark/75">
+                      {benefit}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+              <div className="mt-8 grid gap-3 sm:grid-cols-2">
+                <div className="flex min-h-24 items-center justify-center rounded-lg border border-primary/25 bg-white p-6">
+                  <p className="flex flex-col items-center justify-center gap-2 text-center text-sm font-semibold text-neutral-dark">
+                    <MessageCircle
+                      className="h-5 w-5 text-primary"
+                      aria-hidden="true"
+                    />
+                    Lower-friction collaboration
                   </p>
                 </div>
-
-                <div className="space-y-4">
-                  <div className="relative aspect-video">
-                    <iframe
-                      className="absolute inset-0 h-full w-full rounded-lg"
-                      src="https://www.youtube-nocookie.com/embed/JOn_dJ-g3vY"
-                      title="HCIL Brown Bag Speaker Series: Matt Akamatsu (February 2026)"
-                      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                      allowFullScreen
+                <div className="flex min-h-24 items-center justify-center rounded-lg border border-secondary/25 bg-white p-6">
+                  <p className="flex flex-col items-center justify-center gap-2 text-center text-sm font-semibold text-neutral-dark">
+                    <CircleGauge
+                      className="h-5 w-5 text-secondary"
+                      aria-hidden="true"
                     />
-                  </div>
-                  <h3 className="text-xl font-semibold text-neutral-dark">
-                    HCIL Brown Bag Speaker Series: Matt Akamatsu
-                  </h3>
-                  <p className="text-neutral-dark">Matt Akamatsu</p>
-                </div>
-
-                <div className="space-y-4">
-                  <div className="relative aspect-video">
-                    <iframe
-                      className="absolute inset-0 h-full w-full rounded-lg"
-                      src="https://www.youtube-nocookie.com/embed/Fm-lzNhVMKs"
-                      title="Discourse Graphs: A New Model for Scientific Communication"
-                      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                      allowFullScreen
-                    />
-                  </div>
-                  <h3 className="text-xl font-semibold text-neutral-dark">
-                    Discourse Graphs: A New Model for Scientific Communication
-                  </h3>
-                  <p className="text-neutral-dark">
-                    Matt Akamatsu, Topos Institute
-                  </p>
-                </div>
-
-                <div className="space-y-4">
-                  <div className="relative aspect-video">
-                    <iframe
-                      className="absolute inset-0 h-full w-full rounded-lg"
-                      src="https://www.youtube-nocookie.com/embed/2xGQepp-f-8"
-                      title="Open Sourcing Scientific Research with Lab Discourse Graphs"
-                      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                      allowFullScreen
-                    />
-                  </div>
-                  <h3 className="text-xl font-semibold text-neutral-dark">
-                    Open Sourcing Scientific Research with Lab Discourse Graphs
-                  </h3>
-                  <p className="text-neutral-dark">
-                    Matt Akamatsu, Desci Denver 2024
-                  </p>
-                </div>
-
-                <div className="space-y-4">
-                  <div className="relative aspect-video">
-                    <iframe
-                      className="absolute inset-0 h-full w-full rounded-lg"
-                      src="https://www.youtube-nocookie.com/embed/53kLyq7PceQ"
-                      title="Accelerating Scientific Discovery with Discourse Graphs"
-                      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                      allowFullScreen
-                    />
-                  </div>
-                  <h3 className="text-xl font-semibold text-neutral-dark">
-                    Accelerating Scientific Discovery with Discourse Graphs
-                  </h3>
-                  <p className="text-neutral-dark">
-                    Joel Chan, Protocol Labs Research Seminar
-                  </p>
-                </div>
-
-                <div className="space-y-4">
-                  <div className="relative aspect-video">
-                    <iframe
-                      className="absolute inset-0 h-full w-full rounded-lg"
-                      src="https://www.youtube-nocookie.com/embed/P0KUt2yrUkw"
-                      title="Research roadmapping with Discourse Graphs"
-                      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                      allowFullScreen
-                    />
-                  </div>
-                  <h3 className="text-xl font-semibold text-neutral-dark">
-                    Research roadmapping with Discourse Graphs
-                  </h3>
-                  <p className="text-neutral-dark">
-                    Karola Kirsanow, NYC Protocol Labs Research Seminar
+                    Faster discovery cycles
                   </p>
                 </div>
               </div>
-            </CardContent>
-          </Card>
-          {/* Team */}
-          <Card id="team" className="rounded-xl bg-white/50 p-8 shadow-md">
-            <CardHeader>
-              <CardTitle className="text-4xl font-bold text-primary">
-                Team
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
-                {TEAM_MEMBERS.map((member) => (
-                  <TeamPerson key={member.name} member={member} />
+            </div>
+
+            <figure>
+              <div className="relative aspect-[4/3] overflow-hidden rounded-lg border border-neutral-dark/10 bg-white shadow-sm">
+                <Image
+                  src="/section6.webp"
+                  alt="MATSU lab Discourse Graph snapshot"
+                  fill
+                  className="object-cover"
+                  sizes="(min-width: 1024px) 58vw, 100vw"
+                />
+              </div>
+              <figcaption className="mt-3 text-sm text-neutral-dark/65">
+                Snapshot of <Link href="https://matsulab.com/">MATSU lab</Link>{" "}
+                Discourse Graph
+              </figcaption>
+            </figure>
+          </div>
+        </section>
+
+        <section
+          id="resources"
+          className="scroll-mt-36 bg-white px-5 py-16 sm:px-6 md:scroll-mt-24 lg:py-24"
+        >
+          <div className="mx-auto max-w-7xl">
+            <div className="flex flex-col justify-between gap-6 md:flex-row md:items-end">
+              <SectionHeader
+                eyebrow="Resources"
+                isWide
+                title="Read the ideas behind the project"
+                description="A short set of writing and project notes for understanding discourse graphs as research infrastructure."
+              />
+              <ArrowLink href="/#plugins">Explore plugins</ArrowLink>
+            </div>
+            <div className="mt-10 grid gap-4 lg:grid-cols-2">
+              {RESOURCE_LINKS.map((resource) => (
+                <Link
+                  key={resource.href}
+                  href={resource.href}
+                  className="group rounded-lg border border-neutral-dark/10 bg-neutral-light p-5 transition-colors hover:border-secondary"
+                >
+                  <p className="text-sm font-semibold text-secondary">
+                    {resource.meta}
+                  </p>
+                  <h3 className="mt-2 text-xl font-semibold text-neutral-dark">
+                    {resource.title}
+                  </h3>
+                  <p className="mt-4 inline-flex items-center gap-2 text-sm font-semibold text-primary">
+                    Open resource
+                    <ArrowRight
+                      className="h-4 w-4 transition-transform group-hover:translate-x-1"
+                      aria-hidden="true"
+                    />
+                  </p>
+                </Link>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section
+          id="events"
+          className="scroll-mt-36 px-5 py-16 sm:px-6 md:scroll-mt-24 lg:py-24"
+        >
+          <div className="mx-auto max-w-7xl">
+            <SectionHeader
+              eyebrow="Events"
+              isWide
+              title="Recent talks, panels, and workshops"
+              description="Places where the team and collaborators have presented the Discourse Graphs model and project."
+            />
+            <div className="mt-10 divide-y divide-neutral-dark/10 border-y border-neutral-dark/10">
+              {EVENTS.map((event) => (
+                <article
+                  key={event.href}
+                  className="grid gap-4 py-6 md:grid-cols-[1fr_auto] md:items-center"
+                >
+                  <div>
+                    <h3 className="text-xl font-semibold text-neutral-dark">
+                      {event.title}
+                    </h3>
+                    <p className="mt-2 text-sm text-neutral-dark/65">
+                      {event.meta}
+                    </p>
+                  </div>
+                  <Link
+                    href={event.href}
+                    className="inline-flex items-center gap-2 text-sm font-semibold text-secondary transition-colors hover:text-secondary/70"
+                  >
+                    {event.linkText}
+                    <ExternalLink className="h-4 w-4" aria-hidden="true" />
+                  </Link>
+                </article>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {blogs.length > 0 && (
+          <section
+            id="updates"
+            className="scroll-mt-36 bg-white px-5 py-16 sm:px-6 md:scroll-mt-24 lg:py-24"
+          >
+            <div className="mx-auto max-w-7xl">
+              <div className="flex flex-col justify-between gap-6 md:flex-row md:items-end">
+                <SectionHeader
+                  eyebrow="Updates"
+                  isWide
+                  title="Latest project updates"
+                  description="Recent posts from the Discourse Graphs team."
+                />
+                <ArrowLink href="/blog">See all updates</ArrowLink>
+              </div>
+              <div className="mt-10 grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+                {blogs.map((blog) => (
+                  <Card
+                    key={blog.slug}
+                    className="rounded-lg border-neutral-dark/10 bg-neutral-light shadow-sm"
+                  >
+                    <CardContent className="flex h-full flex-col p-6">
+                      <p className="text-sm text-neutral-dark/60">
+                        {blog.date}
+                      </p>
+                      <Link
+                        href={`/blog/${blog.slug}`}
+                        className="mt-4 text-xl font-semibold text-neutral-dark transition-colors hover:text-secondary"
+                      >
+                        {blog.title}
+                      </Link>
+                      <p className="mt-6 text-sm text-neutral-dark/60">
+                        By {blog.author}
+                      </p>
+                    </CardContent>
+                  </Card>
                 ))}
               </div>
-            </CardContent>
-          </Card>
+            </div>
+          </section>
+        )}
 
-          {/* Supporters */}
-          <Card
-            id="supporters"
-            className="rounded-xl bg-white/50 p-8 shadow-md"
-          >
-            <CardHeader>
-              <CardTitle className="text-4xl font-bold text-primary">
-                Supporters
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="mx-auto grid max-w-[800px] grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
-                <Link
-                  href="https://research.protocol.ai/"
-                  className="mx-auto flex h-[88px] w-[200px] items-center justify-center transition-opacity hover:opacity-80"
-                >
-                  <Image
-                    src="/supporter-logos/PL_Research.svg"
-                    alt="Protocol Labs Research"
-                    width={406}
-                    height={176}
-                    className="h-full w-full object-contain"
-                  />
-                </Link>
-                <Link
-                  href="https://cziscience.medium.com/request-for-information-pathways-to-ai-enabled-research-55c52124def4"
-                  className="mx-auto flex h-[88px] w-[160px] items-center justify-center transition-opacity hover:opacity-80"
-                >
-                  <Image
-                    src="/supporter-logos/Chan_Zuckerberg_Initiative.svg"
-                    alt="Chan Zuckerberg Initiative"
-                    width={112}
-                    height={62}
-                    className="h-full w-full object-contain"
-                  />
-                </Link>
-                <Link
-                  href="https://www.metagov.org/"
-                  className="mx-auto flex h-[88px] w-[160px] items-center justify-center gap-4 transition-opacity hover:text-[rgb(0,204,153)] hover:opacity-80"
-                >
-                  <div className="h-[42px] w-[42px] flex-shrink-0">
-                    <Image
-                      src="/supporter-logos/Metagov.svg"
-                      alt="Metagov"
-                      width={42}
-                      height={42}
-                      className="h-full w-full object-contain"
-                    />
+        <section
+          id="talks"
+          className="scroll-mt-36 px-5 py-16 sm:px-6 md:scroll-mt-24 lg:py-24"
+        >
+          <div className="mx-auto max-w-7xl">
+            <SectionHeader
+              eyebrow="Talks"
+              isWide
+              title="Watch the model explained"
+              description="Videos and recordings that introduce the motivation, use cases, and research workflows behind Discourse Graphs."
+            />
+            <div className="mt-10 grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+              {TALKS.map((talk) => (
+                <article key={talk.title} className="space-y-4">
+                  {talk.kind === "embed" ? (
+                    <div className="relative aspect-video overflow-hidden rounded-lg border border-neutral-dark/10 bg-white shadow-sm">
+                      <iframe
+                        className="absolute inset-0 h-full w-full"
+                        src={talk.embedUrl}
+                        title={talk.title}
+                        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                        allowFullScreen
+                      />
+                    </div>
+                  ) : (
+                    <Link
+                      href={talk.externalHref}
+                      className="flex aspect-video items-center justify-center rounded-lg border border-neutral-dark/10 bg-neutral-dark p-6 text-center text-white shadow-sm transition-colors hover:bg-neutral-dark/90 hover:text-white"
+                    >
+                      <span className="inline-flex items-center gap-2 text-sm font-semibold">
+                        Watch talk
+                        <ExternalLink className="h-4 w-4" aria-hidden="true" />
+                      </span>
+                    </Link>
+                  )}
+                  <div>
+                    <h3 className="text-xl font-semibold text-neutral-dark">
+                      {talk.title}
+                    </h3>
+                    <p className="mt-2 text-sm text-neutral-dark/65">
+                      {talk.speakers}
+                    </p>
                   </div>
-                  <span className="text-[rgb(0,204,153)]">Metagov</span>
-                </Link>
+                </article>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section
+          id="team"
+          className="scroll-mt-36 bg-white px-5 py-16 sm:px-6 md:scroll-mt-24 lg:py-24"
+        >
+          <div className="mx-auto max-w-7xl">
+            <SectionHeader
+              eyebrow="Team"
+              isWide
+              title="Built by researchers, designers, and engineers"
+              description="The project brings together research infrastructure, knowledge synthesis, and tool-building experience."
+            />
+            <div className="mt-10 grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
+              {TEAM_MEMBERS.map((member) => (
+                <div
+                  key={member.name}
+                  className="rounded-lg border border-neutral-dark/10 bg-neutral-light p-6"
+                >
+                  <TeamPerson member={member} />
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section
+          id="supporters"
+          className="scroll-mt-36 px-5 py-16 sm:px-6 md:scroll-mt-24 lg:py-24"
+        >
+          <div className="mx-auto max-w-7xl">
+            <SectionHeader
+              eyebrow="Supporters"
+              isWide
+              title="Supported by open science funders and partners"
+              description="Organizations helping make modular, reusable scientific communication possible."
+            />
+            <div className="mt-10 grid gap-4 sm:grid-cols-2 lg:grid-cols-5">
+              {SUPPORTERS.map((supporter) => (
                 <Link
-                  href="https://experiment.com/grants/metascience"
-                  className="mx-auto flex h-[88px] w-[200px] items-center justify-center transition-opacity hover:opacity-80"
+                  key={supporter.href}
+                  href={supporter.href}
+                  className="flex h-32 items-center justify-center gap-3 rounded-lg border border-neutral-dark/10 bg-white p-6 transition-colors hover:border-secondary"
                 >
                   <Image
-                    src="/supporter-logos/Schmidt_Futures.svg"
-                    alt="Schmidt Futures"
-                    width={267}
-                    height={20}
-                    className="h-full w-full object-contain"
+                    src={supporter.image}
+                    alt={supporter.alt}
+                    width={supporter.width}
+                    height={supporter.height}
+                    className="max-h-16 w-auto object-contain"
                   />
+                  {supporter.label && (
+                    <span className="text-[rgb(0,204,153)]">
+                      {supporter.label}
+                    </span>
+                  )}
                 </Link>
-                <Link
-                  href="https://commons.datacite.org/doi.org/10.71707/cx83-dh41"
-                  className="mx-auto flex h-[88px] w-[200px] items-center justify-center transition-opacity hover:opacity-80"
-                >
-                  <Image
-                    src="/supporter-logos/The_Navigation_Fund.svg"
-                    alt="The Navigation Fund"
-                    width={546}
-                    height={262}
-                    className="h-full w-full object-contain"
-                  />
-                </Link>
-              </div>
-            </CardContent>
-          </Card>
-          {/* Contact */}
-          <Card id="contact" className="rounded-xl bg-white/50 p-8 shadow-md">
-            <CardHeader>
-              <CardTitle className="text-4xl font-bold text-primary">
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section
+          id="contact"
+          className="scroll-mt-36 bg-neutral-dark px-5 py-16 text-white sm:px-6 md:scroll-mt-24 lg:py-24"
+        >
+          <div className="mx-auto grid max-w-7xl gap-10 lg:grid-cols-[0.9fr_1.1fr] lg:items-center">
+            <div>
+              <p className="text-sm font-semibold uppercase tracking-[0.18em] text-primary">
                 Contact
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="space-y-4">
-                <p className="text-neutral-dark">
-                  Are you interested in generating grassroots knowledge with
-                  Discourse Graphs?{" "}
-                  <span className="font-bold">Get Involved! 🚀</span>
+              </p>
+              <h2 className="mt-3 text-3xl font-semibold tracking-tight sm:text-4xl">
+                Help build better infrastructure for collaborative research
+              </h2>
+              <p className="mt-5 text-lg leading-8 text-white/75">
+                We are building user-friendly Discourse Graph plugins in tools
+                for thought and would like to hear from researchers, developers,
+                labs, and funders.
+              </p>
+            </div>
+            <div className="grid gap-4 sm:grid-cols-2">
+              <Link
+                href="mailto:discoursegraphs@homeworld.bio"
+                className="rounded-lg border border-white/15 bg-white/10 p-5 transition-colors hover:border-primary hover:text-white"
+              >
+                <Mail className="h-6 w-6 text-primary" aria-hidden="true" />
+                <h3 className="mt-4 font-semibold">Send us a line</h3>
+                <p className="mt-2 text-sm leading-6 text-white/70">
+                  Talk with us about development, pilots, and collaborations.
                 </p>
-                <p className="text-neutral-dark">
-                  We&apos;re building user-friendly Discourse Graph plugins in
-                  your favorite Tool for Thought and would love to hear from
-                  you.
+              </Link>
+              <Link
+                href={SLACK_URL}
+                className="rounded-lg border border-white/15 bg-white/10 p-5 transition-colors hover:border-secondary hover:text-white"
+              >
+                <MessageCircle
+                  className="h-6 w-6 text-secondary"
+                  aria-hidden="true"
+                />
+                <h3 className="mt-4 font-semibold">Join Slack</h3>
+                <p className="mt-2 text-sm leading-6 text-white/70">
+                  Follow project updates and talk with the community.
                 </p>
-                <p className="text-neutral-dark">
-                  <Link href="mailto:discoursegraphs@homeworld.bio">
-                    Send us a line
-                  </Link>{" "}
-                  if you&apos;re interested in helping to{" "}
-                  <Link href="https://github.com/DiscourseGraphs">develop</Link>{" "}
-                  or{" "}
-                  <Link href="https://experiment.com/projects/sustainable-coordination-in-research-labs-via-graph-enabled-idea-boards/">
-                    beta test
-                  </Link>{" "}
-                  these knowledge generation and synthesis tools.
-                </p>
-                <p className="text-neutral-dark">
-                  And stay up to date by joining us on{" "}
-                  <Link href="https://join.slack.com/t/discoursegraphs/shared_invite/zt-37xklatti-cpEjgPQC0YyKYQWPNgAkEg">
-                    Slack 💬
-                  </Link>
-                  !
-                </p>
-              </div>
-            </CardContent>
-          </Card>
-        </div>
+              </Link>
+            </div>
+          </div>
+        </section>
       </main>
 
-      <footer className="mt-12 border-t border-neutral-light/10 bg-neutral-dark py-10">
-        <div className="mx-auto grid max-w-6xl grid-cols-1 gap-10 px-6 md:grid-cols-3 md:items-start">
-          {/* Logo + copyright */}
+      <footer className="border-t border-white/10 bg-neutral-dark px-5 py-10 text-white sm:px-6">
+        <div className="mx-auto grid max-w-7xl grid-cols-1 gap-10 md:grid-cols-[1fr_0.7fr_1.1fr] md:items-start">
           <div className="flex flex-col gap-3">
             <Logo textClassName="text-white" linked={false} />
-            <p className="text-sm text-secondary">
-              © 2024-{new Date().getFullYear()} Homeworld Collective
+            <p className="text-sm text-white/55">
+              Copyright 2024-{new Date().getFullYear()} Homeworld Collective
             </p>
           </div>
 
-          {/* Links */}
-          <div className="flex flex-col gap-2">
+          <div className="grid gap-2 text-sm">
             <Link
               href="https://github.com/DiscourseGraphs"
-              className="text-secondary transition-colors hover:text-white"
+              className="text-white/70 transition-colors hover:text-primary"
             >
               GitHub
             </Link>
             <Link
               href="https://www.youtube.com/@discoursegraphs"
-              className="text-secondary transition-colors hover:text-white"
+              className="text-white/70 transition-colors hover:text-primary"
             >
               YouTube
             </Link>
             <Link
-              href="https://join.slack.com/t/discoursegraphs/shared_invite/zt-37xklatti-cpEjgPQC0YyKYQWPNgAkEg"
-              className="text-secondary transition-colors hover:text-white"
+              href={SLACK_URL}
+              className="text-white/70 transition-colors hover:text-primary"
             >
               Slack
             </Link>
             <Link
               href="https://bsky.app/profile/discoursegraphs.bsky.social"
-              className="text-secondary transition-colors hover:text-white"
+              className="text-white/70 transition-colors hover:text-primary"
             >
               Bluesky
             </Link>
           </div>
 
-          {/* Email subscription */}
-          <div className="rounded-lg border border-neutral-light/20 p-6">
-            <h3 className="mb-1 text-lg font-semibold text-white">
+          <div className="rounded-lg border border-white/15 p-5">
+            <h3 className="text-lg font-semibold text-white">
               Stay up to date
             </h3>
-            <p className="mb-4 text-sm text-secondary">
+            <p className="mt-1 text-sm text-white/65">
               Periodic news and info about the Discourse Graphs project.
             </p>
 
             <form
               action="https://buttondown.com/api/emails/embed-subscribe/DiscourseGraphs"
               method="post"
-              className="flex gap-2"
+              className="mt-4 flex flex-col gap-2 sm:flex-row"
             >
               <input type="hidden" name="embed" value="1" />
               <input
@@ -877,11 +933,11 @@ const Home = async () => {
                 id="bd-email"
                 placeholder="your@email.com"
                 required
-                className="min-w-0 flex-1 rounded border border-neutral-light/30 bg-neutral-dark px-3 py-2 text-sm text-white placeholder-neutral-light/50 focus:outline-none focus:ring-1 focus:ring-white/40"
+                className="min-w-0 flex-1 rounded-md border border-white/20 bg-neutral-dark px-3 py-2 text-sm text-white placeholder-white/40 focus:outline-none focus:ring-1 focus:ring-white/40"
               />
               <button
                 type="submit"
-                className="rounded border border-white px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-white hover:text-neutral-dark"
+                className="rounded-md border border-white px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-white hover:text-neutral-dark"
               >
                 Subscribe
               </button>

--- a/apps/website/app/(home)/page.tsx
+++ b/apps/website/app/(home)/page.tsx
@@ -346,11 +346,8 @@ const Home = async (): Promise<ReactElement> => {
       </section>
 
       <main className="flex-1">
-        <section
-          id="about"
-          className="scroll-mt-36 px-5 py-16 sm:px-6 md:scroll-mt-24 lg:py-24"
-        >
-          <div className="mx-auto max-w-7xl">
+        <section className="px-5 py-16 sm:px-6 lg:py-24">
+          <div id="about" className="mx-auto max-w-7xl scroll-mt-20">
             <div className="grid gap-10 lg:grid-cols-[0.8fr_1.2fr] lg:items-center">
               <SectionHeader
                 eyebrow="About"
@@ -463,11 +460,8 @@ const Home = async (): Promise<ReactElement> => {
           </div>
         </section>
 
-        <section
-          id="plugins"
-          className="scroll-mt-36 bg-white px-5 py-16 sm:px-6 md:scroll-mt-24 lg:py-24"
-        >
-          <div className="mx-auto max-w-7xl">
+        <section className="bg-white px-5 py-16 sm:px-6 lg:py-24">
+          <div id="plugins" className="mx-auto max-w-7xl scroll-mt-20">
             <SectionHeader
               eyebrow="Plugins"
               isWide
@@ -601,11 +595,8 @@ const Home = async (): Promise<ReactElement> => {
           </div>
         </section>
 
-        <section
-          id="resources"
-          className="scroll-mt-36 bg-white px-5 py-16 sm:px-6 md:scroll-mt-24 lg:py-24"
-        >
-          <div className="mx-auto max-w-7xl">
+        <section className="bg-white px-5 py-16 sm:px-6 lg:py-24">
+          <div id="resources" className="mx-auto max-w-7xl scroll-mt-20">
             <div className="flex flex-col justify-between gap-6 md:flex-row md:items-end">
               <SectionHeader
                 eyebrow="Resources"
@@ -641,11 +632,8 @@ const Home = async (): Promise<ReactElement> => {
           </div>
         </section>
 
-        <section
-          id="events"
-          className="scroll-mt-36 px-5 py-16 sm:px-6 md:scroll-mt-24 lg:py-24"
-        >
-          <div className="mx-auto max-w-7xl">
+        <section className="px-5 py-16 sm:px-6 lg:py-24">
+          <div id="events" className="mx-auto max-w-7xl scroll-mt-20">
             <SectionHeader
               eyebrow="Events"
               isWide
@@ -680,11 +668,8 @@ const Home = async (): Promise<ReactElement> => {
         </section>
 
         {blogs.length > 0 && (
-          <section
-            id="updates"
-            className="scroll-mt-36 bg-white px-5 py-16 sm:px-6 md:scroll-mt-24 lg:py-24"
-          >
-            <div className="mx-auto max-w-7xl">
+          <section className="bg-white px-5 py-16 sm:px-6 lg:py-24">
+            <div id="updates" className="mx-auto max-w-7xl scroll-mt-20">
               <div className="flex flex-col justify-between gap-6 md:flex-row md:items-end">
                 <SectionHeader
                   eyebrow="Updates"
@@ -721,11 +706,8 @@ const Home = async (): Promise<ReactElement> => {
           </section>
         )}
 
-        <section
-          id="talks"
-          className="scroll-mt-36 px-5 py-16 sm:px-6 md:scroll-mt-24 lg:py-24"
-        >
-          <div className="mx-auto max-w-7xl">
+        <section className="px-5 py-16 sm:px-6 lg:py-24">
+          <div id="talks" className="mx-auto max-w-7xl scroll-mt-20">
             <SectionHeader
               eyebrow="Talks"
               isWide
@@ -770,11 +752,8 @@ const Home = async (): Promise<ReactElement> => {
           </div>
         </section>
 
-        <section
-          id="team"
-          className="scroll-mt-36 bg-white px-5 py-16 sm:px-6 md:scroll-mt-24 lg:py-24"
-        >
-          <div className="mx-auto max-w-7xl">
+        <section className="bg-white px-5 py-16 sm:px-6 lg:py-24">
+          <div id="team" className="mx-auto max-w-7xl scroll-mt-20">
             <SectionHeader
               eyebrow="Team"
               isWide
@@ -794,11 +773,8 @@ const Home = async (): Promise<ReactElement> => {
           </div>
         </section>
 
-        <section
-          id="supporters"
-          className="scroll-mt-36 px-5 py-16 sm:px-6 md:scroll-mt-24 lg:py-24"
-        >
-          <div className="mx-auto max-w-7xl">
+        <section className="px-5 py-16 sm:px-6 lg:py-24">
+          <div id="supporters" className="mx-auto max-w-7xl scroll-mt-20">
             <SectionHeader
               eyebrow="Supporters"
               isWide
@@ -830,11 +806,11 @@ const Home = async (): Promise<ReactElement> => {
           </div>
         </section>
 
-        <section
-          id="contact"
-          className="scroll-mt-36 bg-neutral-dark px-5 py-16 text-white sm:px-6 md:scroll-mt-24 lg:py-24"
-        >
-          <div className="mx-auto grid max-w-7xl gap-10 lg:grid-cols-[0.9fr_1.1fr] lg:items-center">
+        <section className="bg-neutral-dark px-5 pb-48 pt-16 text-white sm:px-6 lg:pb-56 lg:pt-24">
+          <div
+            id="contact"
+            className="mx-auto grid max-w-7xl scroll-mt-20 gap-10 lg:grid-cols-[0.9fr_1.1fr] lg:items-center"
+          >
             <div>
               <p className="text-sm font-semibold uppercase tracking-[0.18em] text-primary">
                 Contact

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "@radix-ui/react-checkbox": "^1.3.3",
+    "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.4",

--- a/packages/ui/src/components/ui/dropdown-menu.tsx
+++ b/packages/ui/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,200 @@
+"use client";
+
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
+import { Check, ChevronRight, Circle } from "lucide-react";
+import * as React from "react";
+
+import { cn } from "@repo/ui/lib/utils";
+
+const DropdownMenu = DropdownMenuPrimitive.Root;
+
+const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
+
+const DropdownMenuGroup = DropdownMenuPrimitive.Group;
+
+const DropdownMenuPortal = DropdownMenuPrimitive.Portal;
+
+const DropdownMenuSub = DropdownMenuPrimitive.Sub;
+
+const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup;
+
+const DropdownMenuSubTrigger = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.SubTrigger>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> & {
+    inset?: boolean;
+  }
+>(({ className, inset, children, ...props }, ref) => (
+  <DropdownMenuPrimitive.SubTrigger
+    ref={ref}
+    className={cn(
+      "focus:bg-accent data-[state=open]:bg-accent flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none",
+      inset && "pl-8",
+      className,
+    )}
+    {...props}
+  >
+    {children}
+    <ChevronRight className="ml-auto h-4 w-4" />
+  </DropdownMenuPrimitive.SubTrigger>
+));
+DropdownMenuSubTrigger.displayName =
+  DropdownMenuPrimitive.SubTrigger.displayName;
+
+const DropdownMenuSubContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.SubContent
+    ref={ref}
+    className={cn(
+      "bg-popover text-popover-foreground z-50 min-w-32 overflow-hidden rounded-md border p-1 shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+      className,
+    )}
+    {...props}
+  />
+));
+DropdownMenuSubContent.displayName =
+  DropdownMenuPrimitive.SubContent.displayName;
+
+const DropdownMenuContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        "bg-popover text-popover-foreground z-50 min-w-40 overflow-hidden rounded-md border p-1 shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className,
+      )}
+      {...props}
+    />
+  </DropdownMenuPrimitive.Portal>
+));
+DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
+
+const DropdownMenuItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
+    inset?: boolean;
+  }
+>(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Item
+    ref={ref}
+    className={cn(
+      "focus:bg-accent focus:text-accent-foreground relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      inset && "pl-8",
+      className,
+    )}
+    {...props}
+  />
+));
+DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName;
+
+const DropdownMenuCheckboxItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.CheckboxItem>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem>
+>(({ className, children, checked, ...props }, ref) => (
+  <DropdownMenuPrimitive.CheckboxItem
+    ref={ref}
+    className={cn(
+      "focus:bg-accent focus:text-accent-foreground relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className,
+    )}
+    checked={checked}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <DropdownMenuPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </DropdownMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </DropdownMenuPrimitive.CheckboxItem>
+));
+DropdownMenuCheckboxItem.displayName =
+  DropdownMenuPrimitive.CheckboxItem.displayName;
+
+const DropdownMenuRadioItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.RadioItem>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.RadioItem>
+>(({ className, children, ...props }, ref) => (
+  <DropdownMenuPrimitive.RadioItem
+    ref={ref}
+    className={cn(
+      "focus:bg-accent focus:text-accent-foreground relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className,
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <DropdownMenuPrimitive.ItemIndicator>
+        <Circle className="h-2 w-2 fill-current" />
+      </DropdownMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </DropdownMenuPrimitive.RadioItem>
+));
+DropdownMenuRadioItem.displayName = DropdownMenuPrimitive.RadioItem.displayName;
+
+const DropdownMenuLabel = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> & {
+    inset?: boolean;
+  }
+>(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Label
+    ref={ref}
+    className={cn(
+      "px-2 py-1.5 text-sm font-semibold",
+      inset && "pl-8",
+      className,
+    )}
+    {...props}
+  />
+));
+DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName;
+
+const DropdownMenuSeparator = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.Separator
+    ref={ref}
+    className={cn("bg-muted -mx-1 my-1 h-px", className)}
+    {...props}
+  />
+));
+DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName;
+
+const DropdownMenuShortcut = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLSpanElement>) => {
+  return (
+    <span
+      className={cn("ml-auto text-xs tracking-widest opacity-60", className)}
+      {...props}
+    />
+  );
+};
+DropdownMenuShortcut.displayName = "DropdownMenuShortcut";
+
+export {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuPortal,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -706,6 +706,9 @@ importers:
       '@radix-ui/react-checkbox':
         specifier: ^1.3.3
         version: 1.3.3(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-dropdown-menu':
+        specifier: ^2.1.16
+        version: 2.1.16(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@radix-ui/react-label':
         specifier: ^2.1.7
         version: 2.1.7(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -14526,6 +14529,21 @@ snapshots:
       '@types/react': 19.1.12
       '@types/react-dom': 19.1.9(@types/react@19.1.12)
 
+  '@radix-ui/react-dropdown-menu@2.1.16(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.12)(react@19.1.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.12)(react@19.1.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.12)(react@19.1.1)
+      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.12)(react@19.1.1)
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      '@types/react-dom': 19.1.9(@types/react@19.1.12)
+
   '@radix-ui/react-focus-guards@1.0.1(@types/react@18.2.21)(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.28.3
@@ -14722,6 +14740,32 @@ snapshots:
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
       react-remove-scroll: 2.7.1(@types/react@19.1.12)(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      '@types/react-dom': 19.1.9(@types/react@19.1.12)
+
+  '@radix-ui/react-menu@2.1.16(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.12)(react@19.1.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.12)(react@19.1.1)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.1.12)(react@19.1.1)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.1.12)(react@19.1.1)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.12)(react@19.1.1)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.12)(react@19.1.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.12)(react@19.1.1)
+      aria-hidden: 1.2.6
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+      react-remove-scroll: 2.7.1(@types/react@19.1.12)(react@19.1.1)
     optionalDependencies:
       '@types/react': 19.1.12
       '@types/react-dom': 19.1.9(@types/react@19.1.12)
@@ -15086,6 +15130,23 @@ snapshots:
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.12)(react@19.0.0)
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      '@types/react-dom': 19.1.9(@types/react@19.1.12)
+
+  '@radix-ui/react-roving-focus@1.1.11(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.12)(react@19.1.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.12)(react@19.1.1)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.1.12)(react@19.1.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.12)(react@19.1.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.12)(react@19.1.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.12)(react@19.1.1)
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
     optionalDependencies:
       '@types/react': 19.1.12
       '@types/react-dom': 19.1.9(@types/react@19.1.12)


### PR DESCRIPTION
Intent is not to make this a major redesign. This is a quick, low-commitment pass that keeps the existing palette and gives us some minor improvements.

What Changed

- Refreshed the homepage layout, spacing, section rhythm, and visual hierarchy while keeping the same color palette.
- Updated the hero area and primary calls to action for a cleaner first impression.
- Added a visible Docs link into the main navigation. [fixes DIS-330](https://linear.app/discourse-graphs/issue/DIS-330/add-a-link-to-documentation-from-the-top-bar-menu-of-the-website) 
- Reworked small-mobile navigation into an actual dropdown menu

<img width="1490" height="939" alt="image" src="https://github.com/user-attachments/assets/95f612d6-5040-4bf6-9ad6-ca7f9cecd2e8" />
<img width="3785" height="1363" alt="image" src="https://github.com/user-attachments/assets/5f87073b-52b1-4221-8569-a047663f10ef" />
<img width="3787" height="1972" alt="image" src="https://github.com/user-attachments/assets/905ee328-ad74-46a4-ab5f-17a5943cb32d" />
<img width="3017" height="1456" alt="image" src="https://github.com/user-attachments/assets/dc75c322-52e7-476f-91b9-0a14c0e0f540" />



