### PR TITLE
ENG-2060 Remove discourse context overlay button from blocks on canvas

### DIFF
--- a/apps/roam/src/components/canvas/DiscourseNodeUtil.tsx
+++ b/apps/roam/src/components/canvas/DiscourseNodeUtil.tsx
@@ -752,7 +752,9 @@ export class DiscourseNodeUtil extends BaseBoxShapeUtil<DiscourseNodeShape> {
           >
             {overlayMounted &&
               isOverlayEnabled &&
-              getDiscourseNodeTypeId({ shape }) !== "blck-node" && (
+              !["blck-node", "page-node"].includes(
+                getDiscourseNodeTypeId({ shape }),
+              ) && (
                 <div
                   className="roamjs-discourse-context-overlay-container absolute right-1 top-1"
                   onPointerDown={(e) => e.stopPropagation()}

--- a/apps/roam/src/components/canvas/DiscourseNodeUtil.tsx
+++ b/apps/roam/src/components/canvas/DiscourseNodeUtil.tsx
@@ -750,20 +750,22 @@ export class DiscourseNodeUtil extends BaseBoxShapeUtil<DiscourseNodeShape> {
               fontSize: FONT_SIZES[shape.props.size],
             }}
           >
-            {overlayMounted && isOverlayEnabled && (
-              <div
-                className="roamjs-discourse-context-overlay-container absolute right-1 top-1"
-                onPointerDown={(e) => e.stopPropagation()}
-              >
-                <DiscourseContextOverlay
-                  uid={shape.props.uid}
-                  id={`${shape.id}-overlay`}
-                  opacity="50"
-                  textColor={textColor}
-                  iconColor={textColor}
-                />
-              </div>
-            )}
+            {overlayMounted &&
+              isOverlayEnabled &&
+              getDiscourseNodeTypeId({ shape }) !== "blck-node" && (
+                <div
+                  className="roamjs-discourse-context-overlay-container absolute right-1 top-1"
+                  onPointerDown={(e) => e.stopPropagation()}
+                >
+                  <DiscourseContextOverlay
+                    uid={shape.props.uid}
+                    id={`${shape.id}-overlay`}
+                    opacity="50"
+                    textColor={textColor}
+                    iconColor={textColor}
+                  />
+                </div>
+              )}
             {showEmbeddedRoamBlock ? (
               <div className="w-full min-w-0">
                 <RenderRoamBlockString


### PR DESCRIPTION
https://github.com/user-attachments/assets/0d013169-fb21-4704-bccc-3bfe7e5fbf7b

Blocks on a tldraw canvas were showing the discourse context overlay button, but discourse context does not apply to blocks. This skips rendering the overlay for `blck-node` shapes, and per review feedback also for `page-node` shapes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/1287" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
