### PR TITLE
ENG-2157 Decorate imported node titles in Obsidian from core_title

### DIFF
--- a/apps/obsidian/src/utils/getDiscourseNodeFormatExpression.ts
+++ b/apps/obsidian/src/utils/getDiscourseNodeFormatExpression.ts
@@ -1,9 +1,11 @@
+import { FORMAT_PLACEHOLDER } from "@repo/database/lib/decorateTitle";
+
 export const getDiscourseNodeFormatExpression = (format: string) =>
   format
     ? new RegExp(
         `^${format
           .replace(/(\[|\]|\?|\.|\+)/g, "\\$1")
-          .replace(/{[a-zA-Z]+}/g, "(.*?)")}$`,
+          .replace(FORMAT_PLACEHOLDER, "(.*?)")}$`,
         "s",
       )
     : /$^/;

--- a/apps/obsidian/src/utils/importNodes.ts
+++ b/apps/obsidian/src/utils/importNodes.ts
@@ -21,6 +21,8 @@ import {
 } from "./importRelations";
 import { createTemplateFile } from "./templates";
 import { resolveFolderForSpaceUri } from "./importFolderMetadata";
+import { getNodeTypeById } from "./typeUtils";
+import { decorateTitle } from "@repo/database/lib/decorateTitle";
 
 type PublishedNode = {
   source_local_id: string;
@@ -327,7 +329,12 @@ type NodeTypeSchemaForInstance = {
   name: string;
 };
 
-export const fetchNodeTypeSchemasForInstances = async ({
+type NodeInstanceImportInfo = {
+  schema?: NodeTypeSchemaForInstance;
+  coreTitle?: string;
+};
+
+export const fetchNodeImportInfoForInstances = async ({
   client,
   spaceId,
   nodeInstanceIds,
@@ -335,12 +342,14 @@ export const fetchNodeTypeSchemasForInstances = async ({
   client: DGSupabaseClient;
   spaceId: number;
   nodeInstanceIds: string[];
-}): Promise<Map<string, NodeTypeSchemaForInstance>> => {
-  const result = new Map<string, NodeTypeSchemaForInstance>();
+}): Promise<Map<string, NodeInstanceImportInfo>> => {
+  const result = new Map<string, NodeInstanceImportInfo>();
 
   const { data: instanceRows, error: instanceError } = await client
     .from("my_concepts")
-    .select("source_local_id, schema_id")
+    .select(
+      "source_local_id, schema_id, core_title:literal_content->>core_title",
+    )
     .eq("space_id", spaceId)
     .eq("is_schema", false)
     .eq("is_relation", false)
@@ -358,35 +367,42 @@ export const fetchNodeTypeSchemasForInstances = async ({
         .filter((id): id is number => id !== null),
     ),
   ];
-  if (schemaIds.length === 0) return result;
-
-  const { data: schemaRows, error: schemaError } = await client
-    .from("my_concepts")
-    .select("id, source_local_id, name")
-    .eq("space_id", spaceId)
-    .eq("is_schema", true)
-    .eq("is_relation", false)
-    .in("id", schemaIds);
-
-  if (schemaError || !schemaRows) {
-    console.error("Error fetching node type schemas:", schemaError);
-    return result;
-  }
 
   const schemasById = new Map<number, NodeTypeSchemaForInstance>();
-  for (const row of schemaRows) {
-    if (row.id !== null && row.source_local_id !== null && row.name !== null) {
-      schemasById.set(row.id, {
-        nodeTypeId: row.source_local_id,
-        name: row.name,
-      });
+  if (schemaIds.length > 0) {
+    const { data: schemaRows, error: schemaError } = await client
+      .from("my_concepts")
+      .select("id, source_local_id, name")
+      .eq("space_id", spaceId)
+      .eq("is_schema", true)
+      .eq("is_relation", false)
+      .in("id", schemaIds);
+
+    if (schemaError || !schemaRows) {
+      console.error("Error fetching node type schemas:", schemaError);
+    } else {
+      for (const row of schemaRows) {
+        if (
+          row.id !== null &&
+          row.source_local_id !== null &&
+          row.name !== null
+        ) {
+          schemasById.set(row.id, {
+            nodeTypeId: row.source_local_id,
+            name: row.name,
+          });
+        }
+      }
     }
   }
 
   for (const row of instanceRows) {
-    if (row.source_local_id === null || row.schema_id === null) continue;
-    const schema = schemasById.get(row.schema_id);
-    if (schema) result.set(row.source_local_id, schema);
+    if (row.source_local_id === null) continue;
+    result.set(row.source_local_id, {
+      schema:
+        row.schema_id === null ? undefined : schemasById.get(row.schema_id),
+      coreTitle: row.core_title ?? undefined,
+    });
   }
 
   return result;
@@ -1159,8 +1175,6 @@ export const mapNodeTypeIdToLocal = async ({
 
 const processFileContent = async ({
   plugin,
-  client,
-  sourceSpaceId,
   sourceSpaceUri,
   rawContent,
   filePath,
@@ -1168,11 +1182,9 @@ const processFileContent = async ({
   importedModifiedAt,
   authorId,
   nodeInstanceId,
-  nodeTypeIdFromConcept,
+  nodeTypeId,
 }: {
   plugin: DiscourseGraphPlugin;
-  client: DGSupabaseClient;
-  sourceSpaceId: number;
   sourceSpaceUri: string;
   rawContent: string;
   filePath: string;
@@ -1180,25 +1192,9 @@ const processFileContent = async ({
   importedModifiedAt?: number;
   authorId?: number;
   nodeInstanceId: string;
-  nodeTypeIdFromConcept?: string;
-}): Promise<
-  { file: TFile; error?: never } | { file?: never; error: string }
-> => {
-  // 1. Parse frontmatter from rawContent (metadataCache is updated async and is
-  //    often empty immediately after create/modify) and resolve the node type
-  //    before any vault write, so a failed lookup leaves existing files untouched.
-  const { frontmatter } = parseFrontmatter(rawContent);
-  const sourceNodeTypeId =
-    typeof frontmatter.nodeTypeId === "string"
-      ? frontmatter.nodeTypeId
-      : nodeTypeIdFromConcept;
-  if (sourceNodeTypeId === undefined) {
-    return {
-      error: "importedNode missing sourceNodeTypeId",
-    };
-  }
-
-  // 2. Create or update the file with the fetched content.
+  nodeTypeId: string;
+}): Promise<TFile> => {
+  // Create or update the file with the fetched content.
   // On create, set file metadata (ctime/mtime) to original vault dates via vault adapter.
   let file: TFile | null = plugin.app.vault.getFileByPath(filePath);
   const stat =
@@ -1214,19 +1210,11 @@ const processFileContent = async ({
     await plugin.app.vault.process(file, () => rawContent, stat);
   }
 
-  const mappedNodeTypeId = await mapNodeTypeIdToLocal({
-    plugin,
-    client,
-    sourceSpaceId,
-    sourceSpaceUri,
-    sourceNodeTypeId,
-  });
-
   await plugin.app.fileManager.processFrontMatter(
     file,
     (fm) => {
       const record = fm as Record<string, unknown>;
-      record.nodeTypeId = mappedNodeTypeId;
+      record.nodeTypeId = nodeTypeId;
       record.nodeInstanceId = nodeInstanceId;
       record.importedFromRid = spaceUriAndLocalIdToRid(
         sourceSpaceUri,
@@ -1239,7 +1227,7 @@ const processFileContent = async ({
     stat,
   );
 
-  return { file };
+  return file;
 };
 
 export const importSelectedNodes = async ({
@@ -1308,7 +1296,7 @@ export const importSelectedNodes = async ({
       spaceName,
     });
 
-    const nodeTypeSchemasByInstance = await fetchNodeTypeSchemasForInstances({
+    const nodeImportInfoByInstance = await fetchNodeImportInfoForInstances({
       client,
       spaceId,
       nodeInstanceIds: nodes.map((n) => n.nodeInstanceId),
@@ -1355,8 +1343,44 @@ export const importSelectedNodes = async ({
         const originalNodePath: string | undefined =
           contentFilePath ?? node.filePath;
 
-        // Sanitize file name
-        const sanitizedFileName = sanitizeFileName(fileName);
+        const nodeImportInfo = nodeImportInfoByInstance.get(
+          node.nodeInstanceId,
+        );
+
+        // Parse frontmatter from content (metadataCache is updated async and is
+        // often empty immediately after create/modify) and resolve the node type
+        // before any vault write, so a failed lookup leaves existing files untouched.
+        const { frontmatter } = parseFrontmatter(content);
+        const sourceNodeTypeId =
+          typeof frontmatter.nodeTypeId === "string"
+            ? frontmatter.nodeTypeId
+            : nodeImportInfo?.schema?.nodeTypeId;
+        if (sourceNodeTypeId === undefined) {
+          console.error(
+            `Error processing file content for node ${node.nodeInstanceId}:`,
+            "importedNode missing sourceNodeTypeId",
+          );
+          failedCount++;
+          processedCount++;
+          onProgress?.(processedCount, totalNodes);
+          continue;
+        }
+
+        const mappedNodeTypeId = await mapNodeTypeIdToLocal({
+          plugin,
+          client,
+          sourceSpaceId: spaceId,
+          sourceSpaceUri: spaceUri,
+          sourceNodeTypeId,
+        });
+
+        const localNodeType = getNodeTypeById(plugin, mappedNodeTypeId);
+        const coreTitle = nodeImportInfo?.coreTitle;
+        const titleForFileName =
+          coreTitle !== undefined && localNodeType?.format
+            ? decorateTitle(localNodeType.format, coreTitle)
+            : fileName;
+        const sanitizedFileName = sanitizeFileName(titleForFileName);
         let finalFilePath: string;
 
         if (existingFile) {
@@ -1364,10 +1388,13 @@ export const importSelectedNodes = async ({
           finalFilePath = existingFile.path;
         } else {
           // Preserve source vault folder structure under import/{vaultName} when we have filePath from Content
-          const pathUnderImport =
+          const sourceFolder =
             contentFilePath && contentFilePath.includes("/")
-              ? sanitizePathForImport(contentFilePath)
-              : `${sanitizedFileName}.md`;
+              ? sanitizePathForImport(contentFilePath.replace(/\/[^/]*$/, ""))
+              : "";
+          const pathUnderImport = sourceFolder
+            ? `${sourceFolder}/${sanitizedFileName}.md`
+            : `${sanitizedFileName}.md`;
           finalFilePath = `${importFolderPath}/${pathUnderImport}`;
 
           // Ensure all parent folders exist (e.g. import/VaultName/Discourse Nodes/SubFolder)
@@ -1380,12 +1407,8 @@ export const importSelectedNodes = async ({
           }
         }
 
-        // Process the file content (maps nodeTypeId, handles frontmatter, stores import timestamps)
-        // This updates existing file or creates new one
-        const result = await processFileContent({
+        const processedFile = await processFileContent({
           plugin,
-          client,
-          sourceSpaceId: spaceId,
           sourceSpaceUri: spaceUri,
           rawContent: content,
           filePath: finalFilePath,
@@ -1393,24 +1416,8 @@ export const importSelectedNodes = async ({
           importedModifiedAt: modifiedAt,
           authorId,
           nodeInstanceId: node.nodeInstanceId,
-          nodeTypeIdFromConcept: nodeTypeSchemasByInstance.get(
-            node.nodeInstanceId,
-          )?.nodeTypeId,
+          nodeTypeId: mappedNodeTypeId,
         });
-
-        if (result.error) {
-          console.error(
-            `Error processing file content for node ${node.nodeInstanceId}:`,
-            result.error,
-          );
-          failedCount++;
-          processedCount++;
-          onProgress?.(processedCount, totalNodes);
-          continue;
-        }
-
-        // typescript should not need this assertion?
-        const processedFile = result.file!;
 
         // Import assets for this node (use originalNodePath so assets go under import/{space}/ relative to note)
         const assetImportResult = await importAssetsForNode({

--- a/apps/obsidian/src/utils/importNodes.ts
+++ b/apps/obsidian/src/utils/importNodes.ts
@@ -1376,11 +1376,11 @@ export const importSelectedNodes = async ({
 
         const localNodeType = getNodeTypeById(plugin, mappedNodeTypeId);
         const coreTitle = nodeImportInfo?.coreTitle;
-        const titleForFileName =
-          coreTitle !== undefined && localNodeType?.format
+        const decoratedTitle =
+          coreTitle !== undefined && localNodeType
             ? decorateTitle(localNodeType.format, coreTitle)
-            : fileName;
-        const sanitizedFileName = sanitizeFileName(titleForFileName);
+            : null;
+        const sanitizedFileName = sanitizeFileName(decoratedTitle ?? fileName);
         let finalFilePath: string;
 
         if (existingFile) {

--- a/apps/obsidian/src/utils/importPreview.ts
+++ b/apps/obsidian/src/utils/importPreview.ts
@@ -5,7 +5,7 @@ import {
   getImportedNodesInfo,
   getLocalNodeKeyToEndpointId,
 } from "./relationsStore";
-import { fetchNodeTypeSchemasForInstances, getSpaceUris } from "./importNodes";
+import { fetchNodeImportInfoForInstances, getSpaceUris } from "./importNodes";
 import { QueryEngine } from "~/services/QueryEngine";
 import {
   fetchRelationInstancesFromSpace,
@@ -82,13 +82,16 @@ export const computeImportPreview = async ({
   }
 
   for (const [spaceId, nodes] of nodesBySpace.entries()) {
-    const nodeTypeSchemasByInstance = await fetchNodeTypeSchemasForInstances({
+    const nodeImportInfoByInstance = await fetchNodeImportInfoForInstances({
       client,
       spaceId,
       nodeInstanceIds: nodes.map((n) => n.nodeInstanceId),
     });
 
-    for (const { nodeTypeId, name } of nodeTypeSchemasByInstance.values()) {
+    for (const { schema } of nodeImportInfoByInstance.values()) {
+      if (!schema) continue;
+      const { nodeTypeId, name } = schema;
+
       // Track name for triplet resolution
       if (!nodeTypeIdToName.has(nodeTypeId)) {
         nodeTypeIdToName.set(nodeTypeId, name);

--- a/packages/database/src/lib/__tests__/decorateTitle.test.ts
+++ b/packages/database/src/lib/__tests__/decorateTitle.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { decorateTitle } from "../decorateTitle";
+
+describe("decorateTitle", () => {
+  it("substitutes the core title for {content}", () => {
+    expect(decorateTitle("[[CLM]] - {content}", "sleep improves memory")).toBe(
+      "[[CLM]] - sleep improves memory",
+    );
+    expect(decorateTitle("CLM - {content}", "sleep improves memory")).toBe(
+      "CLM - sleep improves memory",
+    );
+  });
+
+  it("matches the content placeholder case-insensitively", () => {
+    expect(decorateTitle("QUE - {Content}", "why")).toBe("QUE - why");
+  });
+
+  it("substitutes the empty string for other placeholders", () => {
+    expect(
+      decorateTitle("[[EVD]] - {content} - {Source}", "REM sleep and recall"),
+    ).toBe("[[EVD]] - REM sleep and recall - ");
+  });
+
+  it("returns the empty string for an empty format", () => {
+    expect(decorateTitle("", "anything")).toBe("");
+  });
+
+  it("keeps a core title that contains the separator", () => {
+    expect(decorateTitle("CLM - {content}", "a - b")).toBe("CLM - a - b");
+  });
+});

--- a/packages/database/src/lib/__tests__/decorateTitle.test.ts
+++ b/packages/database/src/lib/__tests__/decorateTitle.test.ts
@@ -15,17 +15,21 @@ describe("decorateTitle", () => {
     expect(decorateTitle("QUE - {Content}", "why")).toBe("QUE - why");
   });
 
-  it("substitutes the empty string for other placeholders", () => {
+  it("returns null for a format with placeholders the core title cannot fill", () => {
     expect(
       decorateTitle("[[EVD]] - {content} - {Source}", "REM sleep and recall"),
-    ).toBe("[[EVD]] - REM sleep and recall - ");
+    ).toBeNull();
   });
 
-  it("returns the empty string for an empty format", () => {
-    expect(decorateTitle("", "anything")).toBe("");
+  it("returns null for a format without a content placeholder", () => {
+    expect(decorateTitle("", "anything")).toBeNull();
+    expect(decorateTitle("CLM", "anything")).toBeNull();
   });
 
-  it("keeps a core title that contains the separator", () => {
+  it("keeps a core title that contains the separator or replacement patterns", () => {
     expect(decorateTitle("CLM - {content}", "a - b")).toBe("CLM - a - b");
+    expect(decorateTitle("CLM - {content}", "costs $& more")).toBe(
+      "CLM - costs $& more",
+    );
   });
 });

--- a/packages/database/src/lib/decorateTitle.ts
+++ b/packages/database/src/lib/decorateTitle.ts
@@ -1,12 +1,22 @@
 // Inverse of the apps' extractContentFromTitle: rebuild a local title from a
 // node type format and the core_title stored in Concept.literal_content.
-// "{content}" takes the core title; every other placeholder (e.g. "{Source}")
-// becomes the empty string, so "[[EVD]] - {content} - {Source}" yields
-// "[[EVD]] - <core title> - ". Callers decide the fallback when the format is
-// empty or the core title is missing.
-const FORMAT_PLACEHOLDER = /{[a-zA-Z]+}/g;
+// Returns null when the format cannot be rebuilt from the core title alone:
+// it is empty, has no {content} placeholder, or carries other placeholders
+// such as {Source} whose values the database does not hold yet. Callers fall
+// back to the incoming title in that case.
+export const FORMAT_PLACEHOLDER = /{[a-zA-Z]+}/g;
 
-export const decorateTitle = (format: string, coreTitle: string): string =>
-  format.replace(FORMAT_PLACEHOLDER, (placeholder) =>
-    placeholder.toLowerCase() === "{content}" ? coreTitle : "",
-  );
+export const decorateTitle = (
+  format: string,
+  coreTitle: string,
+): string | null => {
+  const placeholders = format.match(FORMAT_PLACEHOLDER) ?? [];
+  if (
+    placeholders.length === 0 ||
+    placeholders.some(
+      (placeholder) => placeholder.toLowerCase() !== "{content}",
+    )
+  )
+    return null;
+  return format.replace(FORMAT_PLACEHOLDER, () => coreTitle);
+};

--- a/packages/database/src/lib/decorateTitle.ts
+++ b/packages/database/src/lib/decorateTitle.ts
@@ -1,0 +1,12 @@
+// Inverse of the apps' extractContentFromTitle: rebuild a local title from a
+// node type format and the core_title stored in Concept.literal_content.
+// "{content}" takes the core title; every other placeholder (e.g. "{Source}")
+// becomes the empty string, so "[[EVD]] - {content} - {Source}" yields
+// "[[EVD]] - <core title> - ". Callers decide the fallback when the format is
+// empty or the core title is missing.
+const FORMAT_PLACEHOLDER = /{[a-zA-Z]+}/g;
+
+export const decorateTitle = (format: string, coreTitle: string): string =>
+  format.replace(FORMAT_PLACEHOLDER, (placeholder) =>
+    placeholder.toLowerCase() === "{content}" ? coreTitle : "",
+  );


### PR DESCRIPTION


https://github.com/user-attachments/assets/71c3b7a5-54f2-4312-8c68-ad2889afa6e3


This is what we are following: 
<img width="1647" height="1330" alt="image" src="https://github.com/user-attachments/assets/43646cd6-7dc8-495b-9b4a-a009b3b16c97" />
This PR is the bottom path of the diagram: decorate on import, Obsidian.

Obsidian's import used the incoming title verbatim, so a node published from Roam arrived carrying `[[CLM]] - ` and ignored what the local vault calls that node type. This rebuilds the file name from `core_title` with the local node type's format, so the same node lands as `CLM - sleep improves memory` in a vault that formats claims that way. Fallback is the incoming title, used when `core_title` is absent (rows published before ENG-2153/2154), the local type has no format, or the format cannot be rebuilt from the core title alone (no `{content}` placeholder, or a second placeholder such as `{Source}` whose value the database does not hold). That last case is why Roam's shipped `[[EVD]] - {content} - {Source}` keeps the incoming title: substituting the empty string dropped the source from a name that used to carry it and left a dangling separator.

Three pieces:

- The instance query in `importNodes.ts` reads the single JSON key by path (`core_title:literal_content->>core_title`), so the import-preview path that shares it stays free of the payload column. postgrest-js types that projection as `string`, but it is null for rows published before ENG-2153, so the `?? undefined` is load-bearing.
- Local node type resolution moves out of `processFileContent` into the per-node loop, because the local format has to be known before the file name is built. `processFileContent` now only writes the file and frontmatter. Its only error came from that resolution, so it returns a `TFile` instead of a result union.
- The name build applies the format with `decorateTitle`, a pure helper in `packages/database/src/lib` because ENG-2156 needs the same transform in Roam. It returns `null` when the format cannot be rebuilt, and the caller falls back. I didn't reuse `formatNodeName`: it splits the compiled regex source on the first `(.*?)`, so a multi-placeholder format produces a name ending in a literal `(.*?)`. The placeholder pattern is exported as `FORMAT_PLACEHOLDER` and `getDiscourseNodeFormatExpression` now uses it, so decorate and match cannot drift apart.

`decorateTitle` is deterministic and one `sanitizedFileName` feeds both the create path and the rename guard, so once a file carries the decorated name, re-import and refresh leave it alone. Files imported before this change carry the incoming title, so their next refresh renames them once (and rewrites inbound wikilinks); that is the intended migration. A related fix falls out: Obsidian-origin nodes that lived in a subfolder used to be created at their full source path, skipping the decorated name, and a later refresh would then rename them. The create path now keeps the folders and replaces the last segment.

Merge order: nothing on `main` writes `core_title` yet (#1317 / #1318 are open). Merged alone, every `coreTitle` is undefined and the import keeps today's names; the decoration in the demo needs those producers. The subfolder create-path fix is live regardless.

Refactor parity (what moved and what changed on the way):

| Old | New | Parity |
|---|---|---|
| `fetchNodeTypeSchemasForInstances` → `Map<id, Schema>` | `fetchNodeImportInfoForInstances` → `Map<id, {schema?, coreTitle?}>` | changed: an entry per visible instance, not only schema-resolved ones |
| early return on empty `schemaIds` / schema-fetch error | fall through with `schema: undefined` | changed: core titles survive a schema-fetch failure |
| node-type derivation inside `processFileContent` | same code in the `importSelectedNodes` loop | identical logic; errors go to `console.error` + `continue` instead of a result union |
| `mapNodeTypeIdToLocal` after the vault write | before the vault write | changed: a failed import can leave a created node type behind |
| `processFileContent` → `{file} \| {error}` | → `TFile` | changed: the one error source moved out, the caller's `result.file!` is gone |
| create path `sanitizePathForImport(contentFilePath)` | source folder + derived basename | changed: create and refresh agree on the name |

Tests for the helper live in `packages/database` (apps/obsidian has no test runner), so the ticket's test bullet is covered for the pure part and the `importNodes` wiring is not. That part is on the demo.

Known and deferred, each pre-existing and left as it was:

- `core_title` is a bare `literal_content` key on both sides: `CrossAppNode.coreTitle` is the contract field (ENG-2153), the serialized key has no shared constant. The producers live on #1317/#1318 and this PR is based on `main`, so the constant is a follow-up once those land.
- `formatNodeName` (local node creation) and `decorateTitle` (import) now disagree on multi-placeholder formats; converging them needs a ticket because `formatNodeName`'s `null` doubles as form validation.
- `mapNodeTypeIdToLocal` runs one `my_concepts` query per imported node, as it did inside `processFileContent` before; batching it is not this ticket.
- A type created from a Roam schema keeps Roam's `[[CLM]] - {content}` format without going through `checkInvalidChars`, so it decorates as `[[CLM]] - x.md`; the incoming title carried the same brackets before this change.
- The create path has never allocated a unique name when the target file exists; decorated names are unique whenever the incoming ones are (one placeholder, distinct type prefixes), so this change does not widen that gap.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/1330" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
