### PR TITLE
[ENG-2081] Update plugin settings menu badge styling

### DIFF
--- a/apps/obsidian/src/components/GeneralSettings.tsx
+++ b/apps/obsidian/src/components/GeneralSettings.tsx
@@ -31,57 +31,71 @@ const InfoSection = () => {
           Discourse Graphs
         </div>
 
-        <a
-          href={COMMUNITY_URL}
-          className="flex items-center gap-1 text-sm no-underline hover:opacity-80"
-          style={{ color: "var(--interactive-accent)" }}
-          target="_blank"
-          rel="noopener noreferrer"
-          aria-label="Community"
-        >
-          <span className="icon flex items-center">
-            <SlackLogoIcon />
-          </span>
-          <span>Community</span>
-          <span
-            className="icon"
-            ref={(el) => (el && setIcon(el, "arrow-up-right")) || undefined}
-          />
-        </a>
-        <a
-          href={DOCS_URL}
-          className="flex items-center gap-1 text-sm no-underline hover:opacity-80"
-          style={{ color: "var(--interactive-accent)" }}
-          target="_blank"
-          rel="noopener noreferrer"
-          aria-label="Docs"
-        >
-          <div
-            className="icon"
-            ref={(el) => (el && setIcon(el, "book")) || undefined}
-          />
-          <span>Docs</span>
-          <span
-            className="icon"
-            ref={(el) => (el && setIcon(el, "arrow-up-right")) || undefined}
-          />
-        </a>
+        <div className="mt-2 flex flex-col items-start gap-1">
+          <a
+            href={COMMUNITY_URL}
+            className="flex items-center gap-1 text-sm no-underline hover:opacity-80"
+            style={{ color: "var(--interactive-accent)" }}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Community"
+          >
+            <span className="icon flex w-4 items-center justify-center">
+              <SlackLogoIcon />
+            </span>
+            <span>Community</span>
+            <span
+              className="icon"
+              ref={(el) => (el && setIcon(el, "arrow-up-right")) || undefined}
+            />
+          </a>
+          <a
+            href={DOCS_URL}
+            className="flex items-center gap-1 text-sm no-underline hover:opacity-80"
+            style={{ color: "var(--interactive-accent)" }}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Docs"
+          >
+            <div
+              className="icon flex w-4 items-center justify-center"
+              ref={(el) => (el && setIcon(el, "book")) || undefined}
+            />
+            <span>Docs</span>
+            <span
+              className="icon"
+              ref={(el) => (el && setIcon(el, "arrow-up-right")) || undefined}
+            />
+          </a>
 
-        <button
-          onClick={() => new FeedbackModal(plugin.app, plugin).open()}
-          className="mt-2 flex cursor-pointer items-center gap-1 rounded border-none bg-transparent px-2 py-1 text-sm hover:opacity-80"
-          style={{ color: "var(--interactive-accent)" }}
-          aria-label="Send feedback"
-        >
-          <span
-            className="icon inline-flex items-center"
-            ref={(el) => (el && setIcon(el, "message-square")) || undefined}
-          />
-          <span>Send feedback</span>
-        </button>
+          <button
+            onClick={() => new FeedbackModal(plugin.app, plugin).open()}
+            className="flex cursor-pointer items-center gap-1 text-sm no-underline hover:opacity-80"
+            style={{
+              color: "var(--interactive-accent)",
+              background: "transparent",
+              border: "none",
+              boxShadow: "none",
+              padding: 0,
+              margin: 0,
+              borderRadius: 0,
+              height: "auto",
+              minHeight: 0,
+              lineHeight: "inherit",
+              fontFamily: "inherit",
+            }}
+            aria-label="Send feedback"
+          >
+            <span
+              className="icon flex w-4 items-center justify-center"
+              ref={(el) => (el && setIcon(el, "message-square")) || undefined}
+            />
+            <span>Send feedback</span>
+          </button>
+        </div>
 
         <span
-          className="text-muted text-xs"
+          className="text-muted mt-2 text-xs"
           style={{ color: "var(--interactive-accent)" }}
         >
           {plugin.manifest.version}

--- a/apps/obsidian/src/components/GeneralSettings.tsx
+++ b/apps/obsidian/src/components/GeneralSettings.tsx
@@ -70,20 +70,7 @@ const InfoSection = () => {
 
           <button
             onClick={() => new FeedbackModal(plugin.app, plugin).open()}
-            className="flex cursor-pointer items-center gap-1 text-sm no-underline hover:opacity-80"
-            style={{
-              color: "var(--interactive-accent)",
-              background: "transparent",
-              border: "none",
-              boxShadow: "none",
-              padding: 0,
-              margin: 0,
-              borderRadius: 0,
-              height: "auto",
-              minHeight: 0,
-              lineHeight: "inherit",
-              fontFamily: "inherit",
-            }}
+            className="!m-0 flex !h-auto !min-h-0 cursor-pointer items-center gap-1 !rounded-none !border-0 !bg-transparent !p-0 !font-[inherit] text-sm !leading-[inherit] !text-[var(--interactive-accent)] no-underline !shadow-none hover:opacity-80 focus-visible:!outline focus-visible:!outline-2 focus-visible:!outline-offset-2"
             aria-label="Send feedback"
           >
             <span


### PR DESCRIPTION
[https://www.loom.com/share/cf111ca3ac2d45639e93e2977f36891b](<https://www.loom.com/share/cf111ca3ac2d45639e93e2977f36891b>)

## Summary

* Restyled the "Send feedback" button in the Obsidian plugin settings credits badge to match the plain-link styling of the Community/Docs links (removed the pill background/border/padding, which required inline style overrides since Obsidian's default `button` stylesheet outweighs Tailwind utility classes).
* Grouped Community/Docs/Send feedback into their own container, left-aligned them, and added spacing between that group and the logo/title section above and the version number below.
* Fixed inconsistent leading-icon widths across the three items so the labels line up visually.

## Test plan

- [X] Verified locally in Dev Vault via `pnpm dev --filter @discourse-graphs/obsidian` — built with 0 errors, confirmed visually in Settings → Discourse Graph → General
- [ ] Loom walkthrough (before/after)

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)

---

![Open in Devin Review](https://camo.githubusercontent.com/a4be08b8baaff58c5f163b8bbf073f8cdff8e3a6c7e2f554b621f61ab1557d7e/68747470733a2f2f7374617469632e646576696e2e61692f6173736574732f67682d6f70656e2d696e2d646576696e2d7265766965772d6c696768742e7376673f763d31)

## Summary by CodeRabbit

* **Style**
  * Improved the layout and spacing of Community, Docs, and Send Feedback links in General Settings.
  * Standardized icon sizing and alignment for a more consistent appearance.
  * Refined version text spacing and button styling.