### PR TITLE
[ENG-2085] Add Send feedback command

### DIFF
--- a/apps/obsidian/src/utils/registerCommands.ts
+++ b/apps/obsidian/src/utils/registerCommands.ts
@@ -4,6 +4,7 @@ import { NodeTypeModal } from "~/components/NodeTypeModal";
 import ModifyNodeModal from "~/components/ModifyNodeModal";
 import { BulkIdentifyDiscourseNodesModal } from "~/components/BulkIdentifyDiscourseNodesModal";
 import { ImportNodesModal } from "~/components/ImportNodesModal";
+import { FeedbackModal } from "~/components/FeedbackModal";
 import { convertPageToDiscourseNode, createDiscourseNode } from "./createNode";
 import { refreshAllImportedFiles } from "./importNodes";
 import { VIEW_TYPE_MARKDOWN, VIEW_TYPE_TLDRAW_DG_PREVIEW } from "~/constants";
@@ -199,6 +200,14 @@ export const registerCommands = (plugin: DiscourseGraphPlugin) => {
     name: "Toggle discourse context",
     callback: () => {
       plugin.toggleDiscourseContextView();
+    },
+  });
+
+  plugin.addCommand({
+    id: "send-feedback",
+    name: "Send feedback",
+    callback: () => {
+      new FeedbackModal(plugin.app, plugin).open();
     },
   });
 


### PR DESCRIPTION
https://www.loom.com/share/56e34e6e5eed4b9c86f08f1eadfff2b0

## Summary
- Adds a "Send feedback" command to the command palette that opens the existing feedback modal directly
- Removes the friction of having to go through Settings to send feedback (ENG-2085)

## Test plan
- [x] Ran `Cmd+P` → "Send feedback" in Obsidian dev vault, confirmed the feedback modal opens
- [x] `built with 0 errors` in dev server output
- [ ] Video walkthrough / screenshots to be added by reviewer request

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/1268" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command to open the feedback form directly within Obsidian.
  * Users can now send feedback from the command palette.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->