### PR TITLE
ENG-2050 Re-introduce rid (optional) in the CrossApp base

### DIFF
--- a/packages/database/src/crossAppContracts.ts
+++ b/packages/database/src/crossAppContracts.ts
@@ -10,6 +10,7 @@ export type Rid = string;
 // Common attributes for most types
 export type CrossAppBase = {
   localId: LocalId;
+  rid?: string;
   createdAt: Date;
   modifiedAt?: Date;
   authorId: LocalId;

--- a/packages/database/src/lib/crossAppConverters.ts
+++ b/packages/database/src/lib/crossAppConverters.ts
@@ -8,6 +8,7 @@ import {
   CrossAppRelation,
 } from "../crossAppContracts";
 import { LocalContentDataInput, LocalConceptDataInput } from "../inputTypes";
+import { ridToSpaceUriAndLocalId } from "./rid";
 import { Enums, CompositeTypes } from "../dbTypes";
 
 type InlineEmbeddingInput = CompositeTypes<"inline_embedding_input">;
@@ -70,7 +71,11 @@ export const crossAppNodeToDbContent = (
 export const crossAppNodeToDbConcept = (
   node: CrossAppNode,
 ): LocalConceptDataInput => {
+  const spaceUri = node.rid
+    ? ridToSpaceUriAndLocalId(node.rid).spaceUri
+    : undefined;
   return filterUndefined<LocalConceptDataInput>({
+    space_url: spaceUri,
     source_local_id: node.localId,
     name: node.content.direct.value,
     author_local_id: node.authorId,
@@ -91,7 +96,11 @@ export const crossAppNodeSchemaToDbConcept = (
     template: node.templateTitle,
     template_content: node.template,
   });
+  const spaceUri = node.rid
+    ? ridToSpaceUriAndLocalId(node.rid).spaceUri
+    : undefined;
   return filterUndefined<LocalConceptDataInput>({
+    space_url: spaceUri,
     source_local_id: node.localId,
     name: node.label,
     author_local_id: node.authorId,
@@ -106,7 +115,11 @@ export const crossAppNodeSchemaToDbConcept = (
 export const crossAppRelationTypeSchemaToDbConcept = (
   node: CrossAppRelationTypeSchema,
 ): LocalConceptDataInput => {
+  const spaceUri = node.rid
+    ? ridToSpaceUriAndLocalId(node.rid).spaceUri
+    : undefined;
   return filterUndefined<LocalConceptDataInput>({
+    space_url: spaceUri,
     source_local_id: node.localId,
     name: node.label,
     author_local_id: node.authorId,
@@ -130,7 +143,11 @@ export const crossAppRelationTripleSchemaToDbConcept = (
   const label = "label" in node ? node.label : relationType!.label;
   const complement =
     "complement" in node ? node.complement : relationType!.complement;
+  const spaceUri = node.rid
+    ? ridToSpaceUriAndLocalId(node.rid).spaceUri
+    : undefined;
   return filterUndefined<LocalConceptDataInput>({
+    space_url: spaceUri,
     source_local_id: node.localId,
     name: node.localId, // has to be unique within space. Not seen yet.
     author_local_id: node.authorId,
@@ -153,9 +170,13 @@ export const crossAppRelationTripleSchemaToDbConcept = (
 export const crossAppRelationToDbConcept = (
   node: CrossAppRelation,
 ): LocalConceptDataInput => {
+  const spaceUri = node.rid
+    ? ridToSpaceUriAndLocalId(node.rid).spaceUri
+    : undefined;
   return filterUndefined<LocalConceptDataInput>({
     // use LocalIds... not ideal
     name: `${node.localId}: ${node.source} -${node.relationType}-> ${node.destination}`,
+    space_url: spaceUri,
     source_local_id: node.localId,
     author_local_id: node.authorId,
     schema_represented_by_local_id: node.relationType,


### PR DESCRIPTION
https://linear.app/discourse-graphs/issue/ENG-2050/re-introduce-spaceid-optional-in-the-crossapp-base

https://www.loom.com/share/43856e1dd0e74b2cb131bf81a38fd622

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/1282" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->