### PR TITLE
ENG-1792: Add edit block button to rendered dg-canvas

### DIFF
--- a/apps/roam/src/components/canvas/CanvasEmbed.tsx
+++ b/apps/roam/src/components/canvas/CanvasEmbed.tsx
@@ -51,7 +51,7 @@ const CanvasEmbedChrome = ({
   <div className="relative h-full w-full">
     <TldrawCanvas title={title} />
     <Button
-      className="absolute right-2 top-2 z-20"
+      className="absolute bottom-2 right-8 z-20"
       icon="edit"
       minimal
       small

--- a/apps/roam/src/components/canvas/CanvasEmbed.tsx
+++ b/apps/roam/src/components/canvas/CanvasEmbed.tsx
@@ -83,7 +83,7 @@ export const renderCanvasEmbed = (
     return;
   }
 
-  const location = getUids(button.closest(".roam-block") as HTMLDivElement);
+  const location = getUids(button.closest<HTMLDivElement>(".roam-block"));
 
   const wrapper = document.createElement("div");
   wrapper.className = "dg-canvas-embed my-2 w-full overflow-hidden rounded-md";

--- a/apps/roam/src/components/canvas/CanvasEmbed.tsx
+++ b/apps/roam/src/components/canvas/CanvasEmbed.tsx
@@ -1,8 +1,11 @@
 import React from "react";
+import { Button } from "@blueprintjs/core";
+import posthog from "posthog-js";
 import ExtensionApiContextProvider from "roamjs-components/components/ExtensionApiContext";
 import { OnloadArgs } from "roamjs-components/types";
 import renderWithUnmount from "roamjs-components/util/renderWithUnmount";
 import getBlockUidFromTarget from "roamjs-components/dom/getBlockUidFromTarget";
+import getUids from "roamjs-components/dom/getUids";
 import getTextByBlockUid from "roamjs-components/queries/getTextByBlockUid";
 import getPageUidByPageTitle from "roamjs-components/queries/getPageUidByPageTitle";
 import { TldrawCanvas } from "./Tldraw";
@@ -28,6 +31,36 @@ const CanvasEmbedPlaceholder = ({ message }: { message: string }) => (
   </div>
 );
 
+const handleEditBlock = (location: { blockUid: string; windowId: string }) => {
+  posthog.capture("Canvas Embed: Edit Block Clicked");
+  void window.roamAlphaAPI.ui.setBlockFocusAndSelection({
+    location: {
+      "block-uid": location.blockUid,
+      "window-id": location.windowId,
+    },
+  });
+};
+
+const CanvasEmbedChrome = ({
+  title,
+  location,
+}: {
+  title: string;
+  location: { blockUid: string; windowId: string };
+}) => (
+  <div className="relative h-full w-full">
+    <TldrawCanvas title={title} />
+    <Button
+      className="absolute right-2 top-2 z-20"
+      icon="edit"
+      minimal
+      small
+      title="Edit Block"
+      onClick={() => handleEditBlock(location)}
+    />
+  </div>
+);
+
 export const renderCanvasEmbed = (
   button: HTMLElement,
   onloadArgs: OnloadArgs,
@@ -50,6 +83,8 @@ export const renderCanvasEmbed = (
     return;
   }
 
+  const location = getUids(button.closest(".roam-block") as HTMLDivElement);
+
   const wrapper = document.createElement("div");
   wrapper.className = "dg-canvas-embed my-2 w-full overflow-hidden rounded-md";
   wrapper.style.height = "400px";
@@ -58,7 +93,7 @@ export const renderCanvasEmbed = (
 
   renderWithUnmount(
     <ExtensionApiContextProvider {...onloadArgs}>
-      <TldrawCanvas title={title} />
+      <CanvasEmbedChrome title={title} location={location} />
     </ExtensionApiContextProvider>,
     wrapper,
   );


### PR DESCRIPTION
https://www.loom.com/share/5a61fddb73824341865e254fb3431243


Adds a minimal Blueprint edit button overlaid top-right on the embedded canvas that focuses the underlying {{dg-canvas}} block via setBlockFocusAndSelection, using the same getUids/.roam-block idiom as the ResultsView Edit Block action so it also works for canvases in the right sidebar.

Fixes ENG-1792
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/1203" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->