### PR TITLE
ENG-2169 Synchronize Roam Depot fork before publishing metadata

### DIFF
--- a/apps/roam/RELEASE.md
+++ b/apps/roam/RELEASE.md
@@ -46,10 +46,11 @@ public changelog. See `apps/roam/CHANGELOG.md` for the current changelog format.
 
 ## Submitting to Roam
 
-Before running the Roam release workflow, make sure the Discourse Graphs Roam
-Depot fork is clean and up to date with upstream Roam Depot. The workflow updates
-the Roam Depot metadata from the fork, so pending fork drift can complicate the
-review PR.
+The Roam release workflow synchronizes the Discourse Graphs Roam Depot fork's
+default branch with upstream before reading or updating the extension metadata.
+If GitHub reports a sync conflict, resolve the fork conflict in GitHub and rerun
+the workflow. The workflow does not update extension metadata when synchronization
+fails.
 
 When the version bump and changelog are merged:
 
@@ -96,7 +97,7 @@ version.
 - Runs manually when publishing a prepared release.
 - Builds Roam.
 - Reads the release version from `apps/roam/package.json`.
-- Updates Roam Depot metadata.
+- Synchronizes the Roam Depot fork with upstream, then updates its metadata.
 - Moves the Linear release to `Sent to Roam for Review`.
 
 `roam-release-complete.yaml`

--- a/apps/roam/scripts/publish.ts
+++ b/apps/roam/scripts/publish.ts
@@ -3,9 +3,6 @@ import * as path from "path";
 import * as fs from "fs";
 import { exec } from "child_process";
 import util from "util";
-// Module configuration in roam does not allow ESM import, we need to use require here.
-const { Octokit } = require("@octokit/core");
-const { createAppAuth } = require("@octokit/auth-app");
 
 dotenv.config();
 
@@ -19,6 +16,24 @@ type ExtensionMetadata = {
   source_commit: string;
   source_subdir?: string;
   stripe_account?: string;
+};
+
+type GitHubResponse = {
+  data: unknown;
+  status: number;
+};
+
+export type GitHubClient = {
+  request: (
+    route: string,
+    parameters: Record<string, unknown>,
+  ) => Promise<GitHubResponse>;
+};
+
+type PublishDependencies = {
+  octokit?: GitHubClient;
+  getCommitHash?: () => Promise<string>;
+  getPackageVersion?: () => string;
 };
 
 const getVersion = (root = "."): string => {
@@ -74,7 +89,100 @@ async function getCurrentCommitHash(): Promise<string> {
   return await execGitCommand("git rev-parse HEAD");
 }
 
-const publish = async () => {
+const createGitHubClient = (): GitHubClient => {
+  // Module configuration in Roam does not allow ESM imports for these packages.
+  const { Octokit } = require("@octokit/core");
+  const { createAppAuth } = require("@octokit/auth-app");
+
+  return new Octokit({
+    authStrategy: createAppAuth,
+    auth: {
+      appId: parseInt(getRequiredEnvVar("APP_ID"), 10),
+      privateKey: getRequiredEnvVar("APP_PRIVATE_KEY"),
+      installationId: 59416220,
+    },
+  });
+};
+
+const getGitHubApiErrorDetails = (error: unknown): string => {
+  if (!error || typeof error !== "object") return String(error);
+
+  const apiError = error as {
+    message?: string;
+    status?: number;
+    response?: { data?: { message?: string } };
+  };
+  const message = apiError.response?.data?.message || apiError.message;
+
+  if (apiError.status && message) return `${apiError.status}: ${message}`;
+  if (apiError.status) return String(apiError.status);
+  return message || "Unknown GitHub API error";
+};
+
+export const synchronizeFork = async ({
+  octokit,
+  owner,
+  repo,
+}: {
+  octokit: GitHubClient;
+  owner: string;
+  repo: string;
+}): Promise<void> => {
+  let defaultBranch: string;
+
+  try {
+    const response = await octokit.request("GET /repos/{owner}/{repo}", {
+      owner,
+      repo,
+    });
+    defaultBranch =
+      (response.data as { default_branch?: string }).default_branch || "";
+  } catch (error) {
+    throw new Error(
+      `Could not determine the default branch for ${owner}/${repo}: GitHub API returned ${getGitHubApiErrorDetails(error)}. Verify the GitHub App can read the fork, then rerun the publish workflow. Metadata was not updated.`,
+    );
+  }
+
+  if (!defaultBranch) {
+    throw new Error(
+      `Could not determine the default branch for ${owner}/${repo}: the GitHub API response did not include default_branch. Metadata was not updated.`,
+    );
+  }
+
+  console.log(`Synchronizing ${owner}/${repo}:${defaultBranch} with upstream`);
+  try {
+    await octokit.request("POST /repos/{owner}/{repo}/merge-upstream", {
+      owner,
+      repo,
+      branch: defaultBranch,
+    });
+  } catch (error) {
+    const status =
+      error && typeof error === "object" && "status" in error
+        ? (error as { status?: number }).status
+        : undefined;
+
+    if (status === 409) {
+      throw new Error(
+        `Could not synchronize ${owner}/${repo}:${defaultBranch} with upstream because the branches have conflicts. Resolve the fork conflicts in GitHub, then rerun the publish workflow. Metadata was not updated.`,
+      );
+    }
+
+    throw new Error(
+      `Could not synchronize ${owner}/${repo}:${defaultBranch} with upstream: GitHub API returned ${getGitHubApiErrorDetails(error)}. Verify the GitHub App permissions and fork state, then rerun the publish workflow. Metadata was not updated.`,
+    );
+  }
+
+  console.log(
+    `${owner}/${repo}:${defaultBranch} is synchronized with upstream`,
+  );
+};
+
+export const publish = async ({
+  octokit = createGitHubClient(),
+  getCommitHash = getCurrentCommitHash,
+  getPackageVersion = getVersion,
+}: PublishDependencies = {}): Promise<void> => {
   process.env = {
     ...process.env,
     NODE_ENV: "production",
@@ -83,16 +191,13 @@ const publish = async () => {
   const publishRepo = "roam-depot";
   const destPath = `extensions/${username}/discourse-graph.json`;
 
-  const octokit = new Octokit({
-    authStrategy: createAppAuth,
-    auth: {
-      appId: parseInt(getRequiredEnvVar("APP_ID"), 10),
-      privateKey: getRequiredEnvVar("APP_PRIVATE_KEY"),
-      installationId: 59416220,
-    },
+  await synchronizeFork({
+    octokit,
+    owner: username,
+    repo: publishRepo,
   });
 
-  const commitHash = await getCurrentCommitHash();
+  const commitHash = await getCommitHash();
   console.log(`Current commit hash: ${commitHash}`);
 
   const metadata: ExtensionMetadata = {
@@ -132,7 +237,7 @@ const publish = async () => {
 
   console.log("Publishing ...");
   try {
-    const version = getVersion();
+    const version = getPackageVersion();
     const message = "Release " + version;
 
     const response = await octokit.request(

--- a/apps/roam/scripts/publish.ts
+++ b/apps/roam/scripts/publish.ts
@@ -36,6 +36,15 @@ type PublishDependencies = {
   getPackageVersion?: () => string;
 };
 
+type GitHubClientConstructor = new (options: {
+  authStrategy: unknown;
+  auth: {
+    appId: number;
+    privateKey: string;
+    installationId: number;
+  };
+}) => GitHubClient;
+
 const getVersion = (root = "."): string => {
   const filename = path.join(root, "package.json");
   const json = fs.existsSync(filename)
@@ -90,9 +99,15 @@ async function getCurrentCommitHash(): Promise<string> {
 }
 
 const createGitHubClient = (): GitHubClient => {
-  // Module configuration in Roam does not allow ESM imports for these packages.
-  const { Octokit } = require("@octokit/core");
-  const { createAppAuth } = require("@octokit/auth-app");
+  // Roam's script module configuration does not support ESM imports here.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { Octokit } = require("@octokit/core") as {
+    Octokit: GitHubClientConstructor;
+  };
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { createAppAuth } = require("@octokit/auth-app") as {
+    createAppAuth: unknown;
+  };
 
   return new Octokit({
     authStrategy: createAppAuth,

--- a/apps/roam/src/utils/__tests__/publishScript.test.ts
+++ b/apps/roam/src/utils/__tests__/publishScript.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from "vitest";
+import { publish, type GitHubClient } from "../../../scripts/publish";
+
+const createApiError = ({
+  status,
+  message,
+}: {
+  status: number;
+  message: string;
+}): Error & { status: number } => Object.assign(new Error(message), { status });
+
+const publishWithClient = async (octokit: GitHubClient): Promise<void> =>
+  publish({
+    octokit,
+    getCommitHash: () => Promise.resolve("abc123"),
+    getPackageVersion: () => "1.2.3",
+  });
+
+describe("Roam Depot publishing", () => {
+  it("synchronizes the fork's default branch before reading and updating metadata", async () => {
+    const routes: string[] = [];
+    const request = vi.fn<GitHubClient["request"]>((route) => {
+      routes.push(route);
+
+      if (route === "GET /repos/{owner}/{repo}") {
+        return Promise.resolve({
+          data: { default_branch: "main" },
+          status: 200,
+        });
+      }
+      if (route === "POST /repos/{owner}/{repo}/merge-upstream") {
+        return Promise.resolve({
+          data: { merge_type: "fast-forward" },
+          status: 200,
+        });
+      }
+      if (route === "GET /repos/{owner}/{repo}/contents/{path}") {
+        return Promise.resolve({
+          data: { sha: "metadata-sha" },
+          status: 200,
+        });
+      }
+      return Promise.resolve({ data: {}, status: 200 });
+    });
+
+    await publishWithClient({ request });
+
+    expect(routes).toEqual([
+      "GET /repos/{owner}/{repo}",
+      "POST /repos/{owner}/{repo}/merge-upstream",
+      "GET /repos/{owner}/{repo}/contents/{path}",
+      "PUT /repos/{owner}/{repo}/contents/{path}",
+    ]);
+    expect(request).toHaveBeenNthCalledWith(
+      2,
+      "POST /repos/{owner}/{repo}/merge-upstream",
+      {
+        owner: "DiscourseGraphs",
+        repo: "roam-depot",
+        branch: "main",
+      },
+    );
+  });
+
+  it("does not read or write metadata when synchronization has conflicts", async () => {
+    const routes: string[] = [];
+    const request = vi.fn<GitHubClient["request"]>((route) => {
+      routes.push(route);
+      if (route === "GET /repos/{owner}/{repo}") {
+        return Promise.resolve({
+          data: { default_branch: "main" },
+          status: 200,
+        });
+      }
+      return Promise.reject(
+        createApiError({ status: 409, message: "Conflict" }),
+      );
+    });
+
+    await expect(publishWithClient({ request })).rejects.toThrow(
+      "Resolve the fork conflicts in GitHub, then rerun the publish workflow. Metadata was not updated.",
+    );
+    expect(routes).toEqual([
+      "GET /repos/{owner}/{repo}",
+      "POST /repos/{owner}/{repo}/merge-upstream",
+    ]);
+  });
+
+  it("reports other synchronization API failures without touching metadata", async () => {
+    const routes: string[] = [];
+    const request = vi.fn<GitHubClient["request"]>((route) => {
+      routes.push(route);
+      if (route === "GET /repos/{owner}/{repo}") {
+        return Promise.resolve({
+          data: { default_branch: "main" },
+          status: 200,
+        });
+      }
+      return Promise.reject(
+        createApiError({
+          status: 403,
+          message: "Resource not accessible",
+        }),
+      );
+    });
+
+    await expect(publishWithClient({ request })).rejects.toThrow(
+      "GitHub API returned 403: Resource not accessible. Verify the GitHub App permissions and fork state, then rerun the publish workflow. Metadata was not updated.",
+    );
+    expect(routes).toEqual([
+      "GET /repos/{owner}/{repo}",
+      "POST /repos/{owner}/{repo}/merge-upstream",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- Synchronize the Roam Depot fork's default branch with upstream before updating extension metadata.
- Add actionable errors for sync conflicts, missing branch data, and GitHub API failures.
- Make publishing dependencies injectable and add coverage for successful and failed synchronization.
- Update Roam release documentation with the new workflow behavior.

## Testing

- Added Vitest coverage for synchronization ordering and failure handling.
- Not run (not requested).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/1339" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->