### PR TITLE
eng-1910-add-no-op-content-resolve-endpoint

### DIFF
--- a/apps/website/app/api/internal/space/[id]/concept/route.ts
+++ b/apps/website/app/api/internal/space/[id]/concept/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse, NextRequest } from "next/server";
+
+import { createClient } from "~/utils/supabase/server";
+import {
+  createApiResponse,
+  handleRouteError,
+  defaultOptionsHandler,
+} from "~/utils/supabase/apiUtils";
+import { asPostgrestFailure } from "@repo/database/lib/contextFunctions";
+import type { Json } from "@repo/database/dbTypes";
+import { CrossAppNode } from "@repo/database/crossAppContracts";
+import { crossAppNodeToDbConcept } from "@repo/database/lib/crossAppConverters";
+import { getAccountId } from "~/utils/supabase/account";
+
+type ApiParams = Promise<{ id: string }>;
+export type SegmentDataType = { params: ApiParams };
+
+export const POST = async (
+  request: NextRequest,
+  segmentData: SegmentDataType,
+): Promise<NextResponse> => {
+  const { id: spaceIdS } = await segmentData.params;
+  const spaceId = Number.parseInt(spaceIdS);
+  if (Number.isNaN(spaceId))
+    return createApiResponse(
+      request,
+      asPostgrestFailure("Cannot parse space id", "invalid", 403),
+    );
+
+  const supabase = await createClient();
+
+  const userId = await getAccountId(supabase);
+  if (userId === undefined)
+    return createApiResponse(
+      request,
+      asPostgrestFailure("Please login", "invalid", 401),
+    );
+  try {
+    const body = (await request.json()) as CrossAppNode[];
+    // TODO: Zed validator
+    const concepts = body
+      .map((c) => crossAppNodeToDbConcept(c))
+      .filter((c) => c !== undefined);
+    if (concepts.length === 0) throw new Error("Could not translate concepts");
+    const result = await supabase.rpc("upsert_concepts", {
+      data: concepts as Json,
+      v_space_id: spaceId,
+      v_creator_id: userId,
+      content_as_document: true,
+    });
+    return createApiResponse(request, result);
+  } catch (e: unknown) {
+    return handleRouteError(request, e, "/api/supabase/space/[id]/concept");
+  }
+};
+
+export const OPTIONS = defaultOptionsHandler;

--- a/apps/website/app/api/internal/space/[id]/content/route.ts
+++ b/apps/website/app/api/internal/space/[id]/content/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse, NextRequest } from "next/server";
+
+import { createClient } from "~/utils/supabase/server";
+import {
+  createApiResponse,
+  handleRouteError,
+  defaultOptionsHandler,
+} from "~/utils/supabase/apiUtils";
+import { asPostgrestFailure } from "@repo/database/lib/contextFunctions";
+import type { Json } from "@repo/database/dbTypes";
+import { StandaloneCrossAppContent } from "@repo/database/crossAppContracts";
+import { crossAppStandaloneContentToDbContent } from "@repo/database/lib/crossAppConverters";
+import { getAccountId } from "~/utils/supabase/account";
+
+type ApiParams = Promise<{ id: string }>;
+export type SegmentDataType = { params: ApiParams };
+
+export const POST = async (
+  request: NextRequest,
+  segmentData: SegmentDataType,
+): Promise<NextResponse> => {
+  const { id: spaceIdS } = await segmentData.params;
+  const spaceId = Number.parseInt(spaceIdS);
+  if (Number.isNaN(spaceId))
+    return createApiResponse(
+      request,
+      asPostgrestFailure("Cannot parse space id", "invalid", 403),
+    );
+
+  const supabase = await createClient();
+
+  const userId = await getAccountId(supabase);
+  if (userId === undefined)
+    return createApiResponse(
+      request,
+      asPostgrestFailure("Please login", "invalid", 401),
+    );
+  try {
+    const body = (await request.json()) as StandaloneCrossAppContent[];
+    // TODO: Zed validator
+    const content = body
+      .map((c) => crossAppStandaloneContentToDbContent(c, { dbId: spaceId }))
+      .filter((c) => c !== undefined);
+    if (content.length === 0) throw new Error("Could not translate content");
+    const result = await supabase.rpc("upsert_content", {
+      data: content as Json,
+      v_space_id: spaceId,
+      v_creator_id: userId,
+      content_as_document: true,
+    });
+    return createApiResponse(request, result);
+  } catch (e: unknown) {
+    return handleRouteError(request, e, "/api/supabase/space/[id]/content");
+  }
+};
+
+export const OPTIONS = defaultOptionsHandler;

--- a/apps/website/app/utils/supabase/account.ts
+++ b/apps/website/app/utils/supabase/account.ts
@@ -3,6 +3,23 @@ import type { DGSupabaseClient } from "@repo/database/lib/client";
 
 type AgentType = Database["public"]["Enums"]["AgentType"] | "group";
 
+export const getAccountId = async (
+  client: DGSupabaseClient,
+): Promise<number | undefined> => {
+  const { data, error } = await client.auth.getUser();
+  if (error || !data?.user) return undefined;
+  const userData = data.user;
+  if (typeof userData.id !== "string") return undefined;
+  const id = userData.id;
+  const accountReq = await client
+    .from("PlatformAccount")
+    .select("id")
+    .eq("dg_account", id)
+    .eq("agent_type", "person")
+    .maybeSingle();
+  return accountReq.data?.id;
+};
+
 export const getSessionBaseUserData = async (
   client: DGSupabaseClient,
 ): Promise<{

--- a/packages/database/src/crossAppContracts.ts
+++ b/packages/database/src/crossAppContracts.ts
@@ -77,6 +77,11 @@ type InlineCrossAppTypedContent = InlineCrossAppContent & {
   contentType: ContentType;
 };
 
+export type StandaloneCrossAppContent = InlineCrossAppTypedContent &
+  CrossAppBase & {
+    variant: Enums<"ContentVariant">;
+  };
+
 // A node instance
 export type CrossAppNode = CrossAppBase & {
   nodeType: Ref;

--- a/packages/database/src/lib/crossAppConverters.ts
+++ b/packages/database/src/lib/crossAppConverters.ts
@@ -3,12 +3,14 @@ import {
   Ref,
   CrossAppEmbedding,
   InlineCrossAppContent,
+  StandaloneCrossAppContent,
   CrossAppBase,
   CrossAppNode,
 } from "../crossAppContracts";
 import { LocalContentDataInput, LocalConceptDataInput } from "../inputTypes";
 import { Enums, CompositeTypes } from "../dbTypes";
 
+type ContentDataInput = CompositeTypes<"content_local_input">;
 type InlineEmbeddingInput = CompositeTypes<"inline_embedding_input">;
 type InlineAbstractBase = Partial<CrossAppBase>;
 
@@ -37,6 +39,47 @@ const decodeRef = <DbVarName extends string, LocalVarName extends string>(
   if ("dbId" in ref)
     return { [dbVarName]: ref.dbId } as Record<DbVarName, number>;
   return decodeLocalRef(ref, localVarName);
+};
+
+const decodeRefWithNulls = <
+  DbVarName extends string,
+  LocalVarName extends string,
+>(
+  ref: Ref | undefined,
+  dbVarName: DbVarName,
+  localVarName: LocalVarName,
+): Record<DbVarName, number | null> & Record<LocalVarName, string | null> => {
+  return {
+    [dbVarName]: ref && "dbId" in ref ? ref.dbId : null,
+    [localVarName]: ref && "localId" in ref ? ref.localId : null,
+  } as Record<DbVarName, number | null> & Record<LocalVarName, string | null>;
+};
+
+const decodeRefWithInlineNulls = <
+  DbVarName extends string,
+  LocalVarName extends string,
+  InlineVarName extends string,
+>({
+  ref,
+  dbVarName,
+  localVarName,
+  inlineVarName,
+}: {
+  ref?: Ref;
+  dbVarName: DbVarName;
+  localVarName: LocalVarName;
+  inlineVarName: InlineVarName;
+}): Record<DbVarName, number | null> &
+  Record<LocalVarName, string | null> &
+  Record<InlineVarName, null> => {
+  return {
+    [dbVarName]: null,
+    [localVarName]: null,
+    [inlineVarName]: null,
+    ...decodeRef(ref, dbVarName, localVarName),
+  } as Record<DbVarName, number | null> &
+    Record<LocalVarName, string | null> &
+    Record<InlineVarName, null>;
 };
 
 const crossAppEmbeddingToDbEmbedding = (
@@ -74,6 +117,43 @@ const inlineCrossAppContentToDbContent = (
     ...decodeRef(content.author, "author_id", "author_local_id"),
     embedding_inline: crossAppEmbeddingToDbEmbedding(content.embedding),
   });
+};
+
+export const crossAppStandaloneContentToDbContent = (
+  content: StandaloneCrossAppContent | undefined,
+  space: Ref,
+): ContentDataInput | undefined => {
+  if (content === undefined) return undefined;
+  return {
+    source_local_id: content.localId,
+    text: content.value,
+    scale: content.scale || "document",
+    content_type: content.contentType || "text/plain",
+    variant: content.variant,
+    created: content.createdAt.toISOString(),
+    last_modified: (content.modifiedAt || content.createdAt).toISOString(),
+    embedding_inline: crossAppEmbeddingToDbEmbedding(content.embedding) || null,
+    ...decodeRefWithInlineNulls({
+      ref: content.author,
+      dbVarName: "author_id",
+      localVarName: "author_local_id",
+      inlineVarName: "author_inline",
+    }),
+    ...decodeRefWithNulls(space, "space_id", "space_url"),
+    // provide other explicit null values for type completion
+    ...decodeRefWithInlineNulls({
+      dbVarName: "creator_id",
+      localVarName: "creator_local_id",
+      inlineVarName: "creator_inline",
+    }),
+    ...decodeRefWithInlineNulls({
+      dbVarName: "document_id",
+      localVarName: "document_local_id",
+      inlineVarName: "document_inline",
+    }),
+    ...decodeRefWithNulls(undefined, "part_of_id", "part_of_local_id"),
+    metadata: null,
+  };
 };
 
 export const crossAppNodeToDbContent = (


### PR DESCRIPTION
[ENG-1910: Add no-op Next.js content resolve endpoint](https://linear.app/discourse-graphs/issue/ENG-1910/add-no-op-nextjs-content-resolve-endpoint)

Content and concept upsert, based on cross-app types.

Note: This is ready for review in the sense it's ready for an iteration, we should discuss PR boundaries a bit more. Please focus the review on the PR boundaries, the detailed review can come after.
The PR has two routes, maybe they could be separated.
It introduces a StandaloneContent type for upserting contents outside of concepts, following existing sync functions.
In the loom, I mention an issue with inline authors; but I checked and we do not currently use this anywhere in the sync code.
That said, the upsert_concept route is only useable for nodes, we will expand it when we have checked in the converters for more types.

https://www.loom.com/share/0d11ac2c3dea41e3bfe52141701af5e7
