### PR TITLE
ENG-2167 nodeSchemaToCrossApp is missing modifiedAt

### DIFF
--- a/apps/roam/src/utils/__tests__/roamToCrossAppConverters.test.ts
+++ b/apps/roam/src/utils/__tests__/roamToCrossAppConverters.test.ts
@@ -9,7 +9,11 @@ vi.mock("roamjs-components/queries/getPageViewType", () => ({
 }));
 vi.mock("~/utils/pageToMarkdown", () => ({ toMarkdown: () => "" }));
 
-import { nodeUidsWithTypeToCrossApp } from "~/utils/roamToCrossAppConverters";
+import {
+  nodeSchemaToCrossApp,
+  nodeUidsWithTypeToCrossApp,
+} from "~/utils/roamToCrossAppConverters";
+import type { DiscourseNode } from "~/utils/getDiscourseNodes";
 
 const USER_ROW = { ":db/id": 5, ":user/uid": "user-1" };
 
@@ -58,5 +62,65 @@ describe("nodeUidsWithTypeToCrossApp timestamps", () => {
   it("falls back to the create time when no edit time exists", async () => {
     const node = await convertRow(baseRow);
     expect(node.modifiedAt).toEqual(new Date(1000));
+  });
+});
+
+const nodeSchema = (): DiscourseNode => ({
+  text: "Evidence",
+  type: "_EVD-node",
+  shortcut: "e",
+  format: "[[EVD]] - {content}",
+  specification: [],
+  backedBy: "user",
+  canvasSettings: {},
+});
+
+// For the timestamp tests: what Roam holds about one node type page.
+const convertSchemaPull = (pullResult: Record<string, unknown> | null) => {
+  (globalThis as { window: unknown }).window = {
+    roamAlphaAPI: {
+      pull: () => pullResult,
+    },
+  };
+  return nodeSchemaToCrossApp(nodeSchema());
+};
+
+const schemaPull = {
+  ":create/time": 1000,
+  ":create/user": { ":user/uid": "user-1" },
+};
+
+describe("nodeSchemaToCrossApp timestamps", () => {
+  it("takes the block edit time, as written when the page props change", () => {
+    const schema = convertSchemaPull({ ...schemaPull, ":edit/time": 3000 });
+    expect(schema?.createdAt).toEqual(new Date(1000));
+    expect(schema?.modifiedAt).toEqual(new Date(3000));
+  });
+
+  it("takes the page edit time, as written when a block below it changes", () => {
+    const schema = convertSchemaPull({
+      ...schemaPull,
+      ":edit/time": 2000,
+      ":page/edit-time": 4000,
+    });
+    expect(schema?.modifiedAt).toEqual(new Date(4000));
+  });
+
+  it("keeps the later of the two", () => {
+    const schema = convertSchemaPull({
+      ...schemaPull,
+      ":edit/time": 5000,
+      ":page/edit-time": 4000,
+    });
+    expect(schema?.modifiedAt).toEqual(new Date(5000));
+  });
+
+  it("falls back to the create time when neither exists", () => {
+    const schema = convertSchemaPull(schemaPull);
+    expect(schema?.modifiedAt).toEqual(new Date(1000));
+  });
+
+  it("is null without an author, rather than a concept that cannot be inserted", () => {
+    expect(convertSchemaPull({ ":create/time": 1000 })).toBeNull();
   });
 });

--- a/apps/roam/src/utils/__tests__/roamToCrossAppConverters.test.ts
+++ b/apps/roam/src/utils/__tests__/roamToCrossAppConverters.test.ts
@@ -91,12 +91,6 @@ const schemaPull = {
 };
 
 describe("nodeSchemaToCrossApp timestamps", () => {
-  it("takes the block edit time, as written when the page props change", () => {
-    const schema = convertSchemaPull({ ...schemaPull, ":edit/time": 3000 });
-    expect(schema?.createdAt).toEqual(new Date(1000));
-    expect(schema?.modifiedAt).toEqual(new Date(3000));
-  });
-
   it("takes the page edit time, as written when a block below it changes", () => {
     const schema = convertSchemaPull({
       ...schemaPull,
@@ -104,15 +98,6 @@ describe("nodeSchemaToCrossApp timestamps", () => {
       ":page/edit-time": 4000,
     });
     expect(schema?.modifiedAt).toEqual(new Date(4000));
-  });
-
-  it("keeps the later of the two", () => {
-    const schema = convertSchemaPull({
-      ...schemaPull,
-      ":edit/time": 5000,
-      ":page/edit-time": 4000,
-    });
-    expect(schema?.modifiedAt).toEqual(new Date(5000));
   });
 
   it("falls back to the create time when neither exists", () => {

--- a/apps/roam/src/utils/roamToCrossAppConverters.ts
+++ b/apps/roam/src/utils/roamToCrossAppConverters.ts
@@ -185,20 +185,28 @@ export const nodeSchemaToCrossApp = (
   s: DiscourseNode,
 ): CrossAppNodeSchema | null => {
   const relData = window.roamAlphaAPI.pull(
-    "[:create/time :edit/time {:create/user [:user/uid]}]",
+    "[:create/time :edit/time :page/edit-time {:create/user [:user/uid]}]",
     `[:block/uid "${s.type}"]`,
   ) as unknown as {
     ":create/time": number;
     ":edit/time": number;
+    ":page/edit-time"?: number;
     ":create/user": { ":user/uid": string };
   };
   if (!relData) return null;
   const userUid = (relData[":create/user"] ?? {})[":user/uid"];
   if (!userUid) return null;
+  const createdTime = relData[":create/time"] || Date.now();
+  // A node type's settings live either in the page's props or in blocks below it,
+  // depending on the settings store in use, so neither time alone sees every edit:
+  // :edit/time moves when the props are written, :page/edit-time when a block is.
+  const editTime = relData[":edit/time"] ?? createdTime;
+  const pageEditTime = relData[":page/edit-time"] ?? editTime;
   return {
     localId: s.type,
     label: s.text,
     authorId: userUid,
-    createdAt: new Date(relData[":create/time"] || Date.now()),
+    createdAt: new Date(createdTime),
+    modifiedAt: new Date(Math.max(editTime, pageEditTime, createdTime)),
   };
 };

--- a/apps/roam/src/utils/roamToCrossAppConverters.ts
+++ b/apps/roam/src/utils/roamToCrossAppConverters.ts
@@ -185,11 +185,10 @@ export const nodeSchemaToCrossApp = (
   s: DiscourseNode,
 ): CrossAppNodeSchema | null => {
   const relData = window.roamAlphaAPI.pull(
-    "[:create/time :edit/time :page/edit-time {:create/user [:user/uid]}]",
+    "[:create/time :page/edit-time {:create/user [:user/uid]}]",
     `[:block/uid "${s.type}"]`,
   ) as unknown as {
     ":create/time": number;
-    ":edit/time": number;
     ":page/edit-time"?: number;
     ":create/user": { ":user/uid": string };
   };
@@ -198,15 +197,13 @@ export const nodeSchemaToCrossApp = (
   if (!userUid) return null;
   const createdTime = relData[":create/time"] || Date.now();
   // A node type's settings live either in the page's props or in blocks below it,
-  // depending on the settings store in use, so neither time alone sees every edit:
-  // :edit/time moves when the props are written, :page/edit-time when a block is.
-  const editTime = relData[":edit/time"] ?? createdTime;
-  const pageEditTime = relData[":page/edit-time"] ?? editTime;
+  // but :page/edit-time reflects both.
+  const pageEditTime = relData[":page/edit-time"] || createdTime;
   return {
     localId: s.type,
     label: s.text,
     authorId: userUid,
     createdAt: new Date(createdTime),
-    modifiedAt: new Date(Math.max(editTime, pageEditTime, createdTime)),
+    modifiedAt: new Date(Math.max(pageEditTime, createdTime)),
   };
 };


### PR DESCRIPTION
https://linear.app/discourse-graphs/issue/ENG-2167/nodeschematocrossapp-is-missing-modifiedat

https://www.loom.com/share/da17bd5e58b8479b95934fbabf5b1acf

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/1335" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->