### PR TITLE
ENG-519 Make human-readable labels for node ids

### DIFF
--- a/apps/obsidian/src/components/nodeTypeIdPropertyWidget.ts
+++ b/apps/obsidian/src/components/nodeTypeIdPropertyWidget.ts
@@ -46,6 +46,8 @@ const createWidget = (
   },
 });
 
+let previouslyAssignedWidgetType: string | null = null;
+
 export const registerNodeTypeIdPropertyWidget = (
   plugin: DiscourseGraphPlugin,
 ): void => {
@@ -54,6 +56,13 @@ export const registerNodeTypeIdPropertyWidget = (
 
   if (metadataTypeManager)
     try {
+      const assignedWidget = metadataTypeManager.getAssignedWidget(
+        NODE_TYPE_ID_PROPERTY_KEY,
+      );
+      if (assignedWidget !== WIDGET_TYPE) {
+        previouslyAssignedWidgetType = assignedWidget;
+      }
+
       metadataTypeManager.registeredTypeWidgets[WIDGET_TYPE] =
         createWidget(plugin);
       metadataTypeManager
@@ -76,9 +85,15 @@ export const unregisterNodeTypeIdPropertyWidget = (
         metadataTypeManager.getAssignedWidget(NODE_TYPE_ID_PROPERTY_KEY) ===
         WIDGET_TYPE
       ) {
-        metadataTypeManager
-          .unsetType(NODE_TYPE_ID_PROPERTY_KEY)
-          .catch((error) => console.error(error));
+        if (previouslyAssignedWidgetType) {
+          metadataTypeManager
+            .setType(NODE_TYPE_ID_PROPERTY_KEY, previouslyAssignedWidgetType)
+            .catch((error) => console.error(error));
+        } else {
+          metadataTypeManager
+            .unsetType(NODE_TYPE_ID_PROPERTY_KEY)
+            .catch((error) => console.error(error));
+        }
       }
       delete metadataTypeManager.registeredTypeWidgets[WIDGET_TYPE];
     } catch (error) {

--- a/apps/obsidian/src/components/nodeTypeIdPropertyWidget.ts
+++ b/apps/obsidian/src/components/nodeTypeIdPropertyWidget.ts
@@ -28,15 +28,14 @@ const createWidget = (
   icon: "shapes",
   name: () => "Discourse node type",
   validate: (value: unknown) => typeof value === "string",
-  render: (containerEl: HTMLElement, data: unknown) => {
-    const nodeTypeId = typeof data === "string" ? data : String(data ?? "");
-    const nodeType = getNodeTypeById(plugin, nodeTypeId);
+  render: (containerEl: HTMLElement, data: string) => {
+    const nodeType = getNodeTypeById(plugin, data);
 
     const el = containerEl.createSpan({
       cls: "dg-node-type-id-value",
-      text: nodeType?.name ?? nodeTypeId,
+      text: nodeType?.name ?? data,
     });
-    el.setAttr("title", nodeTypeId);
+    el.setAttr("title", data);
     el.tabIndex = 0;
 
     return {

--- a/apps/obsidian/src/components/nodeTypeIdPropertyWidget.ts
+++ b/apps/obsidian/src/components/nodeTypeIdPropertyWidget.ts
@@ -2,13 +2,17 @@ import type {
   AppWithUnofficialApis,
   PropertyWidget,
   PropertyWidgetComponentBase,
-  MetadataTypeManager,
-} from "./obsidianUnofficialTypes";
+} from "~/utils/obsidianUnofficialTypes";
 import type DiscourseGraphPlugin from "~/index";
 import { getNodeTypeById } from "~/utils/typeUtils";
 
 export const NODE_TYPE_ID_PROPERTY_KEY = "nodeTypeId";
 const WIDGET_TYPE = "dg-node-type-id";
+
+type NodeTypeIdPropertyWidgetComponent = PropertyWidgetComponentBase;
+
+type NodeTypeIdPropertyWidget =
+  PropertyWidget<NodeTypeIdPropertyWidgetComponent>;
 
 /**
  * Obsidian's frontmatter Properties UI (reading view + live preview) renders each
@@ -19,7 +23,7 @@ const WIDGET_TYPE = "dg-node-type-id";
  */
 const createWidget = (
   plugin: DiscourseGraphPlugin,
-): PropertyWidget<PropertyWidgetComponentBase> => ({
+): NodeTypeIdPropertyWidget => ({
   type: WIDGET_TYPE,
   icon: "shapes",
   name: () => "Discourse node type",

--- a/apps/obsidian/src/components/nodeTypeIdPropertyWidget.ts
+++ b/apps/obsidian/src/components/nodeTypeIdPropertyWidget.ts
@@ -56,7 +56,9 @@ export const registerNodeTypeIdPropertyWidget = (
     try {
       metadataTypeManager.registeredTypeWidgets[WIDGET_TYPE] =
         createWidget(plugin);
-      void metadataTypeManager.setType(NODE_TYPE_ID_PROPERTY_KEY, WIDGET_TYPE);
+      metadataTypeManager
+        .setType(NODE_TYPE_ID_PROPERTY_KEY, WIDGET_TYPE)
+        .catch((error) => console.error(error));
     } catch (error) {
       console.error(error);
     }
@@ -74,7 +76,9 @@ export const unregisterNodeTypeIdPropertyWidget = (
         metadataTypeManager.getAssignedWidget(NODE_TYPE_ID_PROPERTY_KEY) ===
         WIDGET_TYPE
       ) {
-        void metadataTypeManager.unsetType(NODE_TYPE_ID_PROPERTY_KEY);
+        metadataTypeManager
+          .unsetType(NODE_TYPE_ID_PROPERTY_KEY)
+          .catch((error) => console.error(error));
       }
       delete metadataTypeManager.registeredTypeWidgets[WIDGET_TYPE];
     } catch (error) {

--- a/apps/obsidian/src/index.ts
+++ b/apps/obsidian/src/index.ts
@@ -44,6 +44,10 @@ import { migrateImportFolderMetadata } from "./utils/importFolderMetadata";
 import { registerTemplateSettingsSync } from "~/utils/templateSettingsSync";
 import { showHelpMenu } from "~/utils/helpMenu";
 import { DISCOURSE_GRAPH_LOGO_ICON_ID, WHITE_LOGO_SVG } from "~/icons";
+import {
+  registerNodeTypeIdPropertyWidget,
+  unregisterNodeTypeIdPropertyWidget,
+} from "~/utils/nodeTypeIdPropertyWidget";
 
 export default class DiscourseGraphPlugin extends Plugin {
   settings: Settings = { ...DEFAULT_SETTINGS };
@@ -74,6 +78,7 @@ export default class DiscourseGraphPlugin extends Plugin {
     });
 
     registerTemplateSettingsSync(this);
+    registerNodeTypeIdPropertyWidget(this);
 
     if (this.settings.syncModeEnabled === true) {
       void initializeSupabaseSync(this).catch((error) => {
@@ -468,6 +473,7 @@ export default class DiscourseGraphPlugin extends Plugin {
   }
 
   onunload() {
+    unregisterNodeTypeIdPropertyWidget(this);
     this.activeNodePopover?.close();
     this.activeNodePopover = null;
     this.cleanupViewActions();

--- a/apps/obsidian/src/index.ts
+++ b/apps/obsidian/src/index.ts
@@ -47,7 +47,7 @@ import { DISCOURSE_GRAPH_LOGO_ICON_ID, WHITE_LOGO_SVG } from "~/icons";
 import {
   registerNodeTypeIdPropertyWidget,
   unregisterNodeTypeIdPropertyWidget,
-} from "~/utils/nodeTypeIdPropertyWidget";
+} from "~/components/nodeTypeIdPropertyWidget";
 
 export default class DiscourseGraphPlugin extends Plugin {
   settings: Settings = { ...DEFAULT_SETTINGS };

--- a/apps/obsidian/src/services/QueryEngine.ts
+++ b/apps/obsidian/src/services/QueryEngine.ts
@@ -1,8 +1,9 @@
-import { TFile, App, prepareFuzzySearch, type SearchResult } from "obsidian";
+import { TFile, App, Plugin, prepareFuzzySearch, type SearchResult } from "obsidian";
 import type DiscourseGraphPlugin from "~/index";
 import { BulkImportPattern, BulkImportCandidate, DiscourseNode } from "~/types";
 import { getDiscourseNodeFormatExpression } from "~/utils/getDiscourseNodeFormatExpression";
 import { extractContentFromTitle } from "~/utils/extractContentFromTitle";
+import { AppWithUnofficialApis } from "~/utils/obsidianUnofficialTypes";
 
 // This is a workaround to get the datacore API.
 // TODO: Remove once we can use datacore npm package
@@ -47,10 +48,15 @@ export class QueryEngine {
   private readonly MIN_QUERY_LENGTH = 2;
 
   constructor(app: App) {
-    const appWithPlugins = app as AppWithPlugins;
-    this.dc = appWithPlugins.plugins?.plugins?.["datacore"]?.api as
-      | { query: (query: string) => DatacorePage[] }
+    const appWithPlugins = app as AppWithUnofficialApis;
+    const datacorePlugin = appWithPlugins.plugins?.plugins?.["datacore"] as
+      | (Plugin & {
+          api: {
+            query: (query: string) => DatacorePage[];
+          };
+        })
       | undefined;
+    this.dc = datacorePlugin?.api;
     this.app = app;
   }
 

--- a/apps/obsidian/src/services/QueryEngine.ts
+++ b/apps/obsidian/src/services/QueryEngine.ts
@@ -1,4 +1,10 @@
-import { TFile, App, Plugin, prepareFuzzySearch, type SearchResult } from "obsidian";
+import {
+  TFile,
+  App,
+  Plugin,
+  prepareFuzzySearch,
+  type SearchResult,
+} from "obsidian";
 import type DiscourseGraphPlugin from "~/index";
 import { BulkImportPattern, BulkImportCandidate, DiscourseNode } from "~/types";
 import { getDiscourseNodeFormatExpression } from "~/utils/getDiscourseNodeFormatExpression";
@@ -414,8 +420,7 @@ export class QueryEngine {
           const file = this.app.vault.getAbstractFileByPath(page.$path);
           if (!(file && file instanceof TFile)) continue;
           if (opts?.excludeImported) {
-            const fm = this.app.metadataCache.getFileCache(file)
-              ?.frontmatter as Record<string, unknown> | undefined;
+            const fm = this.app.metadataCache.getFileCache(file)?.frontmatter;
             if (fm?.importedFromRid) continue;
           }
           files.push(file);
@@ -455,10 +460,7 @@ export class QueryEngine {
     const allFiles = this.app.vault.getMarkdownFiles();
     for (const f of allFiles) {
       const fm = this.app.metadataCache.getFileCache(f)?.frontmatter;
-      if (
-        (fm as Record<string, unknown> | undefined)?.importedFromRid ===
-        importedFromRid
-      ) {
+      if (fm?.importedFromRid === importedFromRid) {
         return f;
       }
     }
@@ -479,9 +481,7 @@ export class QueryEngine {
     }
     const files = this.getFilesWithNodeInstanceId();
     for (const file of files) {
-      const fm = this.app.metadataCache.getFileCache(file)?.frontmatter as
-        | Record<string, unknown>
-        | undefined;
+      const fm = this.app.metadataCache.getFileCache(file)?.frontmatter;
       const id = fm?.nodeInstanceId as string | undefined;
       const rid = fm?.importedFromRid as string | undefined;
       if (id === endpointId || rid === endpointId) return file;
@@ -542,10 +542,7 @@ export class QueryEngine {
     for (const f of allFiles) {
       if (!f.path.startsWith("import/")) continue;
       const fm = this.app.metadataCache.getFileCache(f)?.frontmatter;
-      if (
-        (fm as Record<string, unknown> | undefined)?.importedFromRid &&
-        (fm as Record<string, unknown> | undefined)?.nodeInstanceId
-      ) {
+      if (fm?.importedFromRid && fm?.nodeInstanceId) {
         files.push(f);
       }
     }
@@ -557,7 +554,7 @@ export class QueryEngine {
     const allFiles = this.app.vault.getMarkdownFiles();
     for (const f of allFiles) {
       const fm = this.app.metadataCache.getFileCache(f)?.frontmatter;
-      if ((fm as Record<string, unknown> | undefined)?.nodeInstanceId) {
+      if (fm?.nodeInstanceId) {
         files.push(f);
       }
     }
@@ -570,9 +567,7 @@ export class QueryEngine {
     const files: TFile[] = [];
     const allFiles = this.app.vault.getMarkdownFiles();
     for (const f of allFiles) {
-      const fm = this.app.metadataCache.getFileCache(f)?.frontmatter as
-        | Record<string, unknown>
-        | undefined;
+      const fm = this.app.metadataCache.getFileCache(f)?.frontmatter;
       const nodeTypeId = fm?.nodeTypeId;
       if (!nodeTypeId) continue;
       if (

--- a/apps/obsidian/src/utils/nodeTypeIdPropertyWidget.ts
+++ b/apps/obsidian/src/utils/nodeTypeIdPropertyWidget.ts
@@ -45,17 +45,17 @@ const createWidget = (
 export const registerNodeTypeIdPropertyWidget = (
   plugin: DiscourseGraphPlugin,
 ): void => {
-  const metadataTypeManager = (
-    plugin.app as unknown as { metadataTypeManager: MetadataTypeManager }
-  ).metadataTypeManager;
+  const metadataTypeManager = (plugin.app as AppWithUnofficialApis)
+    .metadataTypeManager;
 
-  try {
-    metadataTypeManager.registeredTypeWidgets[WIDGET_TYPE] =
-      createWidget(plugin);
-    void metadataTypeManager.setType(NODE_TYPE_ID_PROPERTY_KEY, WIDGET_TYPE);
-  } catch (error) {
-    console.error(error);
-  }
+  if (metadataTypeManager)
+    try {
+      metadataTypeManager.registeredTypeWidgets[WIDGET_TYPE] =
+        createWidget(plugin);
+      void metadataTypeManager.setType(NODE_TYPE_ID_PROPERTY_KEY, WIDGET_TYPE);
+    } catch (error) {
+      console.error(error);
+    }
 };
 
 export const unregisterNodeTypeIdPropertyWidget = (

--- a/apps/obsidian/src/utils/nodeTypeIdPropertyWidget.ts
+++ b/apps/obsidian/src/utils/nodeTypeIdPropertyWidget.ts
@@ -1,0 +1,69 @@
+import type {
+  MetadataTypeManager,
+  PropertyWidget,
+  PropertyWidgetComponentBase,
+} from "obsidian-typings";
+import type DiscourseGraphPlugin from "~/index";
+import { getNodeTypeById } from "~/utils/typeUtils";
+
+export const NODE_TYPE_ID_PROPERTY_KEY = "nodeTypeId";
+const WIDGET_TYPE = "dg-node-type-id";
+
+/**
+ * Obsidian's frontmatter Properties UI (reading view + live preview) renders each
+ * property via a widget looked up by `metadataTypeManager`. This is unofficial/
+ * internal API (see `obsidian-typings`), so it degrades gracefully: if Obsidian
+ * ever drops support, the widget type is simply unrecognized and the property
+ * renders as its raw text value, same as before this widget existed.
+ */
+const createWidget = (
+  plugin: DiscourseGraphPlugin,
+): PropertyWidget<PropertyWidgetComponentBase> => ({
+  type: WIDGET_TYPE,
+  icon: "shapes",
+  name: () => "Discourse node type",
+  validate: (value: unknown) => typeof value === "string",
+  render: (containerEl: HTMLElement, data: unknown) => {
+    const nodeTypeId = typeof data === "string" ? data : String(data ?? "");
+    const nodeType = getNodeTypeById(plugin, nodeTypeId);
+
+    const el = containerEl.createSpan({
+      cls: "dg-node-type-id-value",
+      text: nodeType?.name ?? nodeTypeId,
+    });
+    el.setAttr("title", nodeTypeId);
+    el.tabIndex = 0;
+
+    return {
+      type: WIDGET_TYPE,
+      focus: () => el.focus(),
+    };
+  },
+});
+
+export const registerNodeTypeIdPropertyWidget = (
+  plugin: DiscourseGraphPlugin,
+): void => {
+  const metadataTypeManager = (
+    plugin.app as unknown as { metadataTypeManager: MetadataTypeManager }
+  ).metadataTypeManager;
+
+  metadataTypeManager.registeredTypeWidgets[WIDGET_TYPE] = createWidget(plugin);
+  void metadataTypeManager.setType(NODE_TYPE_ID_PROPERTY_KEY, WIDGET_TYPE);
+};
+
+export const unregisterNodeTypeIdPropertyWidget = (
+  plugin: DiscourseGraphPlugin,
+): void => {
+  const metadataTypeManager = (
+    plugin.app as unknown as { metadataTypeManager: MetadataTypeManager }
+  ).metadataTypeManager;
+
+  if (
+    metadataTypeManager.getAssignedWidget(NODE_TYPE_ID_PROPERTY_KEY) ===
+    WIDGET_TYPE
+  ) {
+    void metadataTypeManager.unsetType(NODE_TYPE_ID_PROPERTY_KEY);
+  }
+  delete metadataTypeManager.registeredTypeWidgets[WIDGET_TYPE];
+};

--- a/apps/obsidian/src/utils/nodeTypeIdPropertyWidget.ts
+++ b/apps/obsidian/src/utils/nodeTypeIdPropertyWidget.ts
@@ -1,8 +1,9 @@
 import type {
-  MetadataTypeManager,
+  AppWithUnofficialApis,
   PropertyWidget,
   PropertyWidgetComponentBase,
-} from "obsidian-typings";
+  MetadataTypeManager,
+} from "./obsidianUnofficialTypes";
 import type DiscourseGraphPlugin from "~/index";
 import { getNodeTypeById } from "~/utils/typeUtils";
 
@@ -60,19 +61,19 @@ export const registerNodeTypeIdPropertyWidget = (
 export const unregisterNodeTypeIdPropertyWidget = (
   plugin: DiscourseGraphPlugin,
 ): void => {
-  const metadataTypeManager = (
-    plugin.app as unknown as { metadataTypeManager: MetadataTypeManager }
-  ).metadataTypeManager;
+  const metadataTypeManager = (plugin.app as AppWithUnofficialApis)
+    .metadataTypeManager;
 
-  try {
-    if (
-      metadataTypeManager.getAssignedWidget(NODE_TYPE_ID_PROPERTY_KEY) ===
-      WIDGET_TYPE
-    ) {
-      void metadataTypeManager.unsetType(NODE_TYPE_ID_PROPERTY_KEY);
+  if (metadataTypeManager)
+    try {
+      if (
+        metadataTypeManager.getAssignedWidget(NODE_TYPE_ID_PROPERTY_KEY) ===
+        WIDGET_TYPE
+      ) {
+        void metadataTypeManager.unsetType(NODE_TYPE_ID_PROPERTY_KEY);
+      }
+      delete metadataTypeManager.registeredTypeWidgets[WIDGET_TYPE];
+    } catch (error) {
+      console.error(error);
     }
-    delete metadataTypeManager.registeredTypeWidgets[WIDGET_TYPE];
-  } catch (error) {
-    console.error(error);
-  }
 };

--- a/apps/obsidian/src/utils/nodeTypeIdPropertyWidget.ts
+++ b/apps/obsidian/src/utils/nodeTypeIdPropertyWidget.ts
@@ -48,8 +48,13 @@ export const registerNodeTypeIdPropertyWidget = (
     plugin.app as unknown as { metadataTypeManager: MetadataTypeManager }
   ).metadataTypeManager;
 
-  metadataTypeManager.registeredTypeWidgets[WIDGET_TYPE] = createWidget(plugin);
-  void metadataTypeManager.setType(NODE_TYPE_ID_PROPERTY_KEY, WIDGET_TYPE);
+  try {
+    metadataTypeManager.registeredTypeWidgets[WIDGET_TYPE] =
+      createWidget(plugin);
+    void metadataTypeManager.setType(NODE_TYPE_ID_PROPERTY_KEY, WIDGET_TYPE);
+  } catch (error) {
+    console.error(error);
+  }
 };
 
 export const unregisterNodeTypeIdPropertyWidget = (
@@ -59,11 +64,15 @@ export const unregisterNodeTypeIdPropertyWidget = (
     plugin.app as unknown as { metadataTypeManager: MetadataTypeManager }
   ).metadataTypeManager;
 
-  if (
-    metadataTypeManager.getAssignedWidget(NODE_TYPE_ID_PROPERTY_KEY) ===
-    WIDGET_TYPE
-  ) {
-    void metadataTypeManager.unsetType(NODE_TYPE_ID_PROPERTY_KEY);
+  try {
+    if (
+      metadataTypeManager.getAssignedWidget(NODE_TYPE_ID_PROPERTY_KEY) ===
+      WIDGET_TYPE
+    ) {
+      void metadataTypeManager.unsetType(NODE_TYPE_ID_PROPERTY_KEY);
+    }
+    delete metadataTypeManager.registeredTypeWidgets[WIDGET_TYPE];
+  } catch (error) {
+    console.error(error);
   }
-  delete metadataTypeManager.registeredTypeWidgets[WIDGET_TYPE];
 };

--- a/apps/obsidian/src/utils/obsidianUnofficialTypes.ts
+++ b/apps/obsidian/src/utils/obsidianUnofficialTypes.ts
@@ -87,7 +87,7 @@ export type PropertyWidget<
   validate(value: unknown): boolean;
 };
 
-export type PropertyWidgetEntry = {
+type PropertyWidgetEntry = {
   /**
    * Display name of the property widget.
    */
@@ -126,7 +126,7 @@ type TypeInfo = {
 
 type PropertyWidgetType = string;
 
-export type MetadataTypeManager = {
+type MetadataTypeManager = {
   /**
    * Reference to the {@link obsidian#App}.
    */

--- a/apps/obsidian/src/utils/obsidianUnofficialTypes.ts
+++ b/apps/obsidian/src/utils/obsidianUnofficialTypes.ts
@@ -1,0 +1,252 @@
+import { App, Events, Debouncer, Plugin, Component } from "obsidian";
+
+// extracted the MetaadataTypeManager from "obsidian-types",
+// and parts of internalPlugins, plugins.
+
+type FocusMode = "both" | "end" | "start";
+
+export type PropertyWidgetComponentBase = {
+  /**
+   * The type of the property widget.
+   */
+  type: string;
+  /**
+   * Focus the property widget.
+   *
+   * @param mode - The focus mode.
+   */
+  focus(mode?: FocusMode): void;
+};
+
+type PropertyRenderContext = {
+  /**
+   * Reference to the app.
+   */
+  app: App;
+  /**
+   * Key of the property field.
+   */
+  key: string;
+  /**
+   * Determine the source path of current context.
+   */
+  sourcePath: string;
+  /**
+   * Callback called on property field unfocus.
+   */
+  blur(): void;
+  /**
+   * Callback called on property value change.
+   *
+   * @param value - The new property value.
+   */
+  onChange(value: unknown): void;
+};
+
+export type PropertyWidget<
+  ComponentType extends
+    PropertyWidgetComponentBase = PropertyWidgetComponentBase,
+> = {
+  /**
+   * Lucide-dev icon associated with the widget.
+   */
+  icon: string;
+  /**
+   * Reserved keys for the widget.
+   */
+  reservedKeys?: string[];
+  /**
+   * Identifier for the widget.
+   */
+  type: string;
+  /**
+   * Returns the I18N name of the widget.
+   *
+   * @returns The localized name of the widget.
+   */
+  name(): string;
+  /**
+   * Render function for the widget on field container given context and data.
+   *
+   * @param containerEl - The container element to render the widget into.
+   * @param data - The property data to render.
+   * @param context - The rendering context for the property.
+   * @returns The rendered widget component.
+   */
+  render(
+    containerEl: HTMLElement,
+    data: unknown,
+    context: PropertyRenderContext,
+  ): ComponentType;
+  /**
+   * Validate whether the input value to the widget is correct.
+   *
+   * @param value - The value to validate.
+   * @returns Whether the value is valid.
+   */
+  validate(value: unknown): boolean;
+};
+
+export type PropertyWidgetEntry = {
+  /**
+   * Display name of the property widget.
+   */
+  name: string;
+  /**
+   * The property widget type.
+   */
+  widget: string;
+};
+
+type PropertyInfo = {
+  /**
+   * Name of property.
+   */
+  name: string;
+  /**
+   * Usage count of property.
+   */
+  occurrences: number;
+  /**
+   * Type of property.
+   */
+  widget: string;
+};
+
+type TypeInfo = {
+  /**
+   * The explicitly assigned property widget type.
+   */
+  expected: PropertyWidget;
+  /**
+   * The property widget type inferred from the value.
+   */
+  inferred: PropertyWidget;
+};
+
+type PropertyWidgetType = string;
+
+export type MetadataTypeManager = {
+  /**
+   * Reference to the {@link obsidian#App}.
+   */
+  app: App;
+  /**
+   * Associated widget types for each property.
+   */
+  assignedWidgets: Record<string, PropertyWidgetEntry>;
+  /**
+   * Unix timestamp of the last save
+   */
+  lastSave: number;
+  /**
+   * Debounced handler for property type config file changes on disk.
+   */
+  onConfigFileChange: Debouncer<[], Promise<void>>;
+  /**
+   * Registered properties of the vault.
+   */
+  properties: Record<string, PropertyInfo>;
+  /**
+   * Registered type widgets.
+   */
+  registeredTypeWidgets: Record<PropertyWidgetType, PropertyWidget>;
+  /**
+   * Get all registered properties of the vault.
+   *
+   * @returns Record of property names to their info.
+   */
+  getAllProperties(): Record<string, PropertyInfo>;
+  /**
+   * Get assigned widget type for property.
+   *
+   * @param property - Property name.
+   * @returns The assigned widget type, or `null`.
+   */
+  getAssignedWidget(property: string): null | PropertyWidgetType;
+  /**
+   * Get info for property.
+   *
+   * @param property - Property name.
+   * @returns Information about the property.
+   */
+  getPropertyInfo(property: string): PropertyInfo;
+  /**
+   * Get expected widget type for property and the one inferred from the property value.
+   *
+   * @param property - Property name.
+   * @param value - Property value.
+   * @returns Type information for the property.
+   */
+  getTypeInfo(property: string, value: unknown): TypeInfo;
+  /**
+   * Get property widget.
+   *
+   * @param type - Widget type name.
+   * @returns The property widget.
+   */
+  getWidget(type: string): PropertyWidget;
+  /**
+   * Load metadata type configuration.
+   */
+  load(): Promise<void>;
+  /**
+   * Load property types from config.
+   *
+   * @returns A promise that resolves when the property types are loaded.
+   */
+  loadData(): Promise<void>;
+  /**
+   * Handle raw file system change events for the property type config.
+   *
+   * @param e - The raw file system change event.
+   */
+  onRaw(e: unknown): void;
+  /**
+   * Register event listeners for property type config file changes.
+   */
+  registerListeners(): void;
+  /**
+   * Save property types to config.
+   *
+   * @returns A promise that resolves when the property types are saved.
+   */
+  save(): Promise<void>;
+  /**
+   * Set widget type for property.
+   *
+   * @param property - Property name.
+   * @param type - Widget type to assign.
+   * @returns A promise that resolves when the widget type is set.
+   */
+  setType(property: string, type: PropertyWidgetType): Promise<void>;
+  /**
+   * Unset widget type for property.
+   *
+   * @param property - Property name.
+   * @returns A promise that resolves when the widget type is unset.
+   */
+  unsetType(property: string): Promise<void>;
+  /**
+   * Updates `this.properties` to match the {@link obsidian#MetadataCache}
+   */
+  updatePropertyInfoCache(): void;
+} & Events;
+
+export type InternalPluginInstance = {
+  plugin: InternalPlugin;
+};
+
+type InternalPlugin = {
+  enabled: boolean;
+  instance: InternalPluginInstance;
+} & Component;
+
+export type AppWithUnofficialApis = App & {
+  appId: string;
+  metadataTypeManager?: MetadataTypeManager;
+  plugins?: Events & { plugins?: Record<string, Plugin> };
+  internalPlugins?: Events & {
+    plugins?: Record<string, InternalPlugin>;
+  };
+};

--- a/apps/obsidian/src/utils/obsidianUnofficialTypes.ts
+++ b/apps/obsidian/src/utils/obsidianUnofficialTypes.ts
@@ -128,35 +128,9 @@ type PropertyWidgetType = string;
 
 type MetadataTypeManager = {
   /**
-   * Reference to the {@link obsidian#App}.
-   */
-  app: App;
-  /**
-   * Associated widget types for each property.
-   */
-  assignedWidgets: Record<string, PropertyWidgetEntry>;
-  /**
-   * Unix timestamp of the last save
-   */
-  lastSave: number;
-  /**
-   * Debounced handler for property type config file changes on disk.
-   */
-  onConfigFileChange: Debouncer<[], Promise<void>>;
-  /**
-   * Registered properties of the vault.
-   */
-  properties: Record<string, PropertyInfo>;
-  /**
    * Registered type widgets.
    */
   registeredTypeWidgets: Record<PropertyWidgetType, PropertyWidget>;
-  /**
-   * Get all registered properties of the vault.
-   *
-   * @returns Record of property names to their info.
-   */
-  getAllProperties(): Record<string, PropertyInfo>;
   /**
    * Get assigned widget type for property.
    *
@@ -164,54 +138,6 @@ type MetadataTypeManager = {
    * @returns The assigned widget type, or `null`.
    */
   getAssignedWidget(property: string): null | PropertyWidgetType;
-  /**
-   * Get info for property.
-   *
-   * @param property - Property name.
-   * @returns Information about the property.
-   */
-  getPropertyInfo(property: string): PropertyInfo;
-  /**
-   * Get expected widget type for property and the one inferred from the property value.
-   *
-   * @param property - Property name.
-   * @param value - Property value.
-   * @returns Type information for the property.
-   */
-  getTypeInfo(property: string, value: unknown): TypeInfo;
-  /**
-   * Get property widget.
-   *
-   * @param type - Widget type name.
-   * @returns The property widget.
-   */
-  getWidget(type: string): PropertyWidget;
-  /**
-   * Load metadata type configuration.
-   */
-  load(): Promise<void>;
-  /**
-   * Load property types from config.
-   *
-   * @returns A promise that resolves when the property types are loaded.
-   */
-  loadData(): Promise<void>;
-  /**
-   * Handle raw file system change events for the property type config.
-   *
-   * @param e - The raw file system change event.
-   */
-  onRaw(e: unknown): void;
-  /**
-   * Register event listeners for property type config file changes.
-   */
-  registerListeners(): void;
-  /**
-   * Save property types to config.
-   *
-   * @returns A promise that resolves when the property types are saved.
-   */
-  save(): Promise<void>;
   /**
    * Set widget type for property.
    *
@@ -227,10 +153,6 @@ type MetadataTypeManager = {
    * @returns A promise that resolves when the widget type is unset.
    */
   unsetType(property: string): Promise<void>;
-  /**
-   * Updates `this.properties` to match the {@link obsidian#MetadataCache}
-   */
-  updatePropertyInfoCache(): void;
 } & Events;
 
 export type InternalPluginInstance = {

--- a/apps/obsidian/src/utils/obsidianUnofficialTypes.ts
+++ b/apps/obsidian/src/utils/obsidianUnofficialTypes.ts
@@ -1,4 +1,4 @@
-import { App, Events, Debouncer, Plugin, Component } from "obsidian";
+import { App, Events, Plugin, Component } from "obsidian";
 
 // extracted the MetaadataTypeManager from "obsidian-types",
 // and parts of internalPlugins, plugins.
@@ -85,43 +85,6 @@ export type PropertyWidget<
    * @returns Whether the value is valid.
    */
   validate(value: unknown): boolean;
-};
-
-type PropertyWidgetEntry = {
-  /**
-   * Display name of the property widget.
-   */
-  name: string;
-  /**
-   * The property widget type.
-   */
-  widget: string;
-};
-
-type PropertyInfo = {
-  /**
-   * Name of property.
-   */
-  name: string;
-  /**
-   * Usage count of property.
-   */
-  occurrences: number;
-  /**
-   * Type of property.
-   */
-  widget: string;
-};
-
-type TypeInfo = {
-  /**
-   * The explicitly assigned property widget type.
-   */
-  expected: PropertyWidget;
-  /**
-   * The property widget type inferred from the value.
-   */
-  inferred: PropertyWidget;
 };
 
 type PropertyWidgetType = string;

--- a/apps/obsidian/src/utils/obsidianUnofficialTypes.ts
+++ b/apps/obsidian/src/utils/obsidianUnofficialTypes.ts
@@ -1,6 +1,6 @@
 import { App, Events, Plugin, Component } from "obsidian";
 
-// extracted the MetaadataTypeManager from "obsidian-types",
+// extracted the MetadataTypeManager from "obsidian-types",
 // and parts of internalPlugins, plugins.
 
 type FocusMode = "both" | "end" | "start";

--- a/apps/obsidian/src/utils/supabaseContext.ts
+++ b/apps/obsidian/src/utils/supabaseContext.ts
@@ -7,7 +7,7 @@ import {
   FatalError,
 } from "@repo/database/lib/contextFunctions";
 import type DiscourseGraphPlugin from "~/index";
-
+import type { AppWithUnofficialApis } from "./obsidianUnofficialTypes";
 type Platform = Enums<"Platform">;
 
 export type SupabaseContext = {
@@ -58,7 +58,7 @@ const getOrCreateAccountLocalId = async (
  * @see https://help.obsidian.md/Extending+Obsidian/Obsidian+URI
  */
 export const getVaultId = (app: DiscourseGraphPlugin["app"]): string => {
-  return (app as unknown as { appId: string }).appId;
+  return (app as AppWithUnofficialApis).appId;
 };
 
 /** Canonical space URL for an Obsidian vault; stored as Space.url in the DB. */

--- a/apps/obsidian/src/utils/templates.ts
+++ b/apps/obsidian/src/utils/templates.ts
@@ -6,6 +6,10 @@ import {
   getFrontMatterInfo,
 } from "obsidian";
 import type { Settings } from "~/types";
+import type {
+  AppWithUnofficialApis,
+  InternalPluginInstance,
+} from "./obsidianUnofficialTypes";
 
 type TemplatePluginInfo = {
   isEnabled: boolean;
@@ -47,13 +51,18 @@ const mergeFrontmatter = (
 
 export const getTemplatePluginInfo = (app: App): TemplatePluginInfo => {
   try {
-    const templatesPlugin = (app as any).internalPlugins?.plugins?.templates;
+    const templatesPlugin = (app as AppWithUnofficialApis).internalPlugins
+      ?.plugins?.templates;
 
     if (!templatesPlugin || !templatesPlugin.enabled) {
       return { isEnabled: false, folderPath: "" };
     }
 
-    const folderPath = templatesPlugin.instance?.options?.folder || "";
+    const instance = templatesPlugin.instance as InternalPluginInstance & {
+      options?: { folder?: string };
+    };
+
+    const folderPath = instance.options?.folder || "";
 
     return {
       isEnabled: true,


### PR DESCRIPTION
https://linear.app/discourse-graphs/issue/ENG-519/make-human-readable-labels-for-node-ids

https://www.loom.com/share/e8b03f27c6a947fbaea0ebf416a0981b

Since the loom, I extracted the MetadataTypeManager from obsidian-types. I also unified other unofficial aspects in the obsidianUnofficialTypes.ts, and refactored a few files to use that instead of ad-hoc. 

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/1271" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->