### PR TITLE
ENG-2164 Correct is_relation migration, strike 2

### DIFF
--- a/packages/database/supabase/migrations/20260819023727_is_relation_column.sql
+++ b/packages/database/supabase/migrations/20260819023727_is_relation_column.sql
@@ -99,7 +99,8 @@ CREATE TRIGGER concept_propagate_derived_columns_trigger
     FOR EACH ROW WHEN (NEW.is_schema AND OLD.literal_content IS DISTINCT FROM NEW.literal_content)
     EXECUTE FUNCTION public.concept_propagate_derived_columns();
 
--- the trigger will propagate to instances
-UPDATE public."Concept" SET is_relation=public.compute_is_relation_local(null::BIGINT, literal_content) WHERE is_schema;
+-- do schemas first, so their values are correct for next step
+UPDATE public."Concept" SET is_relation=public.compute_is_relation_local(null::BIGINT, literal_content) WHERE schema_id IS NULL;
+UPDATE public."Concept" SET is_relation=public.compute_is_relation_local(null::BIGINT, literal_content) WHERE schema_id IS NOT NULL;
 
 ALTER TABLE public."Concept" ALTER COLUMN is_relation SET NOT NULL;


### PR DESCRIPTION
https://linear.app/discourse-graphs/issue/ENG-2164/correct-is-relation-migration-strike-2

same loom as last time

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/1326" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->