### PR TITLE
ENG-1997 Add agent-facing Roam Playwright skills and proof workflow

### DIFF
--- a/skills/roam-load-extension/SKILL.md
+++ b/skills/roam-load-extension/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: dg-roam-load-extension
+name: roam-load-extension
 description: Build and load the local Discourse Graphs apps/roam extension into Roam Research through Roam Depot developer mode using a Playwright test account. Use when verifying local apps/roam changes in a real Roam graph, checking that DG commands/settings load, or capturing proof after loading apps/roam/dist.
 ---
 
@@ -7,18 +7,18 @@ description: Build and load the local Discourse Graphs apps/roam extension into 
 
 Use this skill to build `apps/roam`, load `apps/roam/dist` through Roam Depot developer mode, and verify that the Discourse Graphs extension is active.
 
-It composes with `dg-roam-playwright-session` for account/profile selection.
+It composes with `roam-playwright-session` for account/profile selection.
 
 ## Quick Start
 
 ```sh
-pnpm --filter roam playwright:load-extension -- --slot 1
+pnpm --filter roam playwright:loadExtension -- --slot 1
 ```
 
 Use another slot for isolated work:
 
 ```sh
-pnpm --filter roam playwright:load-extension -- --slot 2
+pnpm --filter roam playwright:loadExtension -- --slot 2
 ```
 
 The script builds `apps/roam` by default, loads `apps/roam/dist`, verifies `window.roamjs.extension.queryBuilder`, and writes proof under `local/roam-playwright/artifacts`.

--- a/skills/roam-load-extension/SKILL.md
+++ b/skills/roam-load-extension/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: dg-roam-load-extension
+description: Build and load the local Discourse Graphs apps/roam extension into Roam Research through Roam Depot developer mode using a Playwright test account. Use when verifying local apps/roam changes in a real Roam graph, checking that DG commands/settings load, or capturing proof after loading apps/roam/dist.
+---
+
+# DG Roam Load Extension
+
+Use this skill to build `apps/roam`, load `apps/roam/dist` through Roam Depot developer mode, and verify that the Discourse Graphs extension is active.
+
+It composes with `dg-roam-playwright-session` for account/profile selection.
+
+## Quick Start
+
+```sh
+pnpm --filter roam playwright:load-extension -- --slot 1
+```
+
+Use another slot for isolated work:
+
+```sh
+pnpm --filter roam playwright:load-extension -- --slot 2
+```
+
+The script builds `apps/roam` by default, loads `apps/roam/dist`, verifies `window.roamjs.extension.queryBuilder`, and writes proof under `local/roam-playwright/artifacts`.
+
+## Options
+
+- `--slot 1|2|3`: Select the Roam account/profile.
+- `--skip-build`: Load the existing `apps/roam/dist` without rebuilding.
+- `--headed`: Run with a visible Chromium window.
+- `--keep-open`: Leave the browser open after loading.
+- `--dist <path>`: Load a different Roam extension folder. Use only when intentionally testing another build output.
+
+## Folder Loading
+
+Roam Depot's folder button calls `window.showDirectoryPicker()`, not an `<input type="file">`. The script installs a temporary in-page directory-picker shim backed by the files in `apps/roam/dist`.
+
+An IndexedDB clone warning for the fake directory handle is expected. Treat successful DG global verification and screenshot proof as the source of truth.
+
+## Safety Notes
+
+- Do not commit `.env`, browser profiles, or artifacts.
+- Do not commit real Roam test account emails, graph names, graph URLs, or proof screenshots.
+- Do not change Supabase local/branch/production config as part of this skill.
+- Do not run production-backend smoke tests in this workflow.

--- a/skills/roam-playwright-session/SKILL.md
+++ b/skills/roam-playwright-session/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: dg-roam-playwright-session
+description: Open Roam Research with a Discourse Graphs Playwright test account and persistent profile for apps/roam extension testing. Use when developing or verifying the Discourse Graphs Roam extension, rotating between the three local Playwright Roam accounts, capturing screenshot proof, or inspecting live Roam DOM behavior from this repository.
+---
+
+# DG Roam Playwright Session
+
+Use this skill to open a real Roam Research graph with one of the local Playwright test accounts.
+
+Secrets must live only in the ignored `apps/roam/.env`. Do not print, inspect, or commit passwords, cookies, local storage, or Playwright profile contents.
+
+## Quick Start
+
+Open slot 1:
+
+```sh
+pnpm --filter roam playwright:open -- --slot 1
+```
+
+Use slots 2 or 3 for isolated concurrent work:
+
+```sh
+pnpm --filter roam playwright:open -- --slot 2
+pnpm --filter roam playwright:open -- --slot 3
+```
+
+The script writes screenshots and JSON proof under `local/roam-playwright/artifacts`.
+
+## Environment
+
+The ignored `apps/roam/.env` should contain one set per slot:
+
+```sh
+DG_ROAM_PLAYWRIGHT_EMAIL_1=
+DG_ROAM_PLAYWRIGHT_PASSWORD_1=
+DG_ROAM_PLAYWRIGHT_GRAPH_URL_1=
+DG_ROAM_PLAYWRIGHT_PROFILE_DIR_1=
+```
+
+Repeat for `_2` and `_3`.
+
+Account emails and graph URLs are intentionally required from the ignored app `.env`. Do not add real test account identifiers, graph names, graph URLs, or passwords to committed files.
+
+Profile directories default to ignored local paths under `local/roam-playwright/profiles/`.
+
+## Safety Notes
+
+- Only one Chromium process can own a persistent profile at a time.
+- Use a different `--slot` for concurrent agents.
+- Use `--headed --allow-login` if manual login recovery is needed.
+- Do not run Supabase smoke tests as part of this skill; this skill is only for Roam login/session proof.

--- a/skills/roam-playwright-session/SKILL.md
+++ b/skills/roam-playwright-session/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: dg-roam-playwright-session
+name: roam-playwright-session
 description: Open Roam Research with a Discourse Graphs Playwright test account and persistent profile for apps/roam extension testing. Use when developing or verifying the Discourse Graphs Roam extension, rotating between the three local Playwright Roam accounts, capturing screenshot proof, or inspecting live Roam DOM behavior from this repository.
 ---
 


### PR DESCRIPTION
## Summary

Part of ENG-1308. This is PR 3 of 3 in the Roam Playwright stack and targets `eng-1996-add-roam-depot-extension-loader`.

- Add an agent-facing skill for opening a configured Roam Playwright session.
- Add an agent-facing skill for building and loading `apps/roam/dist` through Roam Depot developer mode.
- Document local-only profile/artifact handling and public-repo safety expectations.

## Validation

- Skill docs scanned for real account identifiers, graph names, and test-account email strings.
- `pnpm --dir apps/roam exec eslint --no-color --format stylish scripts/playwright/roam-session.ts scripts/playwright/open-roam.ts scripts/playwright/load-extension.ts`
- `pnpm --filter roam build`
- Prior local 3-slot smoke run produced proof screenshots for login, Roam Depot extension load, and DG settings visibility. The screenshots are attached to ENG-1997 in Linear.

## Notes

No local profiles, artifacts, screenshots, account identifiers, graph names, or secrets are committed.