### PR TITLE
ENG-1140 Implement simplified discourse context overlay

### DIFF
--- a/apps/roam/src/components/CreateRelationDialog.tsx
+++ b/apps/roam/src/components/CreateRelationDialog.tsx
@@ -1,12 +1,5 @@
 import React, { useState, useMemo } from "react";
-import {
-  Dialog,
-  Classes,
-  Label,
-  Button,
-  Icon,
-  Callout,
-} from "@blueprintjs/core";
+import { Dialog, Classes, Label, Button, Callout } from "@blueprintjs/core";
 import renderOverlay from "roamjs-components/util/renderOverlay";
 import { render as renderToast } from "roamjs-components/components/Toast";
 import MenuItemSelect from "roamjs-components/components/MenuItemSelect";
@@ -392,26 +385,28 @@ export const renderCreateRelationDialog = (
 };
 
 export const CreateRelationButton = (
-  props: CreateRelationDialogProps,
+  props: CreateRelationDialogProps & { fill?: boolean },
 ): React.JSX.Element | null => {
+  const { fill = false, ...relationProps } = props;
   const storedRelationsEnabled = getStoredRelationsEnabled();
   if (!storedRelationsEnabled) return null;
   let extProps: ExtendedCreateRelationDialogProps | null = null;
   try {
-    extProps = extendProps(props);
+    extProps = extendProps(relationProps);
   } catch (e) {
     // the node's type was not identified. Swallow silently.
   }
   return (
     <Button
-      className="m-2"
+      className="m-0"
       minimal
+      outlined
+      fill={fill}
+      text="Add relation"
       disabled={extProps === null}
       onClick={() => {
         renderCreateRelationDialog(extProps);
       }}
-    >
-      <Icon icon="plus" />
-    </Button>
+    />
   );
 };

--- a/apps/roam/src/components/DiscourseContext.tsx
+++ b/apps/roam/src/components/DiscourseContext.tsx
@@ -29,13 +29,11 @@ const ContextTab = ({
   parentUid,
   r,
   groupByTarget,
-  setGroupByTarget,
   onRefresh,
 }: {
   parentUid: string;
   r: DiscourseContextResults[number];
   groupByTarget: boolean;
-  setGroupByTarget: (b: boolean) => void;
   onRefresh: (ignoreCache?: boolean) => void;
 }) => {
   const [subTabId, setSubTabId] = useState(0);
@@ -80,27 +78,7 @@ const ContextTab = ({
       results={Object.values(results).map(removeTargetFromResult)}
       columns={columns}
       onRefresh={onRefresh}
-      header={
-        <h4 className="m-0 mb-2 flex items-center justify-between">
-          <span>{r.label}</span>
-          <span style={{ display: "flex", alignItems: "center" }}>
-            <CreateRelationButton
-              sourceNodeUid={parentUid}
-              onCreated={() => {
-                window.setTimeout(onRefresh, 150, true);
-              }}
-            />
-            <Switch
-              label="Group By Target"
-              checked={groupByTarget}
-              style={{ fontSize: 8, marginLeft: 4, marginBottom: 0 }}
-              onChange={(e) =>
-                setGroupByTarget((e.target as HTMLInputElement).checked)
-              }
-            />
-          </span>
-        </h4>
-      }
+      simplified
     />
   );
   return subTabs.length ? (
@@ -196,14 +174,20 @@ export const ContextContent = ({ uid, results, overlayRefresh }: Props) => {
   const [groupByTarget, setGroupByTarget] = useState(false);
   return queryResults.length ? (
     <>
-      <style>{`.roamjs-discourse-result-panel .roamjs-query-results-header {
-  padding-top: 0;
+      <style>{`.roamjs-discourse-result-panel .roamjs-query-results-delete-relation {
+  visibility: hidden;
 }
 
-.roamjs-discourse-result-panel .roamjs-query-results-metadata {
-  display: none;
+.roamjs-discourse-result-panel tr:hover .roamjs-query-results-delete-relation,
+.roamjs-discourse-result-panel tr:focus-within .roamjs-query-results-delete-relation {
+  visibility: visible;
+}
+
+.roamjs-discourse-context-tabs > .bp3-tab-list {
+  align-self: stretch;
 }`}</style>
       <Tabs
+        className="roamjs-discourse-context-tabs"
         selectedTabId={tabId}
         onChange={(e) => setTabId(Number(e))}
         vertical
@@ -221,7 +205,6 @@ export const ContextContent = ({ uid, results, overlayRefresh }: Props) => {
                 parentUid={uid}
                 r={r}
                 groupByTarget={groupByTarget}
-                setGroupByTarget={setGroupByTarget}
                 onRefresh={onRefresh}
               />
             }
@@ -232,6 +215,22 @@ export const ContextContent = ({ uid, results, overlayRefresh }: Props) => {
             <Spinner />
           </div>
         )}
+        <div className="roamjs-discourse-context-controls mt-auto box-border flex w-full flex-none flex-col px-2 pt-2">
+          <Switch
+            label="Group By Target"
+            checked={groupByTarget}
+            className="mb-1"
+            style={{ fontSize: 8 }}
+            onChange={(e) =>
+              setGroupByTarget((e.target as HTMLInputElement).checked)
+            }
+          />
+          <CreateRelationButton
+            sourceNodeUid={uid}
+            onCreated={delayedRefresh}
+            fill
+          />
+        </div>
       </Tabs>
     </>
   ) : debouncedLoading && !results ? (
@@ -248,8 +247,8 @@ export const ContextContent = ({ uid, results, overlayRefresh }: Props) => {
       />
     </Tabs>
   ) : (
-    <div className="text-center">
-      No discourse relations found.
+    <div className="flex flex-col items-start">
+      <span>No discourse relations found.</span>
       <CreateRelationButton sourceNodeUid={uid} onCreated={delayedRefresh} />
     </div>
   );

--- a/apps/roam/src/components/DiscourseContext.tsx
+++ b/apps/roam/src/components/DiscourseContext.tsx
@@ -174,13 +174,15 @@ export const ContextContent = ({ uid, results, overlayRefresh }: Props) => {
   const [groupByTarget, setGroupByTarget] = useState(false);
   return queryResults.length ? (
     <>
-      <style>{`.roamjs-discourse-result-panel .roamjs-query-results-delete-relation {
-  visibility: hidden;
-}
+      <style>{`@media (hover: hover) and (pointer: fine) {
+  .roamjs-discourse-result-panel .roamjs-query-results-delete-relation {
+    visibility: hidden;
+  }
 
-.roamjs-discourse-result-panel tr:hover .roamjs-query-results-delete-relation,
-.roamjs-discourse-result-panel tr:focus-within .roamjs-query-results-delete-relation {
-  visibility: visible;
+  .roamjs-discourse-result-panel tr:hover .roamjs-query-results-delete-relation,
+  .roamjs-discourse-result-panel tr:focus-within .roamjs-query-results-delete-relation {
+    visibility: visible;
+  }
 }
 
 .roamjs-discourse-context-tabs > .bp3-tab-list {
@@ -219,8 +221,7 @@ export const ContextContent = ({ uid, results, overlayRefresh }: Props) => {
           <Switch
             label="Group By Target"
             checked={groupByTarget}
-            className="mb-1"
-            style={{ fontSize: 8 }}
+            className="mb-1 text-xs"
             onChange={(e) =>
               setGroupByTarget((e.target as HTMLInputElement).checked)
             }

--- a/apps/roam/src/components/results-view/ResultsTable.tsx
+++ b/apps/roam/src/components/results-view/ResultsTable.tsx
@@ -56,6 +56,7 @@ const ResultHeader = React.forwardRef<
     setFilters: (f: FilterData) => void;
     initialFilter: Filters;
     columnWidth?: string;
+    simplified: boolean;
   }
 >(
   ({
@@ -67,6 +68,7 @@ const ResultHeader = React.forwardRef<
     setFilters,
     initialFilter,
     columnWidth,
+    simplified,
   }) => {
     const filterData = useMemo(
       () => ({
@@ -110,7 +112,13 @@ const ResultHeader = React.forwardRef<
         }}
       >
         <div className="flex items-center">
-          <span className="mr-4 inline-block">{c.key}</span>
+          <span
+            className={`roamjs-query-results-column-label ${
+              simplified ? "hidden" : "mr-4 inline-block"
+            }`}
+          >
+            {c.key}
+          </span>
           <span>
             <Filter
               data={filterData}
@@ -381,7 +389,7 @@ const ResultRow = ({
                   <Button
                     minimal
                     icon="delete"
-                    className="float-right"
+                    className="roamjs-query-results-delete-relation float-right"
                     title="Delete relation"
                     onClick={onDelete}
                   ></Button>
@@ -454,6 +462,7 @@ const ResultsTable = ({
   views,
   allResults,
   showInterface,
+  simplified,
 }: {
   columns: Column[];
   results: Result[];
@@ -469,6 +478,7 @@ const ResultsTable = ({
   onRefresh: (ignoreCache?: boolean) => void;
   allResults: Result[];
   showInterface?: boolean;
+  simplified?: boolean;
 }) => {
   const tableRef = useRef<HTMLTableElement | null>(null);
   const dragInfo = useRef<DragInfo>(getInitialDragInfo());
@@ -694,11 +704,12 @@ const ResultsTable = ({
     },
     [setFilters, preventSavingSettings, parentUid],
   );
-  const tableProps = useMemo(
-    () =>
-      layout.rowStyle !== "Bare" ? { striped: true, interactive: true } : {},
-    [layout.rowStyle],
-  );
+  const tableProps = useMemo(() => {
+    if (simplified) return { interactive: true };
+    return layout.rowStyle !== "Bare"
+      ? { striped: true, interactive: true }
+      : {};
+  }, [layout.rowStyle, simplified]);
 
   const [extraRowUid, setExtraRowUid] = useState<string | null>(null);
   const [extraRowType, setExtraRowType] = useState<ExtraRowType>(null);
@@ -749,7 +760,12 @@ const ResultsTable = ({
       data-parent-uid={parentUid}
       {...tableProps}
     >
-      <thead style={{ background: "#eeeeee80" }}>
+      <thead
+        className={`roamjs-query-results-header ${
+          simplified ? "bg-transparent pt-0" : ""
+        }`}
+        style={simplified ? undefined : { background: "#eeeeee80" }}
+      >
         <tr style={{ visibility: !showInterface ? "collapse" : "visible" }}>
           {visibleColumns.map((c) => (
             <ResultHeader
@@ -762,6 +778,7 @@ const ResultsTable = ({
               setFilters={resultHeaderSetFilters}
               initialFilter={filters[c.key]}
               columnWidth={columnWidths[c.uid]}
+              simplified={simplified ?? false}
             />
           ))}
         </tr>

--- a/apps/roam/src/components/results-view/ResultsView.tsx
+++ b/apps/roam/src/components/results-view/ResultsView.tsx
@@ -280,7 +280,7 @@ const ResultsView: ResultsViewComponent = ({
   results,
   hideResults = false,
   hideMenu = false,
-  simplified = false,
+  simplified = false, // eslint-disable-line react/prop-types
   preventSavingSettings = false,
   onEdit,
   onDeleteQuery,

--- a/apps/roam/src/components/results-view/ResultsView.tsx
+++ b/apps/roam/src/components/results-view/ResultsView.tsx
@@ -237,6 +237,7 @@ type ResultsViewComponent = (props: {
   results: Result[];
   hideResults?: boolean;
   hideMenu?: boolean;
+  simplified?: boolean;
   preventSavingSettings?: boolean;
   onEdit?: () => void;
   onDeleteQuery?: () => void;
@@ -279,6 +280,7 @@ const ResultsView: ResultsViewComponent = ({
   results,
   hideResults = false,
   hideMenu = false,
+  simplified = false,
   preventSavingSettings = false,
   onEdit,
   onDeleteQuery,
@@ -1383,6 +1385,7 @@ const ResultsView: ResultsViewComponent = ({
                   onRefresh={onRefresh}
                   allResults={results}
                   showInterface={showInterface}
+                  simplified={simplified}
                 />
               ) : layoutMode === "line" ? (
                 <Charts
@@ -1429,10 +1432,13 @@ const ResultsView: ResultsViewComponent = ({
               </div>
             )}
             <div
+              className={`roamjs-query-results-metadata ${
+                simplified ? "bg-transparent" : ""
+              } ${!showInterface ? "hidden" : ""}`}
               style={
-                !showInterface
-                  ? { display: "none" }
-                  : { background: "#eeeeee80" }
+                showInterface && !simplified
+                  ? { background: "#eeeeee80" }
+                  : undefined
               }
             >
               <div


### PR DESCRIPTION
Before

<img width="1562" height="580" alt="image" src="https://github.com/user-attachments/assets/c033af82-08dd-4504-9b30-db010112f537" />


After

<img width="1554" height="471" alt="image" src="https://github.com/user-attachments/assets/0f7af9fd-e2ea-49bc-8acd-b0cc8b868922" />


## Summary

- Add a simplified results presentation for the discourse context overlay.
- Move grouping and relation controls into a dedicated sidebar section.
- Improve relation deletion visibility and simplify the add-relation button.

## Testing

Not run (not requested)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/1294" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->