### PR TITLE
ENG-2110 Add node type filter dropdown menu

### DIFF
--- a/apps/obsidian/src/components/NodeSearchModal.tsx
+++ b/apps/obsidian/src/components/NodeSearchModal.tsx
@@ -434,18 +434,6 @@ const NodeSearch = ({
     });
   };
 
-  // Focus stays in the search input while the panel is open, so Escape arrives
-  // here rather than at the panel. Obsidian's Modal closes on Escape from its own
-  // keymap scope, so the native event has to stop or the modal goes too.
-  const closeTypeFilterOnEscape = (
-    event: KeyboardEvent<HTMLDivElement>,
-  ): void => {
-    event.preventDefault();
-    event.nativeEvent.stopImmediatePropagation();
-    setIsTypeFilterOpen(false);
-    inputRef.current?.focus();
-  };
-
   const handleTypeFilterOpenChange = (nextOpen: boolean): void => {
     setIsTypeFilterOpen(nextOpen);
     // Returns the keyboard path to the results the moment the panel closes.
@@ -453,11 +441,6 @@ const NodeSearch = ({
   };
 
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
-    if (event.key === "Escape" && isTypeFilterOpen) {
-      closeTypeFilterOnEscape(event);
-      return;
-    }
-
     if (event.key === "ArrowDown" || event.key === "ArrowUp") {
       // Otherwise the caret jumps to the start or end of the query.
       event.preventDefault();
@@ -499,6 +482,7 @@ const NodeSearch = ({
           className="min-w-0 flex-1"
         />
         <NodeTypeFilterMenu
+          app={app}
           isOpen={isTypeFilterOpen}
           nodeTypes={plugin.settings.nodeTypes}
           onOpenChange={handleTypeFilterOpenChange}

--- a/apps/obsidian/src/components/NodeSearchModal.tsx
+++ b/apps/obsidian/src/components/NodeSearchModal.tsx
@@ -329,8 +329,7 @@ const NodeSearch = ({
   const [query, setQuery] = useState("");
   const [debouncedQuery, setDebouncedQuery] = useState("");
   const [activeIndex, setActiveIndex] = useState(0);
-  // The single source of truth for active type filters: F6's chips will read and
-  // write this same state, so either surface can manage them.
+  // Single source of truth: ENG-2111's tag chips will read and write this too.
   const [selectedNodeTypeIds, setSelectedNodeTypeIds] = useState<string[]>([]);
   const [isTypeFilterOpen, setIsTypeFilterOpen] = useState(false);
   const inputRef = useRef<HTMLInputElement | null>(null);

--- a/apps/obsidian/src/components/NodeSearchModal.tsx
+++ b/apps/obsidian/src/components/NodeSearchModal.tsx
@@ -21,6 +21,7 @@ import {
 import { createRoot, Root } from "react-dom/client";
 import type DiscourseGraphPlugin from "~/index";
 import { NodeSearchFooter } from "~/components/NodeSearchFooter";
+import { NodeTypeFilterMenu } from "~/components/NodeTypeFilterMenu";
 import {
   openFileInNewLeaf,
   openFileInNewTab,
@@ -328,6 +329,10 @@ const NodeSearch = ({
   const [query, setQuery] = useState("");
   const [debouncedQuery, setDebouncedQuery] = useState("");
   const [activeIndex, setActiveIndex] = useState(0);
+  // The single source of truth for active type filters: F6's chips will read and
+  // write this same state, so either surface can manage them.
+  const [selectedNodeTypeIds, setSelectedNodeTypeIds] = useState<string[]>([]);
+  const [isTypeFilterOpen, setIsTypeFilterOpen] = useState(false);
   const inputRef = useRef<HTMLInputElement | null>(null);
   const userNames = useAuthorNames({ app, plugin, candidateState });
 
@@ -374,6 +379,7 @@ const NodeSearch = ({
     return rankDiscourseNodesByTitle({
       candidates: candidateState.candidates,
       query: debouncedQuery,
+      nodeTypeIds: selectedNodeTypeIds,
     })
       .slice(0, MAX_VISIBLE_RESULTS)
       .map((result) => ({
@@ -383,7 +389,7 @@ const NodeSearch = ({
           badge: getFallbackNodeTypeBadge(result.title),
         },
       }));
-  }, [candidateState, debouncedQuery, nodeTypesById]);
+  }, [candidateState, debouncedQuery, nodeTypesById, selectedNodeTypeIds]);
 
   // A narrowing query rebuilds `results` before the effect below can reset the
   // state, so the old index can point past the new list for one render. Clamping
@@ -428,7 +434,30 @@ const NodeSearch = ({
     });
   };
 
+  // Focus stays in the search input while the panel is open, so Escape arrives
+  // here rather than at the panel. Obsidian's Modal closes on Escape from its own
+  // keymap scope, so the native event has to stop or the modal goes too.
+  const closeTypeFilterOnEscape = (
+    event: KeyboardEvent<HTMLDivElement>,
+  ): void => {
+    event.preventDefault();
+    event.nativeEvent.stopImmediatePropagation();
+    setIsTypeFilterOpen(false);
+    inputRef.current?.focus();
+  };
+
+  const handleTypeFilterOpenChange = (nextOpen: boolean): void => {
+    setIsTypeFilterOpen(nextOpen);
+    // Returns the keyboard path to the results the moment the panel closes.
+    if (!nextOpen) inputRef.current?.focus();
+  };
+
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === "Escape" && isTypeFilterOpen) {
+      closeTypeFilterOnEscape(event);
+      return;
+    }
+
     if (event.key === "ArrowDown" || event.key === "ArrowUp") {
       // Otherwise the caret jumps to the start or end of the query.
       event.preventDefault();
@@ -458,14 +487,25 @@ const NodeSearch = ({
     // Bound here rather than on the input so navigation survives focus moving
     // elsewhere in the modal, and so result actions have one place to live.
     <div className="flex h-full flex-col" onKeyDown={handleKeyDown}>
-      <input
-        ref={inputRef}
-        type="text"
-        value={query}
-        placeholder="Search discourse nodes by title"
-        onChange={(event) => setQuery(event.target.value)}
-        className="w-full"
-      />
+      {/* Padded so the filter trigger's count badge, which sits outside the
+          button box, is not clipped by the modal's overflow-hidden content. */}
+      <div className="flex items-center gap-2 px-1 pt-1">
+        <input
+          ref={inputRef}
+          type="text"
+          value={query}
+          placeholder="Search discourse nodes by title"
+          onChange={(event) => setQuery(event.target.value)}
+          className="min-w-0 flex-1"
+        />
+        <NodeTypeFilterMenu
+          isOpen={isTypeFilterOpen}
+          nodeTypes={plugin.settings.nodeTypes}
+          onOpenChange={handleTypeFilterOpenChange}
+          onSelectedNodeTypeIdsChange={setSelectedNodeTypeIds}
+          selectedNodeTypeIds={selectedNodeTypeIds}
+        />
+      </div>
       <div className="border-modifier-border mt-3 flex flex-1 overflow-hidden rounded border">
         <div className="border-modifier-border flex w-2/5 flex-col border-r">
           {candidateState.status === "loading" && (

--- a/apps/obsidian/src/components/NodeTypeFilterMenu.tsx
+++ b/apps/obsidian/src/components/NodeTypeFilterMenu.tsx
@@ -1,4 +1,4 @@
-import { setIcon } from "obsidian";
+import { App, Scope, setIcon } from "obsidian";
 import { useEffect, useMemo, useRef, useState, type ReactElement } from "react";
 import { DiscourseNode } from "~/types";
 import { getAllDiscourseNodeColors } from "~/utils/colorUtils";
@@ -164,12 +164,14 @@ const NodeTypeFilterPanel = ({
 };
 
 export const NodeTypeFilterMenu = ({
+  app,
   isOpen,
   nodeTypes,
   onOpenChange,
   onSelectedNodeTypeIdsChange,
   selectedNodeTypeIds,
 }: {
+  app: App;
   isOpen: boolean;
   nodeTypes: DiscourseNode[];
   onOpenChange: (isOpen: boolean) => void;
@@ -193,6 +195,23 @@ export const NodeTypeFilterMenu = ({
       toPanelSelectedIds({ selectedTypeIds: selectedNodeTypeIds, allTypeIds }),
     [allTypeIds, selectedNodeTypeIds],
   );
+
+  // Escape cannot be intercepted from the DOM. Obsidian registers the Modal's
+  // close-on-Escape before any plugin React tree exists, so a listener added
+  // later always runs second — preventDefault plus stopImmediatePropagation in a
+  // React handler, a capture-phase window listener, and registering on the
+  // Modal's own scope all fail, the last because Scope resolves in registration
+  // order. A pushed scope is the only thing that lands above the modal.
+  useEffect(() => {
+    if (!isOpen) return;
+    const scope = new Scope();
+    scope.register([], "Escape", () => {
+      onOpenChange(false);
+      return false;
+    });
+    app.keymap.pushScope(scope);
+    return () => app.keymap.popScope(scope);
+  }, [app, isOpen, onOpenChange]);
 
   // `activeDocument` rather than `document`, so the listener lands in whichever
   // window holds the modal when Obsidian is running a popout.
@@ -218,15 +237,9 @@ export const NodeTypeFilterMenu = ({
         // Every keystroke stops here while the panel is open. The modal's handler
         // is an ancestor and reads Enter as "open the highlighted result" and the
         // arrows as "move the selection", so typing in the type search would
-        // otherwise open a note and close the whole modal.
+        // otherwise open a note and close the whole modal. Escape is not handled
+        // here because it never reaches the DOM — see the pushed scope above.
         event.stopPropagation();
-        if (event.key !== "Escape") return;
-        // Obsidian's Modal closes on Escape from its own keymap scope, which sits
-        // outside React, so the native event has to stop too or the modal goes
-        // with the panel.
-        event.preventDefault();
-        event.nativeEvent.stopImmediatePropagation();
-        onOpenChange(false);
       }}
     >
       <button
@@ -255,7 +268,7 @@ export const NodeTypeFilterMenu = ({
         {activeFilterCount > 0 && (
           <span
             aria-hidden
-            className="bg-accent pointer-events-none absolute -right-1 -top-1 flex h-3.5 min-w-3.5 items-center justify-center rounded-lg px-1 text-xs font-semibold leading-none text-white"
+            className="bg-accent text-on-accent pointer-events-none absolute -right-1 -top-1 flex h-3.5 min-w-3.5 items-center justify-center rounded-lg px-1 text-xs font-semibold leading-none"
           >
             {activeFilterCount}
           </span>

--- a/apps/obsidian/src/components/NodeTypeFilterMenu.tsx
+++ b/apps/obsidian/src/components/NodeTypeFilterMenu.tsx
@@ -1,0 +1,292 @@
+import { setIcon } from "obsidian";
+import { useEffect, useMemo, useRef, useState, type ReactElement } from "react";
+import { DiscourseNode } from "~/types";
+import { getAllDiscourseNodeColors } from "~/utils/colorUtils";
+import {
+  NODE_TYPE_FILTER_SEARCH_THRESHOLD,
+  filterNodeTypesByQuery,
+  fromPanelSelectedIds,
+  getSelectAllCheckState,
+  hasActiveTypeFilter,
+  toPanelSelectedIds,
+} from "~/utils/discourseNodeTypeFilter";
+
+const FilterIcon = ({ name }: { name: string }): ReactElement => (
+  // Emptied first because React reuses the node across renders and `setIcon`
+  // appends rather than replaces.
+  <span
+    className="flex items-center"
+    ref={(el) => {
+      if (!el) return;
+      el.empty();
+      setIcon(el, name);
+    }}
+  />
+);
+
+const NodeTypeFilterRow = ({
+  color,
+  isChecked,
+  nodeType,
+  onSelectOnly,
+  onToggle,
+}: {
+  color: string | undefined;
+  isChecked: boolean;
+  nodeType: DiscourseNode;
+  onSelectOnly: () => void;
+  onToggle: () => void;
+}): ReactElement => (
+  <div className="hover:bg-modifier-hover group flex items-center gap-2 px-3 py-1.5">
+    <label className="flex min-w-0 flex-1 cursor-pointer items-center gap-2">
+      <input
+        type="checkbox"
+        checked={isChecked}
+        onChange={onToggle}
+        className="shrink-0"
+      />
+      {color && (
+        <span
+          style={{ backgroundColor: color }}
+          className="h-3 w-3 shrink-0 rounded-full"
+        />
+      )}
+      <span className="text-normal truncate text-sm">{nodeType.name}</span>
+    </label>
+    <button
+      type="button"
+      // Hidden until the row is hovered or focused so the list stays scannable,
+      // but focusable by keyboard rather than pointer-only.
+      className="text-muted hover:text-normal shrink-0 opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100"
+      onClick={(event) => {
+        event.stopPropagation();
+        onSelectOnly();
+      }}
+      onMouseDown={(event) => event.preventDefault()}
+    >
+      Only
+    </button>
+  </div>
+);
+
+const NodeTypeFilterPanel = ({
+  nodeTypes,
+  onSelectedIdsChange,
+  selectedIds,
+}: {
+  nodeTypes: DiscourseNode[];
+  onSelectedIdsChange: (ids: string[]) => void;
+  selectedIds: string[];
+}): ReactElement => {
+  const [query, setQuery] = useState("");
+  const searchRef = useRef<HTMLInputElement | null>(null);
+
+  const showTypeSearch = nodeTypes.length > NODE_TYPE_FILTER_SEARCH_THRESHOLD;
+
+  const colorsById = useMemo(() => {
+    const byId = new Map<string, string>();
+    getAllDiscourseNodeColors(nodeTypes).forEach(({ nodeType, colors }) => {
+      byId.set(nodeType.id, colors.backgroundColor);
+    });
+    return byId;
+  }, [nodeTypes]);
+
+  const filteredNodeTypes = useMemo(
+    () => filterNodeTypesByQuery(nodeTypes, query),
+    [nodeTypes, query],
+  );
+
+  const selectedIdSet = useMemo(() => new Set(selectedIds), [selectedIds]);
+
+  const selectAllState = getSelectAllCheckState({
+    selectedIds,
+    totalCount: nodeTypes.length,
+  });
+
+  useEffect(() => {
+    if (showTypeSearch) searchRef.current?.focus();
+  }, [showTypeSearch]);
+
+  const handleSelectAll = (): void => {
+    if (selectAllState === "off") {
+      onSelectedIdsChange(nodeTypes.map((nodeType) => nodeType.id));
+      return;
+    }
+    onSelectedIdsChange([]);
+  };
+
+  const toggleType = (id: string): void => {
+    onSelectedIdsChange(
+      selectedIdSet.has(id)
+        ? selectedIds.filter((selectedId) => selectedId !== id)
+        : [...selectedIds, id],
+    );
+  };
+
+  const hasTypeSearchQuery = query.trim().length > 0;
+
+  return (
+    <div className="border-modifier-border absolute right-0 top-full z-50 mt-1 w-64 overflow-hidden rounded-md border bg-primary shadow-[0_4px_12px_rgba(0,0,0,0.15)]">
+      {showTypeSearch && (
+        <div className="border-modifier-border border-b p-2">
+          <input
+            ref={searchRef}
+            type="text"
+            value={query}
+            placeholder="Filter types…"
+            onChange={(event) => setQuery(event.target.value)}
+            className="w-full"
+          />
+        </div>
+      )}
+      <div className="max-h-64 overflow-y-auto py-1">
+        {filteredNodeTypes.length === 0 ? (
+          <div className="text-muted p-4 text-center text-sm">
+            No matching node types
+          </div>
+        ) : (
+          <>
+            {/* A partial list has no "all" to speak of, so the row is dropped
+                while searching rather than acting on the hidden types too. */}
+            {!hasTypeSearchQuery && (
+              <label className="border-modifier-border hover:bg-modifier-hover flex cursor-pointer items-center gap-2 border-b px-3 py-1.5">
+                <input
+                  type="checkbox"
+                  checked={selectAllState !== "off"}
+                  ref={(el) => {
+                    if (el)
+                      el.indeterminate = selectAllState === "indeterminate";
+                  }}
+                  onChange={handleSelectAll}
+                  className="shrink-0"
+                />
+                <span className="text-normal text-sm font-semibold">
+                  Select all
+                </span>
+              </label>
+            )}
+            {filteredNodeTypes.map((nodeType) => (
+              <NodeTypeFilterRow
+                key={nodeType.id}
+                color={colorsById.get(nodeType.id)}
+                isChecked={selectedIdSet.has(nodeType.id)}
+                nodeType={nodeType}
+                onSelectOnly={() => onSelectedIdsChange([nodeType.id])}
+                onToggle={() => toggleType(nodeType.id)}
+              />
+            ))}
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export const NodeTypeFilterMenu = ({
+  isOpen,
+  nodeTypes,
+  onOpenChange,
+  onSelectedNodeTypeIdsChange,
+  selectedNodeTypeIds,
+}: {
+  isOpen: boolean;
+  nodeTypes: DiscourseNode[];
+  onOpenChange: (isOpen: boolean) => void;
+  onSelectedNodeTypeIdsChange: (ids: string[]) => void;
+  selectedNodeTypeIds: string[];
+}): ReactElement => {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  const allTypeIds = useMemo(
+    () => nodeTypes.map((nodeType) => nodeType.id),
+    [nodeTypes],
+  );
+
+  const isFilterActive = hasActiveTypeFilter({
+    selectedTypeIds: selectedNodeTypeIds,
+    allTypeIds,
+  });
+
+  const panelSelectedIds = useMemo(
+    () =>
+      toPanelSelectedIds({ selectedTypeIds: selectedNodeTypeIds, allTypeIds }),
+    [allTypeIds, selectedNodeTypeIds],
+  );
+
+  // `activeDocument` rather than `document`, so the listener lands in whichever
+  // window holds the modal when Obsidian is running a popout.
+  useEffect(() => {
+    if (!isOpen) return;
+    const handlePointerDown = (event: MouseEvent) => {
+      if (containerRef.current?.contains(event.target as Node)) return;
+      onOpenChange(false);
+    };
+    activeDocument.addEventListener("mousedown", handlePointerDown, true);
+    return () =>
+      activeDocument.removeEventListener("mousedown", handlePointerDown, true);
+  }, [isOpen, onOpenChange]);
+
+  const activeFilterCount = isFilterActive ? selectedNodeTypeIds.length : 0;
+
+  return (
+    <div
+      ref={containerRef}
+      className="relative shrink-0"
+      onKeyDown={(event) => {
+        if (event.key !== "Escape" || !isOpen) return;
+        // Obsidian's Modal closes on Escape from its own keymap scope, so the
+        // native event has to stop here or the whole modal goes with the panel.
+        event.preventDefault();
+        event.nativeEvent.stopImmediatePropagation();
+        // The modal's own Escape handler is an ancestor of this one; stopping the
+        // synthetic event too keeps it from closing the panel a second time.
+        event.stopPropagation();
+        onOpenChange(false);
+      }}
+    >
+      <button
+        type="button"
+        aria-expanded={isOpen}
+        aria-label={
+          activeFilterCount > 0
+            ? `Filter by type, ${activeFilterCount} selected`
+            : "Filter by type"
+        }
+        disabled={nodeTypes.length === 0}
+        title={
+          nodeTypes.length === 0
+            ? "No discourse node types configured"
+            : "Filter by type"
+        }
+        onClick={() => onOpenChange(!isOpen)}
+        // Keeps focus in the search input, so arrow and Enter navigation stays
+        // live while the panel is open.
+        onMouseDown={(event) => event.preventDefault()}
+        className={`clickable-icon relative ${
+          isOpen || isFilterActive ? "is-active" : ""
+        }`}
+      >
+        <FilterIcon name="filter" />
+        {activeFilterCount > 0 && (
+          <span
+            aria-hidden
+            className="bg-accent pointer-events-none absolute -right-1 -top-1 flex h-3.5 min-w-3.5 items-center justify-center rounded-lg px-1 text-xs font-semibold leading-none text-white"
+          >
+            {activeFilterCount}
+          </span>
+        )}
+      </button>
+      {isOpen && (
+        <NodeTypeFilterPanel
+          nodeTypes={nodeTypes}
+          onSelectedIdsChange={(panelIds) =>
+            onSelectedNodeTypeIdsChange(
+              fromPanelSelectedIds({ panelSelectedIds: panelIds, allTypeIds }),
+            )
+          }
+          selectedIds={panelSelectedIds}
+        />
+      )}
+    </div>
+  );
+};

--- a/apps/obsidian/src/components/NodeTypeFilterMenu.tsx
+++ b/apps/obsidian/src/components/NodeTypeFilterMenu.tsx
@@ -6,7 +6,6 @@ import {
   NODE_TYPE_FILTER_SEARCH_THRESHOLD,
   filterNodeTypesByQuery,
   fromPanelSelectedIds,
-  getSelectAllCheckState,
   hasActiveTypeFilter,
   toPanelSelectedIds,
 } from "~/utils/discourseNodeTypeFilter";
@@ -70,10 +69,12 @@ const NodeTypeFilterRow = ({
 );
 
 const NodeTypeFilterPanel = ({
+  isFilterActive,
   nodeTypes,
   onSelectedIdsChange,
   selectedIds,
 }: {
+  isFilterActive: boolean;
   nodeTypes: DiscourseNode[];
   onSelectedIdsChange: (ids: string[]) => void;
   selectedIds: string[];
@@ -98,22 +99,9 @@ const NodeTypeFilterPanel = ({
 
   const selectedIdSet = useMemo(() => new Set(selectedIds), [selectedIds]);
 
-  const selectAllState = getSelectAllCheckState({
-    selectedIds,
-    totalCount: nodeTypes.length,
-  });
-
   useEffect(() => {
     if (showTypeSearch) searchRef.current?.focus();
   }, [showTypeSearch]);
-
-  const handleSelectAll = (): void => {
-    if (selectAllState === "off") {
-      onSelectedIdsChange(nodeTypes.map((nodeType) => nodeType.id));
-      return;
-    }
-    onSelectedIdsChange([]);
-  };
 
   const toggleType = (id: string): void => {
     onSelectedIdsChange(
@@ -123,10 +111,24 @@ const NodeTypeFilterPanel = ({
     );
   };
 
-  const hasTypeSearchQuery = query.trim().length > 0;
-
   return (
     <div className="border-modifier-border absolute right-0 top-full z-50 mt-1 w-64 overflow-hidden rounded-md border bg-primary shadow-[0_4px_12px_rgba(0,0,0,0.15)]">
+      {/* Clearing is the only thing this control ever does, so it says so and
+          appears only when there is a filter to clear. A "select all" checkbox
+          would sit checked-and-inert whenever no filter is active, since an empty
+          selection and a full one are the same state. */}
+      {isFilterActive && (
+        <div className="border-modifier-border border-b p-2">
+          <button
+            type="button"
+            onClick={() => onSelectedIdsChange([])}
+            onMouseDown={(event) => event.preventDefault()}
+            className="w-full text-sm"
+          >
+            {`Clear filter (${selectedIds.length})`}
+          </button>
+        </div>
+      )}
       {showTypeSearch && (
         <div className="border-modifier-border border-b p-2">
           <input
@@ -145,37 +147,16 @@ const NodeTypeFilterPanel = ({
             No matching node types
           </div>
         ) : (
-          <>
-            {/* A partial list has no "all" to speak of, so the row is dropped
-                while searching rather than acting on the hidden types too. */}
-            {!hasTypeSearchQuery && (
-              <label className="border-modifier-border hover:bg-modifier-hover flex cursor-pointer items-center gap-2 border-b px-3 py-1.5">
-                <input
-                  type="checkbox"
-                  checked={selectAllState !== "off"}
-                  ref={(el) => {
-                    if (el)
-                      el.indeterminate = selectAllState === "indeterminate";
-                  }}
-                  onChange={handleSelectAll}
-                  className="shrink-0"
-                />
-                <span className="text-normal text-sm font-semibold">
-                  Select all
-                </span>
-              </label>
-            )}
-            {filteredNodeTypes.map((nodeType) => (
-              <NodeTypeFilterRow
-                key={nodeType.id}
-                color={colorsById.get(nodeType.id)}
-                isChecked={selectedIdSet.has(nodeType.id)}
-                nodeType={nodeType}
-                onSelectOnly={() => onSelectedIdsChange([nodeType.id])}
-                onToggle={() => toggleType(nodeType.id)}
-              />
-            ))}
-          </>
+          filteredNodeTypes.map((nodeType) => (
+            <NodeTypeFilterRow
+              key={nodeType.id}
+              color={colorsById.get(nodeType.id)}
+              isChecked={selectedIdSet.has(nodeType.id)}
+              nodeType={nodeType}
+              onSelectOnly={() => onSelectedIdsChange([nodeType.id])}
+              onToggle={() => toggleType(nodeType.id)}
+            />
+          ))
         )}
       </div>
     </div>
@@ -233,14 +214,18 @@ export const NodeTypeFilterMenu = ({
       ref={containerRef}
       className="relative shrink-0"
       onKeyDown={(event) => {
-        if (event.key !== "Escape" || !isOpen) return;
-        // Obsidian's Modal closes on Escape from its own keymap scope, so the
-        // native event has to stop here or the whole modal goes with the panel.
+        if (!isOpen) return;
+        // Every keystroke stops here while the panel is open. The modal's handler
+        // is an ancestor and reads Enter as "open the highlighted result" and the
+        // arrows as "move the selection", so typing in the type search would
+        // otherwise open a note and close the whole modal.
+        event.stopPropagation();
+        if (event.key !== "Escape") return;
+        // Obsidian's Modal closes on Escape from its own keymap scope, which sits
+        // outside React, so the native event has to stop too or the modal goes
+        // with the panel.
         event.preventDefault();
         event.nativeEvent.stopImmediatePropagation();
-        // The modal's own Escape handler is an ancestor of this one; stopping the
-        // synthetic event too keeps it from closing the panel a second time.
-        event.stopPropagation();
         onOpenChange(false);
       }}
     >
@@ -278,6 +263,7 @@ export const NodeTypeFilterMenu = ({
       </button>
       {isOpen && (
         <NodeTypeFilterPanel
+          isFilterActive={isFilterActive}
           nodeTypes={nodeTypes}
           onSelectedIdsChange={(panelIds) =>
             onSelectedNodeTypeIdsChange(

--- a/apps/obsidian/src/utils/discourseNodeTypeFilter.ts
+++ b/apps/obsidian/src/utils/discourseNodeTypeFilter.ts
@@ -1,0 +1,78 @@
+import { DiscourseNode } from "~/types";
+
+/**
+ * Node type filtering for the search modal. An empty `selectedTypeIds` means no
+ * filter, matching `filterCandidatesByNodeTypeIds` in QueryEngine — so "nothing
+ * selected" and "every type selected" are the same state and both show all nodes.
+ * Ported from Roam's advanced search so both apps filter alike.
+ */
+
+/** Below this many types the list is short enough to scan without a search box. */
+export const NODE_TYPE_FILTER_SEARCH_THRESHOLD = 7;
+
+export type SelectAllCheckState = "off" | "indeterminate" | "on";
+
+export const hasActiveTypeFilter = ({
+  selectedTypeIds,
+  allTypeIds,
+}: {
+  selectedTypeIds: string[];
+  allTypeIds: string[];
+}): boolean =>
+  selectedTypeIds.length > 0 && selectedTypeIds.length < allTypeIds.length;
+
+/**
+ * The stored empty set means "no filter", which the panel shows as every row
+ * checked — otherwise an unfiltered search would render as an empty checklist.
+ */
+export const toPanelSelectedIds = ({
+  selectedTypeIds,
+  allTypeIds,
+}: {
+  selectedTypeIds: string[];
+  allTypeIds: string[];
+}): string[] => (selectedTypeIds.length === 0 ? allTypeIds : selectedTypeIds);
+
+/**
+ * Collapses both "all checked" and "none checked" back to the empty set, so the
+ * count badge and the search agree that neither is a filter.
+ */
+export const fromPanelSelectedIds = ({
+  panelSelectedIds,
+  allTypeIds,
+}: {
+  panelSelectedIds: string[];
+  allTypeIds: string[];
+}): string[] => {
+  if (
+    panelSelectedIds.length === 0 ||
+    panelSelectedIds.length === allTypeIds.length
+  ) {
+    return [];
+  }
+  return panelSelectedIds;
+};
+
+export const filterNodeTypesByQuery = (
+  nodeTypes: DiscourseNode[],
+  query: string,
+): DiscourseNode[] => {
+  const trimmedQuery = query.trim().toLowerCase();
+  if (!trimmedQuery) return nodeTypes;
+
+  return nodeTypes.filter((nodeType) =>
+    nodeType.name.toLowerCase().includes(trimmedQuery),
+  );
+};
+
+export const getSelectAllCheckState = ({
+  selectedIds,
+  totalCount,
+}: {
+  selectedIds: string[];
+  totalCount: number;
+}): SelectAllCheckState => {
+  if (selectedIds.length === 0) return "off";
+  if (selectedIds.length === totalCount) return "on";
+  return "indeterminate";
+};

--- a/apps/obsidian/src/utils/discourseNodeTypeFilter.ts
+++ b/apps/obsidian/src/utils/discourseNodeTypeFilter.ts
@@ -10,8 +10,6 @@ import { DiscourseNode } from "~/types";
 /** Below this many types the list is short enough to scan without a search box. */
 export const NODE_TYPE_FILTER_SEARCH_THRESHOLD = 7;
 
-export type SelectAllCheckState = "off" | "indeterminate" | "on";
-
 export const hasActiveTypeFilter = ({
   selectedTypeIds,
   allTypeIds,
@@ -63,16 +61,4 @@ export const filterNodeTypesByQuery = (
   return nodeTypes.filter((nodeType) =>
     nodeType.name.toLowerCase().includes(trimmedQuery),
   );
-};
-
-export const getSelectAllCheckState = ({
-  selectedIds,
-  totalCount,
-}: {
-  selectedIds: string[];
-  totalCount: number;
-}): SelectAllCheckState => {
-  if (selectedIds.length === 0) return "off";
-  if (selectedIds.length === totalCount) return "on";
-  return "indeterminate";
 };

--- a/apps/obsidian/src/utils/discourseNodeTypeFilter.ts
+++ b/apps/obsidian/src/utils/discourseNodeTypeFilter.ts
@@ -7,7 +7,7 @@ import { DiscourseNode } from "~/types";
  * Ported from Roam's advanced search so both apps filter alike.
  */
 
-/** Below this many types the list is short enough to scan without a search box. */
+/** Type count above which the panel adds a search box; the modal is desktop-only. */
 export const NODE_TYPE_FILTER_SEARCH_THRESHOLD = 7;
 
 export const hasActiveTypeFilter = ({
@@ -19,10 +19,7 @@ export const hasActiveTypeFilter = ({
 }): boolean =>
   selectedTypeIds.length > 0 && selectedTypeIds.length < allTypeIds.length;
 
-/**
- * The stored empty set means "no filter", which the panel shows as every row
- * checked — otherwise an unfiltered search would render as an empty checklist.
- */
+/** Shows no-filter as every row checked, so the panel is never an empty checklist. */
 export const toPanelSelectedIds = ({
   selectedTypeIds,
   allTypeIds,
@@ -31,10 +28,7 @@ export const toPanelSelectedIds = ({
   allTypeIds: string[];
 }): string[] => (selectedTypeIds.length === 0 ? allTypeIds : selectedTypeIds);
 
-/**
- * Collapses both "all checked" and "none checked" back to the empty set, so the
- * count badge and the search agree that neither is a filter.
- */
+/** Collapses both "all checked" and "none checked" back to no filter. */
 export const fromPanelSelectedIds = ({
   panelSelectedIds,
   allTypeIds,


### PR DESCRIPTION
https://www.loom.com/share/f8349cfbe61f447c80986c968f7b9547

## What this does

Adds a node type filter beside the search input in the node search modal. Selecting types narrows results immediately, the active filter shows as a count badge on the trigger, clearing restores the full set, and multiple types return the union.


## Changes

**`apps/obsidian/src/utils/discourseNodeTypeFilter.ts`** (new) — Roam's semantics ported, narrowed to `string[]` ids and Obsidian's `DiscourseNode` (`.id`/`.name` rather than `.type`/`.text`). The piece worth attention is `toPanelSelectedIds`/`fromPanelSelectedIds`: the stored empty set means "no filter", which the panel must render as *every* row checked, and selecting all normalises back to empty. That keeps the stored state, the count badge, and `filterCandidatesByNodeTypeIds` agreeing on what counts as a filter.

**`apps/obsidian/src/components/NodeTypeFilterMenu.tsx`** (new) — Obsidian-native trigger (`clickable-icon` + `setIcon`) with a count badge, over a panel with checkbox rows, colour dots, a per-row "Only" button, a `Clear filter (n)` button while a filter is active, and a type-search input past 7 types. Reuses `getAllDiscourseNodeColors` for the dots so palette fallbacks stay index-stable. Outside-click uses `activeDocument`, following `InlineNodeTypePicker`, so it works in a popout window.

**`apps/obsidian/src/components/NodeSearchModal.tsx`** — `selectedNodeTypeIds` state as the single source of truth so ENG-2111's chips can read and write the same state; trigger inline-right of the input, leaving the row beneath free for those chips; focus returns to the input when the panel closes.

## Two behaviours worth understanding before reviewing

**`Clear filter` rather than `Select all`.** Roam has a tri-state "Select all" checkbox here, and it is the one place this PR knowingly diverges. Because an empty selection and a full one are the same state by design, that checkbox sits checked and inert whenever no filter is active, so clicking it appears to do nothing. Clearing is the control's only real function, so it now says so and appears only when there is something to clear.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
