### PR TITLE
ENG-2174 Standardize repository-wide CI validation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,14 +31,8 @@ jobs:
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Check TypeScript Types
-        run: npx turbo check-types
-
-      - name: Run Tests
-        run: npx turbo run test --filter=roam --ui stream
-
-      - name: Run Package Unit Tests
-        run: npx turbo run test:unit --ui stream
+      - name: Validate
+        run: pnpm ci:validate
 
   lint-changed-files:
     if: github.event_name == 'pull_request'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,3 +83,6 @@ PR titles for Linear-backed work should follow this format:
 
 - Write unit tests for new functionality
 - Ensure tests are meaningful and maintainable
+- Expose workspace unit tests through a `test:unit` script so the root validation command includes them
+- Before opening a pull request or declaring work PR-ready, run `pnpm install --frozen-lockfile` followed by `pnpm ci:validate` from the repository root, and resolve any failures
+- After opening or updating an authorized pull request, wait for its required GitHub checks and report their final status

--- a/apps/roam/package.json
+++ b/apps/roam/package.json
@@ -13,7 +13,7 @@
     "playwright:load-extension": "tsx scripts/playwright/loadExtension.ts",
     "playwright:open": "tsx scripts/playwright/openRoam.ts",
     "check-types": "tsc --noEmit --skipLibCheck",
-    "test": "vitest run --config vitest.config.mts",
+    "test": "pnpm test:unit",
     "test:unit": "vitest run --config vitest.config.mts",
     "test:watch": "vitest --config vitest.config.mts"
   },

--- a/apps/roam/package.json
+++ b/apps/roam/package.json
@@ -14,6 +14,7 @@
     "playwright:open": "tsx scripts/playwright/openRoam.ts",
     "check-types": "tsc --noEmit --skipLibCheck",
     "test": "vitest run --config vitest.config.mts",
+    "test:unit": "vitest run --config vitest.config.mts",
     "test:watch": "vitest --config vitest.config.mts"
   },
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "build": "turbo build",
+    "ci:validate": "turbo check-types && turbo run test:unit --ui stream",
     "dev": "turbo dev",
     "lint": "turbo lint",
     "deploy": "turbo deploy",

--- a/packages/content-model/package.json
+++ b/packages/content-model/package.json
@@ -17,7 +17,8 @@
     "build": "tsc -p tsconfig.build.json",
     "check-types": "tsc --noEmit --skipLibCheck",
     "lint": "eslint .",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:unit": "vitest run"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",

--- a/packages/content-model/package.json
+++ b/packages/content-model/package.json
@@ -17,7 +17,7 @@
     "build": "tsc -p tsconfig.build.json",
     "check-types": "tsc --noEmit --skipLibCheck",
     "lint": "eslint .",
-    "test": "vitest run",
+    "test": "pnpm test:unit",
     "test:unit": "vitest run"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- Add a root `ci:validate` command for type checking and workspace unit tests
- Expose `test:unit` scripts for the Roam app and content-model package
- Update CI to use the shared validation command
- Document repository validation requirements

## Testing

- Unit tests: not run (not requested)