### PR TITLE
ENG-2160 Namespace the Discourse Graph Roam testing skills

### DIFF
--- a/skills/dg-roam-load-extension/SKILL.md
+++ b/skills/dg-roam-load-extension/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: roam-load-extension
+name: dg-roam-load-extension
 description: Build and load the local Discourse Graphs apps/roam extension into Roam Research through Roam Depot developer mode using a Playwright test account. Use when verifying local apps/roam changes in a real Roam graph, checking that DG commands/settings load, or capturing proof after loading apps/roam/dist.
 ---
 
@@ -7,7 +7,7 @@ description: Build and load the local Discourse Graphs apps/roam extension into 
 
 Use this skill to build `apps/roam`, load `apps/roam/dist` through Roam Depot developer mode, and verify that the Discourse Graphs extension is active.
 
-It composes with `roam-playwright-session` for account/profile selection.
+It composes with `dg-roam-playwright-session` for account/profile selection.
 
 ## Quick Start
 

--- a/skills/dg-roam-load-extension/agents/openai.yaml
+++ b/skills/dg-roam-load-extension/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "DG Roam Load Extension"
+  short_description: "Load the local DG extension into Roam"
+  default_prompt: "Use $dg-roam-load-extension to load the local DG extension into Roam."

--- a/skills/dg-roam-playwright-session/SKILL.md
+++ b/skills/dg-roam-playwright-session/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: roam-playwright-session
+name: dg-roam-playwright-session
 description: Open Roam Research with a Discourse Graphs Playwright test account and persistent profile for apps/roam extension testing. Use when developing or verifying the Discourse Graphs Roam extension, rotating between the three local Playwright Roam accounts, capturing screenshot proof, or inspecting live Roam DOM behavior from this repository.
 ---
 

--- a/skills/dg-roam-playwright-session/agents/openai.yaml
+++ b/skills/dg-roam-playwright-session/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "DG Roam Playwright Session"
+  short_description: "Open DG Roam Playwright test sessions"
+  default_prompt: "Use $dg-roam-playwright-session to open a DG Roam Playwright test session."


### PR DESCRIPTION
## Summary

- Rename the DG-specific Roam testing skills with the `dg-` namespace.
- Add matching `agents/openai.yaml` discovery metadata.
- Keep the existing Playwright session, test-account, credential, and extension-loading behavior unchanged.

## Validation

- `quick_validate.py skills/dg-roam-playwright-session`
- `quick_validate.py skills/dg-roam-load-extension`
- Discovery metadata and folder/frontmatter contract check
- Stale skill-reference scan

## Scope check

- [x] Ran `$scope-check` against ENG-2160 and the final diff.
- Scope beyond `Done When`: None.

Linear: https://linear.app/discourse-graphs/issue/ENG-2160/namespace-the-discourse-graph-roam-testing-skills
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/1319" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->