### PR TITLE
ENG-1982 Update create base view button to emphasize "Create New Base View"

### DIFF
--- a/apps/obsidian/src/components/NodeTypeSettings.tsx
+++ b/apps/obsidian/src/components/NodeTypeSettings.tsx
@@ -1234,7 +1234,7 @@ const NodeTypeSettings = () => {
                   void createBaseForNodeType(plugin, editingNodeType)
                 }
               >
-                Create Base view
+                Create new Base view
               </button>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Changes button label from "Create Base view" to "Create new Base view" in the Obsidian plugin node type settings
-> user less confused about whether they're opening an existing file or creating a new one
🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/1185" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->