### PR TITLE
ENG-1909 Add no-op Next.js content upsert endpoint

### DIFF
--- a/apps/website/app/api/internal/space/[id]/content/route.ts
+++ b/apps/website/app/api/internal/space/[id]/content/route.ts
@@ -29,13 +29,13 @@ export const POST = async (
 
   const supabase = await createClient();
 
-  const userId = await getAccountId(supabase);
-  if (userId === undefined)
-    return createApiResponse(
-      request,
-      asPostgrestFailure("Please login", "invalid", 401),
-    );
   try {
+    const userId = await getAccountId(supabase);
+    if (userId === undefined)
+      return createApiResponse(
+        request,
+        asPostgrestFailure("Please login", "invalid", 401),
+      );
     const body = (await request.json()) as StandaloneCrossAppContent[];
     // TODO: Zed validator
     const content = body

--- a/apps/website/app/api/internal/space/[id]/content/route.ts
+++ b/apps/website/app/api/internal/space/[id]/content/route.ts
@@ -39,7 +39,16 @@ export const POST = async (
     const body = (await request.json()) as StandaloneCrossAppContent[];
     // TODO: Zed validator
     const content = body
-      .map((c) => crossAppStandaloneContentToDbContent(c, spaceId))
+      .map((c) =>
+        crossAppStandaloneContentToDbContent(
+          {
+            ...c,
+            createdAt: new Date(c.createdAt),
+            modifiedAt: new Date(c.modifiedAt || c.createdAt),
+          },
+          spaceId,
+        ),
+      )
       .filter((c) => c !== undefined);
     if (content.length === 0) throw new Error("Could not translate content");
     const result = await supabase.rpc("upsert_content", {

--- a/apps/website/app/api/internal/space/[id]/content/route.ts
+++ b/apps/website/app/api/internal/space/[id]/content/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse, NextRequest } from "next/server";
+
+import { createClient } from "~/utils/supabase/server";
+import {
+  createApiResponse,
+  handleRouteError,
+  defaultOptionsHandler,
+} from "~/utils/supabase/apiUtils";
+import { asPostgrestFailure } from "@repo/database/lib/contextFunctions";
+import type { Json } from "@repo/database/dbTypes";
+import { StandaloneCrossAppContent } from "@repo/database/crossAppContracts";
+import { crossAppStandaloneContentToDbContent } from "@repo/database/lib/crossAppConverters";
+import { getAccountId } from "~/utils/supabase/account";
+
+type ApiParams = Promise<{ id: string }>;
+export type SegmentDataType = { params: ApiParams };
+
+export const POST = async (
+  request: NextRequest,
+  segmentData: SegmentDataType,
+): Promise<NextResponse> => {
+  const { id: spaceIdS } = await segmentData.params;
+  const spaceId = Number.parseInt(spaceIdS);
+  if (Number.isNaN(spaceId))
+    return createApiResponse(
+      request,
+      asPostgrestFailure("Cannot parse space id", "invalid", 403),
+    );
+
+  const supabase = await createClient();
+
+  const userId = await getAccountId(supabase);
+  if (userId === undefined)
+    return createApiResponse(
+      request,
+      asPostgrestFailure("Please login", "invalid", 401),
+    );
+  try {
+    const body = (await request.json()) as StandaloneCrossAppContent[];
+    // TODO: Zed validator
+    const content = body
+      .map((c) => crossAppStandaloneContentToDbContent(c, spaceId))
+      .filter((c) => c !== undefined);
+    if (content.length === 0) throw new Error("Could not translate content");
+    const result = await supabase.rpc("upsert_content", {
+      data: content as Json,
+      v_space_id: spaceId,
+      v_creator_id: userId,
+      content_as_document: true,
+    });
+    return createApiResponse(request, result);
+  } catch (e: unknown) {
+    return handleRouteError(request, e, "/api/supabase/space/[id]/content");
+  }
+};
+
+export const OPTIONS = defaultOptionsHandler;

--- a/apps/website/app/utils/supabase/account.ts
+++ b/apps/website/app/utils/supabase/account.ts
@@ -17,6 +17,7 @@ export const getAccountId = async (
     .eq("dg_account", id)
     .eq("agent_type", "person")
     .maybeSingle();
+  if (accountReq.error) throw accountReq.error;
   return accountReq.data?.id;
 };
 

--- a/apps/website/app/utils/supabase/account.ts
+++ b/apps/website/app/utils/supabase/account.ts
@@ -3,6 +3,23 @@ import type { DGSupabaseClient } from "@repo/database/lib/client";
 
 type AgentType = Database["public"]["Enums"]["AgentType"] | "group";
 
+export const getAccountId = async (
+  client: DGSupabaseClient,
+): Promise<number | undefined> => {
+  const { data, error } = await client.auth.getUser();
+  if (error || !data?.user) return undefined;
+  const userData = data.user;
+  if (typeof userData.id !== "string") return undefined;
+  const id = userData.id;
+  const accountReq = await client
+    .from("PlatformAccount")
+    .select("id")
+    .eq("dg_account", id)
+    .eq("agent_type", "person")
+    .maybeSingle();
+  return accountReq.data?.id;
+};
+
 export const getSessionBaseUserData = async (
   client: DGSupabaseClient,
 ): Promise<{

--- a/packages/database/src/crossAppContracts.ts
+++ b/packages/database/src/crossAppContracts.ts
@@ -71,6 +71,11 @@ type InlineCrossAppTypedContent = InlineCrossAppContent & {
   contentType: ContentType;
 };
 
+export type StandaloneCrossAppContent = InlineCrossAppTypedContent &
+  CrossAppBase & {
+    variant: Enums<"ContentVariant">;
+  };
+
 // A node instance
 export type CrossAppNode = CrossAppBase & {
   nodeType: LocalId;

--- a/packages/database/src/lib/crossAppConverters.ts
+++ b/packages/database/src/lib/crossAppConverters.ts
@@ -1,6 +1,7 @@
 import {
   CrossAppEmbedding,
   InlineCrossAppContent,
+  StandaloneCrossAppContent,
   CrossAppNode,
   CrossAppNodeSchema,
   CrossAppRelationTypeSchema,
@@ -10,6 +11,7 @@ import {
 import { LocalContentDataInput, LocalConceptDataInput } from "../inputTypes";
 import { Enums, CompositeTypes } from "../dbTypes";
 
+type ContentDataInput = CompositeTypes<"content_local_input">;
 type InlineEmbeddingInput = CompositeTypes<"inline_embedding_input">;
 
 const crossAppEmbeddingToDbEmbedding = (
@@ -47,6 +49,38 @@ const inlineCrossAppContentToDbContent = (
     author_local_id: content.authorId,
     embedding_inline: crossAppEmbeddingToDbEmbedding(content.embedding),
   });
+};
+
+export const crossAppStandaloneContentToDbContent = (
+  content: StandaloneCrossAppContent | undefined,
+  spaceId: number,
+): ContentDataInput | undefined => {
+  if (content === undefined) return undefined;
+  return {
+    source_local_id: content.localId,
+    author_local_id: content.authorId,
+    text: content.value,
+    scale: content.scale || "document",
+    content_type: content.contentType || "text/plain",
+    variant: content.variant,
+    created: content.createdAt.toISOString(),
+    last_modified: (content.modifiedAt || content.createdAt).toISOString(),
+    embedding_inline: crossAppEmbeddingToDbEmbedding(content.embedding) || null,
+    space_id: spaceId,
+    // provide other explicit null values for type completion
+    space_url: null,
+    author_inline: null,
+    author_id: null,
+    document_id: null,
+    creator_id: null,
+    creator_local_id: null,
+    creator_inline: null,
+    document_local_id: null,
+    document_inline: null,
+    part_of_id: null,
+    part_of_local_id: null,
+    metadata: null,
+  };
 };
 
 export const crossAppNodeToDbContent = (


### PR DESCRIPTION
https://linear.app/discourse-graphs/issue/ENG-1909/add-no-op-nextjs-content-upsert-endpoint

Content upsert, based on cross-app types.

This introduces a StandaloneCrossAppContent type for upserting contents outside of concepts, following existing sync functions.

Rationale : This is the closest to the current upsert_content practices, since the upsert unification (eng-1824) has been delayed. So it should make eng-1911  as easy as possible.

There is an alternative approach: Do not create StandaloneCrossAppContent, but send the CrossAppNode with the standalone contents; and extract just the contents in the endpoint. In the longer run that is the right approach; but it is only optimal if we are doing the unification of upsert_content and upsert_concepts at the same time, which goes against PR minimalism. But I'm happy to revisit.

Also: I have not, in this PR, introduced a bulk conversion utility function, which could be more optimal in some cases. I think it is worth doing, but clearly a separate scope.

https://www.loom.com/share/202c49deb3014d2e8f60632f38ff71b4