### PR TITLE
ENG-2058 Align default Source node color across apps and documentation

### DIFF
--- a/apps/obsidian/src/constants.ts
+++ b/apps/obsidian/src/constants.ts
@@ -35,7 +35,7 @@ export const DEFAULT_NODE_TYPES: Record<string, DiscourseNode> = {
     id: generateUid("node"),
     name: "Source",
     format: "SRC - {content}",
-    color: "#3B82F6",
+    color: "#9E9E9E",
     tag: "src-candidate",
     created: now,
     modified: now,

--- a/apps/website/app/components/docs/NodeTag.tsx
+++ b/apps/website/app/components/docs/NodeTag.tsx
@@ -4,7 +4,7 @@ const NODE_TAG_COLORS = {
   que: "#99890E", // Question
   clm: "#7DA13E", // Claim
   evd: "#DB134A", // Evidence
-  src: "#3B82F6", // Source
+  src: "#9E9E9E", // Source
   hyp: "#8CE99A", // Hypothesis
   res: "#4DABF7", // Result
   iss: "#E599F7", // Issue


### PR DESCRIPTION
## Summary

* Updated Obsidian's `DEFAULT_NODE_TYPES.source.color` and  website docs from `#3B82F6` to `#9E9E9E`

## Test plan

- [X] `eslint` passes on both changed files
- [X] `prettier --check` passes on both changed files
- [X] `tsc --noEmit` passes for `apps/website` and `apps/obsidian`
- [X] Confirmed no other hardcoded Source-color occurrences exist in the codebase (grep across website/obsidian/roam/packages)

Linear: [ENG-2058](https://linear.app/discourse-graphs/issue/ENG-2058/align-default-source-node-color-across-apps-and-documentation)

---

![Open in Devin Review](https://camo.githubusercontent.com/a4be08b8baaff58c5f163b8bbf073f8cdff8e3a6c7e2f554b621f61ab1557d7e/68747470733a2f2f7374617469632e646576696e2e61692f6173736574732f67682d6f70656e2d696e2d646576696e2d7265766965772d6c696768742e7376673f763d31)