### PR TITLE
ENG-2037 Add tabbed node card context menu to Roam tldraw

### DIFF
--- a/apps/roam/src/components/canvas/CustomStylePanel.tsx
+++ b/apps/roam/src/components/canvas/CustomStylePanel.tsx
@@ -56,19 +56,11 @@ const ContextTabContent = ({ shape }: { shape: DiscourseNodeShape }) => {
     };
   }, [uid]);
 
-  const nodeShapesByUid = useValue(
-    "discourse-node-shapes-by-uid",
-    () =>
-      new Map(
-        editor
-          .getCurrentPageShapes()
-          .filter((s): s is DiscourseNodeShape =>
-            isDiscourseNodeShape(editor, s),
-          )
-          .map((s) => [s.props.uid, s]),
-      ),
-    [editor],
-  );
+  const getNodeShapeByUid = (relatedUid: string) =>
+    editor
+      .getCurrentPageShapes()
+      .filter((s): s is DiscourseNodeShape => isDiscourseNodeShape(editor, s))
+      .find((s) => s.props.uid === relatedUid);
 
   const relationIdsInResults = useMemo(
     () =>
@@ -126,6 +118,8 @@ const ContextTabContent = ({ shape }: { shape: DiscourseNodeShape }) => {
       nodeType: node.type,
       extensionAPI,
     });
+    const existing = getNodeShapeByUid(relatedUid);
+    if (existing) return existing;
     const x = shape.x + shape.props.w + NEW_NODE_OFFSET_PX;
     const columnBottoms = editor
       .getCurrentPageShapes()
@@ -159,25 +153,6 @@ const ContextTabContent = ({ shape }: { shape: DiscourseNodeShape }) => {
     return editor.getShape<DiscourseNodeShape>(id);
   };
 
-  const removeRelationFromCanvas = ({
-    relationId,
-    nodeShape,
-  }: {
-    relationId: string;
-    nodeShape: DiscourseNodeShape;
-  }) => {
-    const arrows = getRelationArrowsBetween({
-      editor,
-      shapeId: shape.id,
-      otherShapeId: nodeShape.id,
-      relationIds: new Set([relationId]),
-    });
-    const bindingIds = arrows
-      .flatMap((arrow) => editor.getBindingsFromShape(arrow.id, relationId))
-      .map((b) => b.id);
-    editor.deleteShapes(arrows.map((a) => a.id)).deleteBindings(bindingIds);
-  };
-
   const addRelationToCanvas = async ({
     relationId,
     complement,
@@ -192,9 +167,16 @@ const ContextTabContent = ({ shape }: { shape: DiscourseNodeShape }) => {
     label: string;
   }) => {
     const nodeShape =
-      nodeShapesByUid.get(relatedUid) ??
+      getNodeShapeByUid(relatedUid) ??
       (await addNodeToCanvas({ relatedUid, text }));
     if (!nodeShape) return;
+    const alreadyOnCanvas = getRelationArrowsBetween({
+      editor,
+      shapeId: shape.id,
+      otherShapeId: nodeShape.id,
+      relationIds: new Set([relationId]),
+    });
+    if (alreadyOnCanvas.length) return;
     const startId = complement ? nodeShape.id : shape.id;
     const endId = complement ? shape.id : nodeShape.id;
     const { bend } = getParallelArrowBend({
@@ -244,9 +226,22 @@ const ContextTabContent = ({ shape }: { shape: DiscourseNodeShape }) => {
     const key = `${relationId}:${relatedUid}`;
     setPendingKeys((prev) => [...prev, key]);
     try {
-      const nodeShape = nodeShapesByUid.get(relatedUid);
-      if (arrowKeysOnCanvas.has(key) && nodeShape) {
-        removeRelationFromCanvas({ relationId, nodeShape });
+      const nodeShape = getNodeShapeByUid(relatedUid);
+      const existingArrows = nodeShape
+        ? getRelationArrowsBetween({
+            editor,
+            shapeId: shape.id,
+            otherShapeId: nodeShape.id,
+            relationIds: new Set([relationId]),
+          })
+        : [];
+      if (existingArrows.length) {
+        const bindingIds = existingArrows
+          .flatMap((arrow) => editor.getBindingsFromShape(arrow.id, relationId))
+          .map((b) => b.id);
+        editor
+          .deleteShapes(existingArrows.map((a) => a.id))
+          .deleteBindings(bindingIds);
       } else {
         await addRelationToCanvas({
           relationId,

--- a/apps/roam/src/components/canvas/CustomStylePanel.tsx
+++ b/apps/roam/src/components/canvas/CustomStylePanel.tsx
@@ -24,6 +24,7 @@ import {
 import { dispatchToastEvent } from "./ToastListener";
 
 const NEW_NODE_OFFSET_PX = 80;
+const NEW_NODE_GAP_PX = 24;
 
 const ContextTabContent = ({ shape }: { shape: DiscourseNodeShape }) => {
   const editor = useEditor();
@@ -94,14 +95,23 @@ const ContextTabContent = ({ shape }: { shape: DiscourseNodeShape }) => {
       nodeType: node.type,
       extensionAPI,
     });
+    const x = shape.x + shape.props.w + NEW_NODE_OFFSET_PX;
+    const columnBottoms = editor
+      .getCurrentPageShapes()
+      .filter((s): s is DiscourseNodeShape => isDiscourseNodeShape(editor, s))
+      .filter((s) => s.x < x + w && s.x + s.props.w > x)
+      .map((s) => s.y + s.props.h);
+    const y = columnBottoms.length
+      ? Math.max(...columnBottoms) + NEW_NODE_GAP_PX
+      : shape.y;
     const id = createShapeId();
     withAutoCanvasRelationsSuppressed(() =>
       editor.createShapes([
         {
           id,
           type: DISCOURSE_NODE_SHAPE_TYPE,
-          x: shape.x + shape.props.w + NEW_NODE_OFFSET_PX,
-          y: shape.y,
+          x,
+          y,
           props: {
             uid: relatedUid,
             title: text,
@@ -138,6 +148,12 @@ const ContextTabContent = ({ shape }: { shape: DiscourseNodeShape }) => {
       } else {
         await addToCanvas({ relatedUid, text });
       }
+    } catch {
+      dispatchToastEvent({
+        id: "dg-context-tab-toggle-failed",
+        title: "Failed to update the canvas for this result.",
+        severity: "error",
+      });
     } finally {
       setPendingUids((prev) => prev.filter((u) => u !== relatedUid));
     }

--- a/apps/roam/src/components/canvas/CustomStylePanel.tsx
+++ b/apps/roam/src/components/canvas/CustomStylePanel.tsx
@@ -1,5 +1,12 @@
-import React, { ReactElement, useEffect, useMemo, useState } from "react";
+import React, {
+  ReactElement,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import {
+  Box,
   DefaultStylePanel,
   DefaultStylePanelContent,
   TLUiStylePanelProps,
@@ -12,26 +19,28 @@ import { Button, Tab, Tabs } from "@blueprintjs/core";
 import { useExtensionAPI } from "roamjs-components/components/ExtensionApiContext";
 import getPageTitleByPageUid from "roamjs-components/queries/getPageTitleByPageUid";
 import getDiscourseContextResults from "~/utils/getDiscourseContextResults";
+import { useDiscourseContextMutationRefresh } from "~/utils/discourseContextMutationRefresh";
 import type { DiscourseContextResults } from "~/components/DiscourseContext";
 import findDiscourseNode from "~/utils/findDiscourseNode";
 import calcCanvasNodeSizeAndImg from "~/utils/calcCanvasNodeSizeAndImg";
 import { RenderRoamBlockString } from "~/utils/roamReactComponents";
+import { getPersonalSetting } from "~/components/settings/utils/accessors";
+import { PERSONAL_KEYS } from "~/components/settings/utils/settingKeys";
 import { withAutoCanvasRelationsSuppressed } from "./autoCanvasRelationsSuppression";
 import { getAllRelations, isDiscourseNodeShape } from "./canvasUtils";
 import {
   DISCOURSE_NODE_SHAPE_TYPE,
   DiscourseNodeShape,
+  DiscourseNodeUtil,
   getDiscourseNodeTypeId,
 } from "./DiscourseNodeUtil";
 import { getRelationColor } from "./DiscourseRelationShape/DiscourseRelationUtil";
-import {
-  getParallelArrowBend,
-  getRelationArrowsBetween,
-} from "./DiscourseRelationShape/helpers";
+import { getParallelArrowBend } from "./DiscourseRelationShape/helpers";
 import { dispatchToastEvent } from "./ToastListener";
 
 const NEW_NODE_OFFSET_PX = 80;
 const NEW_NODE_GAP_PX = 24;
+const CAMERA_INSET_PX = 64;
 
 const ContextTabContent = ({
   shape,
@@ -42,14 +51,18 @@ const ContextTabContent = ({
   const extensionAPI = useExtensionAPI();
   const [results, setResults] = useState<DiscourseContextResults | null>(null);
   const [failed, setFailed] = useState(false);
-  const [pendingKeys, setPendingKeys] = useState<string[]>([]);
+  const [refreshCount, setRefreshCount] = useState(0);
+  const [pendingUids, setPendingUids] = useState<string[]>([]);
   const uid = shape.props.uid;
 
   useEffect(() => {
-    let cancelled = false;
     setResults(null);
+  }, [uid]);
+
+  useEffect(() => {
+    let cancelled = false;
     setFailed(false);
-    getDiscourseContextResults({ uid })
+    getDiscourseContextResults({ uid, ignoreCache: refreshCount > 0 })
       .then((r) => {
         if (!cancelled) setResults(r);
       })
@@ -59,7 +72,13 @@ const ContextTabContent = ({
     return () => {
       cancelled = true;
     };
-  }, [uid]);
+  }, [uid, refreshCount]);
+
+  const onMutationRefresh = useCallback(
+    () => setRefreshCount((count) => count + 1),
+    [],
+  );
+  useDiscourseContextMutationRefresh({ uid, onMutationRefresh });
 
   const getNodeShapeByUid = (
     relatedUid: string,
@@ -69,127 +88,84 @@ const ContextTabContent = ({
       .filter((s): s is DiscourseNodeShape => isDiscourseNodeShape(editor, s))
       .find((s) => s.props.uid === relatedUid);
 
-  const relationIdsInResults = useMemo(
-    () =>
-      new Set(
-        (results ?? []).flatMap((relation) =>
-          Object.values(relation.results).flatMap((result) =>
-            result.id ? [result.id] : [],
-          ),
-        ),
-      ),
+  const relatedUids = useMemo(
+    () => (results ?? []).flatMap((relation) => Object.keys(relation.results)),
     [results],
   );
 
-  const arrowKeysOnCanvas = useValue(
-    "discourse-relation-arrow-keys",
-    () => {
-      const keys = new Set<string>();
-      relationIdsInResults.forEach((relationId) => {
-        editor.getBindingsToShape(shape.id, relationId).forEach((binding) => {
-          const farBinding = editor
-            .getBindingsFromShape(binding.fromId, relationId)
-            .find((b) => b.toId !== shape.id);
-          if (!farBinding) return;
-          const farShape = editor.getShape(farBinding.toId);
-          if (farShape && isDiscourseNodeShape(editor, farShape)) {
-            keys.add(`${relationId}:${farShape.props.uid}`);
-          }
-        });
-      });
-      return keys;
-    },
-    [editor, shape.id, relationIdsInResults],
+  const pageUidsInResults = useMemo(
+    () => new Set(relatedUids.filter((u) => getPageTitleByPageUid(u))),
+    [relatedUids],
   );
 
-  const addNodeToCanvas = async ({
-    relatedUid,
-    text,
+  const uidsOnCanvas = useValue(
+    "discourse-node-uids-on-canvas",
+    () =>
+      new Set(
+        editor
+          .getCurrentPageShapes()
+          .filter((s): s is DiscourseNodeShape =>
+            isDiscourseNodeShape(editor, s),
+          )
+          .map((s) => s.props.uid),
+      ),
+    [editor],
+  );
+
+  const getFreePositionInColumn = ({
+    anchorBounds,
+    w,
+    h,
   }: {
-    relatedUid: string;
-    text: string;
-  }): Promise<DiscourseNodeShape | undefined> => {
-    if (!extensionAPI) return undefined;
-    const node = findDiscourseNode({ uid: relatedUid });
-    if (!node) {
-      dispatchToastEvent({
-        id: "dg-context-tab-missing-node",
-        title: "Could not find a discourse node for this result.",
-        severity: "error",
-      });
-      return undefined;
-    }
-    const { w, h, imageUrl } = await calcCanvasNodeSizeAndImg({
-      nodeText: text,
-      uid: relatedUid,
-      nodeType: node.type,
-      extensionAPI,
-    });
-    const existing = getNodeShapeByUid(relatedUid);
-    if (existing) return existing;
-    const anchorBounds = editor.getShapePageBounds(shape.id);
-    if (!anchorBounds) return undefined;
+    anchorBounds: Box;
+    w: number;
+    h: number;
+  }): { x: number; y: number } => {
     const x = anchorBounds.maxX + NEW_NODE_OFFSET_PX;
-    const columnBottoms = editor
+    const blockers = editor
       .getCurrentPageShapes()
       .filter((s): s is DiscourseNodeShape => isDiscourseNodeShape(editor, s))
       .flatMap((s) => {
         const bounds = editor.getShapePageBounds(s.id);
-        return bounds && bounds.minX < x + w && bounds.maxX > x
-          ? [bounds.maxY]
-          : [];
-      });
-    const y = columnBottoms.length
-      ? Math.max(...columnBottoms) + NEW_NODE_GAP_PX
-      : anchorBounds.minY;
-    const id = createShapeId();
-    withAutoCanvasRelationsSuppressed(() =>
-      editor.createShapes([
-        {
-          id,
-          type: DISCOURSE_NODE_SHAPE_TYPE,
-          x,
-          y,
-          props: {
-            uid: relatedUid,
-            title: text,
-            w,
-            h,
-            ...(imageUrl && { imageUrl }),
-            size: "s",
-            fontFamily: "sans",
-            nodeTypeId: node.type,
-          },
-        },
-      ]),
-    );
-    return editor.getShape<DiscourseNodeShape>(id);
+        return bounds && bounds.minX < x + w && bounds.maxX > x ? [bounds] : [];
+      })
+      .sort((a, b) => a.minY - b.minY);
+    let y = anchorBounds.minY;
+    for (const blocker of blockers) {
+      if (blocker.maxY + NEW_NODE_GAP_PX <= y) continue;
+      if (blocker.minY >= y + h + NEW_NODE_GAP_PX) break;
+      y = blocker.maxY + NEW_NODE_GAP_PX;
+    }
+    return { x, y };
   };
 
-  const addRelationToCanvas = async ({
+  const bringIntoView = ({
+    anchorBounds,
+    shapeId,
+  }: {
+    anchorBounds: Box;
+    shapeId: DiscourseNodeShape["id"];
+  }): void => {
+    const newBounds = editor.getShapePageBounds(shapeId);
+    if (!newBounds || Box.Contains(editor.getViewportPageBounds(), newBounds))
+      return;
+    editor.zoomToBounds(Box.Common([anchorBounds, newBounds]), {
+      inset: CAMERA_INSET_PX,
+      animation: { duration: 200 },
+    });
+  };
+
+  const drawRelationArrow = ({
+    nodeShape,
     relationId,
     complement,
-    relatedUid,
-    text,
     label,
   }: {
+    nodeShape: DiscourseNodeShape;
     relationId: string;
     complement: boolean;
-    relatedUid: string;
-    text: string;
     label: string;
-  }): Promise<void> => {
-    const nodeShape =
-      getNodeShapeByUid(relatedUid) ??
-      (await addNodeToCanvas({ relatedUid, text }));
-    if (!nodeShape) return;
-    const alreadyOnCanvas = getRelationArrowsBetween({
-      editor,
-      shapeId: shape.id,
-      otherShapeId: nodeShape.id,
-      relationIds: new Set([relationId]),
-    });
-    if (alreadyOnCanvas.length) return;
+  }): void => {
     const startId = complement ? nodeShape.id : shape.id;
     const endId = complement ? shape.id : nodeShape.id;
     const { bend } = getParallelArrowBend({
@@ -223,7 +199,7 @@ const ContextTabContent = ({
       ]);
   };
 
-  const toggleRelationOnCanvas = async ({
+  const addNodeToCanvas = async ({
     relationId,
     complement,
     relatedUid,
@@ -236,27 +212,81 @@ const ContextTabContent = ({
     text: string;
     label: string;
   }): Promise<void> => {
-    const key = `${relationId}:${relatedUid}`;
-    setPendingKeys((prev) => [...prev, key]);
+    if (!extensionAPI) return;
+    const node = findDiscourseNode({ uid: relatedUid });
+    if (!node) {
+      dispatchToastEvent({
+        id: "dg-context-tab-missing-node",
+        title: "Could not find a discourse node for this result.",
+        severity: "error",
+      });
+      return;
+    }
+    const { w, h, imageUrl } = await calcCanvasNodeSizeAndImg({
+      nodeText: text,
+      uid: relatedUid,
+      nodeType: node.type,
+      extensionAPI,
+    });
+    if (getNodeShapeByUid(relatedUid)) return;
+    const anchorBounds = editor.getShapePageBounds(shape.id);
+    if (!anchorBounds) return;
+    const { x, y } = getFreePositionInColumn({ anchorBounds, w, h });
+    const id = createShapeId();
+    withAutoCanvasRelationsSuppressed(() =>
+      editor.createShapes([
+        {
+          id,
+          type: DISCOURSE_NODE_SHAPE_TYPE,
+          x,
+          y,
+          props: {
+            uid: relatedUid,
+            title: text,
+            w,
+            h,
+            ...(imageUrl && { imageUrl }),
+            size: "s",
+            fontFamily: "sans",
+            nodeTypeId: node.type,
+          },
+        },
+      ]),
+    );
+    const created = editor.getShape<DiscourseNodeShape>(id);
+    if (!created) return;
+    bringIntoView({ anchorBounds, shapeId: id });
+    const autoCanvasRelations = getPersonalSetting<boolean>([
+      PERSONAL_KEYS.autoCanvasRelations,
+    ]);
+    const util = editor.getShapeUtil(created);
+    if (autoCanvasRelations && util instanceof DiscourseNodeUtil) {
+      await util.createExistingRelations({ shape: created });
+      return;
+    }
+    drawRelationArrow({ nodeShape: created, relationId, complement, label });
+  };
+
+  const toggleNodeOnCanvas = async ({
+    relationId,
+    complement,
+    relatedUid,
+    text,
+    label,
+  }: {
+    relationId: string;
+    complement: boolean;
+    relatedUid: string;
+    text: string;
+    label: string;
+  }): Promise<void> => {
+    setPendingUids((prev) => [...prev, relatedUid]);
     try {
       const nodeShape = getNodeShapeByUid(relatedUid);
-      const existingArrows = nodeShape
-        ? getRelationArrowsBetween({
-            editor,
-            shapeId: shape.id,
-            otherShapeId: nodeShape.id,
-            relationIds: new Set([relationId]),
-          })
-        : [];
-      if (existingArrows.length) {
-        const bindingIds = existingArrows
-          .flatMap((arrow) => editor.getBindingsFromShape(arrow.id, relationId))
-          .map((b) => b.id);
-        editor
-          .deleteShapes(existingArrows.map((a) => a.id))
-          .deleteBindings(bindingIds);
+      if (nodeShape) {
+        editor.deleteShapes([nodeShape.id]);
       } else {
-        await addRelationToCanvas({
+        await addNodeToCanvas({
           relationId,
           complement,
           relatedUid,
@@ -271,7 +301,7 @@ const ContextTabContent = ({
         severity: "error",
       });
     } finally {
-      setPendingKeys((prev) => prev.filter((k) => k !== key));
+      setPendingUids((prev) => prev.filter((u) => u !== relatedUid));
     }
   };
 
@@ -286,9 +316,9 @@ const ContextTabContent = ({
   }
 
   return (
-    <div className="max-h-96 overflow-y-auto p-3">
+    <div className="max-h-96 space-y-3 overflow-y-auto p-3">
       {results.map((relation) => (
-        <div key={relation.label} className="mb-3 last:mb-0">
+        <div key={relation.label}>
           <div className="mb-1 text-xs font-semibold text-gray-500">
             {relation.label}
           </div>
@@ -296,8 +326,7 @@ const ContextTabContent = ({
             {Object.entries(relation.results).map(([relatedUid, result]) => {
               const text = result.text ?? relatedUid;
               const relationId = result.id;
-              const key = `${relationId}:${relatedUid}`;
-              const onCanvas = !!relationId && arrowKeysOnCanvas.has(key);
+              const onCanvas = uidsOnCanvas.has(relatedUid);
               return (
                 <li
                   key={relatedUid}
@@ -309,7 +338,7 @@ const ContextTabContent = ({
                   >
                     <RenderRoamBlockString
                       string={
-                        getPageTitleByPageUid(relatedUid) ? `[[${text}]]` : text
+                        pageUidsInResults.has(relatedUid) ? `[[${text}]]` : text
                       }
                     />
                   </span>
@@ -320,12 +349,12 @@ const ContextTabContent = ({
                       icon={onCanvas ? "minus" : "plus"}
                       title={
                         onCanvas
-                          ? "Remove relation from canvas"
-                          : "Add relation to canvas"
+                          ? "Remove node from canvas"
+                          : "Add node to canvas"
                       }
-                      loading={pendingKeys.includes(key)}
+                      loading={pendingUids.includes(relatedUid)}
                       onClick={() =>
-                        void toggleRelationOnCanvas({
+                        void toggleNodeOnCanvas({
                           relationId,
                           complement: result.complement === 1,
                           relatedUid,

--- a/apps/roam/src/components/canvas/CustomStylePanel.tsx
+++ b/apps/roam/src/components/canvas/CustomStylePanel.tsx
@@ -1,0 +1,247 @@
+import React, { useEffect, useState } from "react";
+import {
+  DefaultStylePanel,
+  DefaultStylePanelContent,
+  TLUiStylePanelProps,
+  createShapeId,
+  useEditor,
+  useRelevantStyles,
+  useValue,
+} from "tldraw";
+import { Button, Tab, Tabs } from "@blueprintjs/core";
+import { useExtensionAPI } from "roamjs-components/components/ExtensionApiContext";
+import getDiscourseContextResults from "~/utils/getDiscourseContextResults";
+import type { DiscourseContextResults } from "~/components/DiscourseContext";
+import findDiscourseNode from "~/utils/findDiscourseNode";
+import calcCanvasNodeSizeAndImg from "~/utils/calcCanvasNodeSizeAndImg";
+import { withAutoCanvasRelationsSuppressed } from "./autoCanvasRelationsSuppression";
+import { isDiscourseNodeShape } from "./canvasUtils";
+import {
+  DISCOURSE_NODE_SHAPE_TYPE,
+  DiscourseNodeShape,
+  DiscourseNodeUtil,
+} from "./DiscourseNodeUtil";
+import { dispatchToastEvent } from "./ToastListener";
+
+const NEW_NODE_OFFSET_PX = 80;
+
+const ContextTabContent = ({ shape }: { shape: DiscourseNodeShape }) => {
+  const editor = useEditor();
+  const extensionAPI = useExtensionAPI();
+  const [results, setResults] = useState<DiscourseContextResults | null>(null);
+  const [failed, setFailed] = useState(false);
+  const [pendingUids, setPendingUids] = useState<string[]>([]);
+  const uid = shape.props.uid;
+
+  useEffect(() => {
+    let cancelled = false;
+    setResults(null);
+    setFailed(false);
+    getDiscourseContextResults({ uid })
+      .then((r) => {
+        if (!cancelled) setResults(r);
+      })
+      .catch(() => {
+        if (!cancelled) setFailed(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [uid]);
+
+  const nodeShapesByUid = useValue(
+    "discourse-node-shapes-by-uid",
+    () =>
+      new Map(
+        editor
+          .getCurrentPageShapes()
+          .filter((s): s is DiscourseNodeShape =>
+            isDiscourseNodeShape(editor, s),
+          )
+          .map((s) => [s.props.uid, s]),
+      ),
+    [editor],
+  );
+
+  const removeFromCanvas = (nodeShape: DiscourseNodeShape) => {
+    const util = editor.getShapeUtil(nodeShape);
+    if (util instanceof DiscourseNodeUtil) {
+      util.deleteRelationsInCanvas({ shape: nodeShape });
+    }
+    editor.deleteShapes([nodeShape.id]);
+  };
+
+  const addToCanvas = async ({
+    relatedUid,
+    text,
+  }: {
+    relatedUid: string;
+    text: string;
+  }) => {
+    if (!extensionAPI) return;
+    const node = findDiscourseNode({ uid: relatedUid });
+    if (!node) {
+      dispatchToastEvent({
+        id: "dg-context-tab-missing-node",
+        title: "Could not find a discourse node for this result.",
+        severity: "error",
+      });
+      return;
+    }
+    const { w, h, imageUrl } = await calcCanvasNodeSizeAndImg({
+      nodeText: text,
+      uid: relatedUid,
+      nodeType: node.type,
+      extensionAPI,
+    });
+    const id = createShapeId();
+    withAutoCanvasRelationsSuppressed(() =>
+      editor.createShapes([
+        {
+          id,
+          type: DISCOURSE_NODE_SHAPE_TYPE,
+          x: shape.x + shape.props.w + NEW_NODE_OFFSET_PX,
+          y: shape.y,
+          props: {
+            uid: relatedUid,
+            title: text,
+            w,
+            h,
+            ...(imageUrl && { imageUrl }),
+            size: "s",
+            fontFamily: "sans",
+            nodeTypeId: node.type,
+          },
+        },
+      ]),
+    );
+    const created = editor.getShape<DiscourseNodeShape>(id);
+    if (!created) return;
+    const util = editor.getShapeUtil(created);
+    if (util instanceof DiscourseNodeUtil) {
+      await util.createExistingRelations({ shape: created });
+    }
+  };
+
+  const toggleCanvasPresence = async ({
+    relatedUid,
+    text,
+  }: {
+    relatedUid: string;
+    text: string;
+  }) => {
+    setPendingUids((prev) => [...prev, relatedUid]);
+    try {
+      const existing = nodeShapesByUid.get(relatedUid);
+      if (existing) {
+        removeFromCanvas(existing);
+      } else {
+        await addToCanvas({ relatedUid, text });
+      }
+    } finally {
+      setPendingUids((prev) => prev.filter((u) => u !== relatedUid));
+    }
+  };
+
+  if (failed) {
+    return <div className="p-3 text-sm">Failed to load relations.</div>;
+  }
+  if (results === null) {
+    return <div className="p-3 text-sm">Loading relations...</div>;
+  }
+  if (results.length === 0) {
+    return <div className="p-3 text-sm">No relations found.</div>;
+  }
+
+  return (
+    <div className="max-h-96 overflow-y-auto p-3">
+      {results.map((relation) => (
+        <div key={relation.label} className="mb-3 last:mb-0">
+          <div className="mb-1 text-xs font-semibold text-gray-500">
+            {relation.label}
+          </div>
+          <ul className="m-0 list-none p-0">
+            {Object.entries(relation.results).map(([relatedUid, result]) => {
+              const text = result.text ?? relatedUid;
+              const onCanvas = nodeShapesByUid.has(relatedUid);
+              return (
+                <li
+                  key={relatedUid}
+                  className="flex items-center justify-between gap-2 py-1"
+                >
+                  <span
+                    className="min-w-0 flex-1 truncate text-sm"
+                    title={text}
+                  >
+                    {text}
+                  </span>
+                  <Button
+                    minimal
+                    small
+                    icon={onCanvas ? "minus" : "plus"}
+                    title={onCanvas ? "Remove from canvas" : "Add to canvas"}
+                    loading={pendingUids.includes(relatedUid)}
+                    onClick={() =>
+                      void toggleCanvasPresence({ relatedUid, text })
+                    }
+                  />
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+const NodeCardPanelContent = ({ shape }: { shape: DiscourseNodeShape }) => {
+  const styles = useRelevantStyles();
+  const [activeTab, setActiveTab] = useState<"context" | "styling">("context");
+  return (
+    <div className="dg-node-style-panel px-2 pt-1">
+      <Tabs
+        id="dg-node-card-tabs"
+        selectedTabId={activeTab}
+        onChange={(tabId) =>
+          setActiveTab(tabId === "styling" ? "styling" : "context")
+        }
+        renderActiveTabPanelOnly
+      >
+        <Tab
+          id="context"
+          title="Context"
+          panel={<ContextTabContent shape={shape} />}
+        />
+        <Tab
+          id="styling"
+          title="Styling"
+          panel={<DefaultStylePanelContent styles={styles} />}
+        />
+      </Tabs>
+    </div>
+  );
+};
+
+export const CustomStylePanel = (props: TLUiStylePanelProps) => {
+  const editor = useEditor();
+  const selectedNodeShape = useValue(
+    "selected-discourse-node-shape",
+    () => {
+      const selected = editor.getOnlySelectedShape();
+      return selected && isDiscourseNodeShape(editor, selected)
+        ? selected
+        : null;
+    },
+    [editor],
+  );
+  if (!selectedNodeShape) return <DefaultStylePanel {...props} />;
+  return (
+    <DefaultStylePanel {...props}>
+      <NodeCardPanelContent
+        key={selectedNodeShape.id}
+        shape={selectedNodeShape}
+      />
+    </DefaultStylePanel>
+  );
+};

--- a/apps/roam/src/components/canvas/CustomStylePanel.tsx
+++ b/apps/roam/src/components/canvas/CustomStylePanel.tsx
@@ -10,10 +10,14 @@ import {
 } from "tldraw";
 import { Button, Tab, Tabs } from "@blueprintjs/core";
 import { useExtensionAPI } from "roamjs-components/components/ExtensionApiContext";
+import getPageTitleByPageUid from "roamjs-components/queries/getPageTitleByPageUid";
 import getDiscourseContextResults from "~/utils/getDiscourseContextResults";
 import type { DiscourseContextResults } from "~/components/DiscourseContext";
 import findDiscourseNode from "~/utils/findDiscourseNode";
 import calcCanvasNodeSizeAndImg from "~/utils/calcCanvasNodeSizeAndImg";
+import { RenderRoamBlockString } from "~/utils/roamReactComponents";
+import { getPersonalSetting } from "~/components/settings/utils/accessors";
+import { PERSONAL_KEYS } from "~/components/settings/utils/settingKeys";
 import { withAutoCanvasRelationsSuppressed } from "./autoCanvasRelationsSuppression";
 import { isDiscourseNodeShape } from "./canvasUtils";
 import {
@@ -127,9 +131,14 @@ const ContextTabContent = ({ shape }: { shape: DiscourseNodeShape }) => {
     );
     const created = editor.getShape<DiscourseNodeShape>(id);
     if (!created) return;
-    const util = editor.getShapeUtil(created);
-    if (util instanceof DiscourseNodeUtil) {
-      await util.createExistingRelations({ shape: created });
+    const autoCanvasRelations = getPersonalSetting<boolean>([
+      PERSONAL_KEYS.autoCanvasRelations,
+    ]);
+    if (autoCanvasRelations) {
+      const util = editor.getShapeUtil(created);
+      if (util instanceof DiscourseNodeUtil) {
+        await util.createExistingRelations({ shape: created });
+      }
     }
   };
 
@@ -189,7 +198,11 @@ const ContextTabContent = ({ shape }: { shape: DiscourseNodeShape }) => {
                     className="min-w-0 flex-1 truncate text-sm"
                     title={text}
                   >
-                    {text}
+                    <RenderRoamBlockString
+                      string={
+                        getPageTitleByPageUid(relatedUid) ? `[[${text}]]` : text
+                      }
+                    />
                   </span>
                   <Button
                     minimal

--- a/apps/roam/src/components/canvas/CustomStylePanel.tsx
+++ b/apps/roam/src/components/canvas/CustomStylePanel.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { ReactElement, useEffect, useMemo, useState } from "react";
 import {
   DefaultStylePanel,
   DefaultStylePanelContent,
@@ -21,6 +21,7 @@ import { getAllRelations, isDiscourseNodeShape } from "./canvasUtils";
 import {
   DISCOURSE_NODE_SHAPE_TYPE,
   DiscourseNodeShape,
+  getDiscourseNodeTypeId,
 } from "./DiscourseNodeUtil";
 import { getRelationColor } from "./DiscourseRelationShape/DiscourseRelationUtil";
 import {
@@ -32,7 +33,11 @@ import { dispatchToastEvent } from "./ToastListener";
 const NEW_NODE_OFFSET_PX = 80;
 const NEW_NODE_GAP_PX = 24;
 
-const ContextTabContent = ({ shape }: { shape: DiscourseNodeShape }) => {
+const ContextTabContent = ({
+  shape,
+}: {
+  shape: DiscourseNodeShape;
+}): ReactElement => {
   const editor = useEditor();
   const extensionAPI = useExtensionAPI();
   const [results, setResults] = useState<DiscourseContextResults | null>(null);
@@ -56,7 +61,9 @@ const ContextTabContent = ({ shape }: { shape: DiscourseNodeShape }) => {
     };
   }, [uid]);
 
-  const getNodeShapeByUid = (relatedUid: string) =>
+  const getNodeShapeByUid = (
+    relatedUid: string,
+  ): DiscourseNodeShape | undefined =>
     editor
       .getCurrentPageShapes()
       .filter((s): s is DiscourseNodeShape => isDiscourseNodeShape(editor, s))
@@ -120,15 +127,21 @@ const ContextTabContent = ({ shape }: { shape: DiscourseNodeShape }) => {
     });
     const existing = getNodeShapeByUid(relatedUid);
     if (existing) return existing;
-    const x = shape.x + shape.props.w + NEW_NODE_OFFSET_PX;
+    const anchorBounds = editor.getShapePageBounds(shape.id);
+    if (!anchorBounds) return undefined;
+    const x = anchorBounds.maxX + NEW_NODE_OFFSET_PX;
     const columnBottoms = editor
       .getCurrentPageShapes()
       .filter((s): s is DiscourseNodeShape => isDiscourseNodeShape(editor, s))
-      .filter((s) => s.x < x + w && s.x + s.props.w > x)
-      .map((s) => s.y + s.props.h);
+      .flatMap((s) => {
+        const bounds = editor.getShapePageBounds(s.id);
+        return bounds && bounds.minX < x + w && bounds.maxX > x
+          ? [bounds.maxY]
+          : [];
+      });
     const y = columnBottoms.length
       ? Math.max(...columnBottoms) + NEW_NODE_GAP_PX
-      : shape.y;
+      : anchorBounds.minY;
     const id = createShapeId();
     withAutoCanvasRelationsSuppressed(() =>
       editor.createShapes([
@@ -165,7 +178,7 @@ const ContextTabContent = ({ shape }: { shape: DiscourseNodeShape }) => {
     relatedUid: string;
     text: string;
     label: string;
-  }) => {
+  }): Promise<void> => {
     const nodeShape =
       getNodeShapeByUid(relatedUid) ??
       (await addNodeToCanvas({ relatedUid, text }));
@@ -222,7 +235,7 @@ const ContextTabContent = ({ shape }: { shape: DiscourseNodeShape }) => {
     relatedUid: string;
     text: string;
     label: string;
-  }) => {
+  }): Promise<void> => {
     const key = `${relationId}:${relatedUid}`;
     setPendingKeys((prev) => [...prev, key]);
     try {
@@ -332,7 +345,11 @@ const ContextTabContent = ({ shape }: { shape: DiscourseNodeShape }) => {
   );
 };
 
-const NodeCardPanelContent = ({ shape }: { shape: DiscourseNodeShape }) => {
+const NodeCardPanelContent = ({
+  shape,
+}: {
+  shape: DiscourseNodeShape;
+}): ReactElement => {
   const styles = useRelevantStyles();
   const [activeTab, setActiveTab] = useState<"context" | "styling">("context");
   return (
@@ -360,15 +377,18 @@ const NodeCardPanelContent = ({ shape }: { shape: DiscourseNodeShape }) => {
   );
 };
 
-export const CustomStylePanel = (props: TLUiStylePanelProps) => {
+export const CustomStylePanel = (props: TLUiStylePanelProps): ReactElement => {
   const editor = useEditor();
   const selectedNodeShape = useValue(
     "selected-discourse-node-shape",
     () => {
       const selected = editor.getOnlySelectedShape();
-      return selected && isDiscourseNodeShape(editor, selected)
-        ? selected
-        : null;
+      if (!selected || !isDiscourseNodeShape(editor, selected)) return null;
+      return ["blck-node", "page-node"].includes(
+        getDiscourseNodeTypeId({ shape: selected }),
+      )
+        ? null
+        : selected;
     },
     [editor],
   );

--- a/apps/roam/src/components/canvas/CustomStylePanel.tsx
+++ b/apps/roam/src/components/canvas/CustomStylePanel.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import {
   DefaultStylePanel,
   DefaultStylePanelContent,
@@ -16,15 +16,17 @@ import type { DiscourseContextResults } from "~/components/DiscourseContext";
 import findDiscourseNode from "~/utils/findDiscourseNode";
 import calcCanvasNodeSizeAndImg from "~/utils/calcCanvasNodeSizeAndImg";
 import { RenderRoamBlockString } from "~/utils/roamReactComponents";
-import { getPersonalSetting } from "~/components/settings/utils/accessors";
-import { PERSONAL_KEYS } from "~/components/settings/utils/settingKeys";
 import { withAutoCanvasRelationsSuppressed } from "./autoCanvasRelationsSuppression";
-import { isDiscourseNodeShape } from "./canvasUtils";
+import { getAllRelations, isDiscourseNodeShape } from "./canvasUtils";
 import {
   DISCOURSE_NODE_SHAPE_TYPE,
   DiscourseNodeShape,
-  DiscourseNodeUtil,
 } from "./DiscourseNodeUtil";
+import { getRelationColor } from "./DiscourseRelationShape/DiscourseRelationUtil";
+import {
+  getParallelArrowBend,
+  getRelationArrowsBetween,
+} from "./DiscourseRelationShape/helpers";
 import { dispatchToastEvent } from "./ToastListener";
 
 const NEW_NODE_OFFSET_PX = 80;
@@ -35,7 +37,7 @@ const ContextTabContent = ({ shape }: { shape: DiscourseNodeShape }) => {
   const extensionAPI = useExtensionAPI();
   const [results, setResults] = useState<DiscourseContextResults | null>(null);
   const [failed, setFailed] = useState(false);
-  const [pendingUids, setPendingUids] = useState<string[]>([]);
+  const [pendingKeys, setPendingKeys] = useState<string[]>([]);
   const uid = shape.props.uid;
 
   useEffect(() => {
@@ -68,22 +70,47 @@ const ContextTabContent = ({ shape }: { shape: DiscourseNodeShape }) => {
     [editor],
   );
 
-  const removeFromCanvas = (nodeShape: DiscourseNodeShape) => {
-    const util = editor.getShapeUtil(nodeShape);
-    if (util instanceof DiscourseNodeUtil) {
-      util.deleteRelationsInCanvas({ shape: nodeShape });
-    }
-    editor.deleteShapes([nodeShape.id]);
-  };
+  const relationIdsInResults = useMemo(
+    () =>
+      new Set(
+        (results ?? []).flatMap((relation) =>
+          Object.values(relation.results).flatMap((result) =>
+            result.id ? [result.id] : [],
+          ),
+        ),
+      ),
+    [results],
+  );
 
-  const addToCanvas = async ({
+  const arrowKeysOnCanvas = useValue(
+    "discourse-relation-arrow-keys",
+    () => {
+      const keys = new Set<string>();
+      relationIdsInResults.forEach((relationId) => {
+        editor.getBindingsToShape(shape.id, relationId).forEach((binding) => {
+          const farBinding = editor
+            .getBindingsFromShape(binding.fromId, relationId)
+            .find((b) => b.toId !== shape.id);
+          if (!farBinding) return;
+          const farShape = editor.getShape(farBinding.toId);
+          if (farShape && isDiscourseNodeShape(editor, farShape)) {
+            keys.add(`${relationId}:${farShape.props.uid}`);
+          }
+        });
+      });
+      return keys;
+    },
+    [editor, shape.id, relationIdsInResults],
+  );
+
+  const addNodeToCanvas = async ({
     relatedUid,
     text,
   }: {
     relatedUid: string;
     text: string;
-  }) => {
-    if (!extensionAPI) return;
+  }): Promise<DiscourseNodeShape | undefined> => {
+    if (!extensionAPI) return undefined;
     const node = findDiscourseNode({ uid: relatedUid });
     if (!node) {
       dispatchToastEvent({
@@ -91,7 +118,7 @@ const ContextTabContent = ({ shape }: { shape: DiscourseNodeShape }) => {
         title: "Could not find a discourse node for this result.",
         severity: "error",
       });
-      return;
+      return undefined;
     }
     const { w, h, imageUrl } = await calcCanvasNodeSizeAndImg({
       nodeText: text,
@@ -129,33 +156,105 @@ const ContextTabContent = ({ shape }: { shape: DiscourseNodeShape }) => {
         },
       ]),
     );
-    const created = editor.getShape<DiscourseNodeShape>(id);
-    if (!created) return;
-    const autoCanvasRelations = getPersonalSetting<boolean>([
-      PERSONAL_KEYS.autoCanvasRelations,
-    ]);
-    if (autoCanvasRelations) {
-      const util = editor.getShapeUtil(created);
-      if (util instanceof DiscourseNodeUtil) {
-        await util.createExistingRelations({ shape: created });
-      }
-    }
+    return editor.getShape<DiscourseNodeShape>(id);
   };
 
-  const toggleCanvasPresence = async ({
+  const removeRelationFromCanvas = ({
+    relationId,
+    nodeShape,
+  }: {
+    relationId: string;
+    nodeShape: DiscourseNodeShape;
+  }) => {
+    const arrows = getRelationArrowsBetween({
+      editor,
+      shapeId: shape.id,
+      otherShapeId: nodeShape.id,
+      relationIds: new Set([relationId]),
+    });
+    const bindingIds = arrows
+      .flatMap((arrow) => editor.getBindingsFromShape(arrow.id, relationId))
+      .map((b) => b.id);
+    editor.deleteShapes(arrows.map((a) => a.id)).deleteBindings(bindingIds);
+  };
+
+  const addRelationToCanvas = async ({
+    relationId,
+    complement,
     relatedUid,
     text,
+    label,
   }: {
+    relationId: string;
+    complement: boolean;
     relatedUid: string;
     text: string;
+    label: string;
   }) => {
-    setPendingUids((prev) => [...prev, relatedUid]);
+    const nodeShape =
+      nodeShapesByUid.get(relatedUid) ??
+      (await addNodeToCanvas({ relatedUid, text }));
+    if (!nodeShape) return;
+    const startId = complement ? nodeShape.id : shape.id;
+    const endId = complement ? shape.id : nodeShape.id;
+    const { bend } = getParallelArrowBend({
+      editor,
+      startShapeId: startId,
+      endShapeId: endId,
+      relationIds: new Set(getAllRelations().map((r) => r.id)),
+    });
+    const arrowId = createShapeId();
+    editor
+      .createShapes([
+        {
+          id: arrowId,
+          type: relationId,
+          props: { color: getRelationColor(label), bend },
+        },
+      ])
+      .createBindings([
+        {
+          type: relationId,
+          fromId: arrowId,
+          toId: startId,
+          props: { terminal: "start" },
+        },
+        {
+          type: relationId,
+          fromId: arrowId,
+          toId: endId,
+          props: { terminal: "end" },
+        },
+      ]);
+  };
+
+  const toggleRelationOnCanvas = async ({
+    relationId,
+    complement,
+    relatedUid,
+    text,
+    label,
+  }: {
+    relationId: string;
+    complement: boolean;
+    relatedUid: string;
+    text: string;
+    label: string;
+  }) => {
+    const key = `${relationId}:${relatedUid}`;
+    setPendingKeys((prev) => [...prev, key]);
     try {
-      const existing = nodeShapesByUid.get(relatedUid);
-      if (existing) {
-        removeFromCanvas(existing);
+      const nodeShape = nodeShapesByUid.get(relatedUid);
+      if (arrowKeysOnCanvas.has(key) && nodeShape) {
+        removeRelationFromCanvas({ relationId, nodeShape });
       } else {
-        await addToCanvas({ relatedUid, text });
+        await addRelationToCanvas({
+          relationId,
+          complement,
+          relatedUid,
+          text,
+          label,
+        });
       }
     } catch {
       dispatchToastEvent({
@@ -164,7 +263,7 @@ const ContextTabContent = ({ shape }: { shape: DiscourseNodeShape }) => {
         severity: "error",
       });
     } finally {
-      setPendingUids((prev) => prev.filter((u) => u !== relatedUid));
+      setPendingKeys((prev) => prev.filter((k) => k !== key));
     }
   };
 
@@ -188,7 +287,9 @@ const ContextTabContent = ({ shape }: { shape: DiscourseNodeShape }) => {
           <ul className="m-0 list-none p-0">
             {Object.entries(relation.results).map(([relatedUid, result]) => {
               const text = result.text ?? relatedUid;
-              const onCanvas = nodeShapesByUid.has(relatedUid);
+              const relationId = result.id;
+              const key = `${relationId}:${relatedUid}`;
+              const onCanvas = !!relationId && arrowKeysOnCanvas.has(key);
               return (
                 <li
                   key={relatedUid}
@@ -204,16 +305,28 @@ const ContextTabContent = ({ shape }: { shape: DiscourseNodeShape }) => {
                       }
                     />
                   </span>
-                  <Button
-                    minimal
-                    small
-                    icon={onCanvas ? "minus" : "plus"}
-                    title={onCanvas ? "Remove from canvas" : "Add to canvas"}
-                    loading={pendingUids.includes(relatedUid)}
-                    onClick={() =>
-                      void toggleCanvasPresence({ relatedUid, text })
-                    }
-                  />
+                  {relationId && (
+                    <Button
+                      minimal
+                      small
+                      icon={onCanvas ? "minus" : "plus"}
+                      title={
+                        onCanvas
+                          ? "Remove relation from canvas"
+                          : "Add relation to canvas"
+                      }
+                      loading={pendingKeys.includes(key)}
+                      onClick={() =>
+                        void toggleRelationOnCanvas({
+                          relationId,
+                          complement: result.complement === 1,
+                          relatedUid,
+                          text,
+                          label: relation.label,
+                        })
+                      }
+                    />
+                  )}
                 </li>
               );
             })}

--- a/apps/roam/src/components/canvas/DiscourseNodeUtil.tsx
+++ b/apps/roam/src/components/canvas/DiscourseNodeUtil.tsx
@@ -36,7 +36,10 @@ import { getCleanTagText } from "~/components/settings/NodeConfig";
 import { discourseContext } from "./Tldraw";
 import getDiscourseContextResults from "~/utils/getDiscourseContextResults";
 import calcCanvasNodeSizeAndImg from "~/utils/calcCanvasNodeSizeAndImg";
-import { createTextJsxFromSpans } from "./DiscourseRelationShape/helpers";
+import {
+  createTextJsxFromSpans,
+  getParallelArrowBend,
+} from "./DiscourseRelationShape/helpers";
 import { loadImage } from "~/utils/loadImage";
 import { getRelationColor } from "./DiscourseRelationShape/DiscourseRelationUtil";
 import { getPersonalSetting } from "~/components/settings/utils/accessors";
@@ -316,10 +319,27 @@ export class DiscourseNodeUtil extends BaseBoxShapeUtil<DiscourseNodeShape> {
         return { relationId, complement, nodeId, arrowId, label };
       });
 
+    const allRelationIds = getRelationIds();
+    const reservedBendsByPair = new Map<string, number[]>();
     const shapesToCreate = toCreate.map(
-      ({ relationId, arrowId, label }, index) => {
+      ({ relationId, complement, nodeId, arrowId, label }, index) => {
         const color = getRelationColor(label, index);
-        return { id: arrowId, type: relationId, props: { color } };
+        const startId = complement ? nodesInCanvas[nodeId].id : shape.id;
+        const endId = complement ? shape.id : nodesInCanvas[nodeId].id;
+        const pairKey = [startId, endId].sort().join(":");
+        const reservedCanonicalBends = reservedBendsByPair.get(pairKey) ?? [];
+        const { bend, canonicalBend } = getParallelArrowBend({
+          editor,
+          startShapeId: startId,
+          endShapeId: endId,
+          relationIds: allRelationIds,
+          reservedCanonicalBends,
+        });
+        reservedBendsByPair.set(pairKey, [
+          ...reservedCanonicalBends,
+          canonicalBend,
+        ]);
+        return { id: arrowId, type: relationId, props: { color, bend } };
       },
     );
 

--- a/apps/roam/src/components/canvas/DiscourseRelationShape/DiscourseRelationUtil.tsx
+++ b/apps/roam/src/components/canvas/DiscourseRelationShape/DiscourseRelationUtil.tsx
@@ -115,6 +115,7 @@ import getPageTitleByPageUid from "roamjs-components/queries/getPageTitleByPageU
 import { AddReferencedNodeType } from "./DiscourseRelationTool";
 import { dispatchToastEvent } from "~/components/canvas/ToastListener";
 import internalError from "~/utils/internalError";
+import { refreshDiscourseContextsForMutatedUids } from "~/utils/discourseContextMutationRefresh";
 
 const COLOR_ARRAY = Array.from(DefaultColorStyle.values)
   .filter((c) => !["red", "green", "grey"].includes(c))
@@ -248,6 +249,9 @@ export const createAllReferencedNodeUtils = (
           id: "tldraw-success",
           title: `Updated node title.`,
           severity: "success",
+        });
+        refreshDiscourseContextsForMutatedUids({
+          uids: [source.props.uid, target.props.uid],
         });
       };
 
@@ -780,6 +784,9 @@ export const createAllRelationShapeUtils = (
             ),
           })(newTriples)();
         }
+        refreshDiscourseContextsForMutatedUids({
+          uids: [source.props.uid, target.props.uid],
+        });
       };
 
       override getDefaultProps(): DiscourseRelationShape["props"] {

--- a/apps/roam/src/components/canvas/DiscourseRelationShape/helpers.tsx
+++ b/apps/roam/src/components/canvas/DiscourseRelationShape/helpers.tsx
@@ -150,6 +150,83 @@ export function getArrowBindings(
     end: bindings.find((b) => b.props.terminal === "end"),
   };
 }
+const PARALLEL_ARROW_BEND_PX = 40;
+export function getRelationArrowsBetween({
+  editor,
+  shapeId,
+  otherShapeId,
+  relationIds,
+}: {
+  editor: Editor;
+  shapeId: TLShapeId;
+  otherShapeId: TLShapeId;
+  relationIds: Set<string>;
+}): DiscourseRelationShape[] {
+  return Array.from(relationIds).flatMap((relationId) =>
+    editor
+      .getBindingsToShape<RelationBinding>(shapeId, relationId)
+      .map((binding) => binding.fromId)
+      .filter((arrowId) =>
+        editor
+          .getBindingsFromShape<RelationBinding>(arrowId, relationId)
+          .some((binding) => binding.toId === otherShapeId),
+      )
+      .flatMap((arrowId) => {
+        const arrow = editor.getShape<DiscourseRelationShape>(arrowId);
+        return arrow ? [arrow] : [];
+      }),
+  );
+}
+export function getParallelArrowBend({
+  editor,
+  startShapeId,
+  endShapeId,
+  relationIds,
+  reservedCanonicalBends = [],
+}: {
+  editor: Editor;
+  startShapeId: TLShapeId;
+  endShapeId: TLShapeId;
+  relationIds: Set<string>;
+  reservedCanonicalBends?: number[];
+}): { bend: number; canonicalBend: number } {
+  // Canonical frame: bend as seen from the lexicographically lower shape id,
+  // so arrows in opposite directions still land on distinct visual arcs.
+  const lowerShapeId = startShapeId < endShapeId ? startShapeId : endShapeId;
+  const existingCanonicalBends = getRelationArrowsBetween({
+    editor,
+    shapeId: startShapeId,
+    otherShapeId: endShapeId,
+    relationIds,
+  }).map((arrow) => {
+    const startBinding = editor
+      .getBindingsFromShape<RelationBinding>(arrow.id, arrow.type)
+      .find((binding) => binding.props.terminal === "start");
+    return startBinding?.toId === lowerShapeId
+      ? arrow.props.bend
+      : -arrow.props.bend;
+  });
+  const occupied = [...existingCanonicalBends, ...reservedCanonicalBends];
+  const slotOffset = (slot: number) =>
+    slot === 0
+      ? 0
+      : Math.ceil(slot / 2) *
+        PARALLEL_ARROW_BEND_PX *
+        (slot % 2 === 1 ? 1 : -1);
+  let slot = 0;
+  while (
+    occupied.some(
+      (bend) => Math.abs(bend - slotOffset(slot)) < PARALLEL_ARROW_BEND_PX / 2,
+    )
+  ) {
+    slot += 1;
+  }
+  const canonicalBend = slotOffset(slot);
+  return {
+    bend: startShapeId === lowerShapeId ? canonicalBend : -canonicalBend,
+    canonicalBend,
+  };
+}
 function getStraightArrowInfo(
   editor: Editor,
   relation: DiscourseRelationShape,

--- a/apps/roam/src/components/canvas/DiscourseRelationShape/helpers.tsx
+++ b/apps/roam/src/components/canvas/DiscourseRelationShape/helpers.tsx
@@ -207,7 +207,7 @@ export function getParallelArrowBend({
       : -arrow.props.bend;
   });
   const occupied = [...existingCanonicalBends, ...reservedCanonicalBends];
-  const slotOffset = (slot: number) =>
+  const slotOffset = (slot: number): number =>
     slot === 0
       ? 0
       : Math.ceil(slot / 2) *

--- a/apps/roam/src/components/canvas/tldrawStyles.ts
+++ b/apps/roam/src/components/canvas/tldrawStyles.ts
@@ -85,4 +85,8 @@ export default /* css */ `
   width: 280px;
   max-width: 280px;
 }
+
+.dg-node-style-panel .bp3-tab-list {
+  justify-content: center;
+}
 `;

--- a/apps/roam/src/components/canvas/tldrawStyles.ts
+++ b/apps/roam/src/components/canvas/tldrawStyles.ts
@@ -79,4 +79,10 @@ export default /* css */ `
   background-color: var(--color-muted-2);
   opacity: 1;
 }
+
+/* Widen the style panel when it shows the node card Context/Styling tabs */
+.tlui-style-panel:has(.dg-node-style-panel) {
+  width: 280px;
+  max-width: 280px;
+}
 `;

--- a/apps/roam/src/components/canvas/uiOverrides.tsx
+++ b/apps/roam/src/components/canvas/uiOverrides.tsx
@@ -71,6 +71,7 @@ import { createOrUpdateArrowBinding } from "./DiscourseRelationShape/helpers";
 import DiscourseGraphPanel from "./DiscourseToolPanel";
 import type { CanvasNodeShortcuts } from "~/components/settings/utils/zodSchema";
 import { CustomDefaultToolbar } from "./CustomDefaultToolbar";
+import { CustomStylePanel } from "./CustomStylePanel";
 import { renderModifyNodeDialog } from "~/components/ModifyNodeDialog";
 import { CanvasSyncMode } from "./canvasSyncMode";
 import { getPersonalSetting } from "~/components/settings/utils/accessors";
@@ -545,6 +546,7 @@ export const createUiComponents = ({
   canvasSyncMode: CanvasSyncMode;
 }): TLUiComponents => {
   return {
+    StylePanel: CustomStylePanel,
     Toolbar: (props) => {
       const tools = useTools();
       return (

--- a/apps/roam/src/utils/__tests__/getDiscourseContextResults.test.ts
+++ b/apps/roam/src/utils/__tests__/getDiscourseContextResults.test.ts
@@ -34,7 +34,9 @@ vi.mock("~/utils/getDiscourseRelations", () => ({
   default: () => [],
 }));
 
-import getDiscourseContextResults from "~/utils/getDiscourseContextResults";
+import getDiscourseContextResults, {
+  invalidateDiscourseContextCache,
+} from "~/utils/getDiscourseContextResults";
 
 const makeNode = ({
   type,
@@ -159,5 +161,47 @@ describe("getDiscourseContextResults", () => {
     });
     expect(onResult).toHaveBeenNthCalledWith(1, results[0]);
     expect(onResult).toHaveBeenNthCalledWith(2, results[1]);
+  });
+});
+
+describe("discourse context cache invalidation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (globalThis as { window: unknown }).window = {
+      roamAlphaAPI: { util: { generateUID: mocks.generateUID } },
+    };
+    mocks.generateUID.mockReturnValue("cache-condition");
+  });
+
+  it("invalidates a changed node even when no panel is mounted, preserving other nodes", async () => {
+    mocks.getSetting.mockReturnValue(false);
+    mocks.findDiscourseNode.mockReturnValue({ type: "CLM" });
+    const nodes = [
+      makeNode({ type: "CLM", text: "Claim" }),
+      makeNode({ type: "QUE", text: "Question" }),
+    ];
+    const relations: DiscourseRelation[] = [
+      {
+        id: "cache-supports",
+        label: "Supports",
+        complement: "Supported By",
+        source: "CLM",
+        destination: "QUE",
+        triples: [],
+      },
+    ];
+    const get = (uid: string) =>
+      getDiscourseContextResults({ uid, nodes, relations });
+    mocks.fireQuery.mockResolvedValue([]);
+    await get("cache-node");
+    await get("cache-other");
+    mocks.fireQuery.mockClear();
+    await get("cache-node");
+    expect(mocks.fireQuery).not.toHaveBeenCalled();
+    invalidateDiscourseContextCache({ uids: ["cache-node"] });
+    await get("cache-other");
+    expect(mocks.fireQuery).not.toHaveBeenCalled();
+    await get("cache-node");
+    expect(mocks.fireQuery).toHaveBeenCalledOnce();
   });
 });

--- a/apps/roam/src/utils/__tests__/nodeCardPanel.test.ts
+++ b/apps/roam/src/utils/__tests__/nodeCardPanel.test.ts
@@ -1,0 +1,194 @@
+// @vitest-environment jsdom
+import React from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { act } from "react-dom/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CustomStylePanel } from "~/components/canvas/CustomStylePanel";
+
+const mocks = vi.hoisted(() => ({
+  context: vi.fn(),
+  autoRelations: vi.fn(),
+  createExistingRelations: vi.fn(),
+  selected: {
+    id: "shape:focal",
+    type: "discourse-node",
+    props: { uid: "focal", nodeTypeId: "claim" },
+  },
+  shapes: new Map<
+    string,
+    { id: string; type: string; props: { uid?: string; nodeTypeId?: string } }
+  >(),
+  nextId: 0,
+}));
+vi.mock("tldraw", () => {
+  const editor = {
+    getOnlySelectedShape: () => mocks.selected,
+    getCurrentPageShapes: () => [...mocks.shapes.values()],
+    getShape: (id: string) => mocks.shapes.get(id),
+    getShapePageBounds: () => ({ minX: 0, maxX: 200, minY: 0, maxY: 100 }),
+    getViewportPageBounds: () => ({}),
+    getShapeUtil: () => new MockNodeUtil(),
+    zoomToBounds: vi.fn(),
+    createShapes: (shapes: (typeof mocks.selected)[]) => {
+      shapes.forEach((s) => mocks.shapes.set(s.id, s));
+      return editor;
+    },
+    createBindings: vi.fn(),
+    deleteShapes: (ids: string[]) => {
+      ids.forEach((id) => mocks.shapes.delete(id));
+      return editor;
+    },
+  };
+  class MockNodeUtil {
+    createExistingRelations = mocks.createExistingRelations;
+  }
+  return {
+    useEditor: () => editor,
+    useValue: (_name: string, compute: () => unknown) => compute(),
+    useRelevantStyles: () => ({}),
+    createShapeId: () => `shape:new-${++mocks.nextId}`,
+    Box: { Contains: () => true },
+    DefaultStylePanel: ({ children }: { children?: React.ReactNode }) =>
+      React.createElement("div", {}, children ?? "Default styling"),
+    DefaultStylePanelContent: () =>
+      React.createElement("div", {}, "Native styling controls"),
+    MockNodeUtil,
+  };
+});
+vi.mock("~/components/canvas/DiscourseNodeUtil", async () => {
+  const { MockNodeUtil } = (await import("tldraw")) as unknown as {
+    MockNodeUtil: new () => unknown;
+  };
+  return {
+    DISCOURSE_NODE_SHAPE_TYPE: "discourse-node",
+    DiscourseNodeUtil: MockNodeUtil,
+    getDiscourseNodeTypeId: ({ shape }: { shape: typeof mocks.selected }) =>
+      shape.props.nodeTypeId,
+  };
+});
+vi.mock("~/components/canvas/canvasUtils", () => ({
+  getAllRelations: () => [{ id: "supports" }],
+  isDiscourseNodeShape: (_editor: unknown, shape: typeof mocks.selected) =>
+    shape.type === "discourse-node",
+}));
+vi.mock("~/utils/getDiscourseContextResults", () => ({
+  default: mocks.context,
+}));
+vi.mock("~/utils/discourseContextMutationRefresh", () => ({
+  useDiscourseContextMutationRefresh: vi.fn(),
+}));
+vi.mock("~/utils/findDiscourseNode", () => ({
+  default: () => ({ type: "evidence" }),
+}));
+vi.mock("~/utils/calcCanvasNodeSizeAndImg", () => ({
+  default: () => Promise.resolve({ w: 200, h: 100 }),
+}));
+vi.mock("~/utils/roamReactComponents", () => ({
+  RenderRoamBlockString: ({ string }: { string: string }) =>
+    React.createElement("span", {}, string),
+}));
+vi.mock("~/components/settings/utils/accessors", () => ({
+  getPersonalSetting: mocks.autoRelations,
+}));
+vi.mock(
+  "~/components/canvas/DiscourseRelationShape/DiscourseRelationUtil",
+  () => ({ getRelationColor: () => "blue" }),
+);
+vi.mock("~/components/canvas/DiscourseRelationShape/helpers", () => ({
+  getParallelArrowBend: () => ({ bend: 0 }),
+}));
+vi.mock("~/components/canvas/ToastListener", () => ({
+  dispatchToastEvent: vi.fn(),
+}));
+vi.mock("roamjs-components/components/ExtensionApiContext", () => ({
+  useExtensionAPI: () => ({}),
+}));
+vi.mock("roamjs-components/queries/getPageTitleByPageUid", () => ({
+  default: () => "Related evidence",
+}));
+
+let root: Root;
+let container: HTMLDivElement;
+const render = async (): Promise<void> => {
+  await act(async () => {
+    root.render(React.createElement(CustomStylePanel));
+    await Promise.resolve();
+  });
+};
+const click = async (selector: string): Promise<void> => {
+  const element = container.querySelector<HTMLElement>(selector);
+  if (!element) throw new Error(`Missing control: ${selector}`);
+  await act(async () => {
+    element.click();
+    await Promise.resolve();
+  });
+};
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  mocks.selected = {
+    id: "shape:focal",
+    type: "discourse-node",
+    props: { uid: "focal", nodeTypeId: "claim" },
+  };
+  mocks.shapes.clear();
+  mocks.shapes.set(mocks.selected.id, mocks.selected);
+  mocks.nextId = 0;
+  mocks.context.mockResolvedValue([
+    {
+      label: "Supported By",
+      results: {
+        evidence: { text: "Related evidence", id: "supports", complement: 1 },
+      },
+    },
+  ]);
+  mocks.autoRelations.mockReturnValue(false);
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+});
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.unstubAllGlobals();
+});
+
+describe("node card panel", () => {
+  it("opens Context and switches to the existing Styling controls", async () => {
+    await render();
+    expect(container.textContent).toContain("Supported By");
+    expect(container.textContent).toContain("[[Related evidence]]");
+    await click('[data-tab-id="styling"]');
+    expect(container.textContent).toContain("Native styling controls");
+    await click('[data-tab-id="context"]');
+    expect(container.textContent).toContain("Supported By");
+  });
+  it.each(["page-node", "blck-node"])(
+    "keeps default styling for %s",
+    async (nodeTypeId) => {
+      mocks.selected.props.nodeTypeId = nodeTypeId;
+      await render();
+      expect(container.textContent).toBe("Default styling");
+      expect(mocks.context).not.toHaveBeenCalled();
+    },
+  );
+  it("adds and removes the related node while preserving its context row", async () => {
+    await render();
+    await click('button[title="Add node to canvas"]');
+    expect(
+      [...mocks.shapes.values()].some((s) => s.props.uid === "evidence"),
+    ).toBe(true);
+    await click('button[title="Remove node from canvas"]');
+    expect(
+      [...mocks.shapes.values()].some((s) => s.props.uid === "evidence"),
+    ).toBe(false);
+    expect(container.textContent).toContain("Related evidence");
+    expect(mocks.createExistingRelations).not.toHaveBeenCalled();
+  });
+  it("uses automatic relation creation only when enabled", async () => {
+    mocks.autoRelations.mockReturnValue(true);
+    await render();
+    await click('button[title="Add node to canvas"]');
+    expect(mocks.createExistingRelations).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/roam/src/utils/discourseContextMutationRefresh.ts
+++ b/apps/roam/src/utils/discourseContextMutationRefresh.ts
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import { invalidateDiscourseContextCache } from "./getDiscourseContextResults";
 
 export const DISCOURSE_CONTEXT_MUTATION_REFRESH_EVENT =
   "roamjs:discourse-context:mutation-refresh";
@@ -14,6 +15,7 @@ export const refreshDiscourseContextsForMutatedUids = ({
     new Set(uids.map((uid) => uid?.trim()).filter(Boolean)),
   );
   if (!uniqueUids.length) return;
+  invalidateDiscourseContextCache({ uids: uniqueUids });
   document.body.dispatchEvent(
     new CustomEvent<DiscourseContextMutationRefreshDetail>(
       DISCOURSE_CONTEXT_MUTATION_REFRESH_EVENT,

--- a/apps/roam/src/utils/getDiscourseContextResults.ts
+++ b/apps/roam/src/utils/getDiscourseContextResults.ts
@@ -350,4 +350,23 @@ const getDiscourseContextResults = async ({
   return asResultList;
 };
 
+/*
+ * Cache keys are `${targetUid}~${relationText}~${targetType}`, so a node's
+ * entries have to be found by prefix. Mutating a relation has to drop them
+ * unconditionally rather than relying on a mounted listener to refetch with
+ * ignoreCache, because the next reader is usually a component that was not
+ * mounted when the mutation happened.
+ */
+export const invalidateDiscourseContextCache = ({
+  uids,
+}: {
+  uids: string[];
+}): void => {
+  uids.forEach((uid) => {
+    Object.keys(resultCache)
+      .filter((key) => key.startsWith(`${uid}~`))
+      .forEach((key) => delete resultCache[key]);
+  });
+};
+
 export default getDiscourseContextResults;


### PR DESCRIPTION
Overrides tldraw's StylePanel for Roam: selecting a single node card shows a Context tab (default) listing all discourse relations grouped by relation type, with +/− buttons that add or remove the related node on the canvas, and a Styling tab that reuses the stock styling controls. Regular tldraw shapes and multi-selection keep the default style panel. Adding a node also draws its existing relation arrows via createExistingRelations; removing deletes the node shape and its arrows — relation data in Roam is never modified.

---

![Open in Devin Review](https://camo.githubusercontent.com/a4be08b8baaff58c5f163b8bbf073f8cdff8e3a6c7e2f554b621f61ab1557d7e/68747470733a2f2f7374617469632e646576696e2e61692f6173736574732f67682d6f70656e2d696e2d646576696e2d7265766965772d6c696768742e7376673f763d31)