### PR TITLE
ENG-1965: Rename Template-Block-props buffer block to Template

### DIFF
--- a/apps/roam/src/components/settings/components/EphemeralBlocksPanel.tsx
+++ b/apps/roam/src/components/settings/components/EphemeralBlocksPanel.tsx
@@ -14,7 +14,7 @@ import {
 import type { DiscourseNodeBaseProps } from "./BlockPropSettingPanels";
 
 const DEBOUNCE_MS = 250;
-const TEMPLATE_BUFFER_TEXT = "Template (editing)";
+const TEMPLATE_BUFFER_TEXT = "Template";
 
 type DualWriteBlocksPanelProps = DiscourseNodeBaseProps & {
   uid: string;

--- a/apps/roam/src/components/settings/components/EphemeralBlocksPanel.tsx
+++ b/apps/roam/src/components/settings/components/EphemeralBlocksPanel.tsx
@@ -14,7 +14,7 @@ import {
 import type { DiscourseNodeBaseProps } from "./BlockPropSettingPanels";
 
 const DEBOUNCE_MS = 250;
-const TEMPLATE_BUFFER_TEXT = "Template-Block-props";
+const TEMPLATE_BUFFER_TEXT = "Template (editing)";
 
 type DualWriteBlocksPanelProps = DiscourseNodeBaseProps & {
   uid: string;


### PR DESCRIPTION
Renames the ephemeral template buffer block users were seeing in the node settings Template tab (and on the raw node type page) from Template-Block-props to Template.

Safety note on the text-match lookups: getSubTree({parentUid: node.type, key: "Template"}) in NodeConfig.tsx / DiscourseNodeSuggestiveRules.tsx also matches this text, but getBasicTreeByParentUid returns children order-sorted and the legacy Template block is auto-created at order 0 before the buffer (order: last) can exist, so the lookup deterministically resolves to the legacy block. No read path matches the old Template-Block-props text, so no compatibility shim is needed.

Fixes ENG-1965