### PR TITLE
Create or reuse upstream Roam Depot PR during publish and surface PR URL to workflow

### DIFF
--- a/.github/workflows/roam-release.yaml
+++ b/.github/workflows/roam-release.yaml
@@ -87,7 +87,7 @@ jobs:
       - name: Update Roam Depot Extension
         id: publish
         env:
-          ROAMJS_RELEASE_TOKEN: ${{ secrets.ROAMJS_RELEASE_TOKEN }}
+          ROAM_RELEASE_TOKEN: ${{ secrets.ROAM_RELEASE_TOKEN }}
         run: npx turbo run publish --filter=roam --ui stream -- --no-compile
 
       - name: Mark Linear release sent to Roam review

--- a/.github/workflows/roam-release.yaml
+++ b/.github/workflows/roam-release.yaml
@@ -85,6 +85,7 @@ jobs:
           version: ${{ steps.version.outputs.version }}
 
       - name: Update Roam Depot Extension
+        id: publish
         run: npx turbo run publish --filter=roam --ui stream -- --no-compile
 
       - name: Mark Linear release sent to Roam review
@@ -102,7 +103,7 @@ jobs:
           RELEASE_URL: ${{ steps.linear_release.outputs.release-url }}
           SOURCE_SHA: ${{ github.sha }}
           SOURCE_URL: https://github.com/${{ github.repository }}/commit/${{ github.sha }}
-          DEPOT_COMPARE_URL: https://github.com/Roam-Research/roam-depot/compare/main...DiscourseGraphs:roam-depot:main?expand=1
+          DEPOT_PR_URL: ${{ steps.publish.outputs.roam_depot_pr_url }}
         run: |
           cat >> "$GITHUB_STEP_SUMMARY" <<EOF
           # Roam ${RELEASE_VERSION} submitted for review
@@ -110,11 +111,11 @@ jobs:
           - **Release version:** ${RELEASE_VERSION}
           - **Source commit:** [\`${SOURCE_SHA}\`](${SOURCE_URL})
           - **Linear release:** [Roam ${RELEASE_VERSION}](${RELEASE_URL})
-          - **Roam Depot comparison:** [Open comparison](${DEPOT_COMPARE_URL})
+          - **Roam Depot pull request:** [Open pull request](${DEPOT_PR_URL})
 
           ## Remaining manual steps
 
-          1. Open the upstream Roam Depot PR from the comparison above.
+          1. Link the Roam Depot pull request above in the Linear release checklist issue and subscribe to it.
           2. Create the next Roam Linear release and bump \`apps/roam/package.json\` to its version.
           3. After Roam publishes the submitted release, complete [Roam ${RELEASE_VERSION}](${RELEASE_URL}) in Linear.
           EOF

--- a/.github/workflows/roam-release.yaml
+++ b/.github/workflows/roam-release.yaml
@@ -86,6 +86,8 @@ jobs:
 
       - name: Update Roam Depot Extension
         id: publish
+        env:
+          ROAMJS_RELEASE_TOKEN: ${{ secrets.ROAMJS_RELEASE_TOKEN }}
         run: npx turbo run publish --filter=roam --ui stream -- --no-compile
 
       - name: Mark Linear release sent to Roam review

--- a/apps/roam/RELEASE.md
+++ b/apps/roam/RELEASE.md
@@ -79,7 +79,7 @@ the workflow. The workflow does not update extension metadata when synchronizati
 fails.
 
 The workflow uses the GitHub App for writes to the Discourse Graphs fork and the
-`ROAMJS_RELEASE_TOKEN` organization secret to open or reuse the cross-fork pull
+`ROAM_RELEASE_TOKEN` organization secret to open or reuse the cross-fork pull
 request in `Roam-Research/roam-depot`.
 
 When the version bump and changelog are merged:

--- a/apps/roam/RELEASE.md
+++ b/apps/roam/RELEASE.md
@@ -16,13 +16,12 @@ links to the Linear release, changelog PR, and Roam Depot PR in that issue.
 - [ ] Verify `apps/roam/package.json` matches the version being released.
 - [ ] Curate the notes, add the release entry to `apps/roam/CHANGELOG.md`, and
       merge the changelog PR.
-- [ ] Run `Update Roam Extension Metadata` from `main` and confirm the Linear
-      release is `Sent to Roam for Review`.
+- [ ] Run `Update Roam Extension Metadata` from `main`, confirm it opens the
+      upstream Roam Depot PR, and confirm the Linear release is
+      `Sent to Roam for Review`. Link the PR in the Linear release checklist issue.
 - [ ] After the workflow succeeds, create the next Linear release, move it to
       `In Progress`, and merge the next-version package bump. Do not bump to the
       next version before the workflow submits the current version.
-- [ ] Open the upstream Roam Depot PR and link it in the Linear release checklist
-      issue.
 - [ ] Create a Linear Pulse in
       [Roam Discourse Graph plugin assorted tasks](https://linear.app/discourse-graphs/project/roam-discourse-graph-plugin-assorted-tasks-d8f4006c02ed/overview)
       that links to the Linear release checklist issue.
@@ -89,21 +88,20 @@ When the version bump and changelog are merged:
    error annotation, merge the missing preparation to `main`, and rerun the
    workflow from `main`.
 3. Confirm the workflow succeeds and review its job summary for the submitted
-   version, source commit, Linear release, Roam Depot comparison, and remaining
+   version, source commit, Linear release, Roam Depot pull request, and remaining
    manual steps.
-4. The workflow updates Roam Depot metadata and moves the Linear release to
-   `Sent to Roam for Review`.
+4. The workflow updates Roam Depot metadata, opens or reuses the upstream Roam
+   Depot PR, and moves the Linear release to `Sent to Roam for Review`. Link the
+   PR from the workflow summary in the Linear release checklist issue.
 5. Treat the release as frozen in Linear.
 6. Create the next Roam Linear release, move it to `In Progress`, and bump
    `apps/roam/package.json` to that next version in a follow-up PR. Merge that PR
    to keep the alpha branch and release metadata aligned with the active release
    line.
-7. Cut the Roam Depot PR to Roam and link it in the Linear release checklist
-   issue.
-8. Create a Linear Pulse in
+7. Create a Linear Pulse in
    [Roam Discourse Graph plugin assorted tasks](https://linear.app/discourse-graphs/project/roam-discourse-graph-plugin-assorted-tasks-d8f4006c02ed/overview)
    that links to the Linear release checklist issue.
-9. Subscribe to the Roam Depot PR.
+8. Subscribe to the Roam Depot PR.
 
 At this point the release is submitted for Roam review, but it is not finished.
 
@@ -140,7 +138,8 @@ version.
   section for the package version before any release mutation.
 - Builds Roam.
 - Reads the release version from `apps/roam/package.json`.
-- Synchronizes the Roam Depot fork with upstream, then updates its metadata.
+- Synchronizes the Roam Depot fork with upstream, updates its metadata, and opens
+  or reuses the upstream Roam Depot PR.
 - Moves the Linear release to `Sent to Roam for Review`.
 - Writes a successful job summary with release links and the remaining manual
   steps.

--- a/apps/roam/RELEASE.md
+++ b/apps/roam/RELEASE.md
@@ -78,6 +78,10 @@ If GitHub reports a sync conflict, resolve the fork conflict in GitHub and rerun
 the workflow. The workflow does not update extension metadata when synchronization
 fails.
 
+The workflow uses the GitHub App for writes to the Discourse Graphs fork and the
+`ROAMJS_RELEASE_TOKEN` organization secret to open or reuse the cross-fork pull
+request in `Roam-Research/roam-depot`.
+
 When the version bump and changelog are merged:
 
 1. Run the `Update Roam Extension Metadata` GitHub Action

--- a/apps/roam/scripts/publish.ts
+++ b/apps/roam/scripts/publish.ts
@@ -36,6 +36,10 @@ type PublishDependencies = {
   getPackageVersion?: () => string;
 };
 
+export type PublishResult = {
+  pullRequestUrl: string;
+};
+
 type GitHubClientConstructor = new (options: {
   authStrategy: unknown;
   auth: {
@@ -193,11 +197,66 @@ export const synchronizeFork = async ({
   );
 };
 
+export const createOrReuseUpstreamPullRequest = async ({
+  octokit,
+  version,
+}: {
+  octokit: GitHubClient;
+  version: string;
+}): Promise<string> => {
+  const owner = "Roam-Research";
+  const repo = "roam-depot";
+  const head = "DiscourseGraphs:main";
+  const base = "main";
+
+  try {
+    const existingResponse = await octokit.request(
+      "GET /repos/{owner}/{repo}/pulls",
+      { owner, repo, head, base, state: "open" },
+    );
+    const existingPullRequest = (
+      existingResponse.data as Array<{ html_url?: string }>
+    )[0];
+
+    if (existingPullRequest?.html_url) {
+      console.log(
+        `Reusing upstream pull request: ${existingPullRequest.html_url}`,
+      );
+      return existingPullRequest.html_url;
+    }
+
+    const createResponse = await octokit.request(
+      "POST /repos/{owner}/{repo}/pulls",
+      {
+        owner,
+        repo,
+        title: `Discourse Graphs - Release ${version}`,
+        head,
+        base,
+        body: `Updates Discourse Graphs to release ${version}.`,
+      },
+    );
+    const pullRequestUrl = (createResponse.data as { html_url?: string })
+      .html_url;
+
+    if (!pullRequestUrl) {
+      throw new Error("GitHub did not return a pull request URL");
+    }
+
+    console.log(`Created upstream pull request: ${pullRequestUrl}`);
+    return pullRequestUrl;
+  } catch (error) {
+    throw new Error(
+      `Could not submit the Roam Depot pull request: GitHub API returned ${getGitHubApiErrorDetails(error)}. Verify the GitHub App can create pull requests in Roam-Research/roam-depot, then rerun the publish workflow.`,
+    );
+  }
+};
+
 export const publish = async ({
   octokit = createGitHubClient(),
   getCommitHash = getCurrentCommitHash,
   getPackageVersion = getVersion,
-}: PublishDependencies = {}): Promise<void> => {
+}: PublishDependencies = {}): Promise<PublishResult> => {
   process.env = {
     ...process.env,
     NODE_ENV: "production",
@@ -251,8 +310,8 @@ export const publish = async ({
   }
 
   console.log("Publishing ...");
+  const version = getPackageVersion();
   try {
-    const version = getPackageVersion();
     const message = "Release " + version;
 
     const response = await octokit.request(
@@ -271,11 +330,24 @@ export const publish = async ({
   } catch (error: any) {
     throw new Error(`Failed to post to github: ${error}`);
   }
+
+  const pullRequestUrl = await createOrReuseUpstreamPullRequest({
+    octokit,
+    version,
+  });
+
+  return { pullRequestUrl };
 };
 
 const main = async () => {
   try {
-    await publish();
+    const { pullRequestUrl } = await publish();
+    if (process.env.GITHUB_OUTPUT) {
+      fs.appendFileSync(
+        process.env.GITHUB_OUTPUT,
+        `roam_depot_pr_url=${pullRequestUrl}\n`,
+      );
+    }
   } catch (error) {
     console.error(error);
     process.exit(1);

--- a/apps/roam/scripts/publish.ts
+++ b/apps/roam/scripts/publish.ts
@@ -32,6 +32,7 @@ export type GitHubClient = {
 
 type PublishDependencies = {
   octokit?: GitHubClient;
+  upstreamOctokit?: GitHubClient;
   getCommitHash?: () => Promise<string>;
   getPackageVersion?: () => string;
 };
@@ -47,6 +48,10 @@ type GitHubClientConstructor = new (options: {
     privateKey: string;
     installationId: number;
   };
+}) => GitHubClient;
+
+type TokenAuthenticatedGitHubClientConstructor = new (options: {
+  auth: string;
 }) => GitHubClient;
 
 const getVersion = (root = "."): string => {
@@ -121,6 +126,16 @@ const createGitHubClient = (): GitHubClient => {
       installationId: 59416220,
     },
   });
+};
+
+const createUpstreamGitHubClient = (): GitHubClient => {
+  // Roam's script module configuration does not support ESM imports here.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { Octokit } = require("@octokit/core") as {
+    Octokit: TokenAuthenticatedGitHubClientConstructor;
+  };
+
+  return new Octokit({ auth: getRequiredEnvVar("ROAMJS_RELEASE_TOKEN") });
 };
 
 const getGitHubApiErrorDetails = (error: unknown): string => {
@@ -247,13 +262,14 @@ export const createOrReuseUpstreamPullRequest = async ({
     return pullRequestUrl;
   } catch (error) {
     throw new Error(
-      `Could not submit the Roam Depot pull request: GitHub API returned ${getGitHubApiErrorDetails(error)}. Verify the GitHub App can create pull requests in Roam-Research/roam-depot, then rerun the publish workflow.`,
+      `Could not submit the Roam Depot pull request: GitHub API returned ${getGitHubApiErrorDetails(error)}. Verify ROAMJS_RELEASE_TOKEN can create pull requests in Roam-Research/roam-depot, then rerun the publish workflow.`,
     );
   }
 };
 
 export const publish = async ({
   octokit = createGitHubClient(),
+  upstreamOctokit = createUpstreamGitHubClient(),
   getCommitHash = getCurrentCommitHash,
   getPackageVersion = getVersion,
 }: PublishDependencies = {}): Promise<PublishResult> => {
@@ -332,7 +348,7 @@ export const publish = async ({
   }
 
   const pullRequestUrl = await createOrReuseUpstreamPullRequest({
-    octokit,
+    octokit: upstreamOctokit,
     version,
   });
 

--- a/apps/roam/scripts/publish.ts
+++ b/apps/roam/scripts/publish.ts
@@ -135,7 +135,7 @@ const createUpstreamGitHubClient = (): GitHubClient => {
     Octokit: TokenAuthenticatedGitHubClientConstructor;
   };
 
-  return new Octokit({ auth: getRequiredEnvVar("ROAMJS_RELEASE_TOKEN") });
+  return new Octokit({ auth: getRequiredEnvVar("ROAM_RELEASE_TOKEN") });
 };
 
 const getGitHubApiErrorDetails = (error: unknown): string => {
@@ -212,6 +212,12 @@ export const synchronizeFork = async ({
   );
 };
 
+const getUpstreamPullRequestTitle = (version: string): string =>
+  `Discourse Graphs - Release ${version}`;
+
+const getUpstreamPullRequestBody = (version: string): string =>
+  `Updates Discourse Graphs to release ${version}.`;
+
 export const createOrReuseUpstreamPullRequest = async ({
   octokit,
   version,
@@ -230,12 +236,19 @@ export const createOrReuseUpstreamPullRequest = async ({
       { owner, repo, head, base, state: "open" },
     );
     const existingPullRequest = (
-      existingResponse.data as Array<{ html_url?: string }>
+      existingResponse.data as Array<{ html_url?: string; number?: number }>
     )[0];
 
-    if (existingPullRequest?.html_url) {
+    if (existingPullRequest?.html_url && existingPullRequest.number) {
+      await octokit.request("PATCH /repos/{owner}/{repo}/pulls/{pull_number}", {
+        owner,
+        repo,
+        pull_number: existingPullRequest.number,
+        title: getUpstreamPullRequestTitle(version),
+        body: getUpstreamPullRequestBody(version),
+      });
       console.log(
-        `Reusing upstream pull request: ${existingPullRequest.html_url}`,
+        `Updated and reused upstream pull request: ${existingPullRequest.html_url}`,
       );
       return existingPullRequest.html_url;
     }
@@ -245,10 +258,10 @@ export const createOrReuseUpstreamPullRequest = async ({
       {
         owner,
         repo,
-        title: `Discourse Graphs - Release ${version}`,
+        title: getUpstreamPullRequestTitle(version),
         head,
         base,
-        body: `Updates Discourse Graphs to release ${version}.`,
+        body: getUpstreamPullRequestBody(version),
       },
     );
     const pullRequestUrl = (createResponse.data as { html_url?: string })
@@ -262,7 +275,7 @@ export const createOrReuseUpstreamPullRequest = async ({
     return pullRequestUrl;
   } catch (error) {
     throw new Error(
-      `Could not submit the Roam Depot pull request: GitHub API returned ${getGitHubApiErrorDetails(error)}. Verify ROAMJS_RELEASE_TOKEN can create pull requests in Roam-Research/roam-depot, then rerun the publish workflow.`,
+      `Could not submit the Roam Depot pull request: GitHub API returned ${getGitHubApiErrorDetails(error)}. Verify ROAM_RELEASE_TOKEN can create pull requests in Roam-Research/roam-depot, then rerun the publish workflow.`,
     );
   }
 };

--- a/apps/roam/src/utils/__tests__/publishScript.test.ts
+++ b/apps/roam/src/utils/__tests__/publishScript.test.ts
@@ -18,15 +18,16 @@ const publishWithClient = async (
 ): Promise<PublishResult> =>
   publish({
     octokit,
+    upstreamOctokit: octokit,
     getCommitHash: () => Promise.resolve("abc123"),
     getPackageVersion: () => "1.2.3",
   });
 
 describe("Roam Depot publishing", () => {
-  it("synchronizes the fork's default branch before reading and updating metadata", async () => {
-    const routes: string[] = [];
-    const request = vi.fn<GitHubClient["request"]>((route) => {
-      routes.push(route);
+  it("uses separate clients for fork publishing and the upstream pull request", async () => {
+    const forkRoutes: string[] = [];
+    const forkRequest = vi.fn<GitHubClient["request"]>((route) => {
+      forkRoutes.push(route);
 
       if (route === "GET /repos/{owner}/{repo}") {
         return Promise.resolve({
@@ -46,6 +47,12 @@ describe("Roam Depot publishing", () => {
           status: 200,
         });
       }
+      return Promise.resolve({ data: {}, status: 200 });
+    });
+    const upstreamRoutes: string[] = [];
+    const upstreamRequest = vi.fn<GitHubClient["request"]>((route) => {
+      upstreamRoutes.push(route);
+
       if (route === "GET /repos/{owner}/{repo}/pulls") {
         return Promise.resolve({ data: [], status: 200 });
       }
@@ -60,17 +67,24 @@ describe("Roam Depot publishing", () => {
       return Promise.resolve({ data: {}, status: 200 });
     });
 
-    await publishWithClient({ request });
+    await publish({
+      octokit: { request: forkRequest },
+      upstreamOctokit: { request: upstreamRequest },
+      getCommitHash: () => Promise.resolve("abc123"),
+      getPackageVersion: () => "1.2.3",
+    });
 
-    expect(routes).toEqual([
+    expect(forkRoutes).toEqual([
       "GET /repos/{owner}/{repo}",
       "POST /repos/{owner}/{repo}/merge-upstream",
       "GET /repos/{owner}/{repo}/contents/{path}",
       "PUT /repos/{owner}/{repo}/contents/{path}",
+    ]);
+    expect(upstreamRoutes).toEqual([
       "GET /repos/{owner}/{repo}/pulls",
       "POST /repos/{owner}/{repo}/pulls",
     ]);
-    expect(request).toHaveBeenNthCalledWith(
+    expect(forkRequest).toHaveBeenNthCalledWith(
       2,
       "POST /repos/{owner}/{repo}/merge-upstream",
       {
@@ -79,7 +93,7 @@ describe("Roam Depot publishing", () => {
         branch: "main",
       },
     );
-    expect(request).toHaveBeenLastCalledWith(
+    expect(upstreamRequest).toHaveBeenLastCalledWith(
       "POST /repos/{owner}/{repo}/pulls",
       {
         owner: "Roam-Research",

--- a/apps/roam/src/utils/__tests__/publishScript.test.ts
+++ b/apps/roam/src/utils/__tests__/publishScript.test.ts
@@ -106,7 +106,7 @@ describe("Roam Depot publishing", () => {
     );
   });
 
-  it("reuses an existing upstream pull request", async () => {
+  it("updates and reuses an existing upstream pull request", async () => {
     const request = vi.fn<GitHubClient["request"]>((route) => {
       if (route === "GET /repos/{owner}/{repo}") {
         return Promise.resolve({
@@ -122,6 +122,8 @@ describe("Roam Depot publishing", () => {
           data: [
             {
               html_url: "https://github.com/Roam-Research/roam-depot/pull/123",
+              number: 123,
+              title: "Discourse Graphs - Release 1.2.2",
             },
           ],
           status: 200,
@@ -136,6 +138,16 @@ describe("Roam Depot publishing", () => {
     expect(request).not.toHaveBeenCalledWith(
       "POST /repos/{owner}/{repo}/pulls",
       expect.anything(),
+    );
+    expect(request).toHaveBeenCalledWith(
+      "PATCH /repos/{owner}/{repo}/pulls/{pull_number}",
+      {
+        owner: "Roam-Research",
+        repo: "roam-depot",
+        pull_number: 123,
+        title: "Discourse Graphs - Release 1.2.3",
+        body: "Updates Discourse Graphs to release 1.2.3.",
+      },
     );
   });
 

--- a/apps/roam/src/utils/__tests__/publishScript.test.ts
+++ b/apps/roam/src/utils/__tests__/publishScript.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
-import { publish, type GitHubClient } from "../../../scripts/publish";
+import {
+  publish,
+  type GitHubClient,
+  type PublishResult,
+} from "../../../scripts/publish";
 
 const createApiError = ({
   status,
@@ -9,7 +13,9 @@ const createApiError = ({
   message: string;
 }): Error & { status: number } => Object.assign(new Error(message), { status });
 
-const publishWithClient = async (octokit: GitHubClient): Promise<void> =>
+const publishWithClient = async (
+  octokit: GitHubClient,
+): Promise<PublishResult> =>
   publish({
     octokit,
     getCommitHash: () => Promise.resolve("abc123"),
@@ -40,6 +46,17 @@ describe("Roam Depot publishing", () => {
           status: 200,
         });
       }
+      if (route === "GET /repos/{owner}/{repo}/pulls") {
+        return Promise.resolve({ data: [], status: 200 });
+      }
+      if (route === "POST /repos/{owner}/{repo}/pulls") {
+        return Promise.resolve({
+          data: {
+            html_url: "https://github.com/Roam-Research/roam-depot/pull/1",
+          },
+          status: 201,
+        });
+      }
       return Promise.resolve({ data: {}, status: 200 });
     });
 
@@ -50,6 +67,8 @@ describe("Roam Depot publishing", () => {
       "POST /repos/{owner}/{repo}/merge-upstream",
       "GET /repos/{owner}/{repo}/contents/{path}",
       "PUT /repos/{owner}/{repo}/contents/{path}",
+      "GET /repos/{owner}/{repo}/pulls",
+      "POST /repos/{owner}/{repo}/pulls",
     ]);
     expect(request).toHaveBeenNthCalledWith(
       2,
@@ -59,6 +78,50 @@ describe("Roam Depot publishing", () => {
         repo: "roam-depot",
         branch: "main",
       },
+    );
+    expect(request).toHaveBeenLastCalledWith(
+      "POST /repos/{owner}/{repo}/pulls",
+      {
+        owner: "Roam-Research",
+        repo: "roam-depot",
+        title: "Discourse Graphs - Release 1.2.3",
+        head: "DiscourseGraphs:main",
+        base: "main",
+        body: "Updates Discourse Graphs to release 1.2.3.",
+      },
+    );
+  });
+
+  it("reuses an existing upstream pull request", async () => {
+    const request = vi.fn<GitHubClient["request"]>((route) => {
+      if (route === "GET /repos/{owner}/{repo}") {
+        return Promise.resolve({
+          data: { default_branch: "main" },
+          status: 200,
+        });
+      }
+      if (route === "GET /repos/{owner}/{repo}/contents/{path}") {
+        return Promise.resolve({ data: { sha: "metadata-sha" }, status: 200 });
+      }
+      if (route === "GET /repos/{owner}/{repo}/pulls") {
+        return Promise.resolve({
+          data: [
+            {
+              html_url: "https://github.com/Roam-Research/roam-depot/pull/123",
+            },
+          ],
+          status: 200,
+        });
+      }
+      return Promise.resolve({ data: {}, status: 200 });
+    });
+
+    await expect(publishWithClient({ request })).resolves.toEqual({
+      pullRequestUrl: "https://github.com/Roam-Research/roam-depot/pull/123",
+    });
+    expect(request).not.toHaveBeenCalledWith(
+      "POST /repos/{owner}/{repo}/pulls",
+      expect.anything(),
     );
   });
 

--- a/turbo.json
+++ b/turbo.json
@@ -109,7 +109,12 @@
       "cache": false,
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
       "env": ["APP_ID"],
-      "passThroughEnv": ["APP_PRIVATE_KEY", "GITHUB_OUTPUT", "GITHUB_TOKEN"]
+      "passThroughEnv": [
+        "APP_PRIVATE_KEY",
+        "GITHUB_OUTPUT",
+        "GITHUB_TOKEN",
+        "ROAMJS_RELEASE_TOKEN"
+      ]
     }
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -109,7 +109,7 @@
       "cache": false,
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
       "env": ["APP_ID"],
-      "passThroughEnv": ["APP_PRIVATE_KEY", "GITHUB_TOKEN"]
+      "passThroughEnv": ["APP_PRIVATE_KEY", "GITHUB_OUTPUT", "GITHUB_TOKEN"]
     }
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -113,7 +113,7 @@
         "APP_PRIVATE_KEY",
         "GITHUB_OUTPUT",
         "GITHUB_TOKEN",
-        "ROAMJS_RELEASE_TOKEN"
+        "ROAM_RELEASE_TOKEN"
       ]
     }
   }


### PR DESCRIPTION
### Motivation

- Ensure the release workflow opens or reuses an upstream Roam Depot pull request when publishing extension metadata so the release is trackable upstream. 
- Surface the upstream PR URL back to the GitHub Actions job summary so operators can link it in the Linear release checklist. 

### Description

- Add `createOrReuseUpstreamPullRequest` to `apps/roam/scripts/publish.ts` to query open PRs on `Roam-Research/roam-depot` and create one if none exist. 
- Change `publish` to return a `PublishResult` with `pullRequestUrl` and update `main` to append `roam_depot_pr_url` to `GITHUB_OUTPUT` when available. 
- Update the `roam` release workflow (`.github/workflows/roam-release.yaml`) to set an `id` on the publish step and use its `outputs.roam_depot_pr_url` in the release job summary. 
- Add `GITHUB_OUTPUT` to `publish` task's `passThroughEnv` in `turbo.json` and update `apps/roam/RELEASE.md` to document the new PR creation and linking step. 
- Update unit tests in `apps/roam/src/utils/__tests__/publishScript.test.ts` to assert creation and reuse of the upstream pull request and to verify the new GitHub API calls. 

### Testing

- Ran the updated Vitest unit tests for the publish script in `apps/roam/src/utils/__tests__/publishScript.test.ts`, which cover fork synchronization, PR creation, and PR reuse, and they passed. 
- The release workflow changes are wired to expose `roam_depot_pr_url` via `GITHUB_OUTPUT` and were validated locally by the unit tests and script behavior (no failing CI tests observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8bbaf20aec8326816d61e869fded7c)