### PR TITLE
Fix Open Science Catalyze Panel link to drop #panelists anchor

### DIFF
--- a/apps/website/app/(home)/page.tsx
+++ b/apps/website/app/(home)/page.tsx
@@ -91,7 +91,7 @@ const RESOURCE_LINKS = [
 
 const EVENTS = [
   {
-    href: "https://discoursegraphs.github.io/panel-qa-site/#panelists",
+    href: "https://discoursegraphs.github.io/panel-qa-site/",
     linkText: "View panel notes",
     meta: "June 18, 2026 | Zoom",
     title: "Frontiers in Research: Open Science Catalyze Panel",


### PR DESCRIPTION
## What

The **Frontiers in Research: Open Science Catalyze Panel** entry in the website's `EVENTS` list links to the panel Q&A site's `#panelists` anchor. This changes it to point at the site root so the page opens at the top instead of jumping to the panelists section.

## Change

`apps/website/app/(home)/page.tsx`

```diff
-    href: "https://discoursegraphs.github.io/panel-qa-site/#panelists",
+    href: "https://discoursegraphs.github.io/panel-qa-site/",
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/1239" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->