### PR TITLE
ENG-2097 Exclude Page, Block, and Any from relation endpoint selectors

### DIFF
--- a/apps/roam/src/components/settings/DiscourseRelationConfigPanel.tsx
+++ b/apps/roam/src/components/settings/DiscourseRelationConfigPanel.tsx
@@ -44,7 +44,9 @@ import { render as renderToast } from "roamjs-components/components/Toast";
 import getPageTitleByPageUid from "roamjs-components/queries/getPageTitleByPageUid";
 import updateBlock from "roamjs-components/writes/updateBlock";
 import getTextByBlockUid from "roamjs-components/queries/getTextByBlockUid";
-import getDiscourseNodes from "~/utils/getDiscourseNodes";
+import getDiscourseNodes, {
+  excludeDefaultNodes,
+} from "~/utils/getDiscourseNodes";
 import { isRelationComplete } from "~/utils/isRelationComplete";
 import { getConditionLabels } from "~/utils/conditionToDatalog";
 import { formatHexColor } from "./DiscourseNodeCanvasSettings";
@@ -81,6 +83,7 @@ const edgeDisplayByUid = (uid: string) =>
 export const RelationEditPanel = ({
   editingRelationInfo,
   nodes,
+  configuredNodeTypes,
   back,
   translatorKeys,
   previewUid,
@@ -88,6 +91,7 @@ export const RelationEditPanel = ({
   editingRelationInfo: TreeNode;
   back: () => void;
   nodes: Record<string, { label: string; format: string; color: string }>;
+  configuredNodeTypes: string[];
   translatorKeys: string[];
   previewUid: string;
 }) => {
@@ -748,7 +752,7 @@ export const RelationEditPanel = ({
                 );
               }
             }}
-            items={Object.keys(nodes)}
+            items={configuredNodeTypes}
             transformItem={transformItem}
           />
         </Label>
@@ -765,7 +769,7 @@ export const RelationEditPanel = ({
                 ).data("node", nodes[e]?.label);
               }
             }}
-            items={Object.keys(nodes)}
+            items={configuredNodeTypes}
             transformItem={transformItem}
           />
         </Label>
@@ -991,16 +995,20 @@ const DiscourseRelationConfigPanel = ({
       })),
     [],
   );
-  const nodes = useMemo(() => {
+  const { nodes, configuredNodeTypes } = useMemo(() => {
+    const discourseNodes = getDiscourseNodes();
     const nodes = Object.fromEntries(
-      getDiscourseNodes().map((n) => {
+      discourseNodes.map((n) => {
         const color = formatHexColor(n.canvasSettings.color);
         return [n.type, { label: n.text, format: n.format, color }];
       }),
     );
     // TypeError: Iterator value * is not an entry object
     nodes["*"] = { label: "Any", format: ".+", color: "#000" };
-    return nodes;
+    const configuredNodeTypes = discourseNodes
+      .filter(excludeDefaultNodes)
+      .map((n) => n.type);
+    return { nodes, configuredNodeTypes };
   }, []);
   const previewUid = useSubTree({ parentUid, key: "preview" }).uid;
   const [translatorKeys, setTranslatorKeys] = useState(getConditionLabels);
@@ -1148,6 +1156,7 @@ const DiscourseRelationConfigPanel = ({
       <div style={{ caretColor: "transparent" }}>
         <RelationEditPanel
           nodes={nodes}
+          configuredNodeTypes={configuredNodeTypes}
           editingRelationInfo={editingRelationInfo}
           back={handleBack}
           translatorKeys={translatorKeys}

--- a/apps/roam/src/components/settings/DiscourseRelationConfigPanel.tsx
+++ b/apps/roam/src/components/settings/DiscourseRelationConfigPanel.tsx
@@ -45,7 +45,7 @@ import getPageTitleByPageUid from "roamjs-components/queries/getPageTitleByPageU
 import updateBlock from "roamjs-components/writes/updateBlock";
 import getTextByBlockUid from "roamjs-components/queries/getTextByBlockUid";
 import getDiscourseNodes, {
-  excludeDefaultNodes,
+  getRelationEndpointNodeTypes,
 } from "~/utils/getDiscourseNodes";
 import { isRelationComplete } from "~/utils/isRelationComplete";
 import { getConditionLabels } from "~/utils/conditionToDatalog";
@@ -1005,9 +1005,7 @@ const DiscourseRelationConfigPanel = ({
     );
     // TypeError: Iterator value * is not an entry object
     nodes["*"] = { label: "Any", format: ".+", color: "#000" };
-    const configuredNodeTypes = discourseNodes
-      .filter(excludeDefaultNodes)
-      .map((n) => n.type);
+    const configuredNodeTypes = getRelationEndpointNodeTypes(discourseNodes);
     return { nodes, configuredNodeTypes };
   }, []);
   const previewUid = useSubTree({ parentUid, key: "preview" }).uid;

--- a/apps/roam/src/utils/__tests__/getDiscourseNodes.test.ts
+++ b/apps/roam/src/utils/__tests__/getDiscourseNodes.test.ts
@@ -1,20 +1,20 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { DiscourseNode } from "~/utils/getDiscourseNodes";
 
-const mocks = vi.hoisted(() => {
-  const generateUID = vi.fn(() => "generated-uid");
+vi.hoisted(() => {
   (globalThis as { window: unknown }).window = {
     roamAlphaAPI: {
       util: {
-        generateUID,
+        generateUID: () => "generated-uid",
       },
     },
   };
-  return {
-    isNewSettingsStoreEnabled: vi.fn(),
-    getAllDiscourseNodes: vi.fn(),
-  };
 });
+
+const mocks = vi.hoisted(() => ({
+  isNewSettingsStoreEnabled: vi.fn(),
+  getAllDiscourseNodes: vi.fn(),
+}));
 
 vi.mock("~/components/settings/utils/accessors", () => ({
   isNewSettingsStoreEnabled: mocks.isNewSettingsStoreEnabled,
@@ -22,7 +22,7 @@ vi.mock("~/components/settings/utils/accessors", () => ({
 }));
 
 import getDiscourseNodes, {
-  excludeDefaultNodes,
+  getRelationEndpointNodeTypes,
 } from "~/utils/getDiscourseNodes";
 
 const makeUserNode = ({
@@ -41,33 +41,27 @@ const makeUserNode = ({
   format: "{content}",
 });
 
-describe("getDiscourseNodes", () => {
+describe("getRelationEndpointNodeTypes", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.isNewSettingsStoreEnabled.mockReturnValue(true);
   });
 
-  it("excludes default Page, Block, and synthetic Any from relation endpoint types", () => {
+  it("excludes default Page and Block nodes while keeping user-configured types", () => {
     mocks.getAllDiscourseNodes.mockReturnValue([
       makeUserNode({ text: "Claim", type: "CLM" }),
       makeUserNode({ text: "Evidence", type: "EVD" }),
     ]);
 
     const discourseNodes = getDiscourseNodes();
-    expect(discourseNodes.map((n) => n.type)).toEqual([
+    expect(discourseNodes.map((n) => n.type)).toEqual(
+      expect.arrayContaining(["page-node", "blck-node"]),
+    );
+
+    expect(getRelationEndpointNodeTypes(discourseNodes)).toEqual([
       "CLM",
       "EVD",
-      "page-node",
-      "blck-node",
     ]);
-
-    const endpointTypes = discourseNodes
-      .filter(excludeDefaultNodes)
-      .map((n) => n.type);
-    expect(endpointTypes).toEqual(["CLM", "EVD"]);
-    expect(endpointTypes).not.toContain("page-node");
-    expect(endpointTypes).not.toContain("blck-node");
-    expect(endpointTypes).not.toContain("*");
   });
 
   it("keeps a user-configured node that shares a default node's name", () => {
@@ -75,15 +69,8 @@ describe("getDiscourseNodes", () => {
       makeUserNode({ text: "Page", type: "user-page-node" }),
     ]);
 
-    const discourseNodes = getDiscourseNodes();
-    expect(discourseNodes.map((n) => n.type)).toEqual([
+    expect(getRelationEndpointNodeTypes(getDiscourseNodes())).toEqual([
       "user-page-node",
-      "blck-node",
     ]);
-
-    const endpointTypes = discourseNodes
-      .filter(excludeDefaultNodes)
-      .map((n) => n.type);
-    expect(endpointTypes).toEqual(["user-page-node"]);
   });
 });

--- a/apps/roam/src/utils/__tests__/getDiscourseNodes.test.ts
+++ b/apps/roam/src/utils/__tests__/getDiscourseNodes.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { DiscourseNode } from "~/utils/getDiscourseNodes";
+
+const mocks = vi.hoisted(() => {
+  const generateUID = vi.fn(() => "generated-uid");
+  (globalThis as { window: unknown }).window = {
+    roamAlphaAPI: {
+      util: {
+        generateUID,
+      },
+    },
+  };
+  return {
+    isNewSettingsStoreEnabled: vi.fn(),
+    getAllDiscourseNodes: vi.fn(),
+  };
+});
+
+vi.mock("~/components/settings/utils/accessors", () => ({
+  isNewSettingsStoreEnabled: mocks.isNewSettingsStoreEnabled,
+  getAllDiscourseNodes: mocks.getAllDiscourseNodes,
+}));
+
+import getDiscourseNodes, {
+  excludeDefaultNodes,
+} from "~/utils/getDiscourseNodes";
+
+const makeUserNode = ({
+  text,
+  type,
+}: {
+  text: string;
+  type: string;
+}): DiscourseNode => ({
+  text,
+  type,
+  shortcut: "",
+  specification: [],
+  backedBy: "user",
+  canvasSettings: {},
+  format: "{content}",
+});
+
+describe("getDiscourseNodes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.isNewSettingsStoreEnabled.mockReturnValue(true);
+  });
+
+  it("excludes default Page, Block, and synthetic Any from relation endpoint types", () => {
+    mocks.getAllDiscourseNodes.mockReturnValue([
+      makeUserNode({ text: "Claim", type: "CLM" }),
+      makeUserNode({ text: "Evidence", type: "EVD" }),
+    ]);
+
+    const discourseNodes = getDiscourseNodes();
+    expect(discourseNodes.map((n) => n.type)).toEqual([
+      "CLM",
+      "EVD",
+      "page-node",
+      "blck-node",
+    ]);
+
+    const endpointTypes = discourseNodes
+      .filter(excludeDefaultNodes)
+      .map((n) => n.type);
+    expect(endpointTypes).toEqual(["CLM", "EVD"]);
+    expect(endpointTypes).not.toContain("page-node");
+    expect(endpointTypes).not.toContain("blck-node");
+    expect(endpointTypes).not.toContain("*");
+  });
+
+  it("keeps a user-configured node that shares a default node's name", () => {
+    mocks.getAllDiscourseNodes.mockReturnValue([
+      makeUserNode({ text: "Page", type: "user-page-node" }),
+    ]);
+
+    const discourseNodes = getDiscourseNodes();
+    expect(discourseNodes.map((n) => n.type)).toEqual([
+      "user-page-node",
+      "blck-node",
+    ]);
+
+    const endpointTypes = discourseNodes
+      .filter(excludeDefaultNodes)
+      .map((n) => n.type);
+    expect(endpointTypes).toEqual(["user-page-node"]);
+  });
+});

--- a/apps/roam/src/utils/getDiscourseNodes.ts
+++ b/apps/roam/src/utils/getDiscourseNodes.ts
@@ -14,6 +14,9 @@ export const excludeDefaultNodes = (node: DiscourseNode) => {
   return node.backedBy !== "default";
 };
 
+export const getRelationEndpointNodeTypes = (nodes: DiscourseNode[]) =>
+  nodes.filter(excludeDefaultNodes).map((n) => n.type);
+
 // TODO - only text and type should be required
 export type DiscourseNode = {
   text: string;


### PR DESCRIPTION
https://github.com/user-attachments/assets/37da761e-788b-4a83-97e5-889fad335595

Builds the relation editor's Source and Destination options from configured discourse node types only (via the existing `excludeDefaultNodes`), so `Page`, `Block`, and `Any` can no longer be saved as new relation endpoints.

The full node map still includes Page/Block/Any because the relations table, sorting, and the selector's current-value button use it to display existing relations with generic endpoints — migrating those is out of scope per the ticket. `MenuItemSelect` renders `activeItem` independently of `items`, so editing such a relation still shows its current endpoint; it just can't be selected anew.

Closes ENG-2097

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/1298" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
