### PR TITLE
ENG-1958 - Remove Add Source reference arrow

### DIFF
--- a/apps/roam/src/components/canvas/Tldraw.tsx
+++ b/apps/roam/src/components/canvas/Tldraw.tsx
@@ -525,15 +525,9 @@ const TldrawCanvasShared = ({
 
     return obj;
   }, [allNodes]);
-  const allAddReferencedNodeActions = useMemo(() => {
-    return Object.keys(allAddReferencedNodeByAction);
-  }, [allAddReferencedNodeByAction]);
 
   const isRelationTool = (toolId: string) => {
-    return (
-      allRelationNames.includes(toolId) ||
-      allAddReferencedNodeActions.includes(toolId)
-    );
+    return allRelationNames.includes(toolId);
   };
 
   // Add state for tracking relation creation
@@ -575,10 +569,8 @@ const TldrawCanvasShared = ({
       if (relationCreationRef.current.isCreating) {
         // Find the relation shape that was just created
         const selectedShapes = app.getSelectedShapes();
-        const relationShape = selectedShapes.find(
-          (shape) =>
-            allRelationIds.includes(shape.type) ||
-            allAddReferencedNodeActions.includes(shape.type),
+        const relationShape = selectedShapes.find((shape) =>
+          allRelationIds.includes(shape.type),
         );
 
         if (relationShape) {
@@ -695,7 +687,6 @@ const TldrawCanvasShared = ({
   const customUiComponents: TLUiComponents = createUiComponents({
     allNodes,
     allRelationNames,
-    allAddReferencedNodeActions,
     canvasSyncMode,
   });
 
@@ -1151,7 +1142,6 @@ const TldrawCanvasShared = ({
                   extensionAPI={extensionAPI}
                   allNodes={allNodes}
                   // allRelationIds={allRelationIds}
-                  // allAddReferencedNodeActions={allAddReferencedNodeActions}
                 />
                 <CanvasDrawerPanel />
                 <ClipboardPanel />
@@ -1170,12 +1160,10 @@ const InsideEditorAndUiContext = ({
   extensionAPI,
   allNodes,
   // allRelationIds,
-  // allAddReferencedNodeActions,
 }: {
   extensionAPI: OnloadArgs["extensionAPI"];
   allNodes: DiscourseNode[];
   // allRelationIds: string[];
-  // allAddReferencedNodeActions: string[];
 }) => {
   const editor = useEditor();
   const toasts = useToasts();
@@ -1186,11 +1174,9 @@ const InsideEditorAndUiContext = ({
   //   // possibly migrate to shape.type or shape.name
   //   // or add as meta
   //   const allRelationIdSet = new Set(allRelationIds);
-  //   const allAddReferencedNodeActionsSet = new Set(allAddReferencedNodeActions);
 
   //   return (
-  //     allRelationIdSet.has(shape.type) ||
-  //     allAddReferencedNodeActionsSet.has(shape.type)
+  //     allRelationIdSet.has(shape.type)
   //   );
   // };
 

--- a/apps/roam/src/components/canvas/uiOverrides.tsx
+++ b/apps/roam/src/components/canvas/uiOverrides.tsx
@@ -537,13 +537,11 @@ export const CustomContextMenu = ({
 };
 export const createUiComponents = ({
   allNodes,
-  allAddReferencedNodeActions,
   allRelationNames,
   canvasSyncMode,
 }: {
   allNodes: DiscourseNode[];
   allRelationNames: string[];
-  allAddReferencedNodeActions: string[];
   canvasSyncMode: CanvasSyncMode;
 }): TLUiComponents => {
   return {
@@ -613,11 +611,9 @@ export const createUiComponents = ({
       );
     },
     SharePanel: () => {
-      const allRelations = [
-        ...allRelationNames,
-        ...allAddReferencedNodeActions,
-      ];
-      return <DiscourseGraphPanel nodes={allNodes} relations={allRelations} />;
+      return (
+        <DiscourseGraphPanel nodes={allNodes} relations={allRelationNames} />
+      );
     },
   };
 };


### PR DESCRIPTION
Only the UI, migrations will come with [ENG-1955: Full migration to `discourse-relation` only](https://linear.app/discourse-graphs/issue/ENG-1955/full-migration-to-discourse-relation-only)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/1250" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->