### PR TITLE
ENG-2029 - Discourse context bleeds out of bounds in sidebar

### DIFF
--- a/apps/roam/src/components/PublishNodeTitleButton.tsx
+++ b/apps/roam/src/components/PublishNodeTitleButton.tsx
@@ -48,6 +48,5 @@ export const renderPublishNodeTitleButton = ({
   handleTitleAdditions(
     h1,
     <PublishNodeTitleButton uid={uid} title={title} nodeType={nodeType} />,
-    { layout: "inline" },
   );
 };

--- a/apps/roam/src/utils/handleTitleAdditions.ts
+++ b/apps/roam/src/utils/handleTitleAdditions.ts
@@ -3,16 +3,10 @@ import ReactDOM from "react-dom";
 
 const ROAM_TITLE_CONTAINER_CLASS = "rm-title-display-container";
 const ADDITIONS_CONTAINER_CLASS = "discourse-graph-title-additions";
-const ADDITIONS_CONTAINER_CLASSES = `${ADDITIONS_CONTAINER_CLASS} flex flex-wrap items-start gap-x-2 gap-y-2`;
-const INLINE_ADDITION_CLASSES = "min-w-0 flex-none";
-const BLOCK_ADDITION_CLASSES = "min-w-0 basis-full grow shrink-0";
-
-type TitleAdditionLayout = "inline" | "block";
 
 export const handleTitleAdditions = (
   h1: HTMLHeadingElement,
   element: React.ReactNode,
-  { layout = "block" }: { layout?: TitleAdditionLayout } = {},
 ): void => {
   const titleDisplayContainer =
     h1.closest(`.${ROAM_TITLE_CONTAINER_CLASS}`) ||
@@ -31,7 +25,7 @@ export const handleTitleAdditions = (
     if (!parent) return;
 
     container = document.createElement("div");
-    container.className = ADDITIONS_CONTAINER_CLASSES;
+    container.className = `${ADDITIONS_CONTAINER_CLASS} flex flex-col`;
 
     const oldMarginBottom = getComputedStyle(h1).marginBottom;
     const oldMarginBottomNum = Number.isFinite(parseFloat(oldMarginBottom))
@@ -51,8 +45,6 @@ export const handleTitleAdditions = (
 
   if (React.isValidElement(element)) {
     const renderContainer = document.createElement("div");
-    renderContainer.className =
-      layout === "inline" ? INLINE_ADDITION_CLASSES : BLOCK_ADDITION_CLASSES;
     container.appendChild(renderContainer);
     // eslint-disable-next-line react/no-deprecated
     ReactDOM.render(element, renderContainer);

--- a/apps/roam/src/utils/renderLinkedReferenceAdditions.ts
+++ b/apps/roam/src/utils/renderLinkedReferenceAdditions.ts
@@ -20,7 +20,6 @@ export const renderDiscourseContext = ({
       uid,
       id: nanoid(),
     }),
-    { layout: "inline" },
   );
   h1.setAttribute("data-roamjs-top-discourse-context", "true");
 };


### PR DESCRIPTION
Before
<img width="2532" height="472" alt="image" src="https://github.com/user-attachments/assets/732c886e-9407-42fc-b52d-89041ef32172" />

After
<img width="2558" height="758" alt="image" src="https://github.com/user-attachments/assets/e41238e6-6c91-419e-ab99-cd90bf133e2c" />
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/1228" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->