### PR TITLE
ENG-1957 Add Referenced Nodes in drag/drop

### DIFF
--- a/apps/roam/src/components/canvas/DiscourseRelationShape/DiscourseRelationTool.tsx
+++ b/apps/roam/src/components/canvas/DiscourseRelationShape/DiscourseRelationTool.tsx
@@ -17,7 +17,7 @@ import {
 } from "~/components/canvas/DiscourseNodeUtil";
 
 export type AddReferencedNodeType = Record<string, ReferenceFormatType[]>;
-type ReferenceFormatType = {
+export type ReferenceFormatType = {
   format: string;
   sourceName: string;
   sourceType: string;

--- a/apps/roam/src/components/canvas/Tldraw.tsx
+++ b/apps/roam/src/components/canvas/Tldraw.tsx
@@ -690,7 +690,11 @@ const TldrawCanvasShared = ({
   const editorComponents: TLEditorComponents = {
     ...defaultEditorComponents,
     OnTheCanvas: ToastListener,
-    InFrontOfTheCanvas: DragHandleOverlay,
+    InFrontOfTheCanvas: () => (
+      <DragHandleOverlay
+        allAddReferencedNodeByAction={allAddReferencedNodeByAction}
+      />
+    ),
   };
   const customUiComponents: TLUiComponents = createUiComponents({
     allNodes,

--- a/apps/roam/src/components/canvas/overlays/DragHandleOverlay.tsx
+++ b/apps/roam/src/components/canvas/overlays/DragHandleOverlay.tsx
@@ -1,16 +1,15 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { TLShapeId, useEditor, useValue } from "tldraw";
-import {
-  DiscourseNodeShape,
-  getDiscourseNodeTypeId,
-} from "~/components/canvas/DiscourseNodeUtil";
-import {
-  hasValidRelationTypes,
-  isDiscourseNodeShape,
-} from "~/components/canvas/canvasUtils";
+import { DiscourseNodeShape } from "~/components/canvas/DiscourseNodeUtil";
+import { isDiscourseNodeShape } from "~/components/canvas/canvasUtils";
+import type { AddReferencedNodeType } from "~/components/canvas/DiscourseRelationShape/DiscourseRelationTool";
 import { dispatchToastEvent } from "~/components/canvas/ToastListener";
 import { RelationTypeDropdown } from "./RelationTypeDropdown";
-import { createDefaultRelationBetweenNodes } from "./relationCreation";
+import {
+  createDefaultRelationBetweenNodes,
+  getValidRelationTypesBetween,
+  type RelationTypeOption,
+} from "./relationCreation";
 
 const HANDLE_RADIUS = 5;
 const HANDLE_HIT_AREA = 12;
@@ -63,7 +62,11 @@ const getEdgeMidpoints = (bounds: {
   },
 ];
 
-export const DragHandleOverlay = () => {
+export const DragHandleOverlay = ({
+  allAddReferencedNodeByAction,
+}: {
+  allAddReferencedNodeByAction: AddReferencedNodeType;
+}) => {
   const editor = useEditor();
 
   // Drag state: track the drag line in viewport coords (no tldraw shapes)
@@ -206,15 +209,16 @@ export const DragHandleOverlay = () => {
           return;
         }
 
-        // Validate that relation types exist between these node types
-        const selectedNodeTypeId = getDiscourseNodeTypeId({
-          shape: selectedNode,
+        const validRelationTypes = getValidRelationTypesBetween({
+          editor,
+          startId: selectedNode.id,
+          endId: target.id,
+          allAddReferencedNodeByAction,
         });
-        const targetNodeTypeId = getDiscourseNodeTypeId({ shape: target });
-        if (!hasValidRelationTypes(selectedNodeTypeId, targetNodeTypeId)) {
+        if (!validRelationTypes.length) {
           dispatchToastEvent({
             id: "tldraw-no-valid-relation",
-            title: "No relation types are defined between these node types",
+            title: "No relation options are defined between these node types",
             severity: "warning",
           });
           sourceNodeRef.current = null;
@@ -249,24 +253,25 @@ export const DragHandleOverlay = () => {
         dragCleanupRef.current = null;
       };
     },
-    [selectedNode, editor],
+    [selectedNode, editor, allAddReferencedNodeByAction],
   );
 
   const handleDropdownSelect = useCallback(
-    (relationId: string) => {
+    (option: RelationTypeOption) => {
       if (!pending) return;
 
       void createDefaultRelationBetweenNodes({
         editor,
-        relationId,
+        relationId: option.id,
         sourceId: pending.sourceId,
         targetId: pending.targetId,
+        allAddReferencedNodeByAction,
       });
 
       setPending(null);
       sourceNodeRef.current = null;
     },
-    [editor, pending],
+    [editor, pending, allAddReferencedNodeByAction],
   );
 
   const handleDropdownDismiss = useCallback(() => {
@@ -345,6 +350,7 @@ export const DragHandleOverlay = () => {
           sourceId={pending.sourceId}
           targetId={pending.targetId}
           dropdownPos={pending.dropdownPos}
+          allAddReferencedNodeByAction={allAddReferencedNodeByAction}
           onSelect={handleDropdownSelect}
           onDismiss={handleDropdownDismiss}
         />

--- a/apps/roam/src/components/canvas/overlays/RelationTypeDropdown.tsx
+++ b/apps/roam/src/components/canvas/overlays/RelationTypeDropdown.tsx
@@ -1,12 +1,17 @@
 import React, { useCallback, useEffect, useMemo, useRef } from "react";
 import { TLShapeId, useEditor } from "tldraw";
-import { getValidRelationTypesBetween } from "./relationCreation";
+import type { AddReferencedNodeType } from "~/components/canvas/DiscourseRelationShape/DiscourseRelationTool";
+import {
+  getValidRelationTypesBetween,
+  type RelationTypeOption,
+} from "./relationCreation";
 
 type RelationTypeDropdownProps = {
   sourceId: TLShapeId;
   targetId: TLShapeId;
   dropdownPos: { x: number; y: number };
-  onSelect: (relationId: string) => void;
+  allAddReferencedNodeByAction: AddReferencedNodeType;
+  onSelect: (option: RelationTypeOption) => void;
   onDismiss: () => void;
 };
 
@@ -14,6 +19,7 @@ export const RelationTypeDropdown = ({
   sourceId,
   targetId,
   dropdownPos,
+  allAddReferencedNodeByAction,
   onSelect,
   onDismiss,
 }: RelationTypeDropdownProps) => {
@@ -21,8 +27,14 @@ export const RelationTypeDropdown = ({
   const dropdownRef = useRef<HTMLDivElement>(null);
 
   const validRelationTypes = useMemo(
-    () => getValidRelationTypesBetween(editor, sourceId, targetId),
-    [editor, sourceId, targetId],
+    () =>
+      getValidRelationTypesBetween({
+        editor,
+        startId: sourceId,
+        endId: targetId,
+        allAddReferencedNodeByAction,
+      }),
+    [editor, sourceId, targetId, allAddReferencedNodeByAction],
   );
 
   // Handle click outside
@@ -58,8 +70,8 @@ export const RelationTypeDropdown = ({
   }, [onDismiss]);
 
   const handleSelect = useCallback(
-    (relationId: string) => {
-      onSelect(relationId);
+    (option: RelationTypeOption) => {
+      onSelect(option);
     },
     [onSelect],
   );
@@ -87,8 +99,8 @@ export const RelationTypeDropdown = ({
         </div>
         {validRelationTypes.map((rt) => (
           <button
-            key={rt.id}
-            onClick={() => handleSelect(rt.id)}
+            key={`${rt.kind}-${rt.id}`}
+            onClick={() => handleSelect(rt)}
             className="flex w-full cursor-pointer items-center gap-2 rounded-md border-none bg-transparent px-3 py-2 text-left text-[13px] text-[#333] hover:bg-[#f0f0f0]"
             onMouseEnter={(e) => {
               (e.currentTarget as HTMLElement).style.backgroundColor =

--- a/apps/roam/src/components/canvas/overlays/referencedNodeOptions.ts
+++ b/apps/roam/src/components/canvas/overlays/referencedNodeOptions.ts
@@ -1,0 +1,39 @@
+import type {
+  AddReferencedNodeType,
+  ReferenceFormatType,
+} from "~/components/canvas/DiscourseRelationShape/DiscourseRelationTool";
+
+export type ReferencedNodeActionOption = {
+  id: string;
+  label: string;
+  references: ReferenceFormatType[];
+};
+
+export const getValidReferencedNodeActionOptions = ({
+  allAddReferencedNodeByAction,
+  sourceNodeType,
+  targetNodeType,
+}: {
+  allAddReferencedNodeByAction: AddReferencedNodeType;
+  sourceNodeType: string;
+  targetNodeType: string;
+}): ReferencedNodeActionOption[] =>
+  Object.entries(allAddReferencedNodeByAction).reduce<
+    ReferencedNodeActionOption[]
+  >((options, [id, references]) => {
+    const matchingReferences = references.filter(
+      (reference) =>
+        reference.sourceType === sourceNodeType &&
+        reference.destinationType === targetNodeType,
+    );
+
+    if (!matchingReferences.length) return options;
+
+    options.push({
+      id,
+      label: id,
+      references: matchingReferences,
+    });
+
+    return options;
+  }, []);

--- a/apps/roam/src/components/canvas/overlays/relationCreation.ts
+++ b/apps/roam/src/components/canvas/overlays/relationCreation.ts
@@ -9,6 +9,7 @@ import {
   DiscourseRelationShape,
   getRelationColor,
 } from "~/components/canvas/DiscourseRelationShape/DiscourseRelationUtil";
+import type { AddReferencedNodeType } from "~/components/canvas/DiscourseRelationShape/DiscourseRelationTool";
 import { createOrUpdateArrowBinding } from "~/components/canvas/DiscourseRelationShape/helpers";
 import { getDiscourseNodeTypeId } from "~/components/canvas/DiscourseNodeUtil";
 import {
@@ -18,8 +19,14 @@ import {
 } from "~/components/canvas/canvasUtils";
 import type { DiscourseRelation } from "~/utils/getDiscourseRelations";
 import { isRelationComplete } from "~/utils/isRelationComplete";
+import { getValidReferencedNodeActionOptions } from "./referencedNodeOptions";
 
-type RelationTypeOption = { id: string; label: string; color: string };
+export type RelationTypeOption = {
+  id: string;
+  label: string;
+  color: string;
+  kind: "relation" | "referenced-node";
+};
 
 type DirectionalRelation = Pick<
   DiscourseRelation,
@@ -72,11 +79,17 @@ export const persistRelationArrow = async ({
   }
 };
 
-export const getValidRelationTypesBetween = (
-  editor: Editor,
-  startId: TLShapeId,
-  endId: TLShapeId,
-): RelationTypeOption[] => {
+export const getValidRelationTypesBetween = ({
+  editor,
+  startId,
+  endId,
+  allAddReferencedNodeByAction = {},
+}: {
+  editor: Editor;
+  startId: TLShapeId;
+  endId: TLShapeId;
+  allAddReferencedNodeByAction?: AddReferencedNodeType;
+}): RelationTypeOption[] => {
   const startNode = editor.getShape(startId);
   const endNode = editor.getShape(endId);
   if (!startNode || !endNode) return [];
@@ -112,8 +125,31 @@ export const getValidRelationTypesBetween = (
 
     const hexColor =
       colorPalette[getRelationColor(relation.label)]?.solid ?? "#333";
-    validTypes.push({ id: relation.id, label, color: hexColor });
+    validTypes.push({
+      id: relation.id,
+      label,
+      color: hexColor,
+      kind: "relation",
+    });
   }
+
+  getValidReferencedNodeActionOptions({
+    allAddReferencedNodeByAction,
+    sourceNodeType: startNodeType,
+    targetNodeType: endNodeType,
+  }).forEach((action) => {
+    if (seenLabels.has(action.label)) return;
+    seenLabels.add(action.label);
+
+    const hexColor =
+      colorPalette[getRelationColor(action.label)]?.solid ?? "#333";
+    validTypes.push({
+      id: action.id,
+      label: action.label,
+      color: hexColor,
+      kind: "referenced-node",
+    });
+  });
 
   return validTypes;
 };
@@ -123,15 +159,14 @@ export const createDefaultRelationBetweenNodes = async ({
   relationId,
   sourceId,
   targetId,
+  allAddReferencedNodeByAction = {},
 }: {
   editor: Editor;
   relationId: string;
   sourceId: TLShapeId;
   targetId: TLShapeId;
+  allAddReferencedNodeByAction?: AddReferencedNodeType;
 }): Promise<TLShapeId | null> => {
-  const selectedRelation = getAllRelations().find((r) => r.id === relationId);
-  if (!selectedRelation) return null;
-
   const sourceNode = editor.getShape(sourceId);
   const targetNode = editor.getShape(targetId);
   if (
@@ -141,37 +176,61 @@ export const createDefaultRelationBetweenNodes = async ({
     !isDiscourseNodeShape(editor, targetNode)
   )
     return null;
-  const label = getDirectionalRelationLabel({
-    relation: selectedRelation,
-    sourceNodeType: getDiscourseNodeTypeId({ shape: sourceNode }),
-    targetNodeType: getDiscourseNodeTypeId({ shape: targetNode }),
-  });
+
+  const sourceNodeType = getDiscourseNodeTypeId({ shape: sourceNode });
+  const targetNodeType = getDiscourseNodeTypeId({ shape: targetNode });
+  const selectedRelation = getAllRelations().find((r) => r.id === relationId);
+  const referencedNodeAction = getValidReferencedNodeActionOptions({
+    allAddReferencedNodeByAction,
+    sourceNodeType,
+    targetNodeType,
+  }).find((action) => action.id === relationId);
+
+  if (!selectedRelation && !referencedNodeAction) return null;
 
   const sourceBounds = editor.getShapePageBounds(sourceId);
   if (!sourceBounds) return null;
 
   const arrowId = createShapeId();
-  editor.createShape<DiscourseRelationShape>({
-    id: arrowId,
-    type: relationId,
-    x: sourceBounds.midX,
-    y: sourceBounds.midY,
-    props: {
-      color: getRelationColor(selectedRelation.label),
-      text: label,
-      dash: "draw",
-      size: "m",
-      fill: "none",
-      bend: 0,
-      start: { x: 0, y: 0 },
-      end: { x: 0, y: 0 },
-      arrowheadStart: "none",
-      arrowheadEnd: "arrow",
-      labelPosition: 0.5,
-      font: "draw",
-      scale: 1,
-    },
-  });
+  if (selectedRelation) {
+    const label = getDirectionalRelationLabel({
+      relation: selectedRelation,
+      sourceNodeType,
+      targetNodeType,
+    });
+
+    editor.createShape<DiscourseRelationShape>({
+      id: arrowId,
+      type: relationId,
+      x: sourceBounds.midX,
+      y: sourceBounds.midY,
+      props: {
+        color: getRelationColor(selectedRelation.label),
+        text: label,
+        dash: "draw",
+        size: "m",
+        fill: "none",
+        bend: 0,
+        start: { x: 0, y: 0 },
+        end: { x: 0, y: 0 },
+        arrowheadStart: "none",
+        arrowheadEnd: "arrow",
+        labelPosition: 0.5,
+        font: "draw",
+        scale: 1,
+      },
+    });
+  } else {
+    editor.createShape<DiscourseRelationShape>({
+      id: arrowId,
+      type: relationId,
+      x: sourceBounds.midX,
+      y: sourceBounds.midY,
+      props: {
+        scale: 1,
+      },
+    });
+  }
 
   const newArrow = editor.getShape<DiscourseRelationShape>(arrowId);
   if (!newArrow) return null;

--- a/apps/roam/src/components/canvas/uiOverrides.tsx
+++ b/apps/roam/src/components/canvas/uiOverrides.tsx
@@ -443,11 +443,11 @@ export const CustomContextMenu = ({
       if (!selectedShape || selectedShape.type !== "arrow") return null;
       const boundNodes = getArrowBoundNodeInfo(editor, selectedShape);
       if (!boundNodes) return null;
-      const relationTypes = getValidRelationTypesBetween(
+      const relationTypes = getValidRelationTypesBetween({
         editor,
-        boundNodes.startId,
-        boundNodes.endId,
-      );
+        startId: boundNodes.startId,
+        endId: boundNodes.endId,
+      });
       if (relationTypes.length === 0) return null;
       return { arrowId: selectedShape.id, ...boundNodes, relationTypes };
     },

--- a/apps/roam/src/utils/__tests__/referencedNodeOptions.test.ts
+++ b/apps/roam/src/utils/__tests__/referencedNodeOptions.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import type { AddReferencedNodeType } from "~/components/canvas/DiscourseRelationShape/DiscourseRelationTool";
+import { getValidReferencedNodeActionOptions } from "~/components/canvas/overlays/referencedNodeOptions";
+
+const actionMap: AddReferencedNodeType = {
+  "Add Source": [
+    {
+      format: "[[EVD]] - {content} - {Source}",
+      sourceName: "Source",
+      sourceType: "_SRC-node",
+      destinationType: "_EVD-node",
+      destinationName: "Evidence",
+    },
+  ],
+  "Add Reference": [
+    {
+      format: "[[CLM]] - {content} - {Source}",
+      sourceName: "Source",
+      sourceType: "_SRC-node",
+      destinationType: "_CLM-node",
+      destinationName: "Claim",
+    },
+    {
+      format: "[[ARG]] - {content} - {Source}",
+      sourceName: "Source",
+      sourceType: "_SRC-node",
+      destinationType: "_CLM-node",
+      destinationName: "Claim",
+    },
+  ],
+};
+
+describe("referenced node relation options", () => {
+  it("allows source nodes to add sources to evidence", () => {
+    expect(
+      getValidReferencedNodeActionOptions({
+        allAddReferencedNodeByAction: actionMap,
+        sourceNodeType: "_SRC-node",
+        targetNodeType: "_EVD-node",
+      }).map((option) => option.id),
+    ).toEqual(["Add Source"]);
+  });
+
+  it("does not allow evidence nodes to add sources to source nodes", () => {
+    expect(
+      getValidReferencedNodeActionOptions({
+        allAddReferencedNodeByAction: actionMap,
+        sourceNodeType: "_EVD-node",
+        targetNodeType: "_SRC-node",
+      }),
+    ).toEqual([]);
+  });
+
+  it("does not show source actions for incompatible targets", () => {
+    expect(
+      getValidReferencedNodeActionOptions({
+        allAddReferencedNodeByAction: actionMap,
+        sourceNodeType: "_SRC-node",
+        targetNodeType: "_QUE-node",
+      }),
+    ).toEqual([]);
+  });
+
+  it("returns one option when an action has multiple compatible formats", () => {
+    const options = getValidReferencedNodeActionOptions({
+      allAddReferencedNodeByAction: actionMap,
+      sourceNodeType: "_SRC-node",
+      targetNodeType: "_CLM-node",
+    });
+
+    expect(options).toHaveLength(1);
+    expect(options[0]?.id).toBe("Add Reference");
+    expect(options[0]?.references).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
- Updated DragHandleOverlay to accept allAddReferencedNodeByAction as a prop, enhancing its functionality.
- Modified getValidRelationTypesBetween to accept an object for parameters, allowing for better extensibility.
- Improved RelationTypeDropdown to utilize the new structure for fetching valid relation types, ensuring consistency across components.
- Enhanced type definitions for RelationTypeOption to include a 'kind' property, differentiating between relation types and referenced nodes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/1196" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->