### PR TITLE
ENG-1804 Vertically center the Edit node type header

### DIFF
--- a/apps/obsidian/src/components/NodeTypeSettings.tsx
+++ b/apps/obsidian/src/components/NodeTypeSettings.tsx
@@ -1192,7 +1192,7 @@ const NodeTypeSettings = () => {
               ref={(el) => (el && setIcon(el, "arrow-left")) || undefined}
             />
           </button>
-          <h3 className="dg-h3">
+          <h3 className="dg-h3 !mb-0">
             {isEditingImported
               ? `[Read only] Imported from ${getAndFormatImportSource(editingNodeType.importedFromRid || "", plugin.settings.spaceNames)}`
               : "Edit node type"}


### PR DESCRIPTION
Before
<img width="1985" height="849" alt="image" src="https://github.com/user-attachments/assets/38b4d527-c09c-4c1a-a606-49fc3d68a21d" />


After
<img width="983" height="349" alt="image" src="https://github.com/user-attachments/assets/3cdb9a5b-c651-480a-b33f-81d272fda581" />


## Summary
- Removed the bottom margin from the node type settings heading so it aligns vertically with the back button.
- Keeps the edit header visually centered in the Obsidian settings view.

## Testing
- Not run (not requested)