### PR TITLE
ENG-1857 Import Roam-origin shared nodes through the existing Obsidian importer

### DIFF
--- a/apps/obsidian/src/utils/importNodes.ts
+++ b/apps/obsidian/src/utils/importNodes.ts
@@ -322,6 +322,76 @@ const fetchNodeContentForImport = async ({
   };
 };
 
+type NodeTypeSchemaForInstance = {
+  nodeTypeId: string;
+  name: string;
+};
+
+export const fetchNodeTypeSchemasForInstances = async ({
+  client,
+  spaceId,
+  nodeInstanceIds,
+}: {
+  client: DGSupabaseClient;
+  spaceId: number;
+  nodeInstanceIds: string[];
+}): Promise<Map<string, NodeTypeSchemaForInstance>> => {
+  const result = new Map<string, NodeTypeSchemaForInstance>();
+
+  const { data: instanceRows, error: instanceError } = await client
+    .from("my_concepts")
+    .select("source_local_id, schema_id")
+    .eq("space_id", spaceId)
+    .eq("is_schema", false)
+    .eq("arity", 0)
+    .in("source_local_id", nodeInstanceIds);
+
+  if (instanceError || !instanceRows) {
+    console.error("Error fetching node instance concepts:", instanceError);
+    return result;
+  }
+
+  const schemaIds = [
+    ...new Set(
+      instanceRows
+        .map((row) => row.schema_id)
+        .filter((id): id is number => id !== null),
+    ),
+  ];
+  if (schemaIds.length === 0) return result;
+
+  const { data: schemaRows, error: schemaError } = await client
+    .from("my_concepts")
+    .select("id, source_local_id, name")
+    .eq("space_id", spaceId)
+    .eq("is_schema", true)
+    .eq("arity", 0)
+    .in("id", schemaIds);
+
+  if (schemaError || !schemaRows) {
+    console.error("Error fetching node type schemas:", schemaError);
+    return result;
+  }
+
+  const schemasById = new Map<number, NodeTypeSchemaForInstance>();
+  for (const row of schemaRows) {
+    if (row.id !== null && row.source_local_id !== null && row.name !== null) {
+      schemasById.set(row.id, {
+        nodeTypeId: row.source_local_id,
+        name: row.name,
+      });
+    }
+  }
+
+  for (const row of instanceRows) {
+    if (row.source_local_id === null || row.schema_id === null) continue;
+    const schema = schemasById.get(row.schema_id);
+    if (schema) result.set(row.source_local_id, schema);
+  }
+
+  return result;
+};
+
 /**
  * Fetches created/last_modified from the source space Content (my_contents) for an imported node.
  * Used by the discourse context view to show "last modified in original vault".
@@ -939,9 +1009,6 @@ const sanitizePathForImport = (path: string): string => {
 
 type ParsedFrontmatter = {
   nodeTypeId?: string;
-  nodeInstanceId?: string;
-  publishedToGroups?: string[];
-  authorId?: number;
   [key: string]: unknown;
 };
 
@@ -1096,22 +1163,24 @@ const processFileContent = async ({
   sourceSpaceId,
   sourceSpaceUri,
   rawContent,
-  originalFilePath,
   filePath,
   importedCreatedAt,
   importedModifiedAt,
   authorId,
+  nodeInstanceId,
+  nodeTypeIdFromConcept,
 }: {
   plugin: DiscourseGraphPlugin;
   client: DGSupabaseClient;
   sourceSpaceId: number;
   sourceSpaceUri: string;
   rawContent: string;
-  originalFilePath?: string;
   filePath: string;
   importedCreatedAt?: number;
   importedModifiedAt?: number;
   authorId?: number;
+  nodeInstanceId: string;
+  nodeTypeIdFromConcept?: string;
 }): Promise<
   { file: TFile; error?: never } | { file?: never; error: string }
 > => {
@@ -1134,18 +1203,14 @@ const processFileContent = async ({
   // 2. Parse frontmatter from rawContent (metadataCache is updated async and is
   //    often empty immediately after create/modify), then map nodeTypeId and update frontmatter.
   const { frontmatter } = parseFrontmatter(rawContent);
-  const sourceNodeTypeId = frontmatter.nodeTypeId;
-  if (typeof sourceNodeTypeId !== "string") {
+  const sourceNodeTypeId =
+    typeof frontmatter.nodeTypeId === "string"
+      ? frontmatter.nodeTypeId
+      : nodeTypeIdFromConcept;
+  if (sourceNodeTypeId === undefined) {
     await plugin.app.vault.delete(file);
     return {
       error: "importedNode missing sourceNodeTypeId",
-    };
-  }
-  const sourceNodeId = frontmatter.nodeInstanceId;
-  if (typeof sourceNodeId !== "string") {
-    await plugin.app.vault.delete(file);
-    return {
-      error: "importedNode missing nodeInstanceId",
     };
   }
 
@@ -1161,12 +1226,11 @@ const processFileContent = async ({
     file,
     (fm) => {
       const record = fm as Record<string, unknown>;
-      if (mappedNodeTypeId !== undefined) {
-        record.nodeTypeId = mappedNodeTypeId;
-      }
+      record.nodeTypeId = mappedNodeTypeId;
+      record.nodeInstanceId = nodeInstanceId;
       record.importedFromRid = spaceUriAndLocalIdToRid(
         sourceSpaceUri,
-        sourceNodeId,
+        nodeInstanceId,
         "note",
       );
       record.lastModified = importedModifiedAt;
@@ -1244,6 +1308,12 @@ export const importSelectedNodes = async ({
       spaceName,
     });
 
+    const nodeTypeSchemasByInstance = await fetchNodeTypeSchemasForInstances({
+      client,
+      spaceId,
+      nodeInstanceIds: nodes.map((n) => n.nodeInstanceId),
+    });
+
     // Process each node in this space
     for (const node of nodes) {
       try {
@@ -1318,11 +1388,14 @@ export const importSelectedNodes = async ({
           sourceSpaceId: spaceId,
           sourceSpaceUri: spaceUri,
           rawContent: content,
-          originalFilePath: contentFilePath,
           filePath: finalFilePath,
           importedCreatedAt: createdAt,
           importedModifiedAt: modifiedAt,
           authorId,
+          nodeInstanceId: node.nodeInstanceId,
+          nodeTypeIdFromConcept: nodeTypeSchemasByInstance.get(
+            node.nodeInstanceId,
+          )?.nodeTypeId,
         });
 
         if (result.error) {

--- a/apps/obsidian/src/utils/importNodes.ts
+++ b/apps/obsidian/src/utils/importNodes.ts
@@ -1184,7 +1184,21 @@ const processFileContent = async ({
 }): Promise<
   { file: TFile; error?: never } | { file?: never; error: string }
 > => {
-  // 1. Create or update the file with the fetched content first.
+  // 1. Parse frontmatter from rawContent (metadataCache is updated async and is
+  //    often empty immediately after create/modify) and resolve the node type
+  //    before any vault write, so a failed lookup leaves existing files untouched.
+  const { frontmatter } = parseFrontmatter(rawContent);
+  const sourceNodeTypeId =
+    typeof frontmatter.nodeTypeId === "string"
+      ? frontmatter.nodeTypeId
+      : nodeTypeIdFromConcept;
+  if (sourceNodeTypeId === undefined) {
+    return {
+      error: "importedNode missing sourceNodeTypeId",
+    };
+  }
+
+  // 2. Create or update the file with the fetched content.
   // On create, set file metadata (ctime/mtime) to original vault dates via vault adapter.
   let file: TFile | null = plugin.app.vault.getFileByPath(filePath);
   const stat =
@@ -1198,20 +1212,6 @@ const processFileContent = async ({
     file = await plugin.app.vault.create(filePath, rawContent, stat);
   } else {
     await plugin.app.vault.process(file, () => rawContent, stat);
-  }
-
-  // 2. Parse frontmatter from rawContent (metadataCache is updated async and is
-  //    often empty immediately after create/modify), then map nodeTypeId and update frontmatter.
-  const { frontmatter } = parseFrontmatter(rawContent);
-  const sourceNodeTypeId =
-    typeof frontmatter.nodeTypeId === "string"
-      ? frontmatter.nodeTypeId
-      : nodeTypeIdFromConcept;
-  if (sourceNodeTypeId === undefined) {
-    await plugin.app.vault.delete(file);
-    return {
-      error: "importedNode missing sourceNodeTypeId",
-    };
   }
 
   const mappedNodeTypeId = await mapNodeTypeIdToLocal({

--- a/apps/obsidian/src/utils/importPreview.ts
+++ b/apps/obsidian/src/utils/importPreview.ts
@@ -5,7 +5,7 @@ import {
   getImportedNodesInfo,
   getLocalNodeKeyToEndpointId,
 } from "./relationsStore";
-import { getSpaceUris } from "./importNodes";
+import { fetchNodeTypeSchemasForInstances, getSpaceUris } from "./importNodes";
 import { QueryEngine } from "~/services/QueryEngine";
 import {
   fetchRelationInstancesFromSpace,
@@ -82,69 +82,34 @@ export const computeImportPreview = async ({
   }
 
   for (const [spaceId, nodes] of nodesBySpace.entries()) {
-    // Get schema_ids for the selected node instances
-    const nodeInstanceIds = nodes.map((n) => n.nodeInstanceId);
-    const { data: conceptRows } = await client
-      .from("my_concepts")
-      .select("source_local_id, schema_id")
-      .eq("space_id", spaceId)
-      .eq("is_schema", false)
-      .in("source_local_id", nodeInstanceIds);
+    const nodeTypeSchemasByInstance = await fetchNodeTypeSchemasForInstances({
+      client,
+      spaceId,
+      nodeInstanceIds: nodes.map((n) => n.nodeInstanceId),
+    });
 
-    if (!conceptRows) continue;
-
-    const schemaIds = [
-      ...new Set(
-        (
-          conceptRows as Array<{
-            source_local_id: string;
-            schema_id: number | null;
-          }>
-        )
-          .map((r) => r.schema_id)
-          .filter((id): id is number => id != null),
-      ),
-    ];
-
-    if (schemaIds.length === 0) continue;
-
-    // Resolve schema_ids to node type info
-    const { data: schemaRows } = await client
-      .from("my_concepts")
-      .select("source_local_id, name")
-      .eq("space_id", spaceId)
-      .eq("is_schema", true)
-      .in("id", schemaIds);
-
-    if (!schemaRows) continue;
-
-    for (const schema of schemaRows as Array<{
-      source_local_id: string;
-      name: string;
-    }>) {
-      const sourceNodeTypeId = schema.source_local_id;
-
+    for (const { nodeTypeId, name } of nodeTypeSchemasByInstance.values()) {
       // Track name for triplet resolution
-      if (!nodeTypeIdToName.has(sourceNodeTypeId)) {
-        nodeTypeIdToName.set(sourceNodeTypeId, schema.name);
+      if (!nodeTypeIdToName.has(nodeTypeId)) {
+        nodeTypeIdToName.set(nodeTypeId, name);
       }
 
-      if (seenNodeTypeIds.has(sourceNodeTypeId)) continue;
-      seenNodeTypeIds.add(sourceNodeTypeId);
+      if (seenNodeTypeIds.has(nodeTypeId)) continue;
+      seenNodeTypeIds.add(nodeTypeId);
 
       // Check against local node types (mirrors mapNodeTypeIdToLocal logic without side effects)
       const matchById = plugin.settings.nodeTypes.find(
-        (nt) => nt.id === sourceNodeTypeId,
+        (nt) => nt.id === nodeTypeId,
       );
       if (matchById) continue;
 
       const matchByName = plugin.settings.nodeTypes.find(
-        (nt) => nt.name === schema.name,
+        (nt) => nt.name === name,
       );
       if (matchByName) continue;
 
       // This is a new node type that would be created
-      newNodeTypeSchemas.push({ id: sourceNodeTypeId, name: schema.name });
+      newNodeTypeSchemas.push({ id: nodeTypeId, name });
     }
   }
 

--- a/packages/database/src/lib/__tests__/sharedNodes.test.ts
+++ b/packages/database/src/lib/__tests__/sharedNodes.test.ts
@@ -78,6 +78,58 @@ describe("buildSharedNodes", () => {
     ]);
   });
 
+  it("builds a Roam-origin shared node with a URL-based rid", () => {
+    const roamSpaces: BuildArgs["spaces"] = [
+      {
+        id: 30,
+        name: "Research graph",
+        platform: "Roam",
+        url: "https://roamresearch.com/#/app/research-graph",
+      },
+    ];
+    const roamNodes: BuildArgs["nodes"] = [
+      { ...nodes[0]!, space_id: 30, source_local_id: "roam-uid-1" },
+    ];
+    const roamDirect: BuildArgs["directContents"] = [
+      {
+        ...directContents[0]!,
+        space_id: 30,
+        source_local_id: "roam-uid-1",
+        metadata: null,
+        text: "CLM - Sleep improves memory consolidation",
+      },
+    ];
+    const roamFull: BuildArgs["fullContentSummaries"] = [
+      {
+        last_modified: "2026-06-14T15:00:00",
+        source_local_id: "roam-uid-1",
+        space_id: 30,
+      },
+    ];
+    expect(
+      build({
+        nodesOverride: roamNodes,
+        directOverride: roamDirect,
+        fullOverride: roamFull,
+        spacesOverride: roamSpaces,
+      }),
+    ).toEqual([
+      {
+        rid: "https://roamresearch.com/#/app/research-graph/roam-uid-1",
+        sourceLocalId: "roam-uid-1",
+        spaceId: 30,
+        spaceName: "Research graph",
+        spaceUri: "https://roamresearch.com/#/app/research-graph",
+        platform: "Roam",
+        title: "CLM - Sleep improves memory consolidation",
+        created: "2026-06-14T11:00:00.000Z",
+        lastModified: "2026-06-14T15:00:00.000Z",
+        authorId: 42,
+        directMetadata: null,
+      },
+    ]);
+  });
+
   it("discovers a node without full content", () => {
     expect(build({ fullOverride: [] })[0]?.lastModified).toBe(
       "2026-06-14T13:00:00.000Z",


### PR DESCRIPTION
https://github.com/user-attachments/assets/f3ad7bb3-86ad-4eac-9056-6e22b7187748

## Problem

The producer side of the M1 contract is merged ([FEE-892](https://linear.app/discourse-graphs/issue/FEE-892/add-roam-full-markdown-content-variant-for-shared-nodes) `full` variant, [ENG-1849](https://linear.app/discourse-graphs/issue/ENG-1849/sync-roam-node-type-schema-metadata-for-shared-nodes) schema metadata), and Roam-origin shared nodes already show up in Obsidian's import modal — but importing one was guaranteed to fail. Roam's `full` variant is body-only markdown (`# Title` + body, no YAML — see `buildFullMarkdown` in `apps/roam/src/utils/roamToCrossAppConverters.ts`), while `processFileContent` hard-required `nodeTypeId` + `nodeInstanceId` frontmatter *inside the content*: every Roam node hit "importedNode missing sourceNodeTypeId" and the created file was deleted. Roam-imported files also never got `nodeInstanceId` written to frontmatter, so duplicate prevention (`findExistingImportedFile`, `getLocalNodeInstanceIds`) could never match them and they would re-list as importable forever.

## What changed

* `fetchNodeTypeSchemasForInstances` (importNodes.ts): batched per-space lookup of each instance's node-type schema (`source_local_id` + name) from the source space's Concept rows. This consolidates the two inline queries `computeImportPreview` already ran — the importer now uses the same resolution instead of duplicating it. Both queries carry `arity = 0` per the data-layer invariant (node instances and node-type schemas; relation-type schemas have `roles` → arity 2 and must be excluded).
* `processFileContent`: now takes `nodeInstanceId` (the caller always has it) and `nodeTypeIdFromConcept`. Content frontmatter still wins when present, so Obsidian-origin imports behave exactly as before; the Concept-derived id is only reached by frontmatter-less (Roam-origin) content. For Obsidian-origin the two values are identical by construction (publish writes `schema_represented_by_local_id` from the same frontmatter). It also writes `nodeInstanceId` into the imported file's frontmatter — idempotent for Obsidian-origin, and what makes stable-identity dedup work for Roam-origin.
* `computeImportPreview`: inline instance→schema queries replaced with the shared helper (also drops two `as Array<...>` casts).
* **Test**: Roam-origin fixture for `buildSharedNodes` — URL-based rid (`https://roamresearch.com/#/app/<graph>/<uid>`), platform `Roam`, production-shape (Z-less) timestamps in, normalized ISO out.

## Removals (dead code inside the touched signatures)

* `originalFilePath` param on `processFileContent` — declared and passed, never read (was an eslint warning on main).
* `if (mappedNodeTypeId !== undefined)` — `mapNodeTypeIdToLocal` always returns `string`.
* The "importedNode missing nodeInstanceId" error path — the caller supplies `nodeInstanceId` directly now; the frontmatter read it guarded is gone.
* `ParsedFrontmatter.nodeInstanceId/publishedToGroups/authorId` — never read from this parse (the reads in `refreshImportedFile` are metadata-cache frontmatter, a different object).

## Extraction parity (preview queries → shared helper)

<!-- linear:table-colwidths:266,266,266 -->
| Old (inline in `computeImportPreview`) | New (`fetchNodeTypeSchemasForInstances`) | Delta |
| -- | -- | -- |
| instance query: `space_id, is_schema=false, in(source_local_id)` | same + `arity=0` | invariant conformance |
| schema query: `select source_local_id, name` | `select id, source_local_id, name` + `arity=0` | `id` keys the instance→schema map |
| `if (!conceptRows) continue` (silent) | `console.error` + empty map | failures logged, same control flow |
| iterate unique schema rows | iterate per-instance map values | identical outcomes — dedup preserved by existing `seenNodeTypeIds` / `nodeTypeIdToName.has` |
| `as Array<{...}>` casts ×2 | none (null-guarded narrowing) | honest types against nullable view columns |

## Identity notes

* `importedFromRid` semantics are unchanged for Roam spaces: their space URL is `https://roamresearch.com/#/app/<graph>`, and the https branch of `spaceUriAndLocalIdToRid` ignores the `"note"` subtype — matching the rid `buildSharedNodes` produces for Roam platforms exactly.
* Duplicate prevention now works end-to-end for Roam-origin: `nodeInstanceId` + `importedFromRid` frontmatter → `findExistingImportedFile` (re-import updates in place) and `getLocalNodeInstanceIds` (already-imported nodes drop out of the modal).

## Markdown fidelity gaps (documented per ticket; follow-up ticket candidates)

1. **Node-type format not persisted** — Roam schema `literal_content` is `{label, template?}` only; a Roam type with no name match in Obsidian gets a synthesized format (`CLA - {content}`), not Roam's real one.
2. **Template semantics mismatch** — Roam persists template *text* under `template`; Obsidian treats `nodeType.template` as a template *filename*, so an unmatched Roam type with a template gets an unusable value.
3. `# Title` **H1 duplication** — Roam's `full` embeds the title as H1 and the Obsidian filename carries it too (producer shape from [FEE-892](https://linear.app/discourse-graphs/issue/FEE-892/add-roam-full-markdown-content-variant-for-shared-nodes), not changed here).
4. **Roam syntax passthrough** — `{{[[query]]}}`, `{{[[table]]}}`, `{{[[kanban]]}}`, attributes (`foo::`), `^^highlights^^` (≠ Obsidian `==`), `#[[multi-word tags]]` arrive verbatim; unresolved `[[links]]` become alias-form dead links.
5. **Nodes without** `full` (optional per [ENG-2016](https://linear.app/discourse-graphs/issue/ENG-2016/adjustment-to-cross-app-node-contract-make-full-content-optional)) fail import with a counted error — pre-existing importer behavior, unchanged.

## Out of scope (per ticket)

New import UI, materializer rewrite, relations/assets/refresh behavior. `refreshAllImportedFiles` still refreshes file-by-file (pre-existing loop); the new per-space lookup rides that pattern.

## Testing

* `packages/database` vitest 8/8 (new Roam fixture included); eslint delta 0 vs main (the 17 remaining warnings pre-date this PR, minus one this PR removes); tsc clean on touched files; plugin builds with 0 errors.
* Runtime demo of the real flow (Roam-origin rows → import → dedup on re-open → re-import updates in place) to follow.

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)

---

![Open in Devin Review](https://camo.githubusercontent.com/a4be08b8baaff58c5f163b8bbf073f8cdff8e3a6c7e2f554b621f61ab1557d7e/68747470733a2f2f7374617469632e646576696e2e61692f6173736574732f67682d6f70656e2d696e2d646576696e2d7265766965772d6c696768742e7376673f763d31)