### PR TITLE
ENG-2044 - Fix discourse node bounds when Roam loads at browser zoom

### DIFF
--- a/apps/roam/src/components/canvas/DiscourseNodeUtil.tsx
+++ b/apps/roam/src/components/canvas/DiscourseNodeUtil.tsx
@@ -603,15 +603,20 @@ export class DiscourseNodeUtil extends BaseBoxShapeUtil<DiscourseNodeShape> {
     return (
       <HTMLContainer
         id={shape.id}
-        className="roamjs-tldraw-node pointer-events-auto flex h-full w-full overflow-hidden rounded-2xl"
+        className="roamjs-tldraw-node pointer-events-auto flex h-full min-h-0 w-full min-w-0 overflow-hidden rounded-2xl"
         style={{
           background: backgroundColor,
           color: textColor,
+          width: shape.props.w,
+          height: shape.props.h,
+          maxWidth: shape.props.w,
+          maxHeight: shape.props.h,
+          boxSizing: "border-box",
         }}
         onPointerEnter={() => setOverlayMounted(true)}
       >
         <div
-          className="relative flex h-full w-full flex-col"
+          className="relative flex h-full min-h-0 w-full min-w-0 flex-col"
           style={{ pointerEvents: "all" }}
         >
           {/* Open in Sidebar Button */}


### PR DESCRIPTION
Fix:
<img width="849" height="534" alt="image" src="https://github.com/user-attachments/assets/b02bdb18-6081-4599-b011-867d02b4f142" />
<img width="813" height="513" alt="image" src="https://github.com/user-attachments/assets/b2987690-444d-458d-a00c-8dac103cac7d" />
<img width="1102" height="662" alt="image" src="https://github.com/user-attachments/assets/9e9ea78c-c5d3-4215-b7a8-fb5d219dbcfb" />

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/1240" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->