### PR TITLE
ENG-2035 - Build collaborative canvas prototype

### DIFF
--- a/apps/tldraw-sync-worker/worker/worker.ts
+++ b/apps/tldraw-sync-worker/worker/worker.ts
@@ -6,6 +6,8 @@ import { Environment } from "./types";
 export { TldrawDurableObject } from "./TldrawDurableObject";
 
 const ALLOWED_ORIGINS = [
+  "https://discoursegraphs.com",
+  "https://www.discoursegraphs.com",
   "https://roamresearch.com",
   "http://localhost:3000",
   "app://obsidian.md",

--- a/apps/tldraw-sync-worker/worker/worker.ts
+++ b/apps/tldraw-sync-worker/worker/worker.ts
@@ -13,8 +13,19 @@ const ALLOWED_ORIGINS = [
   "app://obsidian.md",
 ];
 
-const isVercelPreviewUrl = (origin: string): boolean =>
-  /^https:\/\/.*-discourse-graph-[a-z0-9]+\.vercel\.app$/.test(origin);
+const isVercelPreviewUrl = (origin: string): boolean => {
+  try {
+    const url = new URL(origin);
+    return (
+      url.protocol === "https:" &&
+      /^discourse-graph(?:-[a-z0-9-]+)?-discourse-graphs\.vercel\.app$/.test(
+        url.hostname,
+      )
+    );
+  } catch {
+    return false;
+  }
+};
 
 const isAllowedOrigin = (origin: string): boolean =>
   ALLOWED_ORIGINS.some((allowedOrigin) => origin === allowedOrigin) ||

--- a/apps/website/app/(canvas)/canvas/[roomId]/page.tsx
+++ b/apps/website/app/(canvas)/canvas/[roomId]/page.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from "react";
 import { notFound } from "next/navigation";
-import { CanvasRoom } from "../components/CanvasRoom";
+import { CanvasRoomLoader } from "../components/CanvasRoomLoader";
 
 type CanvasPageProps = {
   params: Promise<{ roomId: string }>;
@@ -8,11 +8,13 @@ type CanvasPageProps = {
 
 const ROOM_ID_PATTERN = /^[0-9a-f-]{36}$/i;
 
-const CanvasPage = async ({ params }: CanvasPageProps): Promise<ReactElement> => {
+const CanvasPage = async ({
+  params,
+}: CanvasPageProps): Promise<ReactElement> => {
   const { roomId } = await params;
   if (!ROOM_ID_PATTERN.test(roomId)) notFound();
 
-  return <CanvasRoom roomId={roomId} />;
+  return <CanvasRoomLoader roomId={roomId} />;
 };
 
 export default CanvasPage;

--- a/apps/website/app/(canvas)/canvas/[roomId]/page.tsx
+++ b/apps/website/app/(canvas)/canvas/[roomId]/page.tsx
@@ -1,0 +1,18 @@
+import type { ReactElement } from "react";
+import { notFound } from "next/navigation";
+import { CanvasRoom } from "../components/CanvasRoom";
+
+type CanvasPageProps = {
+  params: Promise<{ roomId: string }>;
+};
+
+const ROOM_ID_PATTERN = /^[0-9a-f-]{36}$/i;
+
+const CanvasPage = async ({ params }: CanvasPageProps): Promise<ReactElement> => {
+  const { roomId } = await params;
+  if (!ROOM_ID_PATTERN.test(roomId)) notFound();
+
+  return <CanvasRoom roomId={roomId} />;
+};
+
+export default CanvasPage;

--- a/apps/website/app/(canvas)/canvas/components/CanvasRoom.tsx
+++ b/apps/website/app/(canvas)/canvas/components/CanvasRoom.tsx
@@ -11,6 +11,7 @@ import {
   Share2,
   X,
 } from "lucide-react";
+import Link from "next/link";
 import { type ReactElement, useEffect, useMemo, useRef, useState } from "react";
 import { useSync } from "@tldraw/sync";
 import {
@@ -193,7 +194,7 @@ const CanvasHeader = ({ roomId }: { roomId: string }): ReactElement => {
   return (
     <header className="flex h-14 shrink-0 items-center justify-between gap-3 border-b border-slate-200 bg-white px-3 shadow-sm sm:px-4">
       <div className="flex min-w-0 items-center gap-3">
-        <a
+        <Link
           href="/"
           className="flex shrink-0 items-center gap-2 text-sm font-semibold text-slate-900 no-underline"
         >
@@ -201,7 +202,7 @@ const CanvasHeader = ({ roomId }: { roomId: string }): ReactElement => {
             DG
           </span>
           <span className="hidden sm:inline">Discourse canvas</span>
-        </a>
+        </Link>
         <span className="hidden h-5 w-px bg-slate-200 sm:block" />
         <span className="truncate text-xs text-slate-500">
           Room {roomId.slice(0, 8)}
@@ -213,6 +214,8 @@ const CanvasHeader = ({ roomId }: { roomId: string }): ReactElement => {
       </div>
 
       <div className="flex shrink-0 items-center gap-2">
+        {/* A hard navigation requests a fresh server-generated room every time. */}
+        {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
         <a
           href="/canvas/new"
           className="inline-flex h-9 items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 text-xs font-semibold text-slate-700 no-underline shadow-sm transition-colors hover:bg-slate-50"
@@ -485,9 +488,10 @@ export const CanvasRoom = ({ roomId }: { roomId: string }): ReactElement => {
   const assets = useMemo<TLAssetStore>(
     () => ({
       resolve: (asset) => asset.props.src,
-      upload: async () => {
-        throw new Error("File uploads are not supported in this prototype.");
-      },
+      upload: () =>
+        Promise.reject(
+          new Error("File uploads are not supported in this prototype."),
+        ),
     }),
     [],
   );

--- a/apps/website/app/(canvas)/canvas/components/CanvasRoom.tsx
+++ b/apps/website/app/(canvas)/canvas/components/CanvasRoom.tsx
@@ -11,13 +11,7 @@ import {
   Share2,
   X,
 } from "lucide-react";
-import {
-  type ReactElement,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { type ReactElement, useEffect, useMemo, useRef, useState } from "react";
 import { useSync } from "@tldraw/sync";
 import {
   Tldraw,
@@ -25,6 +19,7 @@ import {
   type Editor,
   type TLArrowShape,
   type TLAssetStore,
+  type TLShapeId,
   type TLGeoShape,
   type TLShape,
   useEditor,
@@ -100,10 +95,10 @@ const getNodeType = (shape: TLShape): NodeType | null => {
     : null;
 };
 
-const getBoundShapeId = (endpoint: unknown): string | null => {
+const getBoundShapeId = (endpoint: unknown): TLShapeId | null => {
   if (!endpoint || typeof endpoint !== "object") return null;
   const candidate = (endpoint as { boundShapeId?: unknown }).boundShapeId;
-  return typeof candidate === "string" ? candidate : null;
+  return typeof candidate === "string" ? (candidate as TLShapeId) : null;
 };
 
 const getCanvasExport = ({ editor }: { editor: Editor }): CanvasExport => {
@@ -368,9 +363,8 @@ const CanvasChrome = (): ReactElement => {
   const shapeCount = useValue(
     "discourse shape count",
     () =>
-      editor
-        .getCurrentPageShapes()
-        .filter((shape) => getNodeType(shape)).length,
+      editor.getCurrentPageShapes().filter((shape) => getNodeType(shape))
+        .length,
     [editor],
   );
 

--- a/apps/website/app/(canvas)/canvas/components/CanvasRoom.tsx
+++ b/apps/website/app/(canvas)/canvas/components/CanvasRoom.tsx
@@ -1,0 +1,530 @@
+"use client";
+
+import {
+  Check,
+  ChevronDown,
+  CircleHelp,
+  FileDown,
+  GitBranch,
+  Link2,
+  Plus,
+  Share2,
+  X,
+} from "lucide-react";
+import {
+  type ReactElement,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { useSync } from "@tldraw/sync";
+import {
+  Tldraw,
+  createShapeId,
+  type Editor,
+  type TLArrowShape,
+  type TLAssetStore,
+  type TLGeoShape,
+  type TLShape,
+  useEditor,
+  useValue,
+} from "tldraw";
+import {
+  formatCanvasExport,
+  NODE_TYPES,
+  type CanvasExport,
+  type ExportTarget,
+  type NodeType,
+} from "../lib/exportCanvas";
+
+const SYNC_SERVER_URL =
+  process.env.NEXT_PUBLIC_TLDRAW_SYNC_URL ??
+  "https://multiplayer-dg-sync.discoursegraphs.workers.dev";
+
+const NODE_CONFIG: Record<
+  NodeType,
+  { color: "green" | "red" | "yellow"; label: string; prompt: string }
+> = {
+  claim: {
+    color: "green",
+    label: "Claim",
+    prompt: "State a claim...",
+  },
+  evidence: {
+    color: "red",
+    label: "Evidence",
+    prompt: "Add evidence...",
+  },
+  question: {
+    color: "yellow",
+    label: "Question",
+    prompt: "Ask a question...",
+  },
+};
+
+const RELATION_TYPES = ["Supports", "Opposes", "Informs"] as const;
+const COLLABORATOR_NAMES = [
+  "Curious Otter",
+  "Careful Raven",
+  "Bright Finch",
+  "Patient Fox",
+  "Bold Heron",
+  "Quiet Badger",
+] as const;
+
+const getCollaborator = (): { id: string; name: string } => {
+  const storageKey = "dg-canvas-collaborator";
+  const stored = sessionStorage.getItem(storageKey);
+  if (stored) {
+    try {
+      return JSON.parse(stored) as { id: string; name: string };
+    } catch {
+      sessionStorage.removeItem(storageKey);
+    }
+  }
+
+  const id = crypto.randomUUID();
+  const name =
+    COLLABORATOR_NAMES[Math.floor(Math.random() * COLLABORATOR_NAMES.length)] ??
+    "Canvas guest";
+  const collaborator = { id, name };
+  sessionStorage.setItem(storageKey, JSON.stringify(collaborator));
+  return collaborator;
+};
+
+const getNodeType = (shape: TLShape): NodeType | null => {
+  const candidate = shape.meta?.dgType;
+  return NODE_TYPES.includes(candidate as NodeType)
+    ? (candidate as NodeType)
+    : null;
+};
+
+const getBoundShapeId = (endpoint: unknown): string | null => {
+  if (!endpoint || typeof endpoint !== "object") return null;
+  const candidate = (endpoint as { boundShapeId?: unknown }).boundShapeId;
+  return typeof candidate === "string" ? candidate : null;
+};
+
+const getCanvasExport = ({ editor }: { editor: Editor }): CanvasExport => {
+  const shapes = editor.getCurrentPageShapes();
+  const nodes = shapes
+    .flatMap((shape) => {
+      const type = getNodeType(shape);
+      if (!type || shape.type !== "geo") return [];
+      const geoShape = shape as TLGeoShape;
+      return [
+        {
+          id: shape.id,
+          text: geoShape.props.text,
+          type,
+          x: shape.x,
+          y: shape.y,
+        },
+      ];
+    })
+    .sort((a, b) => a.y - b.y || a.x - b.x);
+  const nodeIds = new Set(nodes.map((node) => node.id));
+  const relations = shapes.flatMap((shape) => {
+    if (shape.type !== "arrow") return [];
+    const arrow = shape as TLArrowShape;
+    const fromId = getBoundShapeId(arrow.props.start);
+    const toId = getBoundShapeId(arrow.props.end);
+    if (!fromId || !toId || !nodeIds.has(fromId) || !nodeIds.has(toId)) {
+      return [];
+    }
+    return [
+      {
+        fromId,
+        label: arrow.props.text || "Relates to",
+        toId,
+      },
+    ];
+  });
+
+  return {
+    nodes: nodes.map(({ id, text, type }) => ({ id, text, type })),
+    relations,
+  };
+};
+
+const createNode = ({
+  editor,
+  type,
+}: {
+  editor: Editor;
+  type: NodeType;
+}): void => {
+  const bounds = editor.getViewportPageBounds();
+  const existingNodes = editor
+    .getCurrentPageShapes()
+    .filter((shape) => getNodeType(shape));
+  const offset = (existingNodes.length % 5) * 22;
+  const id = createShapeId();
+  const config = NODE_CONFIG[type];
+
+  editor.createShape<TLGeoShape>({
+    id,
+    type: "geo",
+    x: bounds.x + bounds.w / 2 - 130 + offset,
+    y: bounds.y + bounds.h / 2 - 58 + offset,
+    meta: { dgType: type },
+    props: {
+      align: "start",
+      color: config.color,
+      fill: "solid",
+      font: "sans",
+      geo: "rectangle",
+      h: 116,
+      size: "m",
+      text: config.prompt,
+      verticalAlign: "middle",
+      w: 260,
+    },
+  });
+  editor.select(id);
+  editor.setEditingShape(id);
+};
+
+const CanvasHeader = ({ roomId }: { roomId: string }): ReactElement => {
+  const [copied, setCopied] = useState(false);
+
+  const copyRoomLink = async (): Promise<void> => {
+    await navigator.clipboard.writeText(window.location.href);
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1800);
+  };
+
+  return (
+    <header className="flex h-14 shrink-0 items-center justify-between gap-3 border-b border-slate-200 bg-white px-3 shadow-sm sm:px-4">
+      <div className="flex min-w-0 items-center gap-3">
+        <a
+          href="/"
+          className="flex shrink-0 items-center gap-2 text-sm font-semibold text-slate-900 no-underline"
+        >
+          <span className="grid size-7 place-items-center rounded-lg bg-slate-900 text-[11px] font-bold tracking-tight text-white">
+            DG
+          </span>
+          <span className="hidden sm:inline">Discourse canvas</span>
+        </a>
+        <span className="hidden h-5 w-px bg-slate-200 sm:block" />
+        <span className="truncate text-xs text-slate-500">
+          Room {roomId.slice(0, 8)}
+        </span>
+        <span className="hidden items-center gap-1.5 rounded-full bg-emerald-50 px-2 py-1 text-[11px] font-semibold text-emerald-700 sm:inline-flex">
+          <span className="size-1.5 rounded-full bg-emerald-500" />
+          Live
+        </span>
+      </div>
+
+      <div className="flex shrink-0 items-center gap-2">
+        <a
+          href="/canvas/new"
+          className="inline-flex h-9 items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 text-xs font-semibold text-slate-700 no-underline shadow-sm transition-colors hover:bg-slate-50"
+        >
+          <Plus className="size-4" aria-hidden="true" />
+          <span className="hidden sm:inline">New</span>
+        </a>
+        <button
+          type="button"
+          onClick={() => void copyRoomLink()}
+          className="inline-flex h-9 items-center gap-1.5 rounded-lg bg-slate-900 px-3 text-xs font-semibold text-white shadow-sm transition-colors hover:bg-slate-700"
+        >
+          {copied ? (
+            <Check className="size-4" aria-hidden="true" />
+          ) : (
+            <Share2 className="size-4" aria-hidden="true" />
+          )}
+          {copied ? "Copied" : "Share"}
+        </button>
+      </div>
+    </header>
+  );
+};
+
+type ExportDialogProps = {
+  canvas: CanvasExport;
+  onClose: () => void;
+};
+
+const ExportDialog = ({ canvas, onClose }: ExportDialogProps): ReactElement => {
+  const [target, setTarget] = useState<ExportTarget>("roam");
+  const [copied, setCopied] = useState(false);
+  const output = formatCanvasExport({ canvas, target });
+
+  const copyExport = async (): Promise<void> => {
+    await navigator.clipboard.writeText(output);
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1800);
+  };
+
+  return (
+    <div
+      className="pointer-events-auto fixed inset-0 z-[999] grid place-items-center bg-slate-950/35 p-4 backdrop-blur-[2px]"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="canvas-export-title"
+    >
+      <div className="w-full max-w-2xl overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-2xl">
+        <div className="flex items-start justify-between gap-6 border-b border-slate-200 px-5 py-4">
+          <div>
+            <h2
+              id="canvas-export-title"
+              className="text-base font-semibold text-slate-900"
+            >
+              Copy your discourse graph
+            </h2>
+            <p className="mt-1 text-xs leading-5 text-slate-500">
+              Paste as editable outline text. This prototype does not sync back.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-lg p-2 text-slate-500 hover:bg-slate-100 hover:text-slate-900"
+            aria-label="Close export"
+          >
+            <X className="size-4" aria-hidden="true" />
+          </button>
+        </div>
+
+        <div className="p-5">
+          <div className="mb-3 inline-flex rounded-lg bg-slate-100 p-1">
+            {(["roam", "obsidian"] as const).map((option) => (
+              <button
+                key={option}
+                type="button"
+                onClick={() => setTarget(option)}
+                className={`rounded-md px-3 py-1.5 text-xs font-semibold capitalize transition-colors ${
+                  target === option
+                    ? "bg-white text-slate-900 shadow-sm"
+                    : "text-slate-500 hover:text-slate-800"
+                }`}
+              >
+                {option}
+              </button>
+            ))}
+          </div>
+          <textarea
+            readOnly
+            value={output || "Add a node to the canvas, then export again."}
+            className="h-64 w-full resize-none rounded-xl border border-slate-200 bg-slate-950 p-4 font-mono text-xs leading-6 text-slate-100 outline-none"
+            aria-label={`${target} export`}
+          />
+          <button
+            type="button"
+            onClick={() => void copyExport()}
+            disabled={!output}
+            className="mt-4 inline-flex h-10 w-full items-center justify-center gap-2 rounded-lg bg-slate-900 px-4 text-sm font-semibold text-white transition-colors hover:bg-slate-700 disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            {copied ? (
+              <Check className="size-4" aria-hidden="true" />
+            ) : (
+              <FileDown className="size-4" aria-hidden="true" />
+            )}
+            {copied ? "Copied to clipboard" : `Copy for ${target}`}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const NodeButton = ({
+  onClick,
+  type,
+}: {
+  onClick: () => void;
+  type: NodeType;
+}): ReactElement => {
+  const config = NODE_CONFIG[type];
+  const accentClasses: Record<NodeType, string> = {
+    claim: "bg-[#7DA13E]",
+    evidence: "bg-[#DB134A]",
+    question: "bg-[#B7A51C]",
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="group flex h-10 w-full items-center gap-2 rounded-lg px-2 text-left text-xs font-semibold text-slate-700 transition-colors hover:bg-slate-100 max-sm:w-auto"
+    >
+      <span className={`size-3 rounded-[4px] ${accentClasses[type]}`} />
+      {config.label}
+      <Plus
+        className="ml-auto size-3.5 text-slate-400 opacity-0 transition-opacity group-hover:opacity-100 max-sm:hidden"
+        aria-hidden="true"
+      />
+    </button>
+  );
+};
+
+const CanvasChrome = (): ReactElement => {
+  const editor = useEditor();
+  const pendingRelation = useRef<string | null>(null);
+  const [isRelationMenuOpen, setIsRelationMenuOpen] = useState(false);
+  const [exportCanvas, setExportCanvas] = useState<CanvasExport | null>(null);
+  const shapeCount = useValue(
+    "discourse shape count",
+    () =>
+      editor
+        .getCurrentPageShapes()
+        .filter((shape) => getNodeType(shape)).length,
+    [editor],
+  );
+
+  useEffect(
+    () =>
+      editor.sideEffects.registerAfterCreateHandler("shape", (shape) => {
+        if (shape.type !== "arrow" || !pendingRelation.current) return;
+        editor.updateShape<TLArrowShape>({
+          id: shape.id,
+          type: "arrow",
+          props: { text: pendingRelation.current },
+        });
+        pendingRelation.current = null;
+      }),
+    [editor],
+  );
+
+  const startRelation = (label: string): void => {
+    pendingRelation.current = label;
+    setIsRelationMenuOpen(false);
+    editor.setCurrentTool("arrow");
+  };
+
+  return (
+    <>
+      <div className="pointer-events-auto absolute left-3 top-3 z-20 w-40 rounded-xl border border-slate-200 bg-white/95 p-2 shadow-lg backdrop-blur max-sm:bottom-16 max-sm:left-1/2 max-sm:top-auto max-sm:flex max-sm:w-auto max-sm:-translate-x-1/2 max-sm:items-center max-sm:gap-1">
+        <p className="px-2 pb-1 pt-0.5 text-[10px] font-bold uppercase tracking-[0.14em] text-slate-400 max-sm:hidden">
+          Add node
+        </p>
+        {NODE_TYPES.map((type) => (
+          <NodeButton
+            key={type}
+            type={type}
+            onClick={() => createNode({ editor, type })}
+          />
+        ))}
+        <div className="my-1 h-px bg-slate-200 max-sm:mx-1 max-sm:h-7 max-sm:w-px" />
+        <div className="relative">
+          <button
+            type="button"
+            onClick={() => setIsRelationMenuOpen((isOpen) => !isOpen)}
+            className="flex h-10 w-full items-center gap-2 rounded-lg px-2 text-left text-xs font-semibold text-slate-700 transition-colors hover:bg-slate-100 max-sm:w-auto"
+          >
+            <GitBranch className="size-4 text-slate-500" aria-hidden="true" />
+            Relation
+            <ChevronDown
+              className="ml-auto size-3.5 text-slate-400 max-sm:hidden"
+              aria-hidden="true"
+            />
+          </button>
+          {isRelationMenuOpen && (
+            <div className="absolute left-full top-0 ml-2 w-32 rounded-xl border border-slate-200 bg-white p-1.5 shadow-xl max-sm:bottom-full max-sm:left-auto max-sm:right-0 max-sm:top-auto max-sm:mb-2 max-sm:ml-0">
+              {RELATION_TYPES.map((relation) => (
+                <button
+                  key={relation}
+                  type="button"
+                  onClick={() => startRelation(relation)}
+                  className="block w-full rounded-lg px-3 py-2 text-left text-xs font-medium text-slate-700 hover:bg-slate-100"
+                >
+                  {relation}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={() => setExportCanvas(getCanvasExport({ editor }))}
+          className="flex h-10 w-full items-center gap-2 rounded-lg px-2 text-left text-xs font-semibold text-slate-700 transition-colors hover:bg-slate-100 max-sm:w-auto"
+        >
+          <FileDown className="size-4 text-slate-500" aria-hidden="true" />
+          Export
+        </button>
+      </div>
+
+      {shapeCount === 0 && (
+        <div className="pointer-events-none absolute inset-0 z-10 grid place-items-center p-6">
+          <div className="pointer-events-auto mb-14 max-w-sm rounded-2xl border border-slate-200 bg-white/95 p-6 text-center shadow-xl backdrop-blur">
+            <div className="mx-auto grid size-10 place-items-center rounded-xl bg-slate-900 text-white">
+              <CircleHelp className="size-5" aria-hidden="true" />
+            </div>
+            <h1 className="mt-4 text-lg font-semibold tracking-tight text-slate-900">
+              Map an idea together
+            </h1>
+            <p className="mt-2 text-sm leading-6 text-slate-500">
+              Start with a question, then connect claims and evidence. Anyone
+              with this link can edit live.
+            </p>
+            <button
+              type="button"
+              onClick={() => createNode({ editor, type: "question" })}
+              className="mt-5 inline-flex h-10 items-center gap-2 rounded-lg bg-slate-900 px-4 text-sm font-semibold text-white hover:bg-slate-700"
+            >
+              <Plus className="size-4" aria-hidden="true" />
+              Add the first question
+            </button>
+          </div>
+        </div>
+      )}
+
+      <div className="pointer-events-none absolute bottom-3 right-3 z-10 hidden items-center gap-2 rounded-lg border border-slate-200 bg-white/90 px-3 py-2 text-[11px] text-slate-500 shadow-sm backdrop-blur md:flex">
+        <Link2 className="size-3.5" aria-hidden="true" />
+        Share the link to collaborate
+      </div>
+
+      {exportCanvas && (
+        <ExportDialog
+          canvas={exportCanvas}
+          onClose={() => setExportCanvas(null)}
+        />
+      )}
+    </>
+  );
+};
+
+export const CanvasRoom = ({ roomId }: { roomId: string }): ReactElement => {
+  const [collaborator] = useState(getCollaborator);
+  const assets = useMemo<TLAssetStore>(
+    () => ({
+      resolve: (asset) => asset.props.src,
+      upload: async () => {
+        throw new Error("File uploads are not supported in this prototype.");
+      },
+    }),
+    [],
+  );
+  const uri = useMemo(
+    () => `${SYNC_SERVER_URL}/connect/web-${roomId}`,
+    [roomId],
+  );
+  const store = useSync({
+    assets,
+    uri,
+    userInfo: collaborator,
+  });
+  const components = useMemo(
+    () => ({
+      InFrontOfTheCanvas: CanvasChrome,
+      SharePanel: () => null,
+    }),
+    [],
+  );
+
+  return (
+    <main className="flex h-dvh flex-col bg-slate-100 text-slate-900">
+      <CanvasHeader roomId={roomId} />
+      <div className="relative min-h-0 flex-1">
+        <Tldraw
+          autoFocus
+          components={components}
+          initialState="select"
+          store={store}
+        />
+      </div>
+    </main>
+  );
+};

--- a/apps/website/app/(canvas)/canvas/components/CanvasRoomLoader.tsx
+++ b/apps/website/app/(canvas)/canvas/components/CanvasRoomLoader.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import type { ReactElement } from "react";
+
+const CanvasRoom = dynamic(
+  () => import("./CanvasRoom").then((module) => module.CanvasRoom),
+  {
+    loading: () => (
+      <main className="grid h-dvh place-items-center bg-slate-100 text-sm font-medium text-slate-500">
+        Opening canvas...
+      </main>
+    ),
+    ssr: false,
+  },
+);
+
+export const CanvasRoomLoader = ({
+  roomId,
+}: {
+  roomId: string;
+}): ReactElement => <CanvasRoom roomId={roomId} />;

--- a/apps/website/app/(canvas)/canvas/lib/exportCanvas.test.ts
+++ b/apps/website/app/(canvas)/canvas/lib/exportCanvas.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { formatCanvasExport, type CanvasExport } from "./exportCanvas";
+
+const canvas: CanvasExport = {
+  nodes: [
+    { id: "evidence", text: "A replicated result", type: "evidence" },
+    { id: "claim", text: "The intervention works", type: "claim" },
+  ],
+  relations: [
+    {
+      fromId: "evidence",
+      label: "Supports",
+      toId: "claim",
+    },
+  ],
+};
+
+describe("formatCanvasExport", () => {
+  it("formats Roam-compatible node tags and relations", () => {
+    expect(formatCanvasExport({ canvas, target: "roam" })).toBe(
+      [
+        "- [[EVD]] - A replicated result",
+        "  - Supports:: [[CLM]] - The intervention works",
+        "- [[CLM]] - The intervention works",
+      ].join("\n"),
+    );
+  });
+
+  it("formats readable Obsidian markdown", () => {
+    expect(formatCanvasExport({ canvas, target: "obsidian" })).toBe(
+      [
+        "- **Evidence:** A replicated result",
+        "  - Supports ? **Claim:** The intervention works",
+        "- **Claim:** The intervention works",
+      ].join("\n"),
+    );
+  });
+
+  it("returns an empty string for an empty canvas", () => {
+    expect(
+      formatCanvasExport({
+        canvas: { nodes: [], relations: [] },
+        target: "roam",
+      }),
+    ).toBe("");
+  });
+});

--- a/apps/website/app/(canvas)/canvas/lib/exportCanvas.ts
+++ b/apps/website/app/(canvas)/canvas/lib/exportCanvas.ts
@@ -1,0 +1,96 @@
+export const NODE_TYPES = ["question", "claim", "evidence"] as const;
+
+export type NodeType = (typeof NODE_TYPES)[number];
+
+export type ExportNode = {
+  id: string;
+  text: string;
+  type: NodeType;
+};
+
+export type ExportRelation = {
+  fromId: string;
+  label: string;
+  toId: string;
+};
+
+export type CanvasExport = {
+  nodes: ExportNode[];
+  relations: ExportRelation[];
+};
+
+export type ExportTarget = "obsidian" | "roam";
+
+const NODE_LABELS: Record<NodeType, string> = {
+  claim: "Claim",
+  evidence: "Evidence",
+  question: "Question",
+};
+
+const ROAM_TAGS: Record<NodeType, string> = {
+  claim: "CLM",
+  evidence: "EVD",
+  question: "QUE",
+};
+
+const normalizeText = (value: string, fallback: string): string =>
+  value.replace(/\s+/g, " ").trim() || fallback;
+
+const getRelationsBySource = ({
+  relations,
+}: {
+  relations: ExportRelation[];
+}): Map<string, ExportRelation[]> => {
+  const relationsBySource = new Map<string, ExportRelation[]>();
+  for (const relation of relations) {
+    const sourceRelations = relationsBySource.get(relation.fromId) ?? [];
+    sourceRelations.push(relation);
+    relationsBySource.set(relation.fromId, sourceRelations);
+  }
+  return relationsBySource;
+};
+
+export const formatCanvasExport = ({
+  canvas,
+  target,
+}: {
+  canvas: CanvasExport;
+  target: ExportTarget;
+}): string => {
+  if (!canvas.nodes.length) return "";
+
+  const nodesById = new Map(canvas.nodes.map((node) => [node.id, node]));
+  const relationsBySource = getRelationsBySource({
+    relations: canvas.relations,
+  });
+
+  return canvas.nodes
+    .flatMap((node) => {
+      const nodeText = normalizeText(
+        node.text,
+        `Untitled ${NODE_LABELS[node.type]}`,
+      );
+      const nodeLine =
+        target === "roam"
+          ? `- [[${ROAM_TAGS[node.type]}]] - ${nodeText}`
+          : `- **${NODE_LABELS[node.type]}:** ${nodeText}`;
+      const relationLines = (relationsBySource.get(node.id) ?? []).flatMap(
+        (relation) => {
+          const destination = nodesById.get(relation.toId);
+          if (!destination) return [];
+
+          const label = normalizeText(relation.label, "Relates to");
+          const destinationText = normalizeText(
+            destination.text,
+            `Untitled ${NODE_LABELS[destination.type]}`,
+          );
+          return target === "roam"
+            ? `  - ${label}:: [[${ROAM_TAGS[destination.type]}]] - ${destinationText}`
+            : `  - ${label} ? **${NODE_LABELS[destination.type]}:** ${destinationText}`;
+        },
+      );
+
+      return [nodeLine, ...relationLines];
+    })
+    .join("\n");
+};

--- a/apps/website/app/(canvas)/canvas/new/page.tsx
+++ b/apps/website/app/(canvas)/canvas/new/page.tsx
@@ -1,8 +1,0 @@
-import { randomUUID } from "node:crypto";
-import { redirect } from "next/navigation";
-
-const NewCanvasPage = (): never => {
-  redirect(`/canvas/${randomUUID()}`);
-};
-
-export default NewCanvasPage;

--- a/apps/website/app/(canvas)/canvas/new/page.tsx
+++ b/apps/website/app/(canvas)/canvas/new/page.tsx
@@ -1,0 +1,8 @@
+import { randomUUID } from "node:crypto";
+import { redirect } from "next/navigation";
+
+const NewCanvasPage = (): never => {
+  redirect(`/canvas/${randomUUID()}`);
+};
+
+export default NewCanvasPage;

--- a/apps/website/app/(canvas)/canvas/new/route.test.ts
+++ b/apps/website/app/(canvas)/canvas/new/route.test.ts
@@ -1,0 +1,22 @@
+import { NextRequest } from "next/server";
+import { describe, expect, it } from "vitest";
+import { GET } from "./route";
+
+describe("GET /canvas/new", () => {
+  it("redirects every request to a fresh, uncached canvas", () => {
+    const request = new NextRequest("https://discoursegraphs.com/canvas/new");
+    const firstResponse = GET(request);
+    const secondResponse = GET(request);
+
+    expect(firstResponse.status).toBe(307);
+    expect(firstResponse.headers.get("cache-control")).toBe(
+      "no-store, max-age=0",
+    );
+    expect(firstResponse.headers.get("location")).toMatch(
+      /^https:\/\/discoursegraphs\.com\/canvas\/[0-9a-f-]{36}$/,
+    );
+    expect(secondResponse.headers.get("location")).not.toBe(
+      firstResponse.headers.get("location"),
+    );
+  });
+});

--- a/apps/website/app/(canvas)/canvas/new/route.ts
+++ b/apps/website/app/(canvas)/canvas/new/route.ts
@@ -1,0 +1,12 @@
+import { randomUUID } from "node:crypto";
+import { type NextRequest, NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+export const GET = (request: NextRequest): NextResponse =>
+  NextResponse.redirect(new URL(`/canvas/${randomUUID()}`, request.url), {
+    status: 307,
+    headers: {
+      "Cache-Control": "no-store, max-age=0",
+    },
+  });

--- a/apps/website/app/(canvas)/layout.tsx
+++ b/apps/website/app/(canvas)/layout.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from "next";
+import type { ReactElement, ReactNode } from "react";
+import { Inter } from "next/font/google";
+import "tldraw/tldraw.css";
+import "~/globals.css";
+
+export const metadata: Metadata = {
+  title: "Canvas | Discourse Graphs",
+  description:
+    "A fast, collaborative canvas for mapping questions, claims, and evidence.",
+};
+
+const inter = Inter({ subsets: ["latin"] });
+
+const CanvasLayout = ({ children }: { children: ReactNode }): ReactElement => (
+  <div className={`${inter.className} h-dvh overflow-hidden antialiased`}>
+    {children}
+  </div>
+);
+
+export default CanvasLayout;

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -21,6 +21,7 @@
     "@supabase/ssr": "catalog:",
     "@supabase/supabase-js": "catalog:",
     "@supabase/auth-js": "catalog:",
+    "@tldraw/sync": "2.4.6",
     "clsx": "^2.1.1",
     "gray-matter": "^4.0.3",
     "lucide-react": "^0.540.0",
@@ -34,6 +35,7 @@
     "react-dom": "catalog:",
     "resend": "^4.0.1",
     "sonner": "^2.0.7",
+    "tldraw": "2.4.6",
     "zod": "^3.24.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -466,6 +466,9 @@ importers:
       '@supabase/supabase-js':
         specifier: 'catalog:'
         version: 2.105.4
+      '@tldraw/sync':
+        specifier: 2.4.6
+        version: 2.4.6(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -505,6 +508,9 @@ importers:
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      tldraw:
+        specifier: 2.4.6
+        version: 2.4.6(patch_hash=56e196052862c9a58a11b43e5e121384cd1d6548416afa0f16e9fbfbf0e4080d)(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       zod:
         specifier: ^3.24.1
         version: 3.25.76
@@ -5088,9 +5094,6 @@ packages:
 
   '@types/node@20.11.0':
     resolution: {integrity: sha512-o9bjXmDNcF7GbM4CNQpmi+TutCgap/K3w1JyKgxAjqx41zp9qlIAVFi0IhCNsJcXolEqLWhbFbEeL0PvYm4pcQ==}
-
-  '@types/node@20.19.13':
-    resolution: {integrity: sha512-yCAeZl7a0DxgNVteXFHt9+uyFbqXGy/ShC4BlcHkoE0AfGXYv/BUiplV72DjMYXHDBXFjhvr6DD1NiRVfB4j8g==}
 
   '@types/node@22.20.0':
     resolution: {integrity: sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==}
@@ -14055,7 +14058,7 @@ snapshots:
 
   '@playwright/test@1.29.0':
     dependencies:
-      '@types/node': 20.19.13
+      '@types/node': 22.20.0
       playwright-core: 1.29.0
 
   '@popperjs/core@2.11.8': {}
@@ -14161,6 +14164,20 @@ snapshots:
       '@types/react': 19.1.12
       '@types/react-dom': 19.1.9(@types/react@19.1.12)
 
+  '@radix-ui/react-alert-dialog@1.1.15(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.12)(react@19.1.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.12)(react@19.1.1)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.12)(react@19.1.1)
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      '@types/react-dom': 19.1.9(@types/react@19.1.12)
+
   '@radix-ui/react-arrow@1.0.3(@types/react-dom@18.2.17)(@types/react@18.2.21)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.28.3
@@ -14170,6 +14187,16 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.2.21
       '@types/react-dom': 18.2.17
+
+  '@radix-ui/react-arrow@1.0.3(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@babel/runtime': 7.28.3
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      '@types/react-dom': 19.1.9(@types/react@19.1.12)
 
   '@radix-ui/react-arrow@1.1.7(@types/react-dom@18.2.17)(@types/react@18.2.21)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
@@ -14281,6 +14308,19 @@ snapshots:
       '@types/react': 18.2.21
       '@types/react-dom': 18.2.17
 
+  '@radix-ui/react-collection@1.0.3(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@babel/runtime': 7.28.3
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@19.1.12)(react@19.1.1)
+      '@radix-ui/react-context': 1.0.1(@types/react@19.1.12)(react@19.1.1)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-slot': 1.0.2(@types/react@19.1.12)(react@19.1.1)
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      '@types/react-dom': 19.1.9(@types/react@19.1.12)
+
   '@radix-ui/react-collection@1.1.7(@types/react-dom@18.2.17)(@types/react@18.2.21)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.2.21)(react@18.2.0)
@@ -14323,6 +14363,13 @@ snapshots:
       react: 18.2.0
     optionalDependencies:
       '@types/react': 18.2.21
+
+  '@radix-ui/react-compose-refs@1.0.1(@types/react@19.1.12)(react@19.1.1)':
+    dependencies:
+      '@babel/runtime': 7.28.3
+      react: 19.1.1
+    optionalDependencies:
+      '@types/react': 19.1.12
 
   '@radix-ui/react-compose-refs@1.1.2(@types/react@18.2.21)(react@18.2.0)':
     dependencies:
@@ -14370,12 +14417,33 @@ snapshots:
       '@types/react': 19.1.12
       '@types/react-dom': 19.1.9(@types/react@19.1.12)
 
+  '@radix-ui/react-context-menu@2.2.16(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.12)(react@19.1.1)
+      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.12)(react@19.1.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.12)(react@19.1.1)
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      '@types/react-dom': 19.1.9(@types/react@19.1.12)
+
   '@radix-ui/react-context@1.0.1(@types/react@18.2.21)(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.28.3
       react: 18.2.0
     optionalDependencies:
       '@types/react': 18.2.21
+
+  '@radix-ui/react-context@1.0.1(@types/react@19.1.12)(react@19.1.1)':
+    dependencies:
+      '@babel/runtime': 7.28.3
+      react: 19.1.1
+    optionalDependencies:
+      '@types/react': 19.1.12
 
   '@radix-ui/react-context@1.1.2(@types/react@18.2.21)(react@18.2.0)':
     dependencies:
@@ -14439,12 +14507,41 @@ snapshots:
       '@types/react': 19.1.12
       '@types/react-dom': 19.1.9(@types/react@19.1.12)
 
+  '@radix-ui/react-dialog@1.1.15(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.12)(react@19.1.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.12)(react@19.1.1)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.1.12)(react@19.1.1)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.12)(react@19.1.1)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.12)(react@19.1.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.12)(react@19.1.1)
+      aria-hidden: 1.2.6
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+      react-remove-scroll: 2.7.1(@types/react@19.1.12)(react@19.1.1)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      '@types/react-dom': 19.1.9(@types/react@19.1.12)
+
   '@radix-ui/react-direction@1.0.1(@types/react@18.2.21)(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.28.3
       react: 18.2.0
     optionalDependencies:
       '@types/react': 18.2.21
+
+  '@radix-ui/react-direction@1.0.1(@types/react@19.1.12)(react@19.1.1)':
+    dependencies:
+      '@babel/runtime': 7.28.3
+      react: 19.1.1
+    optionalDependencies:
+      '@types/react': 19.1.12
 
   '@radix-ui/react-direction@1.1.1(@types/react@18.2.21)(react@18.2.0)':
     dependencies:
@@ -14477,6 +14574,20 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.2.21
       '@types/react-dom': 18.2.17
+
+  '@radix-ui/react-dismissable-layer@1.0.4(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@babel/runtime': 7.28.3
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@19.1.12)(react@19.1.1)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@19.1.12)(react@19.1.1)
+      '@radix-ui/react-use-escape-keydown': 1.0.3(@types/react@19.1.12)(react@19.1.1)
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      '@types/react-dom': 19.1.9(@types/react@19.1.12)
 
   '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@18.2.17)(@types/react@18.2.21)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
@@ -14569,6 +14680,13 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.2.21
 
+  '@radix-ui/react-focus-guards@1.0.1(@types/react@19.1.12)(react@19.1.1)':
+    dependencies:
+      '@babel/runtime': 7.28.3
+      react: 19.1.1
+    optionalDependencies:
+      '@types/react': 19.1.12
+
   '@radix-ui/react-focus-guards@1.1.3(@types/react@18.2.21)(react@18.2.0)':
     dependencies:
       react: 18.2.0
@@ -14598,6 +14716,18 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.2.21
       '@types/react-dom': 18.2.17
+
+  '@radix-ui/react-focus-scope@1.0.3(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@babel/runtime': 7.28.3
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@19.1.12)(react@19.1.1)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@19.1.12)(react@19.1.1)
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      '@types/react-dom': 19.1.9(@types/react@19.1.12)
 
   '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@18.2.17)(@types/react@18.2.21)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
@@ -14670,6 +14800,14 @@ snapshots:
       react: 18.2.0
     optionalDependencies:
       '@types/react': 18.2.21
+
+  '@radix-ui/react-id@1.0.1(@types/react@19.1.12)(react@19.1.1)':
+    dependencies:
+      '@babel/runtime': 7.28.3
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@19.1.12)(react@19.1.1)
+      react: 19.1.1
+    optionalDependencies:
+      '@types/react': 19.1.12
 
   '@radix-ui/react-id@1.1.1(@types/react@18.2.21)(react@18.2.0)':
     dependencies:
@@ -14910,6 +15048,29 @@ snapshots:
       '@types/react': 19.1.12
       '@types/react-dom': 19.1.9(@types/react@19.1.12)
 
+  '@radix-ui/react-popover@1.1.15(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.12)(react@19.1.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.12)(react@19.1.1)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.1.12)(react@19.1.1)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.12)(react@19.1.1)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.12)(react@19.1.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.12)(react@19.1.1)
+      aria-hidden: 1.2.6
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+      react-remove-scroll: 2.7.1(@types/react@19.1.12)(react@19.1.1)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      '@types/react-dom': 19.1.9(@types/react@19.1.12)
+
   '@radix-ui/react-popper@1.1.2(@types/react-dom@18.2.17)(@types/react@18.2.21)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.28.3
@@ -14928,6 +15089,25 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.2.21
       '@types/react-dom': 18.2.17
+
+  '@radix-ui/react-popper@1.1.2(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@babel/runtime': 7.28.3
+      '@floating-ui/react-dom': 2.1.6(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-arrow': 1.0.3(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@19.1.12)(react@19.1.1)
+      '@radix-ui/react-context': 1.0.1(@types/react@19.1.12)(react@19.1.1)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@19.1.12)(react@19.1.1)
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@19.1.12)(react@19.1.1)
+      '@radix-ui/react-use-rect': 1.0.1(@types/react@19.1.12)(react@19.1.1)
+      '@radix-ui/react-use-size': 1.0.1(@types/react@19.1.12)(react@19.1.1)
+      '@radix-ui/rect': 1.0.1
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      '@types/react-dom': 19.1.9(@types/react@19.1.12)
 
   '@radix-ui/react-popper@1.2.8(@types/react-dom@18.2.17)(@types/react@18.2.21)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
@@ -14992,6 +15172,16 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.2.21
       '@types/react-dom': 18.2.17
+
+  '@radix-ui/react-portal@1.0.3(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@babel/runtime': 7.28.3
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      '@types/react-dom': 19.1.9(@types/react@19.1.12)
 
   '@radix-ui/react-portal@1.1.9(@types/react-dom@18.2.17)(@types/react@18.2.21)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
@@ -15062,6 +15252,16 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.2.21
       '@types/react-dom': 18.2.17
+
+  '@radix-ui/react-primitive@1.0.3(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@babel/runtime': 7.28.3
+      '@radix-ui/react-slot': 1.0.2(@types/react@19.1.12)(react@19.1.1)
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      '@types/react-dom': 19.1.9(@types/react@19.1.12)
 
   '@radix-ui/react-primitive@2.1.3(@types/react-dom@18.2.17)(@types/react@18.2.21)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
@@ -15216,6 +15416,36 @@ snapshots:
       '@types/react': 18.2.21
       '@types/react-dom': 18.2.17
 
+  '@radix-ui/react-select@1.2.2(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@babel/runtime': 7.28.3
+      '@radix-ui/number': 1.0.1
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-collection': 1.0.3(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@19.1.12)(react@19.1.1)
+      '@radix-ui/react-context': 1.0.1(@types/react@19.1.12)(react@19.1.1)
+      '@radix-ui/react-direction': 1.0.1(@types/react@19.1.12)(react@19.1.1)
+      '@radix-ui/react-dismissable-layer': 1.0.4(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-focus-guards': 1.0.1(@types/react@19.1.12)(react@19.1.1)
+      '@radix-ui/react-focus-scope': 1.0.3(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-id': 1.0.1(@types/react@19.1.12)(react@19.1.1)
+      '@radix-ui/react-popper': 1.1.2(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-portal': 1.0.3(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-slot': 1.0.2(@types/react@19.1.12)(react@19.1.1)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@19.1.12)(react@19.1.1)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@19.1.12)(react@19.1.1)
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@19.1.12)(react@19.1.1)
+      '@radix-ui/react-use-previous': 1.0.1(@types/react@19.1.12)(react@19.1.1)
+      '@radix-ui/react-visually-hidden': 1.0.3(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      aria-hidden: 1.2.6
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+      react-remove-scroll: 2.5.5(@types/react@19.1.12)(react@19.1.1)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      '@types/react-dom': 19.1.9(@types/react@19.1.12)
+
   '@radix-ui/react-select@2.2.6(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@radix-ui/number': 1.1.1
@@ -15321,6 +15551,25 @@ snapshots:
       '@types/react': 19.1.12
       '@types/react-dom': 19.1.9(@types/react@19.1.12)
 
+  '@radix-ui/react-slider@1.3.6(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@radix-ui/number': 1.1.1
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.12)(react@19.1.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.12)(react@19.1.1)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.1.12)(react@19.1.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.12)(react@19.1.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.12)(react@19.1.1)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.1.12)(react@19.1.1)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.1.12)(react@19.1.1)
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      '@types/react-dom': 19.1.9(@types/react@19.1.12)
+
   '@radix-ui/react-slot@1.0.2(@types/react@18.2.21)(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.28.3
@@ -15328,6 +15577,14 @@ snapshots:
       react: 18.2.0
     optionalDependencies:
       '@types/react': 18.2.21
+
+  '@radix-ui/react-slot@1.0.2(@types/react@19.1.12)(react@19.1.1)':
+    dependencies:
+      '@babel/runtime': 7.28.3
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@19.1.12)(react@19.1.1)
+      react: 19.1.1
+    optionalDependencies:
+      '@types/react': 19.1.12
 
   '@radix-ui/react-slot@1.2.3(@types/react@18.2.21)(react@18.2.0)':
     dependencies:
@@ -15428,6 +15685,26 @@ snapshots:
       '@types/react': 19.1.12
       '@types/react-dom': 19.1.9(@types/react@19.1.12)
 
+  '@radix-ui/react-toast@1.2.15(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.12)(react@19.1.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.12)(react@19.1.1)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.12)(react@19.1.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.12)(react@19.1.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.12)(react@19.1.1)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      '@types/react-dom': 19.1.9(@types/react@19.1.12)
+
   '@radix-ui/react-toggle-group@1.1.11(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -15496,6 +15773,13 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.2.21
 
+  '@radix-ui/react-use-callback-ref@1.0.1(@types/react@19.1.12)(react@19.1.1)':
+    dependencies:
+      '@babel/runtime': 7.28.3
+      react: 19.1.1
+    optionalDependencies:
+      '@types/react': 19.1.12
+
   '@radix-ui/react-use-callback-ref@1.1.1(@types/react@18.2.21)(react@18.2.0)':
     dependencies:
       react: 18.2.0
@@ -15521,6 +15805,14 @@ snapshots:
       react: 18.2.0
     optionalDependencies:
       '@types/react': 18.2.21
+
+  '@radix-ui/react-use-controllable-state@1.0.1(@types/react@19.1.12)(react@19.1.1)':
+    dependencies:
+      '@babel/runtime': 7.28.3
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@19.1.12)(react@19.1.1)
+      react: 19.1.1
+    optionalDependencies:
+      '@types/react': 19.1.12
 
   '@radix-ui/react-use-controllable-state@1.2.2(@types/react@18.2.21)(react@18.2.0)':
     dependencies:
@@ -15575,6 +15867,14 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.2.21
 
+  '@radix-ui/react-use-escape-keydown@1.0.3(@types/react@19.1.12)(react@19.1.1)':
+    dependencies:
+      '@babel/runtime': 7.28.3
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@19.1.12)(react@19.1.1)
+      react: 19.1.1
+    optionalDependencies:
+      '@types/react': 19.1.12
+
   '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@18.2.21)(react@18.2.0)':
     dependencies:
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.2.21)(react@18.2.0)
@@ -15610,6 +15910,13 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.2.21
 
+  '@radix-ui/react-use-layout-effect@1.0.1(@types/react@19.1.12)(react@19.1.1)':
+    dependencies:
+      '@babel/runtime': 7.28.3
+      react: 19.1.1
+    optionalDependencies:
+      '@types/react': 19.1.12
+
   '@radix-ui/react-use-layout-effect@1.1.1(@types/react@18.2.21)(react@18.2.0)':
     dependencies:
       react: 18.2.0
@@ -15634,6 +15941,13 @@ snapshots:
       react: 18.2.0
     optionalDependencies:
       '@types/react': 18.2.21
+
+  '@radix-ui/react-use-previous@1.0.1(@types/react@19.1.12)(react@19.1.1)':
+    dependencies:
+      '@babel/runtime': 7.28.3
+      react: 19.1.1
+    optionalDependencies:
+      '@types/react': 19.1.12
 
   '@radix-ui/react-use-previous@1.1.1(@types/react@18.2.21)(react@18.2.0)':
     dependencies:
@@ -15660,6 +15974,14 @@ snapshots:
       react: 18.2.0
     optionalDependencies:
       '@types/react': 18.2.21
+
+  '@radix-ui/react-use-rect@1.0.1(@types/react@19.1.12)(react@19.1.1)':
+    dependencies:
+      '@babel/runtime': 7.28.3
+      '@radix-ui/rect': 1.0.1
+      react: 19.1.1
+    optionalDependencies:
+      '@types/react': 19.1.12
 
   '@radix-ui/react-use-rect@1.1.1(@types/react@18.2.21)(react@18.2.0)':
     dependencies:
@@ -15689,6 +16011,14 @@ snapshots:
       react: 18.2.0
     optionalDependencies:
       '@types/react': 18.2.21
+
+  '@radix-ui/react-use-size@1.0.1(@types/react@19.1.12)(react@19.1.1)':
+    dependencies:
+      '@babel/runtime': 7.28.3
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@19.1.12)(react@19.1.1)
+      react: 19.1.1
+    optionalDependencies:
+      '@types/react': 19.1.12
 
   '@radix-ui/react-use-size@1.1.1(@types/react@18.2.21)(react@18.2.0)':
     dependencies:
@@ -15720,6 +16050,16 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.2.21
       '@types/react-dom': 18.2.17
+
+  '@radix-ui/react-visually-hidden@1.0.3(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@babel/runtime': 7.28.3
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      '@types/react-dom': 19.1.9(@types/react@19.1.12)
 
   '@radix-ui/react-visually-hidden@1.2.3(@types/react-dom@18.2.17)(@types/react@18.2.21)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
@@ -16637,6 +16977,25 @@ snapshots:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
+  '@tldraw/editor@2.4.6(patch_hash=88df41e89e43122c6a700d4917a83250639461079144bdbab7015f6b761e4582)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@tldraw/state': 2.4.6(patch_hash=b5bbaa41bf2edae401d2bcd96dfa3c24086b564f297ef2df16a3b3156cd51ecc)
+      '@tldraw/state-react': 2.4.6(react@19.1.1)
+      '@tldraw/store': 2.4.6(react@19.1.1)
+      '@tldraw/tlschema': 2.4.6(react@19.1.1)
+      '@tldraw/utils': 2.4.6
+      '@tldraw/validate': 2.4.6
+      '@types/core-js': 2.5.8
+      '@use-gesture/react': 10.3.1(react@19.1.1)
+      classnames: 2.5.1
+      core-js: 3.45.1
+      eventemitter3: 4.0.7
+      idb: 7.1.1
+      is-plain-object: 5.0.0
+      nanoid: 4.0.2
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+
   '@tldraw/editor@3.14.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@tiptap/core': 2.26.2(@tiptap/pm@2.26.2)
@@ -16662,6 +17021,11 @@ snapshots:
     dependencies:
       '@tldraw/state': 2.4.6(patch_hash=b5bbaa41bf2edae401d2bcd96dfa3c24086b564f297ef2df16a3b3156cd51ecc)
       react: 18.2.0
+
+  '@tldraw/state-react@2.4.6(react@19.1.1)':
+    dependencies:
+      '@tldraw/state': 2.4.6(patch_hash=b5bbaa41bf2edae401d2bcd96dfa3c24086b564f297ef2df16a3b3156cd51ecc)
+      react: 19.1.1
 
   '@tldraw/state-react@3.14.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
@@ -16742,6 +17106,25 @@ snapshots:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       tldraw: 2.4.6(patch_hash=56e196052862c9a58a11b43e5e121384cd1d6548416afa0f16e9fbfbf0e4080d)(@types/react-dom@18.2.17)(@types/react@18.2.21)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      ws: 8.18.3
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - bufferutil
+      - utf-8-validate
+
+  '@tldraw/sync@2.4.6(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@tldraw/state': 2.4.6(patch_hash=b5bbaa41bf2edae401d2bcd96dfa3c24086b564f297ef2df16a3b3156cd51ecc)
+      '@tldraw/state-react': 2.4.6(react@19.1.1)
+      '@tldraw/sync-core': 2.4.6(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@tldraw/utils': 2.4.6
+      lodash.isequal: 4.5.0
+      nanoevents: 7.0.1
+      nanoid: 4.0.2
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+      tldraw: 2.4.6(patch_hash=56e196052862c9a58a11b43e5e121384cd1d6548416afa0f16e9fbfbf0e4080d)(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       ws: 8.18.3
     transitivePeerDependencies:
       - '@types/react'
@@ -17060,7 +17443,7 @@ snapshots:
 
   '@types/jsdom@20.0.1':
     dependencies:
-      '@types/node': 20.19.13
+      '@types/node': 22.20.0
       '@types/tough-cookie': 4.0.5
       parse5: 7.3.0
 
@@ -17121,10 +17504,6 @@ snapshots:
   '@types/node@20.11.0':
     dependencies:
       undici-types: 5.26.5
-
-  '@types/node@20.19.13':
-    dependencies:
-      undici-types: 6.21.0
 
   '@types/node@22.20.0':
     dependencies:
@@ -17397,6 +17776,11 @@ snapshots:
     dependencies:
       '@use-gesture/core': 10.3.1
       react: 19.0.0
+
+  '@use-gesture/react@10.3.1(react@19.1.1)':
+    dependencies:
+      '@use-gesture/core': 10.3.1
+      react: 19.1.1
 
   '@vercel/backends@0.3.0(rollup@4.60.3)(typescript@5.9.2)':
     dependencies:
@@ -23179,6 +23563,17 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.2.21
 
+  react-remove-scroll@2.5.5(@types/react@19.1.12)(react@19.1.1):
+    dependencies:
+      react: 19.1.1
+      react-remove-scroll-bar: 2.3.8(@types/react@19.1.12)(react@19.1.1)
+      react-style-singleton: 2.2.3(@types/react@19.1.12)(react@19.1.1)
+      tslib: 2.5.1
+      use-callback-ref: 1.3.3(@types/react@19.1.12)(react@19.1.1)
+      use-sidecar: 1.1.3(@types/react@19.1.12)(react@19.1.1)
+    optionalDependencies:
+      '@types/react': 19.1.12
+
   react-remove-scroll@2.7.1(@types/react@18.2.21)(react@18.2.0):
     dependencies:
       react: 18.2.0
@@ -24574,6 +24969,29 @@ snapshots:
       lz-string: 1.5.0
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+
+  tldraw@2.4.6(patch_hash=56e196052862c9a58a11b43e5e121384cd1d6548416afa0f16e9fbfbf0e4080d)(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
+    dependencies:
+      '@radix-ui/react-alert-dialog': 1.1.15(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-context-menu': 2.2.16(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-dropdown-menu': 2.1.16(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-popover': 1.1.15(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-select': 1.2.2(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-slider': 1.3.6(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-toast': 1.2.15(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@tldraw/editor': 2.4.6(patch_hash=88df41e89e43122c6a700d4917a83250639461079144bdbab7015f6b761e4582)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@tldraw/store': 2.4.6(react@19.1.1)
+      canvas-size: 1.2.6
+      classnames: 2.5.1
+      hotkeys-js: 3.13.15
+      idb: 7.1.1
+      lz-string: 1.5.0
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'


### PR DESCRIPTION
## Summary
- Add a new collaborative canvas route backed by tldraw and the sync worker
- Support creating question, claim, and evidence nodes plus labeled relations
- Add export formatting for Roam and Obsidian with unit coverage
- Allow discoursegraphs.com origins to connect to the sync worker

## Testing
- Added unit tests for canvas export formatting
- Not run (not requested)