### PR TITLE
ENG-2103 Fix styling bug created by Obsidian update

### DIFF
--- a/apps/obsidian/src/components/ImportedSchemaMeta.tsx
+++ b/apps/obsidian/src/components/ImportedSchemaMeta.tsx
@@ -1,0 +1,39 @@
+import { usePlugin } from "./PluginContext";
+import { formatImportSource, getUserNameById } from "~/utils/typeUtils";
+
+type ImportedSchemaMetaProps = {
+  isProvisional: boolean;
+  spaceUri?: string;
+  authorId?: number;
+};
+
+/**
+ * Attribution line shown under an imported relation or relation type: a
+ * provisional badge plus who it came from. Colors come from Obsidian theme
+ * variables so the badge follows the active theme in both light and dark mode.
+ */
+const ImportedSchemaMeta = ({
+  isProvisional,
+  spaceUri,
+  authorId,
+}: ImportedSchemaMetaProps) => {
+  const plugin = usePlugin();
+
+  return (
+    <div className="text-muted flex flex-wrap items-center gap-2 text-xs">
+      {isProvisional && (
+        <span className="text-warning shrink-0 rounded bg-[rgba(var(--color-orange-rgb),0.15)] px-1.5 py-0.5 text-xs font-medium">
+          Provisional
+        </span>
+      )}
+      {spaceUri && (
+        <span>
+          {authorId && `by ${getUserNameById(plugin, authorId)} `}
+          from {formatImportSource(spaceUri, plugin.settings.spaceNames)}
+        </span>
+      )}
+    </div>
+  );
+};
+
+export default ImportedSchemaMeta;

--- a/apps/obsidian/src/components/RelationshipSettings.tsx
+++ b/apps/obsidian/src/components/RelationshipSettings.tsx
@@ -9,9 +9,9 @@ import {
   formatImportSource,
   isAcceptedSchema,
   isProvisionalSchema,
-  getUserNameById,
 } from "~/utils/typeUtils";
 import generateUid from "~/utils/generateUid";
+import ImportedSchemaMeta from "./ImportedSchemaMeta";
 
 const RelationshipSettings = () => {
   const plugin = usePlugin();
@@ -190,17 +190,30 @@ const RelationshipSettings = () => {
       : "imported space";
     const error = errors[index];
 
+    // Imported rows render disabled selects, which cannot be opened to reveal a
+    // truncated label, so expose the full value on hover instead.
+    const relationType = findRelationTypeById(relation.relationshipTypeId);
+    const relationTypeLabel = relationType
+      ? `${relationType.label} / ${relationType.complement}`
+      : undefined;
+    const sourceName = getNodeTypeById(plugin, relation.sourceId)?.name;
+    const destinationName = getNodeTypeById(
+      plugin,
+      relation.destinationId,
+    )?.name;
+
     return (
       <div key={index} className="setting-item">
-        <div className="flex w-full flex-col gap-1">
-          <div className="flex gap-2">
+        <div className="flex min-w-0 flex-1 flex-col gap-1">
+          <div className="flex flex-wrap items-center gap-2">
             <select
               value={relation.sourceId}
               onChange={(e) =>
                 handleRelationChange(index, "sourceId", e.target.value)
               }
-              className={`flex-1 pl-2 ${error ? "input-error" : ""}`}
+              className={`min-w-24 flex-1 pl-2 ${error ? "input-error" : ""}`}
               disabled={isImported}
+              title={sourceName}
             >
               <option value="">Source Node Type</option>
               {plugin.settings.nodeTypes.map((nodeType) => (
@@ -219,8 +232,9 @@ const RelationshipSettings = () => {
                   e.target.value,
                 )
               }
-              className={`flex-1 pl-2 ${error ? "input-error" : ""}`}
+              className={`min-w-56 flex-[3] pl-2 ${error ? "input-error" : ""}`}
               disabled={isImported}
+              title={relationTypeLabel}
             >
               <option value="">Relation Type</option>
               {(isImported
@@ -238,8 +252,9 @@ const RelationshipSettings = () => {
               onChange={(e) =>
                 handleRelationChange(index, "destinationId", e.target.value)
               }
-              className={`flex-1 pl-2 ${error ? "input-error" : ""}`}
+              className={`min-w-24 flex-1 pl-2 ${error ? "input-error" : ""}`}
               disabled={isImported}
+              title={destinationName}
             >
               <option value="">Target Node Type</option>
               {plugin.settings.nodeTypes.map((nodeType) => (
@@ -249,53 +264,31 @@ const RelationshipSettings = () => {
               ))}
             </select>
 
-            {isImported ? (
-              <div className="flex gap-2">
-                {isProvisional && (
-                  <button
-                    onClick={() => void handleAcceptRelation(index)}
-                    className="p-2"
-                    title={`Accept this relation triplet from ${spaceName} to create instances of this relation`}
-                  >
-                    Accept
-                  </button>
-                )}
+            <div className="flex shrink-0 gap-2">
+              {isImported && isProvisional && (
                 <button
-                  onClick={() => confirmDeleteRelation(index)}
-                  className="mod-warning p-2"
+                  onClick={() => void handleAcceptRelation(index)}
+                  className="p-2"
+                  title={`Accept this relation triplet from ${spaceName} to create instances of this relation`}
                 >
-                  Delete
+                  Accept
                 </button>
-              </div>
-            ) : (
+              )}
               <button
                 onClick={() => confirmDeleteRelation(index)}
                 className="mod-warning p-2"
               >
                 Delete
               </button>
-            )}
+            </div>
           </div>
           {error && <div className="text-error text-xs">{error}</div>}
           {isImported && (
-            <div className="text-muted flex items-center gap-2 text-xs">
-              {isProvisional && (
-                <span className="rounded bg-yellow-100 px-1.5 py-0.5 text-xs font-medium text-yellow-800">
-                  Provisional
-                </span>
-              )}
-              {importInfo.spaceUri && (
-                <span>
-                  {relation.authorId &&
-                    `by ${getUserNameById(plugin, relation.authorId)} `}
-                  from{" "}
-                  {formatImportSource(
-                    importInfo.spaceUri,
-                    plugin.settings.spaceNames,
-                  )}
-                </span>
-              )}
-            </div>
+            <ImportedSchemaMeta
+              isProvisional={isProvisional}
+              spaceUri={importInfo.spaceUri}
+              authorId={relation.authorId}
+            />
           )}
         </div>
       </div>
@@ -327,21 +320,17 @@ const RelationshipSettings = () => {
               <h4 className="text-muted mb-2 text-sm font-semibold uppercase tracking-wide">
                 Imported
               </h4>
-              <div className="border-modifier-border rounded border bg-secondary p-2">
-                {importedRelations.map((relation) => {
-                  const index = discourseRelations.indexOf(relation);
-                  return renderRelationItem(relation, index);
-                })}
-              </div>
+              {importedRelations.map((relation) => {
+                const index = discourseRelations.indexOf(relation);
+                return renderRelationItem(relation, index);
+              })}
             </div>
           )}
 
-          <div className="setting-item mt-4">
-            <div className="flex gap-2">
-              <button onClick={handleAddRelation} className="p-2">
-                Add relation
-              </button>
-            </div>
+          <div className="mt-4 flex gap-2">
+            <button onClick={handleAddRelation} className="p-2">
+              Add relation
+            </button>
           </div>
         </>
       )}

--- a/apps/obsidian/src/components/RelationshipTypeSettings.tsx
+++ b/apps/obsidian/src/components/RelationshipTypeSettings.tsx
@@ -16,8 +16,8 @@ import {
   getImportInfo,
   formatImportSource,
   isProvisionalSchema,
-  getUserNameById,
 } from "~/utils/typeUtils";
+import ImportedSchemaMeta from "./ImportedSchemaMeta";
 
 type ColorPickerProps = {
   value: string;
@@ -279,8 +279,8 @@ const RelationshipTypeSettings = () => {
 
     return (
       <div key={index} className="setting-item">
-        <div className="flex w-full flex-col gap-1">
-          <div className="flex gap-2">
+        <div className="flex min-w-0 flex-1 flex-col gap-1">
+          <div className="flex flex-wrap items-center gap-2">
             <input
               type="text"
               placeholder="Label (e.g., supports)"
@@ -289,7 +289,7 @@ const RelationshipTypeSettings = () => {
                 handleRelationTypeChange(index, "label", e.target.value)
               }
               onBlur={() => saveSettings(relationTypesRef.current)}
-              className={`flex-2 ${error ? "input-error" : ""}`}
+              className={`min-w-32 flex-1 ${error ? "input-error" : ""}`}
               disabled={isImported}
             />
             <input
@@ -300,7 +300,7 @@ const RelationshipTypeSettings = () => {
                 handleRelationTypeChange(index, "complement", e.target.value)
               }
               onBlur={() => saveSettings(relationTypesRef.current)}
-              className={`flex-1 ${error ? "input-error" : ""}`}
+              className={`min-w-48 flex-[2] ${error ? "input-error" : ""}`}
               disabled={isImported}
             />
             <ColorPicker
@@ -310,53 +310,31 @@ const RelationshipTypeSettings = () => {
               }
               disabled={isImported}
             />
-            {isImported ? (
-              <div className="flex gap-2">
-                {isProvisional && (
-                  <button
-                    onClick={() => void handleAcceptRelationType(index)}
-                    className="p-2"
-                    title={`Accept this relation type from ${spaceName} to create relations of this type`}
-                  >
-                    Accept
-                  </button>
-                )}
+            <div className="flex shrink-0 gap-2">
+              {isImported && isProvisional && (
                 <button
-                  onClick={() => confirmDeleteRelationType(index)}
-                  className="mod-warning p-2"
+                  onClick={() => void handleAcceptRelationType(index)}
+                  className="p-2"
+                  title={`Accept this relation type from ${spaceName} to create relations of this type`}
                 >
-                  Delete
+                  Accept
                 </button>
-              </div>
-            ) : (
+              )}
               <button
                 onClick={() => confirmDeleteRelationType(index)}
                 className="mod-warning p-2"
               >
                 Delete
               </button>
-            )}
+            </div>
           </div>
           {error && <div className="text-error text-xs">{error}</div>}
           {isImported && (
-            <div className="text-muted flex items-center gap-2 text-xs">
-              {isProvisional && (
-                <span className="rounded bg-yellow-100 px-1.5 py-0.5 text-xs font-medium text-yellow-800">
-                  Provisional
-                </span>
-              )}
-              {importInfo.spaceUri && (
-                <span>
-                  {relationType.authorId &&
-                    `by ${getUserNameById(plugin, relationType.authorId)} `}
-                  from{" "}
-                  {formatImportSource(
-                    importInfo.spaceUri,
-                    plugin.settings.spaceNames,
-                  )}
-                </span>
-              )}
-            </div>
+            <ImportedSchemaMeta
+              isProvisional={isProvisional}
+              spaceUri={importInfo.spaceUri}
+              authorId={relationType.authorId}
+            />
           )}
         </div>
       </div>
@@ -382,21 +360,17 @@ const RelationshipTypeSettings = () => {
           <h4 className="text-muted mb-2 text-sm font-semibold uppercase tracking-wide">
             Imported
           </h4>
-          <div className="border-modifier-border rounded border bg-secondary p-2">
-            {importedRelationTypes.map((relationType) => {
-              const index = relationTypes.indexOf(relationType);
-              return renderRelationTypeItem(relationType, index);
-            })}
-          </div>
+          {importedRelationTypes.map((relationType) => {
+            const index = relationTypes.indexOf(relationType);
+            return renderRelationTypeItem(relationType, index);
+          })}
         </div>
       )}
 
-      <div className="setting-item mt-4">
-        <div className="flex gap-2">
-          <button onClick={handleAddRelationType} className="p-2">
-            Add relation type
-          </button>
-        </div>
+      <div className="mt-4 flex gap-2">
+        <button onClick={handleAddRelationType} className="p-2">
+          Add relation type
+        </button>
       </div>
     </div>
   );

--- a/apps/obsidian/tailwind.config.ts
+++ b/apps/obsidian/tailwind.config.ts
@@ -16,6 +16,7 @@ const config: Pick<Config, "content" | "theme" | "plugins"> = {
         muted: "var(--text-muted)",
         "accent-text": "var(--text-accent)",
         error: "var(--text-error)",
+        warning: "var(--text-warning)",
         "on-accent": "var(--text-on-accent)",
 
         // Interactive elements


### PR DESCRIPTION
https://www.loom.com/share/1ef5a24e03b64131a7ef9a6eb01b3818


## Problem

Obsidian auto-updated to **1.13.4**, and the Discourse relations settings rows started painting their Accept / Delete buttons *outside* the grey row background.


## Root cause

Diffing `app.css` between 1.8.4 and 1.13.4 (extracted from the respective asars) shows two compounding changes:

| | 1.8.4 | 1.13.4 |
| --- | --- | --- |
| `.setting-item` padding | `0.75em 0` (no horizontal) | `var(--size-4-4)` on all sides |
| `.setting-item` background | none | `var(--setting-items-background)` + radius + border |
| settings pane padding | flat `var(--size-4-12)` | `max(var(--size-4-8), (100% - 700px) / 2)` |

So `.setting-item` became a **card**, and plugin settings content got **clamped to ~700px** (previously unclamped).

Both relation rows pass a custom child to `.setting-item` rather than Obsidian's `setting-item-info` / `setting-item-control`, and that child had no `min-width: 0`. Flex items default to `min-width: auto`, and a `<select>`'s min-content is the width of its **widest option** — so the selects refused to shrink, the child rendered wider than the card's content box, and the buttons spilled past the painted background. Obsidian's own `.setting-item-info` carries `min-width: 0` for precisely this reason.

The overflow **predates 1.13**; it was simply invisible until `.setting-item` gained a background to fall outside of.

## Changes

**Make the rows shrinkable** — `flex-1 min-w-0` on the row wrapper (replacing `w-full`), `shrink-0` on the button group, `flex-wrap` on the row.

**Weight the columns by expected content length.** Equal `flex-1` columns gave `Claim` / `New 2` more room than they need while starving the relation type, which holds by far the longest text:


**Hover titles on all three selects.** Imported rows render *disabled* selects, which cannot be opened to reveal a truncated value, so the tooltip is the only recovery for a long node type name.

**`flex-2` was dead code** — not a Tailwind class and absent from the config, so the label input silently got `flex: 0 1 auto` and could not shrink at all.

**Relation type editor:** `complement` now gets the wider column, since its text (`is supported by`) is longer than `label` (`supports`).

**Removed the nested grey wrapper** around the imported lists, which now reads as grey-on-grey against the card background, and stopped wrapping the add buttons in `.setting-item`, which rendered a full-width card around a lone button.

**Theme-aware provisional badge.** Extracted the duplicated badge + attribution line into `ImportedSchemaMeta`, replacing hardcoded `bg-yellow-100` / `text-yellow-800` with `--text-warning` and `--color-orange-rgb` so it follows the active theme.

## Notes

- The native 1.13 `.setting-group` / `.setting-items` grouping is **deliberately avoided** — `minAppVersion` is `1.7.0`, and those classes do not exist in ≤1.12. On older versions the Imported section is now delimited by its heading and top border rather than a grey box.
- Remaining trade-off: a very long node type name (e.g. `Experimental Observation`) still clips at the 96px floor, mitigated by the hover title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/1277" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
  </picture>
</a>
<!-- devin-review-badge-end -->

