### PR TITLE
[ENG-1860] Add Roam manual refresh for imported nodes

### DIFF
--- a/apps/roam/src/components/RefreshImportedNodeTitleButton.tsx
+++ b/apps/roam/src/components/RefreshImportedNodeTitleButton.tsx
@@ -1,0 +1,62 @@
+import { Button } from "@blueprintjs/core";
+import posthog from "posthog-js";
+import React, { useState } from "react";
+import renderToast from "roamjs-components/components/Toast";
+import { handleTitleAdditions } from "~/utils/handleTitleAdditions";
+import { refreshImportedNode } from "~/utils/refreshImportedNode";
+
+const REFRESH_TITLE_BUTTON_ATTRIBUTE =
+  "data-roamjs-refresh-imported-node-title-button";
+
+const RefreshImportedNodeTitleButton = ({
+  uid,
+}: {
+  uid: string;
+}): JSX.Element => {
+  const [refreshing, setRefreshing] = useState(false);
+
+  const refresh = async (): Promise<void> => {
+    setRefreshing(true);
+    try {
+      const result = await refreshImportedNode({ pageUid: uid });
+      renderToast({
+        id: result.success
+          ? "refresh-imported-node-success"
+          : "refresh-imported-node-failed",
+        intent: result.success ? "success" : "danger",
+        content: result.message,
+      });
+    } finally {
+      setRefreshing(false);
+    }
+  };
+
+  return (
+    <Button
+      text="Refresh"
+      icon="refresh"
+      minimal
+      outlined
+      loading={refreshing}
+      onClick={() => {
+        posthog.capture("Refresh Imported Node: Page Title Button Triggered", {
+          pageUid: uid,
+        });
+        void refresh();
+      }}
+    />
+  );
+};
+
+export const renderRefreshImportedNodeTitleButton = ({
+  h1,
+  uid,
+}: {
+  h1: HTMLHeadingElement;
+  uid: string;
+}): void => {
+  if (h1.getAttribute(REFRESH_TITLE_BUTTON_ATTRIBUTE) === uid) return;
+
+  h1.setAttribute(REFRESH_TITLE_BUTTON_ATTRIBUTE, uid);
+  handleTitleAdditions(h1, <RefreshImportedNodeTitleButton uid={uid} />);
+};

--- a/apps/roam/src/utils/__tests__/materializeSharedNode.test.ts
+++ b/apps/roam/src/utils/__tests__/materializeSharedNode.test.ts
@@ -269,6 +269,32 @@ describe("materializeSharedNode", () => {
     expect(mockedWriteImportedSourceIdentity).not.toHaveBeenCalled();
   });
 
+  it("force-updates an imported page whose source has not changed", async () => {
+    const { client } = clientWithFullContent({ text: FULL_MARKDOWN });
+    mockedFindImportedNodeUidBySourceRid.mockResolvedValue(EXISTING_PAGE_UID);
+    mockedGetPageTitleByPageUid.mockReturnValue(sharedNode.title);
+    mockedReadImportedSourceIdentity.mockReturnValue({
+      sourceModifiedAt: sharedNode.lastModified,
+      sourceNodeRid: sharedNode.rid,
+    });
+
+    await expect(
+      materializeSharedNode({ client, sharedNode, force: true }),
+    ).resolves.toEqual({
+      success: true,
+      action: "updated",
+      pageUid: EXISTING_PAGE_UID,
+      sourceModifiedAt: sharedNode.lastModified,
+      sourceNodeRid: sharedNode.rid,
+    });
+    expect(blockFromMarkdown).toHaveBeenCalled();
+    expect(mockedWriteImportedSourceIdentity).toHaveBeenCalledWith({
+      pageUid: EXISTING_PAGE_UID,
+      sourceModifiedAt: sharedNode.lastModified,
+      sourceNodeRid: sharedNode.rid,
+    });
+  });
+
   it("updates an imported page whose source changed since the import", async () => {
     const { client } = clientWithFullContent({ text: FULL_MARKDOWN });
     mockedFindImportedNodeUidBySourceRid.mockResolvedValue(EXISTING_PAGE_UID);

--- a/apps/roam/src/utils/__tests__/refreshImportedNode.test.ts
+++ b/apps/roam/src/utils/__tests__/refreshImportedNode.test.ts
@@ -1,0 +1,187 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import getPageTitleByPageUid from "roamjs-components/queries/getPageTitleByPageUid";
+import type { DGSupabaseClient } from "@repo/database/lib/client";
+import {
+  getSharedNodeByRid,
+  type SharedNode,
+} from "@repo/database/lib/sharedNodes";
+import { readImportedSourceIdentity } from "~/utils/importedSourceIdentity";
+import internalError from "~/utils/internalError";
+import { materializeSharedNode } from "~/utils/materializeSharedNode";
+import { refreshImportedNode } from "~/utils/refreshImportedNode";
+import { getLoggedInClient } from "~/utils/supabaseContext";
+
+vi.mock("roamjs-components/queries/getPageTitleByPageUid", () => ({
+  default: vi.fn(),
+}));
+vi.mock("@repo/database/lib/sharedNodes", () => ({
+  getSharedNodeByRid: vi.fn(),
+}));
+vi.mock("~/utils/importedSourceIdentity", () => ({
+  findImportedNodeUidBySourceRid: vi.fn(),
+  readImportedSourceIdentity: vi.fn(),
+  writeImportedSourceIdentity: vi.fn(),
+}));
+vi.mock("~/utils/internalError", () => ({ default: vi.fn() }));
+vi.mock("~/utils/materializeSharedNode", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("~/utils/materializeSharedNode")>()),
+  materializeSharedNode: vi.fn(),
+}));
+vi.mock("~/utils/supabaseContext", () => ({
+  getLoggedInClient: vi.fn(),
+}));
+
+const mockedGetPageTitleByPageUid = vi.mocked(getPageTitleByPageUid);
+const mockedGetSharedNodeByRid = vi.mocked(getSharedNodeByRid);
+const mockedReadImportedSourceIdentity = vi.mocked(readImportedSourceIdentity);
+const mockedInternalError = vi.mocked(internalError);
+const mockedMaterializeSharedNode = vi.mocked(materializeSharedNode);
+const mockedGetLoggedInClient = vi.mocked(getLoggedInClient);
+
+const PAGE_UID = "imported-page-uid";
+const LOCAL_TITLE = "EVD - old local title";
+const OTHER_PAGE_TITLE = "EVD - duplicate page";
+
+const client = {} as DGSupabaseClient;
+
+const sharedNode: SharedNode = {
+  rid: "orn:obsidian.note:vault-a/node-1",
+  sourceLocalId: "node-1",
+  spaceId: 20,
+  spaceName: "Research vault",
+  spaceUri: "obsidian:vault-a",
+  platform: "Obsidian",
+  title: "EVD - REM sleep and recall",
+  created: "2026-06-14T12:30:00.000Z",
+  lastModified: "2026-06-14T15:00:00.000Z",
+  authorId: 7,
+  directMetadata: null,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedGetPageTitleByPageUid.mockImplementation((uid) =>
+    uid === PAGE_UID ? LOCAL_TITLE : OTHER_PAGE_TITLE,
+  );
+  mockedReadImportedSourceIdentity.mockReturnValue({
+    sourceModifiedAt: "2026-06-14T12:00:00.000Z",
+    sourceNodeRid: sharedNode.rid,
+  });
+  mockedGetLoggedInClient.mockResolvedValue(client);
+  mockedGetSharedNodeByRid.mockResolvedValue(sharedNode);
+  mockedMaterializeSharedNode.mockResolvedValue({
+    success: true,
+    action: "updated",
+    pageUid: PAGE_UID,
+    sourceModifiedAt: sharedNode.lastModified,
+    sourceNodeRid: sharedNode.rid,
+  });
+});
+
+describe("refreshImportedNode", () => {
+  it("refreshes the page from its stored source identity", async () => {
+    await expect(refreshImportedNode({ pageUid: PAGE_UID })).resolves.toEqual({
+      success: true,
+      message: 'Refreshed "EVD - REM sleep and recall" from Research vault.',
+    });
+    expect(mockedGetSharedNodeByRid).toHaveBeenCalledWith({
+      client,
+      rid: sharedNode.rid,
+    });
+    expect(mockedMaterializeSharedNode).toHaveBeenCalledWith({
+      client,
+      sharedNode,
+      force: true,
+    });
+    expect(mockedInternalError).not.toHaveBeenCalled();
+  });
+
+  it("fails when the page has no stored source identity", async () => {
+    mockedReadImportedSourceIdentity.mockReturnValue(undefined);
+
+    await expect(refreshImportedNode({ pageUid: PAGE_UID })).resolves.toEqual({
+      success: false,
+      message: `"${LOCAL_TITLE}" has no stored source identity, so it cannot be refreshed.`,
+    });
+    expect(mockedGetLoggedInClient).not.toHaveBeenCalled();
+    expect(mockedMaterializeSharedNode).not.toHaveBeenCalled();
+    expect(mockedInternalError).not.toHaveBeenCalled();
+  });
+
+  it("fails when the database client is unavailable", async () => {
+    mockedGetLoggedInClient.mockResolvedValue(null);
+
+    await expect(refreshImportedNode({ pageUid: PAGE_UID })).resolves.toEqual({
+      success: false,
+      message: "Could not connect to shared persistence.",
+    });
+    expect(mockedGetSharedNodeByRid).not.toHaveBeenCalled();
+    expect(mockedInternalError).not.toHaveBeenCalled();
+  });
+
+  it("fails when the source node is no longer shared", async () => {
+    mockedGetSharedNodeByRid.mockResolvedValue(null);
+
+    await expect(refreshImportedNode({ pageUid: PAGE_UID })).resolves.toEqual({
+      success: false,
+      message: `The source of "${LOCAL_TITLE}" is no longer shared with your groups, so it cannot be refreshed.`,
+    });
+    expect(mockedMaterializeSharedNode).not.toHaveBeenCalled();
+    expect(mockedInternalError).not.toHaveBeenCalled();
+  });
+
+  it("reports the materialization failure message", async () => {
+    mockedMaterializeSharedNode.mockResolvedValue({
+      success: false,
+      sourceModifiedAt: sharedNode.lastModified,
+      sourceNodeRid: sharedNode.rid,
+      error: {
+        message: 'Failed to replace the content of "EVD - old local title"',
+        stage: "replace-page-content",
+      },
+    });
+
+    await expect(refreshImportedNode({ pageUid: PAGE_UID })).resolves.toEqual({
+      success: false,
+      message: 'Failed to replace the content of "EVD - old local title"',
+    });
+    expect(mockedInternalError).toHaveBeenCalledTimes(1);
+    expect(mockedInternalError.mock.calls[0]?.[0]).toMatchObject({
+      type: "Imported node refresh failed",
+      context: {
+        operation: "refresh-imported-node",
+        pageUid: PAGE_UID,
+        stage: "replace-page-content",
+      },
+    });
+  });
+
+  it("fails when a different page linked to the source was refreshed", async () => {
+    mockedMaterializeSharedNode.mockResolvedValue({
+      success: true,
+      action: "updated",
+      pageUid: "other-page-uid",
+      sourceModifiedAt: sharedNode.lastModified,
+      sourceNodeRid: sharedNode.rid,
+    });
+
+    await expect(refreshImportedNode({ pageUid: PAGE_UID })).resolves.toEqual({
+      success: false,
+      message: `A different page ("${OTHER_PAGE_TITLE}") is linked to the same source and was refreshed instead.`,
+    });
+  });
+
+  it("reports an unexpected error", async () => {
+    const thrown = new Error("network down");
+    mockedGetSharedNodeByRid.mockRejectedValue(thrown);
+
+    await expect(refreshImportedNode({ pageUid: PAGE_UID })).resolves.toEqual({
+      success: false,
+      message: "Could not refresh this page: network down",
+    });
+    expect(mockedInternalError).toHaveBeenCalledTimes(1);
+    const reported = mockedInternalError.mock.calls[0]?.[0];
+    expect(reported?.error).toBe(thrown);
+    expect(reported?.type).toBe("Imported node refresh failed");
+  });
+});

--- a/apps/roam/src/utils/initializeObserversAndListeners.ts
+++ b/apps/roam/src/utils/initializeObserversAndListeners.ts
@@ -122,15 +122,13 @@ export const initObservers = ({
         snapshot: settings,
       });
 
-      const syncEnabled =
-        settings.featureFlags[FEATURE_FLAG_KEYS.suggestiveModeOverlayEnabled];
-      if (syncEnabled && uid && readImportedSourceIdentity(uid)) {
+      const sharingEnabled =
+        settings.featureFlags[FEATURE_FLAG_KEYS.enableNodeSharing];
+      if (sharingEnabled && uid && readImportedSourceIdentity(uid)) {
         renderRefreshImportedNodeTitleButton({ h1, uid });
       }
       const isDiscourseNode = node && node.backedBy !== "default";
       if (isDiscourseNode) {
-        const sharingEnabled =
-          settings.featureFlags[FEATURE_FLAG_KEYS.enableNodeSharing];
         if (sharingEnabled && node.backedBy === "user") {
           renderPublishNodeTitleButton({
             h1,

--- a/apps/roam/src/utils/initializeObserversAndListeners.ts
+++ b/apps/roam/src/utils/initializeObserversAndListeners.ts
@@ -47,6 +47,8 @@ import { mountLeftSidebar } from "~/components/LeftSidebarView";
 import { getCleanTagText } from "~/components/settings/NodeConfig";
 import { getNodeTagStyles } from "~/utils/getDiscourseNodeColors";
 import { renderPublishNodeTitleButton } from "~/components/PublishNodeTitleButton";
+import { renderRefreshImportedNodeTitleButton } from "~/components/RefreshImportedNodeTitleButton";
+import { readImportedSourceIdentity } from "~/utils/importedSourceIdentity";
 import { renderCanvasEmbed } from "~/components/canvas/CanvasEmbed";
 import getPageUidByPageTitle from "roamjs-components/queries/getPageUidByPageTitle";
 import getPageTitleByPageUid from "roamjs-components/queries/getPageTitleByPageUid";
@@ -120,6 +122,11 @@ export const initObservers = ({
         snapshot: settings,
       });
 
+      const syncEnabled =
+        settings.featureFlags[FEATURE_FLAG_KEYS.suggestiveModeOverlayEnabled];
+      if (syncEnabled && uid && readImportedSourceIdentity(uid)) {
+        renderRefreshImportedNodeTitleButton({ h1, uid });
+      }
       const isDiscourseNode = node && node.backedBy !== "default";
       if (isDiscourseNode) {
         const sharingEnabled =

--- a/apps/roam/src/utils/materializeSharedNode.ts
+++ b/apps/roam/src/utils/materializeSharedNode.ts
@@ -292,9 +292,11 @@ const updateImportedPage = async ({
 export const materializeSharedNode = async ({
   client,
   sharedNode,
+  force = false,
 }: {
   client: DGSupabaseClient;
   sharedNode: SharedNode;
+  force?: boolean;
 }): Promise<MaterializeSharedNodeResult> => {
   const rawIdentity: SourceIdentity = {
     sourceModifiedAt: sharedNode.lastModified,
@@ -331,6 +333,7 @@ export const materializeSharedNode = async ({
   }
 
   if (
+    !force &&
     importedPageUid &&
     storedIdentity &&
     isImportUpToDate({

--- a/apps/roam/src/utils/refreshImportedNode.ts
+++ b/apps/roam/src/utils/refreshImportedNode.ts
@@ -1,0 +1,89 @@
+import { getSharedNodeByRid } from "@repo/database/lib/sharedNodes";
+import getPageTitleByPageUid from "roamjs-components/queries/getPageTitleByPageUid";
+import { readImportedSourceIdentity } from "./importedSourceIdentity";
+import internalError from "./internalError";
+import {
+  getErrorMessage,
+  materializeSharedNode,
+} from "./materializeSharedNode";
+import { getLoggedInClient } from "./supabaseContext";
+
+const REFRESH_ERROR_TYPE = "Imported node refresh failed";
+const REFRESH_ERROR_OPERATION = "refresh-imported-node";
+
+type RefreshImportedNodeResult = {
+  success: boolean;
+  message: string;
+};
+
+export const refreshImportedNode = async ({
+  pageUid,
+}: {
+  pageUid: string;
+}): Promise<RefreshImportedNodeResult> => {
+  try {
+    const title = getPageTitleByPageUid(pageUid);
+    const identity = readImportedSourceIdentity(pageUid);
+    if (!identity)
+      return {
+        success: false,
+        message: `"${title}" has no stored source identity, so it cannot be refreshed.`,
+      };
+
+    const client = await getLoggedInClient();
+    if (!client)
+      return {
+        success: false,
+        message: "Could not connect to shared persistence.",
+      };
+
+    const sharedNode = await getSharedNodeByRid({
+      client,
+      rid: identity.sourceNodeRid,
+    });
+    if (!sharedNode)
+      return {
+        success: false,
+        message: `The source of "${title}" is no longer shared with your groups, so it cannot be refreshed.`,
+      };
+
+    const result = await materializeSharedNode({
+      client,
+      sharedNode,
+      force: true,
+    });
+    if (!result.success) {
+      internalError({
+        error: new Error(result.error.message),
+        type: REFRESH_ERROR_TYPE,
+        context: {
+          operation: REFRESH_ERROR_OPERATION,
+          pageUid,
+          stage: result.error.stage,
+        },
+        sendEmail: false,
+      });
+      return { success: false, message: result.error.message };
+    }
+    if (result.pageUid !== pageUid)
+      return {
+        success: false,
+        message: `A different page ("${getPageTitleByPageUid(result.pageUid)}") is linked to the same source and was refreshed instead.`,
+      };
+    return {
+      success: true,
+      message: `Refreshed "${sharedNode.title}" from ${sharedNode.spaceName}.`,
+    };
+  } catch (error) {
+    internalError({
+      error,
+      type: REFRESH_ERROR_TYPE,
+      context: { operation: REFRESH_ERROR_OPERATION, pageUid },
+      sendEmail: false,
+    });
+    return {
+      success: false,
+      message: `Could not refresh this page: ${getErrorMessage(error)}`,
+    };
+  }
+};

--- a/packages/database/src/lib/__tests__/sharedNodes.test.ts
+++ b/packages/database/src/lib/__tests__/sharedNodes.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from "vitest";
-import { buildSharedNodes } from "../sharedNodes";
+import { describe, expect, it, vi } from "vitest";
+import type { DGSupabaseClient } from "../client";
+import { buildSharedNodes, getSharedNodeByRid } from "../sharedNodes";
 
 type BuildArgs = Parameters<typeof buildSharedNodes>[0];
 
@@ -185,5 +186,153 @@ describe("buildSharedNodes", () => {
         fullOverride: fullContentSummaries,
       }).map((node) => node.sourceLocalId),
     ).toEqual(["node-1", "node-2"]);
+  });
+});
+
+type QueryResult = { data: unknown; error: { message: string } | null };
+
+const makeQueryBuilder = (result: QueryResult) => {
+  const builder = {
+    select: vi.fn(),
+    eq: vi.fn(),
+    maybeSingle: vi.fn().mockResolvedValue(result),
+    then: (
+      resolve: (value: QueryResult) => unknown,
+      reject?: (reason: unknown) => unknown,
+    ) => Promise.resolve(result).then(resolve, reject),
+  };
+  builder.select.mockReturnValue(builder);
+  builder.eq.mockReturnValue(builder);
+  return builder;
+};
+
+const makeClient = ({
+  space,
+  concepts = nodes,
+  direct = directContents,
+  full = fullContentSummaries,
+}: {
+  space: BuildArgs["spaces"][number] | null;
+  concepts?: BuildArgs["nodes"];
+  direct?: BuildArgs["directContents"];
+  full?: BuildArgs["fullContentSummaries"];
+}) => {
+  const spacesBuilder = makeQueryBuilder({ data: space, error: null });
+  const conceptsBuilder = makeQueryBuilder({ data: concepts, error: null });
+  const makeContentsBuilder = () => {
+    let variant = "";
+    const builder = {
+      select: vi.fn(),
+      eq: vi.fn(),
+      then: (
+        resolve: (value: QueryResult) => unknown,
+        reject?: (reason: unknown) => unknown,
+      ) =>
+        Promise.resolve({
+          data: variant === "direct" ? direct : variant === "full" ? full : [],
+          error: null,
+        }).then(resolve, reject),
+    };
+    builder.select.mockReturnValue(builder);
+    builder.eq.mockImplementation((column: string, value: unknown) => {
+      if (column === "variant") variant = value as string;
+      return builder;
+    });
+    return builder;
+  };
+  const from = vi.fn((table: string) =>
+    table === "my_spaces"
+      ? spacesBuilder
+      : table === "my_concepts"
+        ? conceptsBuilder
+        : makeContentsBuilder(),
+  );
+  return {
+    client: { from } as unknown as DGSupabaseClient,
+    spacesBuilder,
+    conceptsBuilder,
+  };
+};
+
+describe("getSharedNodeByRid", () => {
+  it("fetches one shared node by its stored rid", async () => {
+    const { client, spacesBuilder, conceptsBuilder } = makeClient({
+      space: spaces[0]!,
+    });
+
+    await expect(getSharedNodeByRid({ client, rid })).resolves.toEqual({
+      rid,
+      sourceLocalId: "node-1",
+      spaceId: 20,
+      spaceName: "Research vault",
+      spaceUri: "obsidian:vault-a",
+      platform: "Obsidian",
+      title: "EVD - REM sleep and recall",
+      created: "2026-06-14T11:00:00.000Z",
+      lastModified: "2026-06-14T15:00:00.000Z",
+      authorId: 42,
+      directMetadata: { source: "obsidian" },
+    });
+    expect(spacesBuilder.eq).toHaveBeenCalledWith("url", "obsidian:vault-a");
+    expect(conceptsBuilder.eq).toHaveBeenCalledWith("space_id", 20);
+    expect(conceptsBuilder.eq).toHaveBeenCalledWith(
+      "source_local_id",
+      "node-1",
+    );
+  });
+
+  it("queries with the space url and local id parsed from a URL-form rid", async () => {
+    const { client, spacesBuilder, conceptsBuilder } = makeClient({
+      space: {
+        id: 30,
+        name: "Research graph",
+        platform: "Roam",
+        url: "https://roamresearch.com/#/app/research-graph",
+      },
+      concepts: [],
+      direct: [],
+      full: [],
+    });
+
+    await expect(
+      getSharedNodeByRid({
+        client,
+        rid: "https://roamresearch.com/#/app/research-graph/roam-uid-1",
+      }),
+    ).resolves.toBeNull();
+    expect(spacesBuilder.eq).toHaveBeenCalledWith(
+      "url",
+      "https://roamresearch.com/#/app/research-graph",
+    );
+    expect(conceptsBuilder.eq).toHaveBeenCalledWith(
+      "source_local_id",
+      "roam-uid-1",
+    );
+  });
+
+  it("returns null when the source space is not visible", async () => {
+    const { client } = makeClient({ space: null });
+
+    await expect(getSharedNodeByRid({ client, rid })).resolves.toBeNull();
+  });
+
+  it("returns null when the node has no direct content", async () => {
+    const { client } = makeClient({ space: spaces[0]!, direct: [] });
+
+    await expect(getSharedNodeByRid({ client, rid })).resolves.toBeNull();
+  });
+
+  it("throws when the space lookup fails", async () => {
+    const failingBuilder = makeQueryBuilder({
+      data: null,
+      error: { message: "permission denied" },
+    });
+    const client = {
+      from: vi.fn(() => failingBuilder),
+    } as unknown as DGSupabaseClient;
+
+    await expect(getSharedNodeByRid({ client, rid })).rejects.toEqual({
+      message: "permission denied",
+    });
   });
 });

--- a/packages/database/src/lib/sharedNodes.ts
+++ b/packages/database/src/lib/sharedNodes.ts
@@ -1,5 +1,5 @@
 import type { DGSupabaseClient } from "./client";
-import { spaceUriAndLocalIdToRid } from "./rid";
+import { ridToSpaceUriAndLocalId, spaceUriAndLocalIdToRid } from "./rid";
 import type { Enums, Json, Tables } from "../dbTypes";
 
 type SharedConcept = Pick<
@@ -53,6 +53,13 @@ export type SharedNodeRows = {
   fullContentSummaries: SharedContentSummary[];
   spaces: SharedSpace[];
 };
+
+const CONCEPT_COLUMNS =
+  "is_schema, last_modified, schema_id, source_local_id, space_id";
+const DIRECT_CONTENT_COLUMNS =
+  "author_id, created, last_modified, metadata, source_local_id, space_id, text, variant";
+const FULL_CONTENT_SUMMARY_COLUMNS = "last_modified, source_local_id, space_id";
+const SPACE_COLUMNS = "id, name, platform, url";
 
 const getResourceKey = ({
   sourceLocalId,
@@ -211,28 +218,21 @@ const getSharedNodeRows = async ({
     await Promise.all([
       client
         .from("my_concepts")
-        .select(
-          "is_schema, last_modified, schema_id, source_local_id, space_id",
-        )
+        .select(CONCEPT_COLUMNS)
         .neq("space_id", currentSpaceId)
         .eq("is_schema", false)
         .eq("arity", 0),
       client
         .from("my_contents")
-        .select(
-          "author_id, created, last_modified, metadata, source_local_id, space_id, text, variant",
-        )
+        .select(DIRECT_CONTENT_COLUMNS)
         .neq("space_id", currentSpaceId)
         .eq("variant", "direct"),
       client
         .from("my_contents")
-        .select("last_modified, source_local_id, space_id")
+        .select(FULL_CONTENT_SUMMARY_COLUMNS)
         .neq("space_id", currentSpaceId)
         .eq("variant", "full"),
-      client
-        .from("my_spaces")
-        .select("id, name, platform, url")
-        .neq("id", currentSpaceId),
+      client.from("my_spaces").select(SPACE_COLUMNS).neq("id", currentSpaceId),
     ]);
   if (conceptsResponse.error) throw conceptsResponse.error;
   if (directResponse.error) throw directResponse.error;
@@ -256,4 +256,55 @@ export const listGroupSharedNodes = async ({
 }): Promise<SharedNode[]> => {
   const rows = await getSharedNodeRows({ client, currentSpaceId });
   return buildSharedNodes(rows);
+};
+
+export const getSharedNodeByRid = async ({
+  client,
+  rid,
+}: {
+  client: DGSupabaseClient;
+  rid: string;
+}): Promise<SharedNode | null> => {
+  const { spaceUri, sourceLocalId } = ridToSpaceUriAndLocalId(rid);
+  const spaceResponse = await client
+    .from("my_spaces")
+    .select(SPACE_COLUMNS)
+    .eq("url", spaceUri)
+    .maybeSingle();
+  if (spaceResponse.error) throw spaceResponse.error;
+  const space = spaceResponse.data;
+  if (!space || typeof space.id !== "number") return null;
+
+  const [conceptsResponse, directResponse, fullResponse] = await Promise.all([
+    client
+      .from("my_concepts")
+      .select(CONCEPT_COLUMNS)
+      .eq("space_id", space.id)
+      .eq("source_local_id", sourceLocalId)
+      .eq("is_schema", false)
+      .eq("arity", 0),
+    client
+      .from("my_contents")
+      .select(DIRECT_CONTENT_COLUMNS)
+      .eq("space_id", space.id)
+      .eq("source_local_id", sourceLocalId)
+      .eq("variant", "direct"),
+    client
+      .from("my_contents")
+      .select(FULL_CONTENT_SUMMARY_COLUMNS)
+      .eq("space_id", space.id)
+      .eq("source_local_id", sourceLocalId)
+      .eq("variant", "full"),
+  ]);
+  if (conceptsResponse.error) throw conceptsResponse.error;
+  if (directResponse.error) throw directResponse.error;
+  if (fullResponse.error) throw fullResponse.error;
+
+  const [sharedNode] = buildSharedNodes({
+    nodes: conceptsResponse.data,
+    directContents: directResponse.data,
+    fullContentSummaries: fullResponse.data,
+    spaces: [space],
+  });
+  return sharedNode ?? null;
 };


### PR DESCRIPTION


https://github.com/user-attachments/assets/0511dd9b-513a-4d77-b2e3-03885330a275

Adds a manual refresh path for imported cross-app nodes in Roam. Pages carrying stored `importedFrom` source identity get a `Refresh` button in the page-title additions (gated on the same node-sharing flag as the import entry point). Clicking it re-fetches the latest shared content by the stored `sourceNodeRid` — never by the local title — and overwrites the local page through the existing `materializeSharedNode` update path, which preserves identity props, renames on title drift, and never duplicates. This mirrors the Obsidian per-note refresh (`refreshImportedFile`).

Two pieces of infra: `getSharedNodeByRid` in `packages/database` fetches one shared node by rid with targeted queries (space by url, then the concept/direct/full rows), reusing `buildSharedNodes`; and `materializeSharedNode` gains an opt-in `force` that bypasses the up-to-date skip, since a manual refresh must restore source content even when stored timestamps say current (MVP0: imported local edits are overwritten by refresh). The outcome surfaces as one toast; materialization failures and unexpected errors also go to PostHog. If the stored rid resolves to a different page holding the same identity, refresh reports that instead of claiming success on the clicked page.

The button check runs outside the discourse-node gate in the H1 observer so imported pages whose titles don't match local node formats still get the button. Refreshing a source with no full content yields a title-only page, matching import's existing (tested) behavior. Refresh-all is ENG-1861, provenance indicators ENG-1875.

## Scope check

- [x] Ran `$scope-check` against ENG-1860 and the final diff.
- Scope beyond `Done When`: None.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/1279" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
