### PR TITLE
ENG-1990: Restore sidebar navigation for blocks containing a smartblock

### DIFF
--- a/apps/roam/src/components/LeftSidebarView.tsx
+++ b/apps/roam/src/components/LeftSidebarView.tsx
@@ -179,9 +179,6 @@ const toggleFoldedState = async ({
   }
 };
 
-const RENDERED_BLOCK_INTERACTIVE_SELECTOR =
-  "a, button, input, [data-link-title], [data-tag], .rm-block-ref";
-
 const RoamRenderedBlock = ({
   uid,
   onNavigate,
@@ -203,7 +200,7 @@ const RoamRenderedBlock = ({
 
   const handleClick = (e: React.MouseEvent) => {
     const target = e.target as HTMLElement;
-    if (target.closest(RENDERED_BLOCK_INTERACTIVE_SELECTOR)) return;
+    if (target.closest("button")) return;
     onNavigate(e);
   };
 
@@ -1063,6 +1060,9 @@ export const mountLeftSidebar = async ({
       .dg-sidebar-rendered-block .block-border-left { display: none; }
       .dg-sidebar-rendered-block .block-ref-count-button { display: none; }
       .dg-sidebar-rendered-block .rm-block-main { min-height: unset; padding: 0; }
+      .dg-sidebar-rendered-block * { pointer-events: none; }
+      .dg-sidebar-rendered-block button,
+      .dg-sidebar-rendered-block button * { pointer-events: auto; }
     `;
     document.head.appendChild(style);
   }

--- a/apps/roam/src/components/LeftSidebarView.tsx
+++ b/apps/roam/src/components/LeftSidebarView.tsx
@@ -179,6 +179,9 @@ const toggleFoldedState = async ({
   }
 };
 
+const RENDERED_BLOCK_INTERACTIVE_SELECTOR =
+  "a, button, input, [data-link-title], [data-tag], .rm-block-ref";
+
 const RoamRenderedBlock = ({
   uid,
   onNavigate,
@@ -200,7 +203,7 @@ const RoamRenderedBlock = ({
 
   const handleClick = (e: React.MouseEvent) => {
     const target = e.target as HTMLElement;
-    if (target.closest("[data-roamjs-smartblock-button]")) return;
+    if (target.closest(RENDERED_BLOCK_INTERACTIVE_SELECTOR)) return;
     onNavigate(e);
   };
 

--- a/apps/roam/src/components/LeftSidebarView.tsx
+++ b/apps/roam/src/components/LeftSidebarView.tsx
@@ -179,7 +179,13 @@ const toggleFoldedState = async ({
   }
 };
 
-const RoamRenderedBlock = ({ uid }: { uid: string }) => {
+const RoamRenderedBlock = ({
+  uid,
+  onNavigate,
+}: {
+  uid: string;
+  onNavigate: (e: React.MouseEvent) => void;
+}) => {
   const [version, setVersion] = useState(0);
 
   useEffect(() => {
@@ -192,8 +198,14 @@ const RoamRenderedBlock = ({ uid }: { uid: string }) => {
     };
   }, [uid]);
 
+  const handleClick = (e: React.MouseEvent) => {
+    const target = e.target as HTMLElement;
+    if (target.closest("[data-roamjs-smartblock-button]")) return;
+    onNavigate(e);
+  };
+
   return (
-    <div className="dg-sidebar-rendered-block">
+    <div className="dg-sidebar-rendered-block" onClick={handleClick}>
       <RenderRoamBlock key={version} uid={uid} open={false} />
     </div>
   );
@@ -215,8 +227,11 @@ const ChildRow = ({
   if (ref.type === "block" && isSmartBlockUid(ref.uid)) {
     return (
       <div className="pl-8 pr-2.5">
-        <div className="section-child-item rounded-sm leading-normal text-gray-600">
-          <RoamRenderedBlock uid={ref.uid} />
+        <div className="section-child-item cursor-pointer rounded-sm leading-normal text-gray-600">
+          <RoamRenderedBlock
+            uid={ref.uid}
+            onNavigate={(e) => void openTarget(e, child.text, onloadArgs)}
+          />
         </div>
       </div>
     );


### PR DESCRIPTION
https://www.loom.com/share/f123ad86812345f1a21cb41205d852f6

Sidebar rows rendered via RoamRenderedBlock (blocks containing a SmartBlock button) had no click handler, so clicking the text did nothing. Per the approach agreed on the ticket: a click watcher on the rendered block now navigates via the existing openTarget unless the click originated on a data-roamjs-smartblock-button element, which passes through to the SmartBlocks extension.

Fixes ENG-1990
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/1199" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->