### PR TITLE
Website: Update hero above-the-fold section

### DIFF
--- a/apps/website/app/(home)/page.tsx
+++ b/apps/website/app/(home)/page.tsx
@@ -285,13 +285,13 @@ const Home = async (): Promise<ReactElement> => {
           sizes="100vw"
         />
         <div className="absolute inset-0 bg-neutral-dark/70" />
-        <div className="relative z-10 mx-auto grid w-full max-w-7xl gap-12 lg:grid-cols-[1.05fr_0.95fr] lg:items-end">
+        <div className="relative z-10 mx-auto w-full max-w-7xl">
           <div className="max-w-3xl">
             <p className="inline-flex rounded-md border border-white/20 bg-white/10 px-3 py-1 text-sm font-semibold text-white/85">
               Open infrastructure for collaborative knowledge synthesis
             </p>
             <h1 className="mt-6 text-5xl font-semibold tracking-tight text-white sm:text-6xl lg:text-7xl">
-              Discourse Graphs
+              Create knowledge. Make connections.
             </h1>
             <p className="text-white/82 mt-6 max-w-2xl text-xl leading-8">
               A tool and ecosystem for turning research claims, evidence, and
@@ -323,24 +323,6 @@ const Home = async (): Promise<ReactElement> => {
                 <MessageCircle className="h-4 w-4" aria-hidden="true" />
               </Link>
             </div>
-          </div>
-
-          <div className="grid gap-3 sm:grid-cols-3 lg:grid-cols-1 xl:grid-cols-3">
-            {[
-              ["Protocol", "Client-agnostic model for structured research"],
-              ["Plugins", "Roam Research and Obsidian workflows"],
-              ["Community", "Researchers building shared graph practices"],
-            ].map(([title, description]) => (
-              <div
-                key={title}
-                className="rounded-lg border border-white/15 bg-white/10 p-4 backdrop-blur"
-              >
-                <p className="text-sm font-semibold text-primary">{title}</p>
-                <p className="text-white/78 mt-2 text-sm leading-6">
-                  {description}
-                </p>
-              </div>
-            ))}
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- Update hero headline from "Discourse Graphs" to "Create knowledge. Make connections."
- Remove the Protocol/Plugins/Community cards from the hero section
- Clean up now-unused grid/gap classes on the hero wrapper

## Test plan
- [x] Verified locally in browser: headline updated, cards removed, layout unaffected
- [ ] Video walkthrough (Loom) — to be added by reviewer/author per team process

<img width="1600" height="900" alt="image" src="https://github.com/user-attachments/assets/808e9767-1314-4762-b488-fcc437891f4e" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/1273" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the homepage hero layout to a single-column design.
  * Revised the hero headline to “Create knowledge. Make connections.”
  * Removed the supporting Protocol, Plugins, and Community cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->