### PR TITLE
ENG-2064 Update Obsidian installaiton instruction

### DIFF
--- a/apps/obsidian/README.md
+++ b/apps/obsidian/README.md
@@ -25,7 +25,7 @@ Datacore is required for Discourse Graphs to work, so install and enable it befo
 Once Datacore is installed and enabled, add the Discourse Graphs plugin from Obsidian's community plugin browser:
 
 1. Open Obsidian → Settings → Community plugins → Browse
-2. Search for "Discourse Graph", then install and enable it
+2. Search for "Discourse Graphs", then install and enable it
 
 Or install directly from the [community plugin page](https://community.obsidian.md/plugins/discourse-graphs).
 

--- a/apps/obsidian/README.md
+++ b/apps/obsidian/README.md
@@ -10,26 +10,17 @@ Break down the research process into atomic units to augment the knowledge synth
 
 # Installation
 
-Discourse Graphs depends on the Datacore plugin, which isn't yet in Obsidian's community plugin browser, so you install it through BRAT (Beta Reviewer's Auto-update Tester). Complete these steps in order: **BRAT → Datacore → Discourse Graphs**.
+Discourse Graphs depends on the Datacore plugin, so install Datacore first. Both plugins are available in Obsidian's community plugin browser.
 
-## 1. Install BRAT
+## 1. Install Datacore
 
-BRAT lets you install plugins that aren't yet published to Obsidian's community plugin browser.
+Datacore is required for Discourse Graphs to work, so install and enable it before the Discourse Graphs plugin.
 
 1. Open Obsidian settings
 2. Go to Community plugins and disable Restricted Mode
-3. Click "Browse", search for "BRAT", then install and enable it
+3. Click "Browse", search for "Datacore", then install and enable it
 
-## 2. Install Datacore via BRAT
-
-Datacore is required for Discourse Graphs to work, so install it before the Discourse Graphs plugin.
-
-1. Run the command "Add a beta plugin for testing", or open the BRAT settings menu and click `Add beta plugin`
-2. Enter the repository URL `https://github.com/blacksmithgu/datacore` and choose "Latest version"
-3. Check the box for "Enable after installing the plugin"
-4. Click `Add plugin`
-
-## 3. Install Discourse Graphs
+## 2. Install Discourse Graphs
 
 Once Datacore is installed and enabled, add the Discourse Graphs plugin from Obsidian's community plugin browser:
 

--- a/apps/obsidian/README.md
+++ b/apps/obsidian/README.md
@@ -10,30 +10,33 @@ Break down the research process into atomic units to augment the knowledge synth
 
 # Installation
 
-Follow the instructions below to install the plugin:
+Discourse Graphs depends on the Datacore plugin, which isn't yet in Obsidian's community plugin browser, so you install it through BRAT (Beta Reviewer's Auto-update Tester). Complete these steps in order: **BRAT → Datacore → Discourse Graphs**.
 
-## Install BRAT
+## 1. Install BRAT
 
-To use the plugin prior to its public release on Obsidian's community plugin browser, install BRAT (Beta Reviewer's Auto-update Tester).
+BRAT lets you install plugins that aren't yet published to Obsidian's community plugin browser.
 
-1. Open Obsidian Settings
-2. Go to Community Plugins and disable Restricted Mode
-3. Click "Browse" and search for "BRAT"
-4. Install BRAT and enable it
+1. Open Obsidian settings
+2. Go to Community plugins and disable Restricted Mode
+3. Click "Browse", search for "BRAT", then install and enable it
 
-## Install DataCore via BRAT
+## 2. Install Datacore via BRAT
 
-1. Add the DataCore plugin from the BRAT settings menu or run command "Add a beta plugin for testing"
-2. Enter the repository URL: `https://github.com/blacksmithgu/datacore` and choose "Latest version"
+Datacore is required for Discourse Graphs to work, so install it before the Discourse Graphs plugin.
+
+1. Run the command "Add a beta plugin for testing", or open the BRAT settings menu and click `Add beta plugin`
+2. Enter the repository URL `https://github.com/blacksmithgu/datacore` and choose "Latest version"
 3. Check the box for "Enable after installing the plugin"
 4. Click `Add plugin`
 
-## Install Discourse Graphs
+## 3. Install Discourse Graphs
 
-1. Add the Discourse Graphs plugin from the BRAT settings menu or run command `Add a beta plugin for testing`
-2. Enter the repository URL: `https://github.com/DiscourseGraphs/discourse-graph-obsidian` and choose "Latest version"
-3. Check the box for "Enable after installing the plugin"
-4. Click `Add plugin`
+Once Datacore is installed and enabled, add the Discourse Graphs plugin from Obsidian's community plugin browser:
+
+1. Open Obsidian → Settings → Community plugins → Browse
+2. Search for "Discourse Graph", then install and enable it
+
+Or install directly from the [community plugin page](https://community.obsidian.md/plugins/discourse-graphs).
 
 # Getting started
 

--- a/apps/website/content/obsidian/welcome/installation.md
+++ b/apps/website/content/obsidian/welcome/installation.md
@@ -5,46 +5,25 @@ author: ""
 published: true
 ---
 
-## Prerequisites
+Discourse Graphs depends on the Datacore plugin, so install Datacore first. Both plugins are available in Obsidian's community plugin browser.
 
-### Install BRAT (Beta Reviewer's Auto-update Tester)
+## Requirements
 
-1. Open Obsidian Settings
-2. Go to Community Plugins and disable Restricted Mode
-3. Click "Browse" and search for "BRAT"
-   ![BRAT](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2Faar5LKpLOk.png?alt=media&token=6f51ac48-19d3-4bb5-9a07-7b32cfa6afe6)
-4. Install BRAT and enable it
+### Install Datacore
 
-### Install DataCore via BRAT
+Datacore is required for Discourse Graphs to work, so install and enable it before the Discourse Graphs plugin.
 
 1. Open Obsidian Settings
-2. Go to "Community Plugins" → "BRAT"
-3. Click "Add Beta Plugin"
-   ![Add plugin](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FdMtstUHPXe.png?alt=media&token=3f139ab9-9802-404d-9554-4a63bac080c5)
-4. Enter the repository URL below and choose "Latest version"
-
-```
-https://github.com/blacksmithgu/datacore
-```
-
-![Add datacore](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FEY3vNGt1Rf.png?alt=media&token=32c60ff1-5272-4cde-8b5f-8f049fb2cf50)
-
-5. Check the box for "Enable after installing the plugin"
-6. Click "Add plugin"
+2. Go to "Community plugins" and disable Restricted Mode
+3. Click "Browse" and search for "Datacore"
+4. Install Datacore and enable it
 
 ## Install Discourse Graphs
 
+Once Datacore is installed and enabled, add the Discourse Graphs plugin from the community plugin browser.
+
 1. Open Obsidian Settings
-2. Go to "Community Plugins" → "BRAT"
-3. Click "Add Beta Plugin"
-   ![Add plugin](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FdMtstUHPXe.png?alt=media&token=3f139ab9-9802-404d-9554-4a63bac080c5)
-4. Enter the repository URL below and choose "Latest version"
+2. Go to "Community plugins" → "Browse"
+3. Search for "Discourse Graph", then install and enable it
 
-```
-https://github.com/DiscourseGraphs/discourse-graph-obsidian
-```
-
-![Add discourse graph](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fdiscourse-graphs%2FSBCK-2lkcu.png?alt=media&token=0375c828-da4d-43b4-8f2c-e691692cb019)
-
-5. Check the box for "Enable after installing the plugin"
-6. Click "Add Plugin"
+Or install directly from the [community plugin page](https://community.obsidian.md/plugins/discourse-graphs).

--- a/apps/website/content/obsidian/welcome/installation.md
+++ b/apps/website/content/obsidian/welcome/installation.md
@@ -26,5 +26,4 @@ Once Datacore is installed and enabled, add the Discourse Graphs plugin from the
 2. Go to "Community plugins" → "Browse"
 3. Search for "Discourse Graphs", then install and enable it
 
-
 Or install directly from the [community plugin page](https://community.obsidian.md/plugins/discourse-graphs).

--- a/apps/website/content/obsidian/welcome/installation.md
+++ b/apps/website/content/obsidian/welcome/installation.md
@@ -24,6 +24,7 @@ Once Datacore is installed and enabled, add the Discourse Graphs plugin from the
 
 1. Open Obsidian Settings
 2. Go to "Community plugins" → "Browse"
-3. Search for "Discourse Graph", then install and enable it
+3. Search for "Discourse Graphs", then install and enable it
+
 
 Or install directly from the [community plugin page](https://community.obsidian.md/plugins/discourse-graphs).


### PR DESCRIPTION
## Summary
Rewrite the installation instruction to reflect that we're now LIVEEE

- Reorders steps to **BRAT → Datacore → Discourse Graphs**
- Folds the standalone "Requirements" bullet into an intro sentence that states the order up front.
- Numbers the three install sections so they read as one sequence rather than independent options.
- Standardizes "DataCore" → "Datacore" and applies sentence case to non-product headings.

## Open question

Step 3 installs Discourse Graphs from Obsidian's community plugin browser. If DG isn't published there yet, that step should stay on the BRAT path (`discourse-graph-obsidian` repo) instead. Please confirm before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/1246" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->