### PR TITLE
ENG-2076 Add file limit to feedback form

### DIFF
--- a/apps/obsidian/src/components/FeedbackModal.tsx
+++ b/apps/obsidian/src/components/FeedbackModal.tsx
@@ -61,6 +61,7 @@ const FeedbackContent = ({ plugin, onClose }: FeedbackContentProps) => {
   const [screenshot, setScreenshot] = useState<File | null>(null);
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const [emailError, setEmailError] = useState<string | null>(null);
+  const [fileSizeError, setFileSizeError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -92,18 +93,22 @@ const FeedbackContent = ({ plugin, onClose }: FeedbackContentProps) => {
   }, [screenshot]);
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setScreenshot(e.target.files?.[0] ?? null);
+    const file = e.target.files?.[0] ?? null;
+    if (file && file.size > MAX_SCREENSHOT_SIZE_BYTES) {
+      setFileSizeError(
+        `Image is too large. Please use an image under ${MAX_SCREENSHOT_SIZE_MB} MB.`,
+      );
+    } else {
+      setFileSizeError(null);
+    }
+    setScreenshot(file);
   };
 
   const removeScreenshot = () => {
     setScreenshot(null);
+    setFileSizeError(null);
     if (fileInputRef.current) fileInputRef.current.value = "";
   };
-
-  const fileSizeError =
-    screenshot && screenshot.size > MAX_SCREENSHOT_SIZE_BYTES
-      ? `Image is too large. Please use an image under ${MAX_SCREENSHOT_SIZE_MB} MB.`
-      : null;
 
   const isSubmittable =
     title.trim().length > 0 &&

--- a/apps/obsidian/src/components/FeedbackModal.tsx
+++ b/apps/obsidian/src/components/FeedbackModal.tsx
@@ -42,6 +42,9 @@ const selectClass = `${fieldClass} appearance-none h-9 leading-none`;
 const accentButtonClass =
   "flex items-center justify-center gap-1.5 bg-accent text-on-accent rounded py-2.5 px-3 text-sm font-medium border-none cursor-pointer hover:opacity-90";
 
+const MAX_SCREENSHOT_SIZE_BYTES = 3 * 1024 * 1024; // 3 MB — stays under Vercel's 4.5 MB body limit after base64 encoding
+const MAX_SCREENSHOT_SIZE_LABEL = "3 MB";
+
 const isValidEmail = (value: string) =>
   /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
 
@@ -58,6 +61,7 @@ const FeedbackContent = ({ plugin, onClose }: FeedbackContentProps) => {
   const [screenshot, setScreenshot] = useState<File | null>(null);
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const [emailError, setEmailError] = useState<string | null>(null);
+  const [fileSizeError, setFileSizeError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -89,11 +93,20 @@ const FeedbackContent = ({ plugin, onClose }: FeedbackContentProps) => {
   }, [screenshot]);
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setScreenshot(e.target.files?.[0] ?? null);
+    const file = e.target.files?.[0] ?? null;
+    if (file && file.size > MAX_SCREENSHOT_SIZE_BYTES) {
+      setFileSizeError(
+        `Image is too large. Please use an image under ${MAX_SCREENSHOT_SIZE_LABEL}.`,
+      );
+    } else {
+      setFileSizeError(null);
+    }
+    setScreenshot(file);
   };
 
   const removeScreenshot = () => {
     setScreenshot(null);
+    setFileSizeError(null);
     if (fileInputRef.current) fileInputRef.current.value = "";
   };
 
@@ -101,7 +114,8 @@ const FeedbackContent = ({ plugin, onClose }: FeedbackContentProps) => {
     title.trim().length > 0 &&
     email.trim().length > 0 &&
     isValidEmail(email.trim()) &&
-    !emailError;
+    !emailError &&
+    !fileSizeError;
 
   const handleSubmit = async () => {
     if (!isSubmittable) return;
@@ -178,7 +192,9 @@ const FeedbackContent = ({ plugin, onClose }: FeedbackContentProps) => {
 
       {/* Screenshot preview */}
       {screenshot && previewUrl && (
-        <div className="bg-modifier-form-field border-modifier-border flex items-center gap-2 rounded border p-2">
+        <div
+          className={`bg-modifier-form-field flex items-center gap-2 rounded border p-2 ${fileSizeError ? "border-error" : "border-modifier-border"}`}
+        >
           <img
             src={previewUrl}
             alt="Screenshot preview"
@@ -201,6 +217,9 @@ const FeedbackContent = ({ plugin, onClose }: FeedbackContentProps) => {
             />
           </button>
         </div>
+      )}
+      {fileSizeError && (
+        <span className="text-error text-xs">{fileSizeError}</span>
       )}
 
       {/* Email */}

--- a/apps/obsidian/src/components/FeedbackModal.tsx
+++ b/apps/obsidian/src/components/FeedbackModal.tsx
@@ -42,8 +42,8 @@ const selectClass = `${fieldClass} appearance-none h-9 leading-none`;
 const accentButtonClass =
   "flex items-center justify-center gap-1.5 bg-accent text-on-accent rounded py-2.5 px-3 text-sm font-medium border-none cursor-pointer hover:opacity-90";
 
-const MAX_SCREENSHOT_SIZE_BYTES = 3 * 1024 * 1024; // 3 MB — stays under Vercel's 4.5 MB body limit after base64 encoding
-const MAX_SCREENSHOT_SIZE_LABEL = "3 MB";
+const MAX_SCREENSHOT_SIZE_MB = 3; // stays under Vercel's 4.5 MB body limit after base64 encoding
+const MAX_SCREENSHOT_SIZE_BYTES = MAX_SCREENSHOT_SIZE_MB * 1024 * 1024;
 
 const isValidEmail = (value: string) =>
   /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
@@ -61,7 +61,6 @@ const FeedbackContent = ({ plugin, onClose }: FeedbackContentProps) => {
   const [screenshot, setScreenshot] = useState<File | null>(null);
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const [emailError, setEmailError] = useState<string | null>(null);
-  const [fileSizeError, setFileSizeError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -93,22 +92,18 @@ const FeedbackContent = ({ plugin, onClose }: FeedbackContentProps) => {
   }, [screenshot]);
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0] ?? null;
-    if (file && file.size > MAX_SCREENSHOT_SIZE_BYTES) {
-      setFileSizeError(
-        `Image is too large. Please use an image under ${MAX_SCREENSHOT_SIZE_LABEL}.`,
-      );
-    } else {
-      setFileSizeError(null);
-    }
-    setScreenshot(file);
+    setScreenshot(e.target.files?.[0] ?? null);
   };
 
   const removeScreenshot = () => {
     setScreenshot(null);
-    setFileSizeError(null);
     if (fileInputRef.current) fileInputRef.current.value = "";
   };
+
+  const fileSizeError =
+    screenshot && screenshot.size > MAX_SCREENSHOT_SIZE_BYTES
+      ? `Image is too large. Please use an image under ${MAX_SCREENSHOT_SIZE_MB} MB.`
+      : null;
 
   const isSubmittable =
     title.trim().length > 0 &&

--- a/apps/website/app/api/feedback/route.ts
+++ b/apps/website/app/api/feedback/route.ts
@@ -200,6 +200,21 @@ export const POST = async (request: NextRequest): Promise<NextResponse> => {
       ) as NextResponse;
     }
 
+    const MAX_SCREENSHOT_BYTES = 3 * 1024 * 1024;
+    if (payload.screenshot) {
+      // base64 string length * 0.75 approximates the decoded byte size
+      const approxBytes = Math.ceil(payload.screenshot.data.length * 0.75);
+      if (approxBytes > MAX_SCREENSHOT_BYTES) {
+        return cors(
+          request,
+          NextResponse.json(
+            { error: "Screenshot exceeds the 3 MB limit" },
+            { status: 413 },
+          ),
+        ) as NextResponse;
+      }
+    }
+
     const description = buildDescription(payload);
     const issue = await createIssue(apiKey, payload.title.trim(), description);
 


### PR DESCRIPTION
## Summary

- Enforce a 3 MB screenshot size limit in the Obsidian feedback form to prevent 413 errors from Vercel's 4.5 MB serverless body limit (base64 encoding adds ~33% overhead)
- Show an inline error with a red border on the preview immediately after the user selects an oversized image
- Block the Submit button while the size error is present
- Add a defensive server-side 413 guard in the feedback API route before passing the payload to Linear

## Test plan


- [x] Open the feedback modal in Obsidian and attach an image under 3 MB — preview appears normally, Submit remains enabled, feedback submits successfully
<img width="675" height="681" alt="image" src="https://github.com/user-attachments/assets/74a4a220-207a-4b3d-88b5-258ef2afb695" />

- [x] Attach an image over 3 MB — preview shows with a red border, error message "Image is too large. Please use an image under 3 MB." appears below it, Submit is disabled
<img width="777" height="709" alt="image" src="https://github.com/user-attachments/assets/0470b98c-b005-4564-a6df-430a5a110991" />

- [x] Remove the oversized image — error clears, Submit re-enables (assuming other required fields are filled)
- API file size limit is added just as an additional security measure
🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/1261" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->