### PR TITLE
Support Ctrl-click for Obsidian canvas nodes

### DIFF
--- a/apps/obsidian/src/components/canvas/TldrawViewComponent.tsx
+++ b/apps/obsidian/src/components/canvas/TldrawViewComponent.tsx
@@ -333,9 +333,9 @@ export const TldrawPreviewComponent = ({
         }
 
         // Handle Shift+Click (open in sidebar) or Cmd+Click (open in new tab)
-        if (e.shiftKey || e.metaKey || e.ctrlKey) {
+        if (e.shiftKey || e.accelKey) {
           const now = Date.now();
-          const openInNewTab = e.metaKey || e.ctrlKey; // Cmd on Mac, Ctrl on other platforms
+          const openInNewTab = e.accelKey; // Cmd on Mac, Ctrl on other platforms
 
           // Debounce to prevent double opening
           if (now - lastShiftClickRef.current < SHIFT_CLICK_DEBOUNCE_MS) {

--- a/apps/obsidian/src/components/canvas/TldrawViewComponent.tsx
+++ b/apps/obsidian/src/components/canvas/TldrawViewComponent.tsx
@@ -333,9 +333,9 @@ export const TldrawPreviewComponent = ({
         }
 
         // Handle Shift+Click (open in sidebar) or Cmd+Click (open in new tab)
-        if (e.shiftKey || e.metaKey) {
+        if (e.shiftKey || e.metaKey || e.ctrlKey) {
           const now = Date.now();
-          const openInNewTab = e.metaKey; // Cmd on Mac, Ctrl on other platforms
+          const openInNewTab = e.metaKey || e.ctrlKey; // Cmd on Mac, Ctrl on other platforms
 
           // Debounce to prevent double opening
           if (now - lastShiftClickRef.current < SHIFT_CLICK_DEBOUNCE_MS) {


### PR DESCRIPTION
## Summary

- Support Ctrl-click for opening Discourse nodes in a new tab
- Preserve Cmd-click and Shift-click behavior
- Debounce modified clicks consistently across platforms

## Testing

Not run (not requested)