### PR TITLE
ENG-2111 Add keyboard-only node type filtering with tag chips

### DIFF
--- a/apps/obsidian/src/components/NodeSearchModal.tsx
+++ b/apps/obsidian/src/components/NodeSearchModal.tsx
@@ -21,6 +21,7 @@ import {
 import { createRoot, Root } from "react-dom/client";
 import type DiscourseGraphPlugin from "~/index";
 import { NodeSearchFooter } from "~/components/NodeSearchFooter";
+import { NodeTypeChipsSearchInput } from "~/components/NodeTypeChipsSearchInput";
 import { NodeTypeFilterMenu } from "~/components/NodeTypeFilterMenu";
 import {
   openFileInNewLeaf,
@@ -332,7 +333,8 @@ const NodeSearch = ({
   // Single source of truth: ENG-2111's tag chips will read and write this too.
   const [selectedNodeTypeIds, setSelectedNodeTypeIds] = useState<string[]>([]);
   const [isTypeFilterOpen, setIsTypeFilterOpen] = useState(false);
-  const inputRef = useRef<HTMLInputElement | null>(null);
+  // An editable span, so the query shares its line boxes with the filter chips.
+  const inputRef = useRef<HTMLSpanElement | null>(null);
   const userNames = useAuthorNames({ app, plugin, candidateState });
 
   const nodeTypesById = useMemo(() => {
@@ -471,14 +473,15 @@ const NodeSearch = ({
     <div className="flex h-full flex-col" onKeyDown={handleKeyDown}>
       {/* Padded so the filter trigger's count badge, which sits outside the
           button box, is not clipped by the modal's overflow-hidden content. */}
-      <div className="flex items-center gap-2 px-1 pt-1">
-        <input
-          ref={inputRef}
-          type="text"
-          value={query}
-          placeholder="Search discourse nodes by title"
-          onChange={(event) => setQuery(event.target.value)}
-          className="min-w-0 flex-1"
+      {/* Top-aligned: the field grows downwards, so the trigger stays on its first line. */}
+      <div className="flex items-start gap-2 px-1 pt-1">
+        <NodeTypeChipsSearchInput
+          inputRef={inputRef}
+          nodeTypes={plugin.settings.nodeTypes}
+          onQueryChange={setQuery}
+          onSelectedNodeTypeIdsChange={setSelectedNodeTypeIds}
+          query={query}
+          selectedNodeTypeIds={selectedNodeTypeIds}
         />
         <NodeTypeFilterMenu
           app={app}

--- a/apps/obsidian/src/components/NodeSearchModal.tsx
+++ b/apps/obsidian/src/components/NodeSearchModal.tsx
@@ -333,7 +333,6 @@ const NodeSearch = ({
   // Single source of truth: ENG-2111's tag chips will read and write this too.
   const [selectedNodeTypeIds, setSelectedNodeTypeIds] = useState<string[]>([]);
   const [isTypeFilterOpen, setIsTypeFilterOpen] = useState(false);
-  // An editable span, so the query shares its line boxes with the filter chips.
   const inputRef = useRef<HTMLSpanElement | null>(null);
   const userNames = useAuthorNames({ app, plugin, candidateState });
 

--- a/apps/obsidian/src/components/NodeTypeChipsSearchInput.tsx
+++ b/apps/obsidian/src/components/NodeTypeChipsSearchInput.tsx
@@ -15,7 +15,6 @@ import {
   getCompletionSuffix,
 } from "~/utils/nodeTypeChipCompletion";
 
-/** `-1` means the caret is in the query rather than on a chip. */
 const NO_FOCUSED_CHIP = -1;
 
 const QUERY_PLACEHOLDER = "Search discourse nodes by title";
@@ -63,8 +62,7 @@ const NodeTypeChipTag = ({
   onRemove: () => void;
   registerRef: (element: HTMLSpanElement | null) => void;
 }): ReactElement => (
-  // Inline-flex, so a chip shares its line box with the query and wraps alongside it.
-  // Out of the tab order: Tab is the commit key, so arrows and Backspace reach chips.
+  // Inline-flex so it shares the query's line box; out of the tab order because Tab commits.
   <span
     ref={registerRef}
     role="button"
@@ -97,7 +95,7 @@ const NodeTypeChipTag = ({
   </span>
 );
 
-/** Chips and the query caret in one field; `NodeSearch` owns the state and, as an ancestor, already handles the arrows, Enter and Escape that bubble out of here. */
+/** `NodeSearch` owns the filter state, and as an ancestor already handles the arrows, Enter and Escape that bubble out of here. */
 export const NodeTypeChipsSearchInput = ({
   inputRef,
   nodeTypes,
@@ -142,11 +140,7 @@ export const NodeTypeChipsSearchInput = ({
 
   const completionSuffix = getCompletionSuffix({ bestPrefixMatch, query });
 
-  /**
-   * The query text is uncontrolled: React owns the chips but never the editable's
-   * content, so re-rendering on each keystroke cannot move the caret. Programmatic
-   * changes therefore have to write the text themselves.
-   */
+  // Uncontrolled, so re-rendering cannot move the caret — hence writing the text by hand.
   const writeQuery = (value: string): void => {
     const field = inputRef.current;
     if (field) field.textContent = value;
@@ -179,9 +173,6 @@ export const NodeTypeChipsSearchInput = ({
     writeQuery("");
   };
 
-  // By id, not by position: `chips` is what the user sees and is the only list an
-  // index here refers to, so removing positionally from `selectedNodeTypeIds` would
-  // hit the wrong filter the moment the two ever differed.
   const removeChip = (chipId: string): void => {
     onSelectedNodeTypeIdsChange(
       selectedNodeTypeIds.filter((id) => id !== chipId),
@@ -230,7 +221,6 @@ export const NodeTypeChipsSearchInput = ({
       return;
     }
 
-    // Typing with a chip focused is a return to the query, not a lost keystroke.
     if (isPlainCharacterKey(event)) {
       event.preventDefault();
       writeQuery(event.key);
@@ -270,14 +260,10 @@ export const NodeTypeChipsSearchInput = ({
 
   return (
     <div
-      // A block box, not a flex row: chips and the query are inline siblings, so they
-      // share line boxes and flow together left to right, top to bottom.
-      // `border-solid` is not redundant: this build omits `@tailwind base`, so there is
-      // no preflight setting a default border style and `border` alone renders nothing.
+      // A block box, not flex: chips and the query are inline siblings, so they flow as one sentence.
+      // `border-solid` is required: with no `@tailwind base`, `border` sets width but no style.
       className="border-modifier-border bg-modifier-form-field min-h-[calc(var(--font-ui-medium)*var(--line-height-tight)_+_12px)] min-w-0 flex-1 cursor-text rounded-[var(--input-radius)] border border-solid px-2 py-1 text-[length:var(--font-ui-medium)] leading-[var(--line-height-tight)] focus-within:border-[color:var(--background-modifier-border-focus)] hover:border-[color:var(--background-modifier-border-hover)]"
-      // Only for clicks on the field's own padding. A click on the text or a chip must
-      // keep the caret the browser just placed, or clicking into the middle of a query
-      // drags it to the end.
+      // Padding clicks only: elsewhere the browser has already placed the caret.
       onClick={(event) => {
         if (event.target === event.currentTarget) focusQuery();
       }}
@@ -312,7 +298,6 @@ export const NodeTypeChipsSearchInput = ({
         onKeyDown={handleQueryKeyDown}
         className="dg-search-chip-input whitespace-pre-wrap break-words align-middle outline-none"
       />
-      {/* Inline rather than an overlay, so it follows the caret and wraps with the text. */}
       {!!bestPrefixMatch && (
         <span aria-hidden className="align-middle">
           <span className="text-muted">{completionSuffix}</span>

--- a/apps/obsidian/src/components/NodeTypeChipsSearchInput.tsx
+++ b/apps/obsidian/src/components/NodeTypeChipsSearchInput.tsx
@@ -1,0 +1,328 @@
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type ReactElement,
+  type RefObject,
+} from "react";
+import { DiscourseNode } from "~/types";
+import { getAllDiscourseNodeColors } from "~/utils/colorUtils";
+import { getHintKeys } from "~/utils/keyboardHints";
+import {
+  getBestPrefixMatch,
+  getCompletionSuffix,
+} from "~/utils/nodeTypeChipCompletion";
+
+/** `-1` means the caret is in the query rather than on a chip. */
+const NO_FOCUSED_CHIP = -1;
+
+const CHIP_LABEL_MAX_WIDTH = "10rem";
+const QUERY_PLACEHOLDER = "Search discourse nodes by title";
+
+type NodeTypeChip = {
+  backgroundColor: string;
+  id: string;
+  name: string;
+  textColor: string;
+};
+
+const isPlainCharacterKey = (event: KeyboardEvent): boolean =>
+  event.key.length === 1 && !event.altKey && !event.ctrlKey && !event.metaKey;
+
+// An editable span has no selectionStart, so the caret comes from the selection.
+const isCaretAtStart = (field: HTMLElement | null): boolean => {
+  const selection = field?.ownerDocument.getSelection();
+  if (!field || !selection?.isCollapsed || !selection.anchorNode) return false;
+  if (!field.contains(selection.anchorNode)) return false;
+  return selection.anchorOffset === 0;
+};
+
+const setCaretToEnd = (field: HTMLElement): void => {
+  const selection = field.ownerDocument.getSelection();
+  if (!selection) return;
+  const range = field.ownerDocument.createRange();
+  range.selectNodeContents(field);
+  range.collapse(false);
+  selection.removeAllRanges();
+  selection.addRange(range);
+};
+
+const NodeTypeChipTag = ({
+  chip,
+  isFocused,
+  onFocusChip,
+  onKeyDown,
+  onRemove,
+  registerRef,
+}: {
+  chip: NodeTypeChip;
+  isFocused: boolean;
+  onFocusChip: () => void;
+  onKeyDown: (event: KeyboardEvent<HTMLSpanElement>) => void;
+  onRemove: () => void;
+  registerRef: (element: HTMLSpanElement | null) => void;
+}): ReactElement => (
+  // Inline-flex, so a chip shares its line box with the query and wraps alongside it.
+  // Out of the tab order: Tab is the commit key, so arrows and Backspace reach chips.
+  <span
+    ref={registerRef}
+    role="button"
+    tabIndex={-1}
+    aria-label={chip.name}
+    title={chip.name}
+    contentEditable={false}
+    onClick={onFocusChip}
+    onKeyDown={onKeyDown}
+    style={{ backgroundColor: chip.backgroundColor, color: chip.textColor }}
+    className={`mr-1 inline-flex select-none items-center gap-1 whitespace-nowrap rounded-full py-0.5 pl-2 pr-1 align-middle text-xs font-semibold ${
+      isFocused ? "outline-accent outline outline-2 outline-offset-1" : ""
+    }`}
+  >
+    <span className="truncate" style={{ maxWidth: CHIP_LABEL_MAX_WIDTH }}>
+      {chip.name}
+    </span>
+    {/* `clickable-icon`, because Obsidian's `button:not(.clickable-icon)` rule outranks a utility class and would paint its own box behind the ×. */}
+    <button
+      type="button"
+      tabIndex={-1}
+      aria-label={`Remove ${chip.name} filter`}
+      onClick={(event) => {
+        event.stopPropagation();
+        onRemove();
+      }}
+      onMouseDown={(event) => event.preventDefault()}
+      className="clickable-icon !h-4 !w-4 !bg-transparent !p-0 !text-inherit !shadow-none hover:!opacity-70"
+    >
+      ×
+    </button>
+  </span>
+);
+
+/** Chips and the query caret in one field; `NodeSearch` owns the state and, as an ancestor, already handles the arrows, Enter and Escape that bubble out of here. */
+export const NodeTypeChipsSearchInput = ({
+  inputRef,
+  nodeTypes,
+  onQueryChange,
+  onSelectedNodeTypeIdsChange,
+  query,
+  selectedNodeTypeIds,
+}: {
+  inputRef: RefObject<HTMLSpanElement | null>;
+  nodeTypes: DiscourseNode[];
+  onQueryChange: (query: string) => void;
+  onSelectedNodeTypeIdsChange: (ids: string[]) => void;
+  query: string;
+  selectedNodeTypeIds: string[];
+}): ReactElement => {
+  const [focusedChipIndex, setFocusedChipIndex] = useState(NO_FOCUSED_CHIP);
+  const chipRefs = useRef<(HTMLSpanElement | null)[]>([]);
+
+  const chipsById = useMemo(() => {
+    const byId = new Map<string, NodeTypeChip>();
+    getAllDiscourseNodeColors(nodeTypes).forEach(({ nodeType, colors }) => {
+      byId.set(nodeType.id, {
+        backgroundColor: colors.backgroundColor,
+        id: nodeType.id,
+        name: nodeType.name,
+        textColor: colors.textColor,
+      });
+    });
+    return byId;
+  }, [nodeTypes]);
+
+  const chips = useMemo(
+    () => selectedNodeTypeIds.flatMap((id) => chipsById.get(id) ?? []),
+    [chipsById, selectedNodeTypeIds],
+  );
+
+  const bestPrefixMatch = getBestPrefixMatch({
+    nodeTypes,
+    query,
+    selectedTypeIds: selectedNodeTypeIds,
+  });
+
+  const completionSuffix = getCompletionSuffix({ bestPrefixMatch, query });
+
+  /**
+   * The query text is uncontrolled: React owns the chips but never the editable's
+   * content, so re-rendering on each keystroke cannot move the caret. Programmatic
+   * changes therefore have to write the text themselves.
+   */
+  const writeQuery = (value: string): void => {
+    const field = inputRef.current;
+    if (field) field.textContent = value;
+    onQueryChange(value);
+  };
+
+  const focusQuery = (): void => {
+    setFocusedChipIndex(NO_FOCUSED_CHIP);
+    const field = inputRef.current;
+    if (!field) return;
+    field.focus();
+    setCaretToEnd(field);
+  };
+
+  useEffect(() => {
+    if (focusedChipIndex === NO_FOCUSED_CHIP) return;
+    if (focusedChipIndex < selectedNodeTypeIds.length) {
+      chipRefs.current[focusedChipIndex]?.focus();
+      return;
+    }
+    // The dropdown can clear the filter mid-focus, stranding focus on a removed node.
+    setFocusedChipIndex(NO_FOCUSED_CHIP);
+    inputRef.current?.focus();
+  }, [focusedChipIndex, inputRef, selectedNodeTypeIds]);
+
+  const commitNodeType = (nodeType: DiscourseNode): void => {
+    if (selectedNodeTypeIds.includes(nodeType.id)) return;
+    // Raw, not canonicalised: collapsing a full selection would vanish the new chip.
+    onSelectedNodeTypeIdsChange([...selectedNodeTypeIds, nodeType.id]);
+    writeQuery("");
+  };
+
+  const removeChipAt = (chipIndex: number): string[] => {
+    const nextIds = selectedNodeTypeIds.filter(
+      (_, index) => index !== chipIndex,
+    );
+    onSelectedNodeTypeIdsChange(nextIds);
+    return nextIds;
+  };
+
+  const handleChipKeyDown = (
+    event: KeyboardEvent<HTMLSpanElement>,
+    chipIndex: number,
+  ): void => {
+    if (event.key === "ArrowLeft") {
+      event.preventDefault();
+      setFocusedChipIndex(Math.max(0, chipIndex - 1));
+      return;
+    }
+
+    if (event.key === "ArrowRight") {
+      event.preventDefault();
+      if (chipIndex >= selectedNodeTypeIds.length - 1) {
+        focusQuery();
+        return;
+      }
+      setFocusedChipIndex(chipIndex + 1);
+      return;
+    }
+
+    if (event.key === "Backspace" || event.key === "Delete") {
+      event.preventDefault();
+      const nextIds = removeChipAt(chipIndex);
+      if (!nextIds.length) {
+        focusQuery();
+        return;
+      }
+      // Backspace walks left, Delete takes the chip that closed the gap: no focus jump.
+      const nextIndex =
+        event.key === "Backspace"
+          ? chipIndex - 1
+          : Math.min(chipIndex, nextIds.length - 1);
+      if (nextIndex < 0) {
+        focusQuery();
+        return;
+      }
+      setFocusedChipIndex(nextIndex);
+      return;
+    }
+
+    // Typing with a chip focused is a return to the query, not a lost keystroke.
+    if (isPlainCharacterKey(event)) {
+      event.preventDefault();
+      writeQuery(event.key);
+      focusQuery();
+    }
+  };
+
+  const handleQueryKeyDown = (event: KeyboardEvent<HTMLSpanElement>): void => {
+    // Suppress the line break only; Enter still bubbles, and modified Enter reaches nothing else.
+    if (event.key === "Enter" && !event.nativeEvent.isComposing) {
+      event.preventDefault();
+    }
+
+    if (event.key === "Tab") {
+      // With nothing pending, Tab is left alone so it still reaches the footer actions.
+      if (!bestPrefixMatch) return;
+      event.preventDefault();
+      commitNodeType(bestPrefixMatch);
+      return;
+    }
+
+    if (!selectedNodeTypeIds.length) return;
+    if (!isCaretAtStart(inputRef.current)) return;
+
+    // Highlight first, so an over-eager Backspace cannot silently drop a filter.
+    if (event.key === "Backspace" && !query.length) {
+      event.preventDefault();
+      setFocusedChipIndex(selectedNodeTypeIds.length - 1);
+      return;
+    }
+
+    if (event.key === "ArrowLeft") {
+      event.preventDefault();
+      setFocusedChipIndex(selectedNodeTypeIds.length - 1);
+    }
+  };
+
+  return (
+    <div
+      // A block box, not a flex row: chips and the query are inline siblings, so they
+      // share line boxes and flow together left to right, top to bottom.
+      // `border-solid` is not redundant: this build omits `@tailwind base`, so there is
+      // no preflight setting a default border style and `border` alone renders nothing.
+      className="border-modifier-border bg-modifier-form-field min-h-[calc(var(--font-ui-medium)*var(--line-height-tight)_+_12px)] min-w-0 flex-1 cursor-text rounded-[var(--input-radius)] border border-solid px-2 py-1 text-[length:var(--font-ui-medium)] leading-[var(--line-height-tight)] focus-within:border-[color:var(--background-modifier-border-focus)] hover:border-[color:var(--background-modifier-border-hover)]"
+      onClick={() => {
+        if (focusedChipIndex === NO_FOCUSED_CHIP) focusQuery();
+      }}
+    >
+      {chips.map((chip, index) => (
+        <NodeTypeChipTag
+          key={chip.id}
+          chip={chip}
+          isFocused={focusedChipIndex === index}
+          onFocusChip={() => setFocusedChipIndex(index)}
+          onKeyDown={(event) => handleChipKeyDown(event, index)}
+          onRemove={() => {
+            removeChipAt(index);
+            focusQuery();
+          }}
+          registerRef={(element) => {
+            chipRefs.current[index] = element;
+          }}
+        />
+      ))}
+      {/* `plaintext-only` so a pasted selection cannot bring markup in with it. */}
+      <span
+        ref={inputRef}
+        contentEditable="plaintext-only"
+        role="textbox"
+        aria-label={QUERY_PLACEHOLDER}
+        spellCheck={false}
+        suppressContentEditableWarning
+        onInput={(event) =>
+          onQueryChange(event.currentTarget.textContent ?? "")
+        }
+        onKeyDown={handleQueryKeyDown}
+        className="dg-search-chip-input whitespace-pre-wrap break-words align-middle outline-none"
+      />
+      {/* Inline rather than an overlay, so it follows the caret and wraps with the text. */}
+      {!!bestPrefixMatch && (
+        <span aria-hidden className="align-middle">
+          <span className="text-muted">{completionSuffix}</span>
+          <kbd className="dg-search-footer-key ml-2">
+            {getHintKeys(["Tab"])[0]}
+          </kbd>
+        </span>
+      )}
+      {!query && !chips.length && (
+        <span aria-hidden className="text-muted pointer-events-none">
+          {QUERY_PLACEHOLDER}
+        </span>
+      )}
+    </div>
+  );
+};

--- a/apps/obsidian/src/components/NodeTypeChipsSearchInput.tsx
+++ b/apps/obsidian/src/components/NodeTypeChipsSearchInput.tsx
@@ -18,7 +18,6 @@ import {
 /** `-1` means the caret is in the query rather than on a chip. */
 const NO_FOCUSED_CHIP = -1;
 
-const CHIP_LABEL_MAX_WIDTH = "10rem";
 const QUERY_PLACEHOLDER = "Search discourse nodes by title";
 
 type NodeTypeChip = {
@@ -80,9 +79,7 @@ const NodeTypeChipTag = ({
       isFocused ? "outline-accent outline outline-2 outline-offset-1" : ""
     }`}
   >
-    <span className="truncate" style={{ maxWidth: CHIP_LABEL_MAX_WIDTH }}>
-      {chip.name}
-    </span>
+    <span className="max-w-40 truncate">{chip.name}</span>
     {/* `clickable-icon`, because Obsidian's `button:not(.clickable-icon)` rule outranks a utility class and would paint its own box behind the ×. */}
     <button
       type="button"
@@ -166,14 +163,14 @@ export const NodeTypeChipsSearchInput = ({
 
   useEffect(() => {
     if (focusedChipIndex === NO_FOCUSED_CHIP) return;
-    if (focusedChipIndex < selectedNodeTypeIds.length) {
+    if (focusedChipIndex < chips.length) {
       chipRefs.current[focusedChipIndex]?.focus();
       return;
     }
     // The dropdown can clear the filter mid-focus, stranding focus on a removed node.
     setFocusedChipIndex(NO_FOCUSED_CHIP);
     inputRef.current?.focus();
-  }, [focusedChipIndex, inputRef, selectedNodeTypeIds]);
+  }, [chips, focusedChipIndex, inputRef]);
 
   const commitNodeType = (nodeType: DiscourseNode): void => {
     if (selectedNodeTypeIds.includes(nodeType.id)) return;
@@ -182,17 +179,19 @@ export const NodeTypeChipsSearchInput = ({
     writeQuery("");
   };
 
-  const removeChipAt = (chipIndex: number): string[] => {
-    const nextIds = selectedNodeTypeIds.filter(
-      (_, index) => index !== chipIndex,
+  // By id, not by position: `chips` is what the user sees and is the only list an
+  // index here refers to, so removing positionally from `selectedNodeTypeIds` would
+  // hit the wrong filter the moment the two ever differed.
+  const removeChip = (chipId: string): void => {
+    onSelectedNodeTypeIdsChange(
+      selectedNodeTypeIds.filter((id) => id !== chipId),
     );
-    onSelectedNodeTypeIdsChange(nextIds);
-    return nextIds;
   };
 
   const handleChipKeyDown = (
     event: KeyboardEvent<HTMLSpanElement>,
     chipIndex: number,
+    chipId: string,
   ): void => {
     if (event.key === "ArrowLeft") {
       event.preventDefault();
@@ -202,7 +201,7 @@ export const NodeTypeChipsSearchInput = ({
 
     if (event.key === "ArrowRight") {
       event.preventDefault();
-      if (chipIndex >= selectedNodeTypeIds.length - 1) {
+      if (chipIndex >= chips.length - 1) {
         focusQuery();
         return;
       }
@@ -212,8 +211,9 @@ export const NodeTypeChipsSearchInput = ({
 
     if (event.key === "Backspace" || event.key === "Delete") {
       event.preventDefault();
-      const nextIds = removeChipAt(chipIndex);
-      if (!nextIds.length) {
+      removeChip(chipId);
+      const remaining = chips.length - 1;
+      if (!remaining) {
         focusQuery();
         return;
       }
@@ -221,7 +221,7 @@ export const NodeTypeChipsSearchInput = ({
       const nextIndex =
         event.key === "Backspace"
           ? chipIndex - 1
-          : Math.min(chipIndex, nextIds.length - 1);
+          : Math.min(chipIndex, remaining - 1);
       if (nextIndex < 0) {
         focusQuery();
         return;
@@ -252,19 +252,19 @@ export const NodeTypeChipsSearchInput = ({
       return;
     }
 
-    if (!selectedNodeTypeIds.length) return;
+    if (!chips.length) return;
     if (!isCaretAtStart(inputRef.current)) return;
 
     // Highlight first, so an over-eager Backspace cannot silently drop a filter.
     if (event.key === "Backspace" && !query.length) {
       event.preventDefault();
-      setFocusedChipIndex(selectedNodeTypeIds.length - 1);
+      setFocusedChipIndex(chips.length - 1);
       return;
     }
 
     if (event.key === "ArrowLeft") {
       event.preventDefault();
-      setFocusedChipIndex(selectedNodeTypeIds.length - 1);
+      setFocusedChipIndex(chips.length - 1);
     }
   };
 
@@ -285,9 +285,9 @@ export const NodeTypeChipsSearchInput = ({
           chip={chip}
           isFocused={focusedChipIndex === index}
           onFocusChip={() => setFocusedChipIndex(index)}
-          onKeyDown={(event) => handleChipKeyDown(event, index)}
+          onKeyDown={(event) => handleChipKeyDown(event, index, chip.id)}
           onRemove={() => {
-            removeChipAt(index);
+            removeChip(chip.id);
             focusQuery();
           }}
           registerRef={(element) => {

--- a/apps/obsidian/src/components/NodeTypeChipsSearchInput.tsx
+++ b/apps/obsidian/src/components/NodeTypeChipsSearchInput.tsx
@@ -275,8 +275,11 @@ export const NodeTypeChipsSearchInput = ({
       // `border-solid` is not redundant: this build omits `@tailwind base`, so there is
       // no preflight setting a default border style and `border` alone renders nothing.
       className="border-modifier-border bg-modifier-form-field min-h-[calc(var(--font-ui-medium)*var(--line-height-tight)_+_12px)] min-w-0 flex-1 cursor-text rounded-[var(--input-radius)] border border-solid px-2 py-1 text-[length:var(--font-ui-medium)] leading-[var(--line-height-tight)] focus-within:border-[color:var(--background-modifier-border-focus)] hover:border-[color:var(--background-modifier-border-hover)]"
-      onClick={() => {
-        if (focusedChipIndex === NO_FOCUSED_CHIP) focusQuery();
+      // Only for clicks on the field's own padding. A click on the text or a chip must
+      // keep the caret the browser just placed, or clicking into the middle of a query
+      // drags it to the end.
+      onClick={(event) => {
+        if (event.target === event.currentTarget) focusQuery();
       }}
     >
       {chips.map((chip, index) => (

--- a/apps/obsidian/src/utils/keyboardHints.ts
+++ b/apps/obsidian/src/utils/keyboardHints.ts
@@ -1,6 +1,6 @@
 import { Platform } from "obsidian";
 
-export type HintKey = "Mod" | "Alt" | "Shift" | "Enter" | "Escape";
+export type HintKey = "Mod" | "Alt" | "Shift" | "Enter" | "Escape" | "Tab";
 
 // Obsidian shows glyphs on macOS and spelled-out words everywhere else.
 const MAC_SYMBOLS: Record<HintKey, string> = {
@@ -9,6 +9,7 @@ const MAC_SYMBOLS: Record<HintKey, string> = {
   Shift: "⇧",
   Enter: "↵",
   Escape: "esc",
+  Tab: "⇥",
 };
 
 const NON_MAC_SYMBOLS: Record<HintKey, string> = {
@@ -17,6 +18,7 @@ const NON_MAC_SYMBOLS: Record<HintKey, string> = {
   Shift: "Shift",
   Enter: "Enter",
   Escape: "Esc",
+  Tab: "Tab",
 };
 
 /** Takes `isMacOS` so the non-mac branch can be checked without that platform. */

--- a/apps/obsidian/src/utils/nodeTypeChipCompletion.ts
+++ b/apps/obsidian/src/utils/nodeTypeChipCompletion.ts
@@ -29,7 +29,6 @@ export const getBestPrefixMatch = ({
   return exactMatch ?? matches[0] ?? null;
 };
 
-/** What is left to type; empty once the name is fully spelled, though still committable. */
 export const getCompletionSuffix = ({
   bestPrefixMatch,
   query,

--- a/apps/obsidian/src/utils/nodeTypeChipCompletion.ts
+++ b/apps/obsidian/src/utils/nodeTypeChipCompletion.ts
@@ -1,0 +1,45 @@
+import { DiscourseNode } from "~/types";
+
+/** Ghost completion for the search modal's chips; prefix-only, as a substring match has no suffix to draw. */
+
+/** Exact match beats the first partial, so a name that prefixes another stays reachable. */
+export const getBestPrefixMatch = ({
+  nodeTypes,
+  query,
+  selectedTypeIds,
+}: {
+  nodeTypes: DiscourseNode[];
+  query: string;
+  selectedTypeIds: string[];
+}): DiscourseNode | null => {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) return null;
+
+  const selectedTypeIdSet = new Set(selectedTypeIds);
+  const matches = nodeTypes.filter(
+    (nodeType) =>
+      !selectedTypeIdSet.has(nodeType.id) &&
+      nodeType.name.toLowerCase().startsWith(normalizedQuery),
+  );
+  if (!matches.length) return null;
+
+  const exactMatch = matches.find(
+    (nodeType) => nodeType.name.toLowerCase() === normalizedQuery,
+  );
+  return exactMatch ?? matches[0] ?? null;
+};
+
+/** What is left to type; empty once the name is fully spelled, though still committable. */
+export const getCompletionSuffix = ({
+  bestPrefixMatch,
+  query,
+}: {
+  bestPrefixMatch: DiscourseNode | null;
+  query: string;
+}): string => {
+  if (!bestPrefixMatch) return "";
+  const trimmedQuery = query.trim();
+  const { name } = bestPrefixMatch;
+  if (name.toLowerCase() === trimmedQuery.toLowerCase()) return "";
+  return name.slice(trimmedQuery.length);
+};


### PR DESCRIPTION
https://www.loom.com/share/7eae3997668c43829896b093d005401a


## What this does

Chips and the query caret now share one field, so a keyboard-first user can narrow by type without reaching for the mouse. Typing offers the best prefix match as ghost text with a `⇥` hint; `Tab` commits it to a chip. Text left unconfirmed stays a plain keyword query, so filtering never happens by accident.

Roam's advanced search is the design and behaviour reference. Obsidian has no tag-input component at all, so this is a build rather than a port.

## Notable decisions

- **State is ENG-2110's.** `selectedNodeTypeIds` stays the single source of truth, so chips and the filter dropdown are two views of one state. No change to `QueryEngine`. The chips write the raw list and skip `fromPanelSelectedIds`' canonicalisation on purpose: collapsing a full selection to "no filter" would make a chip the user just added vanish.
- **Keys bubble instead of being forwarded.** Arrow, Enter and Escape reach `NodeSearch`, whose handler is already an ancestor and already navigates and opens results. Roam threads them through an `onSearchKeyDown` prop; here that would only duplicate it.
- **`Backspace` highlights before it deletes.** The ticket said "removes the most recent chip"; this follows Roam instead, so a stray keystroke cannot silently drop a filter. The chip-focus state it needs is the same state the arrow keys use.
- **Matching is prefix-only.** The suggestion is drawn as a completion of what was typed, and a substring match has no suffix to render.
- **The `Tab` hint shows whenever `Tab` would commit** — including once the query spells a type name in full and no suffix is left to ghost. Roam hides it there, which is exactly when the user is about to press it.
- **The query is a textarea that grows with its content**, so a long query and many chips stay visible rather than scrolling out of the field. Modified `Enter` is suppressed there: the modal deliberately leaves `Mod`/`Ctrl`/`Alt+Enter` unhandled for the insert and dock actions, so the query would otherwise gain a line break.
- **Field chrome comes from Obsidian's own input variables** rather than Tailwind tokens, so it matches a native field (border, `--background-modifier-form-field`, `--input-radius`). Two rules were dropped as dead: `--input-shadow` is `none` in Obsidian 1.13 and `--input-shadow-active` is undefined — native fields there are marked by border colour alone.
- **Tailwind's `ring-*` utilities are inert in this build.** `--tw-ring-shadow` and its offset counterpart are never defined, so the composite `box-shadow` collapses to `none` and a focused chip rendered no state at all. The focused chip takes an `outline` in CSS instead — no variables needed, and unlike a border it does not shift the chips beside it as focus moves.
- Chip remove buttons are `tabIndex={-1}`. `Tab` is the commit key, so focusable remove buttons would wedge themselves into the tab order ahead of the footer actions; keyboard users delete via the highlighted chip.

## Known edge case, documented rather than fixed

Chipping every configured type makes `selectedNodeTypeIds.length === allTypeIds.length`, which `hasActiveTypeFilter` reads as "no filter" — the count badge disappears while the chips stay on screen. Results are identical either way, and the dropdown shows all rows checked, so the two surfaces do not disagree. Suppressing the last chip would be worse: it would silently refuse a type the user asked for.

## Verification

- `pnpm check-types` and `pnpm lint` clean in `apps/obsidian` (0 errors; pre-existing warnings elsewhere untouched).
- **32/32 assertions** driving the running Obsidian over CDP against a test vault, re-run after the rebase: ghost completion, `Tab` commit, immediate narrowing, two-chip union, unconfirmed text applying no filter, `Backspace` highlight-then-remove with the marking asserted on the rendered outline, arrow navigation across chips and back to the caret, results navigation with a chip focused, modified `Enter` inserting no newline, `Tab` fall-through to the filter trigger, field growth without clipping, and chip↔dropdown sync in both directions.
- Field geometry measured: an empty field is 34px like a native input; a long query grows it 34→53px alone and 34→92px with five chips, nothing clipped; all ten types chipped keeps every chip visible.
- **No unit tests.** `apps/obsidian` has no test harness — no `test` script, no vitest config, no test files — the same call ENG-2110 made. The matching rules were split into a pure util so they are ready for one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/1321" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->