### PR TITLE
ENG-2030 Discourse context under page title doesn't show up unless `overlay` is on

### DIFF
--- a/apps/roam/src/utils/initializeObserversAndListeners.ts
+++ b/apps/roam/src/utils/initializeObserversAndListeners.ts
@@ -133,9 +133,7 @@ export const initObservers = ({
             nodeType: node.type,
           });
         }
-        if (settings.personalSettings[PERSONAL_KEYS.discourseContextOverlay]) {
-          renderDiscourseContext({ h1, uid });
-        }
+        renderDiscourseContext({ h1, uid });
         const linkedReferencesDiv = document.querySelector(
           ".rm-reference-main",
         ) as HTMLDivElement;


### PR DESCRIPTION
## Summary

- Always render discourse context under the title of discourse-node pages.
- Keep the `Overlay` preference scoped to discourse context on page references.

## Root cause

The page-title renderer was gated by the same personal preference that enables page-reference overlays, so disabling `Overlay` unintentionally hid the context beneath page titles too.

## Impact

Discourse context now appears beneath page titles in both the main window and sidebar regardless of the page-reference overlay preference.

## Validation

- Roam unit suite: 43 tests passed
- ESLint: changed file passed