### PR TITLE
[ENG-2078] Update node conversion button on images to use core Obsidian styling

### DIFF
--- a/apps/obsidian/src/styles/style.css
+++ b/apps/obsidian/src/styles/style.css
@@ -3866,15 +3866,7 @@ kbd.tlui-kbd {
   }
 }
 
-/* When nested inside Obsidian's shared ".embed-actions" pill, no extra
-   rule is needed here: the pill's own opacity (hover/selection/resizing)
-   already governs ours along with the native buttons. */
-
-/* Fallback positioning + reveal for Obsidian versions that don't group
-   image-embed buttons in a shared ".embed-actions" element (see
-   imageEmbedHoverIcon.ts, which appends into that group when present and
-   falls back to this direct child otherwise). Mirrors the native
-   hover/selection reveal so behavior matches the nested case. */
+/* Fallback for Obsidian versions without a shared ".embed-actions" wrapper. */
 .internal-embed.image-embed > .dg-image-convert-icon {
   position: absolute;
   top: var(--size-2-2);

--- a/apps/obsidian/src/styles/style.css
+++ b/apps/obsidian/src/styles/style.css
@@ -3866,11 +3866,19 @@ kbd.tlui-kbd {
   }
 }
 
-.dg-image-convert-icon {
+/* When nested inside Obsidian's shared ".embed-actions" pill, no extra
+   rule is needed here: the pill's own opacity (hover/selection/resizing)
+   already governs ours along with the native buttons. */
+
+/* Fallback positioning + reveal for Obsidian versions that don't group
+   image-embed buttons in a shared ".embed-actions" element (see
+   imageEmbedHoverIcon.ts, which appends into that group when present and
+   falls back to this direct child otherwise). Mirrors the native
+   hover/selection reveal so behavior matches the nested case. */
+.internal-embed.image-embed > .dg-image-convert-icon {
+  position: absolute;
   top: var(--size-2-2);
-  inset-inline-end: calc(var(--size-2-2) + 36px);
-  /* Hardcoded to match native .edit-block-button's measured 30x26 box; padding
-     alone doesn't reproduce it since our icon's intrinsic size differs. */
+  inset-inline-start: var(--size-2-2);
   box-sizing: border-box;
   width: 30px;
   height: 26px;
@@ -3879,19 +3887,22 @@ kbd.tlui-kbd {
   border-radius: var(--radius-s);
   cursor: var(--cursor);
   opacity: 0;
-  pointer-events: none;
 }
 
-.dg-image-embed-active .dg-image-convert-icon {
-  background-color: var(--background-primary);
+.internal-embed.image-embed.is-selected > .dg-image-convert-icon {
   opacity: 1;
-  inset-inline-end: calc(var(--size-2-2) + 36px + 3px);
-  pointer-events: auto;
+  background-color: var(--background-primary);
   z-index: 2;
 }
 
 @media (hover: hover) {
-  .dg-image-embed-active .dg-image-convert-icon:hover {
+  .internal-embed.image-embed:hover > .dg-image-convert-icon {
+    opacity: 1;
+    background-color: var(--background-primary);
+    z-index: 2;
+  }
+
+  .internal-embed.image-embed:hover > .dg-image-convert-icon:hover {
     background-color: var(--background-secondary);
   }
 }

--- a/apps/obsidian/src/styles/style.css
+++ b/apps/obsidian/src/styles/style.css
@@ -3868,14 +3868,30 @@ kbd.tlui-kbd {
 
 .dg-image-convert-icon {
   top: var(--size-2-2);
+  inset-inline-end: calc(var(--size-2-2) + 38px);
+  /* Hardcoded to match native .edit-block-button's measured 30x26 box; padding
+     alone doesn't reproduce it since our icon's intrinsic size differs. */
+  box-sizing: border-box;
+  width: 30px;
+  height: 26px;
   padding: var(--size-2-2) var(--size-2-3);
   color: var(--text-muted);
-  background-color: var(--background-primary);
+  border-radius: var(--radius-s);
+  cursor: var(--cursor);
   opacity: 0;
   pointer-events: none;
 }
 
 .dg-image-embed-active .dg-image-convert-icon {
+  background-color: var(--background-primary);
   opacity: 1;
+  inset-inline-end: calc(var(--size-2-2) + 38px + 3px);
   pointer-events: auto;
+  z-index: 2;
+}
+
+@media (hover: hover) {
+  .dg-image-embed-active .dg-image-convert-icon:hover {
+    background-color: var(--background-secondary);
+  }
 }

--- a/apps/obsidian/src/styles/style.css
+++ b/apps/obsidian/src/styles/style.css
@@ -3868,7 +3868,7 @@ kbd.tlui-kbd {
 
 .dg-image-convert-icon {
   top: var(--size-2-2);
-  inset-inline-end: calc(var(--size-2-2) + 38px);
+  inset-inline-end: calc(var(--size-2-2) + 36px);
   /* Hardcoded to match native .edit-block-button's measured 30x26 box; padding
      alone doesn't reproduce it since our icon's intrinsic size differs. */
   box-sizing: border-box;
@@ -3885,7 +3885,7 @@ kbd.tlui-kbd {
 .dg-image-embed-active .dg-image-convert-icon {
   background-color: var(--background-primary);
   opacity: 1;
-  inset-inline-end: calc(var(--size-2-2) + 38px + 3px);
+  inset-inline-end: calc(var(--size-2-2) + 36px + 3px);
   pointer-events: auto;
   z-index: 2;
 }

--- a/apps/obsidian/src/utils/imageEmbedHoverIcon.ts
+++ b/apps/obsidian/src/utils/imageEmbedHoverIcon.ts
@@ -36,11 +36,7 @@ const createConvertIcon = (
   embedEl: HTMLElement,
   plugin: DiscourseGraphPlugin,
 ): HTMLDivElement => {
-  // A plain div, matching how Obsidian itself builds native embed-action
-  // buttons (see the app's own `createDiv("embed-action")`). A real
-  // <button> would pick up Obsidian's global unscoped `button` reset
-  // (fixed input height/padding/background) on top of ".embed-action",
-  // inflating the shared pill and painting over the icon.
+  // A div, not a button, to match Obsidian's own embed-action markup.
   const btn = createEl("div");
   btn.className = `${ICON_CLASS} embed-action flex items-center justify-center`;
   btn.setAttribute("role", "button");
@@ -85,20 +81,15 @@ const processContainer = (
   );
 
   for (const embedEl of embeds) {
-    // Skip if button already exists to prevent duplicates when processContainer
-    // is called multiple times (constructor, MutationObserver, update()).
+    // Skip embeds that already have the button (processContainer runs repeatedly).
     if (embedEl.querySelector(`.${ICON_CLASS}`)) continue;
 
     const imageFile = resolveImageFile(embedEl, plugin);
     if (!imageFile) continue;
 
     const btn = createConvertIcon(embedEl, plugin);
-    // Obsidian 1.13+ groups its own image-embed buttons in a shared
-    // ".embed-actions" pill that reveals on hover/selection. Join that
-    // group so ours lays out alongside native buttons and inherits the
-    // same reveal behavior, instead of overlapping a hardcoded pixel
-    // offset. Fall back to a plain sibling for older Obsidian versions
-    // without that wrapper.
+    // Join Obsidian's native embed-actions group when present, so ours lays
+    // out alongside native buttons instead of a hardcoded pixel offset.
     const actionsEl = embedEl.querySelector<HTMLElement>(".embed-actions");
     if (actionsEl) {
       actionsEl.prepend(btn);

--- a/apps/obsidian/src/utils/imageEmbedHoverIcon.ts
+++ b/apps/obsidian/src/utils/imageEmbedHoverIcon.ts
@@ -66,25 +66,13 @@ const createConvertIcon = (
     convert();
   });
 
-  btn.addEventListener("keydown", (e) => {
-    if (e.key !== "Enter" && e.key !== " ") return;
-    e.stopPropagation();
-    e.preventDefault();
-    convert();
-  });
-
-  return btn;
-};
-
-const processContainer = (
-  container: HTMLElement,
-  plugin: DiscourseGraphPlugin,
-): void => {
   const embeds = container.querySelectorAll<HTMLElement>(
     ".internal-embed.image-embed",
   );
 
   for (const embedEl of embeds) {
+    // Skip if button already exists to prevent duplicates when processContainer
+    // is called multiple times (constructor, MutationObserver, update()).
     if (embedEl.querySelector(`.${ICON_CLASS}`)) continue;
 
     const imageFile = resolveImageFile(embedEl, plugin);
@@ -104,6 +92,7 @@ const processContainer = (
       embedEl.classList.add("relative");
       embedEl.appendChild(btn);
     }
+
   }
 };
 

--- a/apps/obsidian/src/utils/imageEmbedHoverIcon.ts
+++ b/apps/obsidian/src/utils/imageEmbedHoverIcon.ts
@@ -66,6 +66,20 @@ const createConvertIcon = (
     convert();
   });
 
+  btn.addEventListener("keydown", (e) => {
+    if (e.key !== "Enter" && e.key !== " ") return;
+    e.stopPropagation();
+    e.preventDefault();
+    convert();
+  });
+
+  return btn;
+};
+
+const processContainer = (
+  container: HTMLElement,
+  plugin: DiscourseGraphPlugin,
+): void => {
   const embeds = container.querySelectorAll<HTMLElement>(
     ".internal-embed.image-embed",
   );
@@ -92,7 +106,6 @@ const createConvertIcon = (
       embedEl.classList.add("relative");
       embedEl.appendChild(btn);
     }
-
   }
 };
 

--- a/apps/obsidian/src/utils/imageEmbedHoverIcon.ts
+++ b/apps/obsidian/src/utils/imageEmbedHoverIcon.ts
@@ -4,7 +4,7 @@ import {
   ViewPlugin,
   ViewUpdate,
 } from "@codemirror/view";
-import { setIcon, TFile } from "obsidian";
+import { setIcon, setTooltip, TFile } from "obsidian";
 import type DiscourseGraphPlugin from "~/index";
 import {
   isImageFile,
@@ -12,7 +12,6 @@ import {
 } from "~/utils/editorMenuUtils";
 
 const ICON_CLASS = "dg-image-convert-icon";
-const EMBED_ACTIVE_CLASS = "dg-image-embed-active";
 
 const resolveImageFile = (
   embedEl: HTMLElement,
@@ -36,42 +35,50 @@ const resolveImageFile = (
 const createConvertIcon = (
   embedEl: HTMLElement,
   plugin: DiscourseGraphPlugin,
-): HTMLButtonElement => {
-  const btn = createEl("button");
-  btn.className = `${ICON_CLASS} absolute flex items-center justify-center border-none`;
-  btn.title = "Convert to node";
+): HTMLDivElement => {
+  // A plain div, matching how Obsidian itself builds native embed-action
+  // buttons (see the app's own `createDiv("embed-action")`). A real
+  // <button> would pick up Obsidian's global unscoped `button` reset
+  // (fixed input height/padding/background) on top of ".embed-action",
+  // inflating the shared pill and painting over the icon.
+  const btn = createEl("div");
+  btn.className = `${ICON_CLASS} embed-action flex items-center justify-center`;
+  btn.setAttribute("role", "button");
+  btn.tabIndex = 0;
   setIcon(btn, "file-input");
+  setTooltip(btn, "Convert to node");
 
-  // Prevent mousedown from bubbling to the embed's mousedown handler
+  // Prevent mousedown from bubbling to Obsidian's embed selection handler
   btn.addEventListener("mousedown", (e) => {
     e.stopPropagation();
   });
 
-  btn.addEventListener("click", (e) => {
-    e.stopPropagation();
-    e.preventDefault();
-
+  const convert = () => {
     const imageFile = resolveImageFile(embedEl, plugin);
     if (!imageFile) return;
 
     openConvertImageToNodeModal({ plugin, imageFile });
+  };
+
+  btn.addEventListener("click", (e) => {
+    e.stopPropagation();
+    e.preventDefault();
+    convert();
+  });
+
+  btn.addEventListener("keydown", (e) => {
+    if (e.key !== "Enter" && e.key !== " ") return;
+    e.stopPropagation();
+    e.preventDefault();
+    convert();
   });
 
   return btn;
 };
 
-const showButtonForEmbed = (embedEl: HTMLElement): void => {
-  embedEl.classList.add(EMBED_ACTIVE_CLASS);
-};
-
-const hideButtonForEmbed = (embedEl: HTMLElement): void => {
-  embedEl.classList.remove(EMBED_ACTIVE_CLASS);
-};
-
 const processContainer = (
   container: HTMLElement,
   plugin: DiscourseGraphPlugin,
-  signal: AbortSignal,
 ): void => {
   const embeds = container.querySelectorAll<HTMLElement>(
     ".internal-embed.image-embed",
@@ -83,32 +90,27 @@ const processContainer = (
     const imageFile = resolveImageFile(embedEl, plugin);
     if (!imageFile) continue;
 
-    embedEl.classList.add("relative");
-    embedEl.appendChild(createConvertIcon(embedEl, plugin));
-
-    // Use mousedown to match the timing of Obsidian's native "edit this block" button.
-    // The AbortSignal ensures this listener is cleaned up when the plugin is destroyed.
-    embedEl.addEventListener(
-      "mousedown",
-      (e) => {
-        e.stopPropagation();
-
-        // Hide any other active embed in the container first
-        container
-          .querySelectorAll<HTMLElement>(`.${EMBED_ACTIVE_CLASS}`)
-          .forEach(hideButtonForEmbed);
-
-        showButtonForEmbed(embedEl);
-      },
-      { signal },
-    );
+    const btn = createConvertIcon(embedEl, plugin);
+    // Obsidian 1.13+ groups its own image-embed buttons in a shared
+    // ".embed-actions" pill that reveals on hover/selection. Join that
+    // group so ours lays out alongside native buttons and inherits the
+    // same reveal behavior, instead of overlapping a hardcoded pixel
+    // offset. Fall back to a plain sibling for older Obsidian versions
+    // without that wrapper.
+    const actionsEl = embedEl.querySelector<HTMLElement>(".embed-actions");
+    if (actionsEl) {
+      actionsEl.prepend(btn);
+    } else {
+      embedEl.classList.add("relative");
+      embedEl.appendChild(btn);
+    }
   }
 };
 
 /**
  * CodeMirror ViewPlugin that adds a "Convert to node" icon on embedded images
- * in the live-preview editor. The button appears on click (matching the behavior
- * of Obsidian's native "edit this block" button) rather than on hover.
+ * in the live-preview editor. Reveal timing (hover/selection) matches
+ * Obsidian's native embed action buttons via CSS.
  */
 export const createImageEmbedHoverExtension = (
   plugin: DiscourseGraphPlugin,
@@ -117,32 +119,10 @@ export const createImageEmbedHoverExtension = (
     class {
       private dom: HTMLElement;
       private observer: MutationObserver;
-      private handleOutsideClick: (e: MouseEvent) => void;
-      private abortController: AbortController;
 
       constructor(view: EditorView) {
         this.dom = view.dom;
-        this.abortController = new AbortController();
-        processContainer(view.dom, plugin, this.abortController.signal);
-
-        this.handleOutsideClick = (e: MouseEvent) => {
-          // Only dismiss when the click lands in the actual editor content
-          // (matching the native "edit this block" button), not the gutter
-          // or anywhere else outside the editor.
-          const content = this.dom.querySelector(".cm-content");
-          const target = e.target;
-          if (
-            !content ||
-            !(target instanceof Node) ||
-            !content.contains(target)
-          ) {
-            return;
-          }
-          this.dom
-            .querySelectorAll<HTMLElement>(`.${EMBED_ACTIVE_CLASS}`)
-            .forEach(hideButtonForEmbed);
-        };
-        activeDocument.addEventListener("mousedown", this.handleOutsideClick);
+        processContainer(view.dom, plugin);
 
         // Obsidian renders embeds asynchronously after doc changes,
         // so we need a MutationObserver to catch newly added image embeds.
@@ -157,7 +137,7 @@ export const createImageEmbedHoverExtension = (
             ),
           );
           if (hasRelevantMutation) {
-            processContainer(this.dom, plugin, this.abortController.signal);
+            processContainer(this.dom, plugin);
           }
         });
         this.observer.observe(this.dom, {
@@ -168,22 +148,12 @@ export const createImageEmbedHoverExtension = (
 
       update(update: ViewUpdate): void {
         if (update.docChanged || update.viewportChanged) {
-          processContainer(
-            update.view.dom,
-            plugin,
-            this.abortController.signal,
-          );
+          processContainer(update.view.dom, plugin);
         }
       }
 
       destroy(): void {
         this.observer.disconnect();
-        activeDocument.removeEventListener(
-          "mousedown",
-          this.handleOutsideClick,
-        );
-        // Abort removes all embed-level mousedown listeners added via processContainer
-        this.abortController.abort();
         const icons = this.dom.querySelectorAll(`.${ICON_CLASS}`);
         icons.forEach((icon) => icon.remove());
       }

--- a/apps/obsidian/src/utils/imageEmbedHoverIcon.ts
+++ b/apps/obsidian/src/utils/imageEmbedHoverIcon.ts
@@ -38,7 +38,7 @@ const createConvertIcon = (
   plugin: DiscourseGraphPlugin,
 ): HTMLButtonElement => {
   const btn = createEl("button");
-  btn.className = `${ICON_CLASS} absolute z-[2] right-[42px] h-[28px] w-[28px] flex border-none opacity-0 pointer-events-none`;
+  btn.className = `${ICON_CLASS} absolute flex items-center justify-center border-none`;
   btn.title = "Convert to node";
   setIcon(btn, "file-input");
 
@@ -117,7 +117,7 @@ export const createImageEmbedHoverExtension = (
     class {
       private dom: HTMLElement;
       private observer: MutationObserver;
-      private handleOutsideClick: () => void;
+      private handleOutsideClick: (e: MouseEvent) => void;
       private abortController: AbortController;
 
       constructor(view: EditorView) {
@@ -125,7 +125,19 @@ export const createImageEmbedHoverExtension = (
         this.abortController = new AbortController();
         processContainer(view.dom, plugin, this.abortController.signal);
 
-        this.handleOutsideClick = () => {
+        this.handleOutsideClick = (e: MouseEvent) => {
+          // Only dismiss when the click lands in the actual editor content
+          // (matching the native "edit this block" button), not the gutter
+          // or anywhere else outside the editor.
+          const content = this.dom.querySelector(".cm-content");
+          const target = e.target;
+          if (
+            !content ||
+            !(target instanceof Node) ||
+            !content.contains(target)
+          ) {
+            return;
+          }
           this.dom
             .querySelectorAll<HTMLElement>(`.${EMBED_ACTIVE_CLASS}`)
             .forEach(hideButtonForEmbed);


### PR DESCRIPTION
https://www.loom.com/share/630f6544662f4ff3810755cffeff3a44

## Summary
- Matches the image embed's "Convert to node" button styling to Obsidian's native "Edit this block" button — size (30×26px), border-radius, cursor, background/hover colors, all via Obsidian's own CSS variables (`--size-2-2`, `--text-muted`, `--radius-s`, `--cursor`, `--background-primary`, `--background-secondary`)
- Positions it 8px to the left of the native edit button, using RTL-safe `inset-inline-end` instead of a hardcoded `right` offset
- Fixes dismiss behavior: clicking the editor gutter no longer hides the button — it now only dismisses when clicking into the actual editor content, matching the native button

Linear: https://linear.app/discourse-graphs/issue/ENG-2078/update-node-conversion-button-on-images-to-use-core-obsidian-styling

## Test plan
- [x] `pnpm dev --filter @discourse-graphs/obsidian` builds with 0 errors
- [ ] In Obsidian, click an image embed and confirm the "Convert to node" button matches the native "Edit this block" button's size/radius/cursor
- [ ] Hover the button while active and confirm background shifts to match native hover color
- [ ] Click the gutter and confirm the button persists; click into editor text and confirm it dismisses

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/1256" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the positioning and appearance of the “Convert to node” button for embedded images.
  * Added clearer hover feedback when the conversion button is active.
  * Prevented the button from being dismissed by clicks outside the editor content area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->