### PR TITLE
[ENG-1960] Prevent node tag menu from stacking on repeated hotkey presses

### DIFF
--- a/apps/obsidian/src/index.ts
+++ b/apps/obsidian/src/index.ts
@@ -44,6 +44,10 @@ export default class DiscourseGraphPlugin extends Plugin {
   settings: Settings = { ...DEFAULT_SETTINGS };
   private tagNodeHandler: TagNodeHandler | null = null;
   private fileChangeListener: FileChangeListener | null = null;
+  private activeNodePopover:
+    | NodeTagSuggestPopover
+    | InlineNodeTypePicker
+    | null = null;
   private currentViewActions: { leaf: WorkspaceLeaf; action: HTMLElement }[] =
     [];
   private pendingCanvasSwitches = new Set<string>();
@@ -282,9 +286,6 @@ export default class DiscourseGraphPlugin extends Plugin {
   }
 
   private setupNodeTagHotkey() {
-    let activePopover: NodeTagSuggestPopover | InlineNodeTypePicker | null =
-      null;
-
     const nodeTagHotkeyExtension = EditorView.domEventHandlers({
       keydown: (event: KeyboardEvent) => {
         // Access settings dynamically to handle changes
@@ -296,8 +297,8 @@ export default class DiscourseGraphPlugin extends Plugin {
         event.preventDefault();
         event.stopPropagation();
 
-        activePopover?.close();
-        activePopover = null;
+        this.activeNodePopover?.close();
+        this.activeNodePopover = null;
 
         const activeView = this.app.workspace.getActiveViewOfType(MarkdownView);
         if (activeView?.editor) {
@@ -311,14 +312,14 @@ export default class DiscourseGraphPlugin extends Plugin {
               plugin: this,
               selectedText: selectedText.trim(),
             });
-            activePopover = picker;
+            this.activeNodePopover = picker;
             picker.open();
           } else {
             const popover = new NodeTagSuggestPopover(
               editor,
               this.settings.nodeTypes,
             );
-            activePopover = popover;
+            this.activeNodePopover = popover;
             popover.open();
           }
         }
@@ -436,6 +437,8 @@ export default class DiscourseGraphPlugin extends Plugin {
   }
 
   onunload() {
+    this.activeNodePopover?.close();
+    this.activeNodePopover = null;
     this.cleanupViewActions();
     activeDocument.body.classList.remove("dg-hide-frontmatter-ids");
 

--- a/apps/obsidian/src/index.ts
+++ b/apps/obsidian/src/index.ts
@@ -282,6 +282,9 @@ export default class DiscourseGraphPlugin extends Plugin {
   }
 
   private setupNodeTagHotkey() {
+    let activePopover: NodeTagSuggestPopover | InlineNodeTypePicker | null =
+      null;
+
     const nodeTagHotkeyExtension = EditorView.domEventHandlers({
       keydown: (event: KeyboardEvent) => {
         // Access settings dynamically to handle changes
@@ -293,26 +296,29 @@ export default class DiscourseGraphPlugin extends Plugin {
         event.preventDefault();
         event.stopPropagation();
 
+        activePopover?.close();
+        activePopover = null;
+
         const activeView = this.app.workspace.getActiveViewOfType(MarkdownView);
         if (activeView?.editor) {
           const editor = activeView.editor;
           const selectedText = editor.getSelection();
 
           if (selectedText && selectedText.trim().length > 0) {
-            // Text is selected: open node type picker to create node from selection
             const picker = new InlineNodeTypePicker({
               editor,
               nodeTypes: this.settings.nodeTypes,
               plugin: this,
               selectedText: selectedText.trim(),
             });
+            activePopover = picker;
             picker.open();
           } else {
-            // No selection: open the candidate node tag popover
             const popover = new NodeTagSuggestPopover(
               editor,
               this.settings.nodeTypes,
             );
+            activePopover = popover;
             popover.open();
           }
         }


### PR DESCRIPTION
https://www.loom.com/share/e13d8f61cf924fa199da98f64d758291

## Summary

- Pressing the node-tags hotkey while the menu was already open stacked a new instance on top instead of dismissing the existing one
- Root cause: `setupNodeTagHotkey()` used `EditorView.domEventHandlers` which fires once per open editor pane; each invocation created a fresh popover instance, bypassing the `if (this.popover)` guard (which only checks the same object instance)
- Fix: track the active popover in a closure variable inside `setupNodeTagHotkey()`; on each hotkey press, close the existing popover first (properly cleaning up its DOM element and document-level event listeners), then open a fresh one at the current cursor position

Fixes [ENG-1960](https://linear.app/discourse-graphs/issue/ENG-1960)

## Test plan

- [x] Press the node-tags hotkey once — menu appears
- [x] Press the hotkey again while the menu is open — existing menu closes, new one opens at cursor position (no stacking)
- [x] Press Escape, then hotkey again — fresh menu opens normally
- [x] With multiple editor panes open, pressing the hotkey once opens only one menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/1187" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->