### PR TITLE
Add Roam release preflight checks and workflow summary

### DIFF
--- a/.github/workflows/roam-release.yaml
+++ b/.github/workflows/roam-release.yaml
@@ -22,6 +22,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Confirm release runs from main
+        shell: bash
+        run: |
+          if [[ "$GITHUB_REF" != "refs/heads/main" ]]; then
+            echo "::error title=Roam release must run from main::Re-run this workflow with 'Use workflow from' set to main. Current ref: $GITHUB_REF"
+            exit 1
+          fi
+
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
@@ -37,20 +45,35 @@ jobs:
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Get version
+        id: version
+        run: echo "version=$(node -p "require('./apps/roam/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Confirm changelog release notes
+        run: pnpm --filter roam release:preflight
+
       - name: Build
         run: npx turbo run build --filter=roam --ui stream
 
-      - name: Get version
-        id: version
-        run: echo "version=$(node -p "require('./apps/roam/package.json').version")" >> $GITHUB_OUTPUT
-
       - name: Sync Linear release
+        id: linear_release
         uses: linear/linear-release-action@v0
         with:
           access_key: ${{ secrets.LINEAR_RELEASES_ACCESS_KEY }}
           name: Roam ${{ steps.version.outputs.version }}
           version: ${{ steps.version.outputs.version }}
           include_paths: "apps/roam/**,packages/tailwind-config/**,packages/utils/**,packages/database/**,packages/ui/**"
+
+      - name: Confirm Linear release details
+        shell: bash
+        env:
+          RELEASE_VERSION: ${{ steps.linear_release.outputs.release-version }}
+          RELEASE_URL: ${{ steps.linear_release.outputs.release-url }}
+        run: |
+          if [[ -z "$RELEASE_VERSION" || -z "$RELEASE_URL" ]]; then
+            echo "::error title=Linear release details unavailable::The Linear release sync did not return a release version and URL. Check the sync logs and Linear release pipeline, then rerun the workflow."
+            exit 1
+          fi
 
       - name: Inject & upload source maps to PostHog
         uses: PostHog/upload-source-maps@v0.5.7.0
@@ -71,3 +94,27 @@ jobs:
           command: update
           version: ${{ steps.version.outputs.version }}
           stage: Sent to Roam for Review
+
+      - name: Write release summary
+        shell: bash
+        env:
+          RELEASE_VERSION: ${{ steps.linear_release.outputs.release-version }}
+          RELEASE_URL: ${{ steps.linear_release.outputs.release-url }}
+          SOURCE_SHA: ${{ github.sha }}
+          SOURCE_URL: https://github.com/${{ github.repository }}/commit/${{ github.sha }}
+          DEPOT_COMPARE_URL: https://github.com/Roam-Research/roam-depot/compare/main...DiscourseGraphs:roam-depot:main?expand=1
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          # Roam ${RELEASE_VERSION} submitted for review
+
+          - **Release version:** ${RELEASE_VERSION}
+          - **Source commit:** [\`${SOURCE_SHA}\`](${SOURCE_URL})
+          - **Linear release:** [Roam ${RELEASE_VERSION}](${RELEASE_URL})
+          - **Roam Depot comparison:** [Open comparison](${DEPOT_COMPARE_URL})
+
+          ## Remaining manual steps
+
+          1. Open the upstream Roam Depot PR from the comparison above.
+          2. Create the next Roam Linear release and bump \`apps/roam/package.json\` to its version.
+          3. After Roam publishes the submitted release, complete [Roam ${RELEASE_VERSION}](${RELEASE_URL}) in Linear.
+          EOF

--- a/apps/roam/RELEASE.md
+++ b/apps/roam/RELEASE.md
@@ -55,14 +55,21 @@ When the version bump and changelog are merged:
 
 1. Run the `Update Roam Extension Metadata` GitHub Action
    (`.github/workflows/roam-release.yaml`) from `main`.
-2. Confirm the workflow succeeds.
-3. The workflow updates Roam Depot metadata and moves the Linear release to
+2. The workflow stops before changing Linear or Roam Depot if it is not running
+   from `main`, if `apps/roam/CHANGELOG.md` has no section matching the version in
+   `apps/roam/package.json`, or if that section has no release notes. Follow the
+   error annotation, merge the missing preparation to `main`, and rerun the
+   workflow from `main`.
+3. Confirm the workflow succeeds and review its job summary for the submitted
+   version, source commit, Linear release, Roam Depot comparison, and remaining
+   manual steps.
+4. The workflow updates Roam Depot metadata and moves the Linear release to
    `Sent to Roam for Review`.
-4. Treat the release as frozen in Linear.
-5. Create the next Roam Linear release, move it to `In Progress`, and bump
+5. Treat the release as frozen in Linear.
+6. Open the upstream Roam Depot PR from the comparison link in the job summary.
+7. Create the next Roam Linear release, move it to `In Progress`, and bump
    `apps/roam/package.json` to that next version in a follow-up PR. This keeps
    the alpha branch and release metadata aligned with the active release line.
-6. Cut the Roam Depot PR to Roam.
 
 At this point the release is submitted for Roam review, but it is not finished.
 
@@ -94,10 +101,14 @@ version.
 `roam-release.yaml`
 
 - Runs manually when publishing a prepared release.
+- Requires the workflow to run from `main` with a matching, non-empty changelog
+  section for the package version before any release mutation.
 - Builds Roam.
 - Reads the release version from `apps/roam/package.json`.
 - Updates Roam Depot metadata.
 - Moves the Linear release to `Sent to Roam for Review`.
+- Writes a successful job summary with release links and the remaining manual
+  steps.
 
 `roam-release-complete.yaml`
 

--- a/apps/roam/package.json
+++ b/apps/roam/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "publish": "tsx scripts/publish.ts",
+    "release:preflight": "tsx scripts/checkReleasePreflight.ts",
     "playwright:load-extension": "tsx scripts/playwright/loadExtension.ts",
     "playwright:open": "tsx scripts/playwright/openRoam.ts",
     "check-types": "tsc --noEmit --skipLibCheck",

--- a/apps/roam/scripts/__tests__/releasePreflight.test.ts
+++ b/apps/roam/scripts/__tests__/releasePreflight.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { checkChangelogSection } from "../releasePreflight";
+
+describe("checkChangelogSection", () => {
+  it("accepts a matching changelog section with release notes", () => {
+    const changelog = `# Changelog
+
+## [0.22.0] - 2026-08-23
+
+### Added
+
+- Add release preflight checks.
+
+## [0.21.0] - 2026-06-22
+
+- Previous release.
+`;
+
+    expect(checkChangelogSection({ changelog, version: "0.22.0" })).toEqual({
+      status: "valid",
+    });
+  });
+
+  it("rejects a changelog without a matching version section", () => {
+    const changelog = `# Changelog
+
+## [0.21.0] - 2026-06-22
+
+- Previous release.
+`;
+
+    expect(checkChangelogSection({ changelog, version: "0.22.0" })).toEqual({
+      status: "missing",
+    });
+  });
+
+  it("rejects a matching section without release notes", () => {
+    const changelog = `# Changelog
+
+## [0.22.0] - 2026-08-23
+
+### Added
+
+## [0.21.0] - 2026-06-22
+
+- Previous release.
+`;
+
+    expect(checkChangelogSection({ changelog, version: "0.22.0" })).toEqual({
+      status: "empty",
+    });
+  });
+});

--- a/apps/roam/scripts/__tests__/releasePreflight.test.ts
+++ b/apps/roam/scripts/__tests__/releasePreflight.test.ts
@@ -21,6 +21,19 @@ describe("checkChangelogSection", () => {
     });
   });
 
+  it("accepts an undated section with a single release note", () => {
+    const changelog = `# Changelog
+
+## [0.22.0]
+
+- Fix the release workflow.
+`;
+
+    expect(checkChangelogSection({ changelog, version: "0.22.0" })).toEqual({
+      status: "valid",
+    });
+  });
+
   it("rejects a changelog without a matching version section", () => {
     const changelog = `# Changelog
 
@@ -44,6 +57,21 @@ describe("checkChangelogSection", () => {
 ## [0.21.0] - 2026-06-22
 
 - Previous release.
+`;
+
+    expect(checkChangelogSection({ changelog, version: "0.22.0" })).toEqual({
+      status: "empty",
+    });
+  });
+
+  it("rejects a matching section containing only a multi-line comment", () => {
+    const changelog = `# Changelog
+
+## [0.22.0]
+
+<!--
+TODO: Add release notes.
+-->
 `;
 
     expect(checkChangelogSection({ changelog, version: "0.22.0" })).toEqual({

--- a/apps/roam/scripts/checkReleasePreflight.ts
+++ b/apps/roam/scripts/checkReleasePreflight.ts
@@ -1,0 +1,56 @@
+import fs from "node:fs";
+import path from "node:path";
+import { checkChangelogSection } from "./releasePreflight";
+
+const PACKAGE_PATH = "package.json";
+const CHANGELOG_PATH = "CHANGELOG.md";
+
+const getPackageVersion = (packageContents: string): string => {
+  const packageJson: unknown = JSON.parse(packageContents);
+  if (
+    !packageJson ||
+    typeof packageJson !== "object" ||
+    !("version" in packageJson) ||
+    typeof packageJson.version !== "string" ||
+    !packageJson.version.trim()
+  ) {
+    throw new Error(`No version found in apps/roam/${PACKAGE_PATH}.`);
+  }
+
+  return packageJson.version.trim();
+};
+
+const escapeWorkflowCommand = (value: string): string =>
+  value.replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A");
+
+const failPreflight = (message: string): never => {
+  console.error(
+    `::error title=Roam release changelog preflight failed::${escapeWorkflowCommand(message)}`,
+  );
+  process.exit(1);
+};
+
+const packageContents = fs.readFileSync(
+  path.resolve(process.cwd(), PACKAGE_PATH),
+  "utf8",
+);
+const changelog = fs.readFileSync(
+  path.resolve(process.cwd(), CHANGELOG_PATH),
+  "utf8",
+);
+const version = getPackageVersion(packageContents);
+const result = checkChangelogSection({ changelog, version });
+
+if (result.status === "missing") {
+  failPreflight(
+    `Add a non-empty "## [${version}]" section to apps/roam/CHANGELOG.md, merge it to main, and rerun the workflow from main.`,
+  );
+}
+
+if (result.status === "empty") {
+  failPreflight(
+    `Add release notes beneath the "## [${version}]" section in apps/roam/CHANGELOG.md, merge them to main, and rerun the workflow from main.`,
+  );
+}
+
+console.log(`Changelog contains release notes for Roam ${version}.`);

--- a/apps/roam/scripts/releasePreflight.ts
+++ b/apps/roam/scripts/releasePreflight.ts
@@ -1,0 +1,43 @@
+export type ChangelogPreflightResult =
+  | { status: "valid" }
+  | { status: "missing" }
+  | { status: "empty" };
+
+const escapeRegExp = (value: string): string =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+const hasReleaseNoteContent = (section: string): boolean =>
+  section.split("\n").some((line) => {
+    const trimmedLine = line.trim();
+    if (!trimmedLine) return false;
+    if (/^#{3,6}\s+/.test(trimmedLine)) return false;
+    if (/^<!--.*-->$/.test(trimmedLine)) return false;
+    return true;
+  });
+
+export const checkChangelogSection = ({
+  changelog,
+  version,
+}: {
+  changelog: string;
+  version: string;
+}): ChangelogPreflightResult => {
+  const headingPattern = new RegExp(
+    `^##\\s+\\[${escapeRegExp(version)}\\](?:\\s+-\\s+.*)?\\s*$`,
+    "m",
+  );
+  const headingMatch = headingPattern.exec(changelog);
+  if (!headingMatch) return { status: "missing" };
+
+  const sectionStart = headingMatch.index + headingMatch[0].length;
+  const remainingChangelog = changelog.slice(sectionStart);
+  const nextSectionIndex = remainingChangelog.search(/^##\s+/m);
+  const section =
+    nextSectionIndex === -1
+      ? remainingChangelog
+      : remainingChangelog.slice(0, nextSectionIndex);
+
+  return hasReleaseNoteContent(section)
+    ? { status: "valid" }
+    : { status: "empty" };
+};

--- a/apps/roam/scripts/releasePreflight.ts
+++ b/apps/roam/scripts/releasePreflight.ts
@@ -6,14 +6,16 @@ export type ChangelogPreflightResult =
 const escapeRegExp = (value: string): string =>
   value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
-const hasReleaseNoteContent = (section: string): boolean =>
-  section.split("\n").some((line) => {
+const hasReleaseNoteContent = (section: string): boolean => {
+  const sectionWithoutComments = section.replace(/<!--[\s\S]*?(?:-->|$)/g, "");
+
+  return sectionWithoutComments.split("\n").some((line) => {
     const trimmedLine = line.trim();
     if (!trimmedLine) return false;
     if (/^#{3,6}\s+/.test(trimmedLine)) return false;
-    if (/^<!--.*-->$/.test(trimmedLine)) return false;
     return true;
   });
+};
 
 export const checkChangelogSection = ({
   changelog,
@@ -23,7 +25,7 @@ export const checkChangelogSection = ({
   version: string;
 }): ChangelogPreflightResult => {
   const headingPattern = new RegExp(
-    `^##\\s+\\[${escapeRegExp(version)}\\](?:\\s+-\\s+.*)?\\s*$`,
+    `^##[ \\t]+\\[${escapeRegExp(version)}\\](?:[ \\t]+-[ \\t]+.*)?[ \\t]*\\r?$`,
     "m",
   );
   const headingMatch = headingPattern.exec(changelog);

--- a/apps/roam/vitest.config.mts
+++ b/apps/roam/vitest.config.mts
@@ -7,7 +7,10 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
 export default defineConfig({
   test: {
     environment: "node",
-    include: ["src/utils/__tests__/**/*.test.ts"],
+    include: [
+      "src/utils/__tests__/**/*.test.ts",
+      "scripts/__tests__/**/*.test.ts",
+    ],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary

- Require Roam releases to run from `main` with matching changelog notes
- Add unit-tested changelog preflight validation
- Verify Linear release outputs before continuing
- Add release links, source details, and manual follow-up steps to the workflow summary
- Document the updated release process

## Testing

- Added Vitest unit tests for valid, missing, and empty changelog sections
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/1338" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->