### PR TITLE
ENG-2114 Insert active result as a link at cursor

### DIFF
--- a/apps/obsidian/src/components/NodeSearchFooter.tsx
+++ b/apps/obsidian/src/components/NodeSearchFooter.tsx
@@ -3,7 +3,9 @@ import { getHintKeys, type HintKey } from "~/utils/keyboardHints";
 
 type NodeSearchFooterProps = {
   canAct: boolean;
+  canInsertLink: boolean;
   onClose: () => void;
+  onInsertLink: () => void;
   onOpenInNewTab: () => void;
   onOpenInSplit: () => void;
 };
@@ -50,11 +52,22 @@ const FooterAction = ({
 // full-width result list, so the actions start at its left edge instead.
 export const NodeSearchFooter = ({
   canAct,
+  canInsertLink,
   onClose,
+  onInsertLink,
   onOpenInNewTab,
   onOpenInSplit,
 }: NodeSearchFooterProps): ReactElement => (
   <div className="prompt-instructions dg-search-footer shrink-0 justify-start px-0 pb-0 text-left">
+    {/* Absent, not disabled: with no cursor there is nothing to insert into. */}
+    {canInsertLink && (
+      <FooterAction
+        disabled={!canAct}
+        keys={["Mod", "Enter"]}
+        label="insert link at cursor"
+        onClick={onInsertLink}
+      />
+    )}
     <FooterAction
       disabled={!canAct}
       keys={["Enter"]}

--- a/apps/obsidian/src/components/NodeSearchModal.tsx
+++ b/apps/obsidian/src/components/NodeSearchModal.tsx
@@ -28,6 +28,11 @@ import {
   openFileInNewTab,
 } from "~/components/canvas/utils/openFileUtils";
 import {
+  insertLinkAtInsertTarget,
+  snapshotInsertTarget,
+  type EditorInsertTarget,
+} from "~/utils/editorInsertTarget";
+import {
   QueryEngine,
   rankDiscourseNodesByTitle,
   type DiscourseNodeCandidate,
@@ -318,9 +323,11 @@ const ResultList = ({
 
 const NodeSearch = ({
   plugin,
+  insertTarget,
   onClose,
 }: {
   plugin: DiscourseGraphPlugin;
+  insertTarget: EditorInsertTarget | null;
   onClose: () => void;
 }): ReactElement => {
   const { app } = plugin;
@@ -440,6 +447,19 @@ const NodeSearch = ({
     if (!nextOpen) inputRef.current?.focus();
   };
 
+  // Closes before inserting, like `openActiveResult`.
+  const insertLinkToActiveResult = (): void => {
+    if (!activeResult || !insertTarget) return;
+    const { file } = activeResult;
+    onClose();
+    try {
+      insertLinkAtInsertTarget({ app, file, target: insertTarget });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      new Notice(`Could not insert a link to ${file.basename}: ${message}`);
+    }
+  };
+
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
     if (event.key === "ArrowDown" || event.key === "ArrowUp") {
       // Otherwise the caret jumps to the start or end of the query.
@@ -451,7 +471,12 @@ const NodeSearch = ({
     if (event.key !== "Enter") return;
     // Enter also commits an IME candidate, which must not open a file.
     if (event.nativeEvent.isComposing) return;
-    // Mod+Enter and Alt+Enter are left alone for the insert and dock actions.
+    if ((event.metaKey || event.ctrlKey) && !event.altKey && insertTarget) {
+      event.preventDefault();
+      insertLinkToActiveResult();
+      return;
+    }
+    // Alt+Enter is left alone for the dock action.
     if (event.metaKey || event.ctrlKey || event.altKey) return;
     // A footer button reached by Tab runs its own action on Enter. Preventing the
     // default here would suppress that click and open a new tab instead.
@@ -516,7 +541,9 @@ const NodeSearch = ({
       </div>
       <NodeSearchFooter
         canAct={candidateState.status === "ready" && !!activeResult}
+        canInsertLink={!!insertTarget}
         onClose={onClose}
+        onInsertLink={insertLinkToActiveResult}
         onOpenInNewTab={() => openActiveResult(openFileInNewTab)}
         onOpenInSplit={() => openActiveResult(openFileInNewLeaf)}
       />
@@ -527,10 +554,13 @@ const NodeSearch = ({
 export class NodeSearchModal extends Modal {
   private plugin: DiscourseGraphPlugin;
   private root: Root | null = null;
+  /** Snapshotted in the constructor: `open()` has not taken focus yet. */
+  private insertTarget: EditorInsertTarget | null;
 
   constructor(app: App, plugin: DiscourseGraphPlugin) {
     super(app);
     this.plugin = plugin;
+    this.insertTarget = snapshotInsertTarget(app);
   }
 
   onOpen() {
@@ -549,7 +579,11 @@ export class NodeSearchModal extends Modal {
     this.root = createRoot(contentEl);
     this.root.render(
       <StrictMode>
-        <NodeSearch plugin={this.plugin} onClose={() => this.close()} />
+        <NodeSearch
+          plugin={this.plugin}
+          insertTarget={this.insertTarget}
+          onClose={() => this.close()}
+        />
       </StrictMode>,
     );
   }

--- a/apps/obsidian/src/components/NodeSearchModal.tsx
+++ b/apps/obsidian/src/components/NodeSearchModal.tsx
@@ -471,7 +471,14 @@ const NodeSearch = ({
     if (event.key !== "Enter") return;
     // Enter also commits an IME candidate, which must not open a file.
     if (event.nativeEvent.isComposing) return;
-    if ((event.metaKey || event.ctrlKey) && !event.altKey && insertTarget) {
+    // activeResult is part of the gate so the chord is not claimed while the
+    // results are still loading, matching the footer button's disabled state.
+    if (
+      (event.metaKey || event.ctrlKey) &&
+      !event.altKey &&
+      insertTarget &&
+      activeResult
+    ) {
       event.preventDefault();
       insertLinkToActiveResult();
       return;

--- a/apps/obsidian/src/utils/editorInsertTarget.ts
+++ b/apps/obsidian/src/utils/editorInsertTarget.ts
@@ -1,0 +1,50 @@
+import { App, MarkdownView, TFile, type EditorPosition } from "obsidian";
+
+/** Held rather than re-looked-up, so the link lands in the pre-open note. */
+export type EditorInsertTarget = {
+  view: MarkdownView;
+  from: EditorPosition;
+  to: EditorPosition;
+};
+
+/**
+ * Call before the modal mounts, while the editor still owns the cursor.
+ * `hasFocus()` is not part of the gate: opening the search from the command
+ * palette means that palette already took focus.
+ */
+export const snapshotInsertTarget = (app: App): EditorInsertTarget | null => {
+  const view = app.workspace.getActiveViewOfType(MarkdownView);
+  // Reading mode has no cursor.
+  if (!view || !view.file || view.getMode() !== "source") return null;
+
+  const { editor } = view;
+  return {
+    view,
+    // A selection is replaced rather than left beside the link.
+    from: editor.getCursor("from"),
+    to: editor.getCursor("to"),
+  };
+};
+
+/** `generateMarkdownLink` is what honours the vault's link-format settings. */
+export const insertLinkAtInsertTarget = ({
+  app,
+  file,
+  target,
+}: {
+  app: App;
+  file: TFile;
+  target: EditorInsertTarget;
+}): void => {
+  const { view, from, to } = target;
+  const sourceFile = view.file;
+  if (!sourceFile) return;
+
+  const link = app.fileManager.generateMarkdownLink(file, sourceFile.path);
+  const { editor } = view;
+  editor.replaceRange(link, from, to);
+
+  app.workspace.setActiveLeaf(view.leaf, { focus: true });
+  editor.setCursor({ line: from.line, ch: from.ch + link.length });
+  editor.focus();
+};


### PR DESCRIPTION
https://www.loom.com/share/62b142bea41b4df6b4e0e19956dc160f

## What

`⌘↵` / `Ctrl+Enter` on the active result inserts a link to it at the cursor you left behind, then closes the search and hands focus back to the editor. The footer gets a matching `insert link at cursor` action.

- The cursor is snapshotted in `NodeSearchModal`'s **constructor** — that runs while the editor still owns the cursor, before `open()` mounts the modal and takes focus.
- The link comes from `app.fileManager.generateMarkdownLink(file, sourcePath)`, so the vault's wikilink-vs-markdown and shortest-path-vs-absolute settings are honoured. Nothing is hand-built.
- A selection is replaced rather than left beside the link, matching the Roam implementation (`insertPageRefAtRange`).
- The footer action is **absent, not disabled**, when nothing was being edited: there is no cursor for it to refer to.

`editor.hasFocus()` is deliberately not part of the gate — opening the search from the command palette means that palette already took focus, so a `hasFocus()` check would hide the action on its most common invocation path. The gate is "an active `MarkdownView` in source mode" instead.

## Scope

Rebased onto `main` now that ENG-2108/2109/2110/2111/2113 have landed, so the diff is only the insert-link path: 3 files, +99/-2.

- `utils/editorInsertTarget.ts` (new) — snapshot the cursor, insert the link
- `NodeSearchModal.tsx` — take the snapshot in the constructor, wire `Mod+Enter`
- `NodeSearchFooter.tsx` — the matching footer action

## Verification

No test infra exists in `apps/obsidian` (no vitest, no `test` script), so this was verified against a running Obsidian 1.13.7 driven over CDP — 19/19 assertions, twice consecutively:

| Check | Result |
| --- | --- |
| Link lands at the pre-open cursor, mid-line, in the correct note | `before[[CLM - a node…]]\| after` |
| Wikilink + shortest path | `[[CLM - a node to be type-casted]]` |
| Markdown + absolute path | `[CLM…](CLM%20-%20a%20node….md)` |
| Modal closes; focus and cursor return to the editor | `hasFocus: true`, cursor past the link |
| Selection is replaced, not orphaned | `replace [[CLM…]] please` |
| Footer click path, not just the chord | inserts and refocuses |
| Absent in reading mode / with no note open | footer shows only open, split, close |

Types pass; no new lint findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/1314" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
