### PR TITLE
ENG-2049 Refactor publishNodesToGroup to use the crossAppNodeSchema

### DIFF
--- a/apps/roam/src/components/Export.tsx
+++ b/apps/roam/src/components/Export.tsx
@@ -88,7 +88,7 @@ import posthog from "posthog-js";
 import { getMyGroups, type MyGroup } from "@repo/database/lib/groups";
 import {
   publishNodeUidsWithTypeToGroups,
-  type nodeUidWithType,
+  type NodeUidWithType,
 } from "~/utils/publishNodesToGroups";
 import { getLoggedInClient, getSupabaseContext } from "~/utils/supabaseContext";
 import { isSyncEnabled } from "~/components/settings/utils/accessors";
@@ -248,7 +248,7 @@ const ExportDialog: ExportDialogComponent = ({
                 ? { uid: r.uid, type: node.type }
                 : null;
             })
-            .filter((n): n is nodeUidWithType => n !== null)
+            .filter((n): n is NodeUidWithType => n !== null)
         : [],
     [results, syncEnabled],
   );
@@ -847,7 +847,7 @@ const ExportDialog: ExportDialogComponent = ({
         client,
         spaceId: context.spaceId,
         groupIds: selectedGroupIds,
-        publishNodes: publishableNodes,
+        nodeUids: publishableNodes,
       });
       posthog.capture("Export Dialog: Publish", {
         groupCount: okGroupIds.length,

--- a/apps/roam/src/components/Export.tsx
+++ b/apps/roam/src/components/Export.tsx
@@ -87,8 +87,8 @@ import { AddReferencedNodeType } from "./canvas/DiscourseRelationShape/Discourse
 import posthog from "posthog-js";
 import { getMyGroups, type MyGroup } from "@repo/database/lib/groups";
 import {
-  publishNodesToGroups,
-  type PublishNode,
+  publishNodeUidsWithTypeToGroups,
+  type nodeUidWithType,
 } from "~/utils/publishNodesToGroups";
 import { getLoggedInClient, getSupabaseContext } from "~/utils/supabaseContext";
 import { isSyncEnabled } from "~/components/settings/utils/accessors";
@@ -248,7 +248,7 @@ const ExportDialog: ExportDialogComponent = ({
                 ? { uid: r.uid, type: node.type }
                 : null;
             })
-            .filter((n): n is PublishNode => n !== null)
+            .filter((n): n is nodeUidWithType => n !== null)
         : [],
     [results, syncEnabled],
   );
@@ -843,11 +843,11 @@ const ExportDialog: ExportDialogComponent = ({
         skippedUnsyncedUids,
         okGroupIds,
         failedGroupIds,
-      } = await publishNodesToGroups({
+      } = await publishNodeUidsWithTypeToGroups({
         client,
         spaceId: context.spaceId,
         groupIds: selectedGroupIds,
-        nodes: publishableNodes,
+        publishNodes: publishableNodes,
       });
       posthog.capture("Export Dialog: Publish", {
         groupCount: okGroupIds.length,

--- a/apps/roam/src/utils/publishNodesToGroups.ts
+++ b/apps/roam/src/utils/publishNodesToGroups.ts
@@ -3,7 +3,7 @@ import type { DGSupabaseClient } from "@repo/database/lib/client";
 import { getAvailableGroupIds } from "@repo/database/lib/groups";
 import { nodeUidsWithTypeToCrossApp } from "./roamToCrossAppConverters";
 
-export type nodeUidWithType = {
+export type NodeUidWithType = {
   uid: string;
   type: string;
 };
@@ -134,13 +134,13 @@ export const publishNodeUidsWithTypeToGroups = async ({
   client,
   spaceId,
   groupIds,
-  publishNodes,
+  nodeUids,
 }: {
   client: DGSupabaseClient;
   spaceId: number;
   groupIds: string[];
-  publishNodes: nodeUidWithType[];
+  nodeUids: NodeUidWithType[];
 }): Promise<PublishNodesResult> => {
-  const nodes = await nodeUidsWithTypeToCrossApp(publishNodes);
+  const nodes = await nodeUidsWithTypeToCrossApp(nodeUids);
   return await publishNodesToGroups({ client, spaceId, groupIds, nodes });
 };

--- a/apps/roam/src/utils/publishNodesToGroups.ts
+++ b/apps/roam/src/utils/publishNodesToGroups.ts
@@ -1,7 +1,9 @@
+import { CrossAppNode } from "@repo/database/crossAppContracts";
 import type { DGSupabaseClient } from "@repo/database/lib/client";
 import { getAvailableGroupIds } from "@repo/database/lib/groups";
+import { nodeUidsWithTypeToCrossApp } from "./roamToCrossAppConverters";
 
-export type PublishNode = {
+export type nodeUidWithType = {
   uid: string;
   type: string;
 };
@@ -37,7 +39,7 @@ export const publishNodesToGroups = async ({
   client: DGSupabaseClient;
   spaceId: number;
   groupIds: string[];
-  nodes: PublishNode[];
+  nodes: CrossAppNode[];
 }): Promise<PublishNodesResult> => {
   const result: PublishNodesResult = {
     publishedNodeUids: [],
@@ -57,7 +59,7 @@ export const publishNodesToGroups = async ({
   );
   if (targetGroupIds.length === 0) return result;
 
-  const uids = [...new Set(nodes.map((node) => node.uid))];
+  const uids = [...new Set(nodes.map((node) => node.localId))];
 
   const syncedRes = await client
     .from("my_concepts")
@@ -77,7 +79,9 @@ export const publishNodesToGroups = async ({
   // Required dependency: the node-type schema concept, when it is synced too.
   const types = [
     ...new Set(
-      nodes.filter((node) => syncedUids.has(node.uid)).map((node) => node.type),
+      nodes
+        .filter((node) => syncedUids.has(node.localId))
+        .map((node) => node.nodeType),
     ),
   ];
   const schemaRes = await client
@@ -124,4 +128,19 @@ export const publishNodesToGroups = async ({
 
   result.publishedNodeUids = result.okGroupIds.length > 0 ? syncedNodeUids : [];
   return result;
+};
+
+export const publishNodeUidsWithTypeToGroups = async ({
+  client,
+  spaceId,
+  groupIds,
+  publishNodes,
+}: {
+  client: DGSupabaseClient;
+  spaceId: number;
+  groupIds: string[];
+  publishNodes: nodeUidWithType[];
+}): Promise<PublishNodesResult> => {
+  const nodes = await nodeUidsWithTypeToCrossApp(publishNodes);
+  return await publishNodesToGroups({ client, spaceId, groupIds, nodes });
 };

--- a/apps/roam/src/utils/roamToCrossAppConverters.ts
+++ b/apps/roam/src/utils/roamToCrossAppConverters.ts
@@ -2,7 +2,7 @@ import type { CrossAppNode } from "@repo/database/crossAppContracts";
 import type { RoamFullContentNode } from "./convertRoamNodeToFullContent";
 import type { DiscourseNode } from "./getDiscourseNodes";
 import type { TreeNode, ViewType } from "roamjs-components/types";
-import type { nodeUidWithType } from "~/utils/publishNodesToGroups";
+import type { NodeUidWithType } from "~/utils/publishNodesToGroups";
 import type { Json } from "@repo/database/dbTypes";
 import { toMarkdown } from "./pageToMarkdown";
 import getFullTreeByParentUid from "roamjs-components/queries/getFullTreeByParentUid";
@@ -68,7 +68,7 @@ export const fullContentNodeToCrossApp = (
 };
 
 export const nodeUidsWithTypeToCrossApp = async (
-  nodes: nodeUidWithType[],
+  nodes: NodeUidWithType[],
 ): Promise<CrossAppNode[]> => {
   const typesByUid = Object.fromEntries(nodes.map((n) => [n.uid, n.type]));
   const nodeRows = (await window.roamAlphaAPI.data.async.pull_many(

--- a/apps/roam/src/utils/roamToCrossAppConverters.ts
+++ b/apps/roam/src/utils/roamToCrossAppConverters.ts
@@ -2,6 +2,8 @@ import type { CrossAppNode } from "@repo/database/crossAppContracts";
 import type { RoamFullContentNode } from "./convertRoamNodeToFullContent";
 import type { DiscourseNode } from "./getDiscourseNodes";
 import type { TreeNode, ViewType } from "roamjs-components/types";
+import type { nodeUidWithType } from "~/utils/publishNodesToGroups";
+import type { Json } from "@repo/database/dbTypes";
 import { toMarkdown } from "./pageToMarkdown";
 import getFullTreeByParentUid from "roamjs-components/queries/getFullTreeByParentUid";
 import getPageViewType from "roamjs-components/queries/getPageViewType";
@@ -63,4 +65,54 @@ export const fullContentNodeToCrossApp = (
       },
     },
   };
+};
+
+export const nodeUidsWithTypeToCrossApp = async (
+  nodes: nodeUidWithType[],
+): Promise<CrossAppNode[]> => {
+  const typesByUid = Object.fromEntries(nodes.map((n) => [n.uid, n.type]));
+  const nodeRows = (await window.roamAlphaAPI.data.async.pull_many(
+    `[:block/uid :create/user :create/time :edit/time :page/edit-time :node/title]`,
+    nodes.map((n) => [":block/uid", n.uid]),
+  )) as Record<string, Json>[];
+  const userEids = [
+    ...new Set(
+      nodeRows.map(
+        (r) => (r[":create/user"] as Record<string, number>)[":db/id"],
+      ),
+    ),
+  ];
+  const userRows = await window.roamAlphaAPI.data.async.pull_many(
+    `[:db/id :user/uid]`,
+    // @ts-expect-error array of dbIds is valid
+    userEids,
+  );
+  const userUidByEid = Object.fromEntries(
+    userRows.map((r) => [r[":db/id"] as number, r[":user/uid"] as string]),
+  );
+  const results = nodeRows.map((row) => {
+    const uid = row[":block/uid"] as string;
+    const userUid =
+      userUidByEid[(row[":create/user"] as Record<string, number>)[":db/id"]];
+
+    return {
+      localId: uid,
+      nodeType: typesByUid[uid],
+      authorId: userUid,
+      createdAt: new Date((row[":create/time"] as number) || Date.now()),
+      modifiedAt: new Date(
+        Math.max(
+          row[":edit/time"] as number,
+          row[":page/edit-time"] as number,
+        ) || Date.now(),
+      ),
+      content: {
+        direct: {
+          localId: uid,
+          value: row[":node/title"] as string,
+        },
+      },
+    };
+  });
+  return results;
 };


### PR DESCRIPTION
[ENG-2049](https://linear.app/discourse-graphs/issue/ENG-2049/refactor-publishnodestogroup-to-use-the-crossappnodeschema)

[https://www.loom.com/share/908e003a749141fcb5d25846018a48eb](<https://www.loom.com/share/908e003a749141fcb5d25846018a48eb>)

Tested with a publication.

---

![Open in Devin Review](https://camo.githubusercontent.com/a4be08b8baaff58c5f163b8bbf073f8cdff8e3a6c7e2f554b621f61ab1557d7e/68747470733a2f2f7374617469632e646576696e2e61692f6173736574732f67682d6f70656e2d696e2d646576696e2d7265766965772d6c696768742e7376673f763d31)