### PR TITLE
ENG-2175 Backfill format on existing node type schema rows

### DIFF
--- a/apps/roam/src/utils/__tests__/conceptConversion.test.ts
+++ b/apps/roam/src/utils/__tests__/conceptConversion.test.ts
@@ -98,6 +98,11 @@ describe("discourseNodeSchemaToLocalConcept source slot", () => {
     });
   });
 
+  it("carries the type author as author_local_id", () => {
+    const concept = discourseNodeSchemaToLocalConcept(CONTEXT, nodeType({}));
+    expect(concept.author_local_id).toBe("author-1");
+  });
+
   it("keeps the label and template it already carried", () => {
     const concept = discourseNodeSchemaToLocalConcept(
       CONTEXT,
@@ -215,11 +220,5 @@ describe("discourseNodeBlockToLocalConcept source slot", () => {
     expect(concept.local_reference_content).toEqual({
       sourceDocument: "source-1",
     });
-  });
-
-  it("carries the type author as author_local_id", () => {
-    stubRoamQuery();
-    const concept = discourseNodeSchemaToLocalConcept(context, claimSchema);
-    expect(concept.author_local_id).toBe("author-1");
   });
 });

--- a/apps/roam/src/utils/__tests__/conceptConversion.test.ts
+++ b/apps/roam/src/utils/__tests__/conceptConversion.test.ts
@@ -216,4 +216,10 @@ describe("discourseNodeBlockToLocalConcept source slot", () => {
       sourceDocument: "source-1",
     });
   });
+
+  it("carries the type author as author_local_id", () => {
+    stubRoamQuery();
+    const concept = discourseNodeSchemaToLocalConcept(context, claimSchema);
+    expect(concept.author_local_id).toBe("author-1");
+  });
 });

--- a/apps/roam/src/utils/__tests__/schemaFormatBackfill.test.ts
+++ b/apps/roam/src/utils/__tests__/schemaFormatBackfill.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import type { DiscourseNode } from "~/utils/getDiscourseNodes";
+import { buildSchemaFormatBackfill } from "~/utils/schemaFormatBackfill";
+
+const nodeType = (type: string): DiscourseNode => ({
+  type,
+  text: "Claim",
+  shortcut: "C",
+  specification: [],
+  backedBy: "user",
+  canvasSettings: {},
+  format: "[[CLM]] - {content}",
+});
+
+describe("buildSchemaFormatBackfill", () => {
+  it("targets rows without a format that match a local node type", () => {
+    const result = buildSchemaFormatBackfill({
+      conceptRows: [
+        { source_local_id: "schema-1", format: null },
+        { source_local_id: "schema-2", format: "[[QUE]] - {content}" },
+      ],
+      nodeTypes: [nodeType("schema-1"), nodeType("schema-2")],
+    });
+    expect(result.nodeTypeIdsToBackfill).toEqual(new Set(["schema-1"]));
+    expect(result.withFormatCount).toBe(1);
+    expect(result.orphanedCount).toBe(0);
+  });
+
+  it("treats an empty format as already set", () => {
+    const result = buildSchemaFormatBackfill({
+      conceptRows: [{ source_local_id: "schema-1", format: "" }],
+      nodeTypes: [nodeType("schema-1")],
+    });
+    expect(result.nodeTypeIdsToBackfill.size).toBe(0);
+    expect(result.withFormatCount).toBe(1);
+  });
+
+  it("reports rows with no matching local node type as orphaned", () => {
+    const result = buildSchemaFormatBackfill({
+      conceptRows: [
+        { source_local_id: "gone-schema", format: null },
+        { source_local_id: "schema-1", format: null },
+      ],
+      nodeTypes: [nodeType("schema-1")],
+    });
+    expect(result.nodeTypeIdsToBackfill).toEqual(new Set(["schema-1"]));
+    expect(result.orphanedCount).toBe(1);
+  });
+
+  it("ignores rows without a source_local_id", () => {
+    const result = buildSchemaFormatBackfill({
+      conceptRows: [{ source_local_id: null, format: null }],
+      nodeTypes: [nodeType("schema-1")],
+    });
+    expect(result.nodeTypeIdsToBackfill.size).toBe(0);
+    expect(result.withFormatCount).toBe(0);
+    expect(result.orphanedCount).toBe(0);
+  });
+
+  it("returns zero counts for an empty probe", () => {
+    const result = buildSchemaFormatBackfill({
+      conceptRows: [],
+      nodeTypes: [nodeType("schema-1")],
+    });
+    expect(result.nodeTypeIdsToBackfill.size).toBe(0);
+    expect(result.withFormatCount).toBe(0);
+    expect(result.orphanedCount).toBe(0);
+  });
+});

--- a/apps/roam/src/utils/conceptConversion.ts
+++ b/apps/roam/src/utils/conceptConversion.ts
@@ -20,7 +20,7 @@ import getPageTitleByPageUid from "roamjs-components/queries/getPageTitleByPageU
 const getNodeExtraData = (
   node_uid: string,
 ): {
-  author_uid: string;
+  author_local_id: string;
   created: string;
   last_modified: string;
   page_uid: string;
@@ -57,7 +57,7 @@ const getNodeExtraData = (
   const created = new Date(created_t).toISOString();
   const last_modified = new Date(last_modified_t).toISOString();
   return {
-    author_uid,
+    author_local_id: author_uid,
     created,
     last_modified,
     page_uid,
@@ -218,7 +218,7 @@ export const discourseRelationDataToLocalConcept = (
   const created = new Date(
     Math.max(...nodeData.map((nd) => new Date(nd.created).getTime())),
   ).toISOString();
-  const author_local_id: string = nodeData[0].author_uid; // take any one; again until I get the relation object
+  const author_local_id: string = nodeData[0].author_local_id; // take any one; again until I get the relation object
   return {
     space_id: context.spaceId,
     source_local_id: relationUid,

--- a/apps/roam/src/utils/schemaFormatBackfill.ts
+++ b/apps/roam/src/utils/schemaFormatBackfill.ts
@@ -1,0 +1,41 @@
+import { difference, intersection } from "@repo/utils/setOperations";
+import { type DiscourseNode } from "./getDiscourseNodes";
+
+export const SCHEMA_FORMAT_PROBE_SELECT =
+  "source_local_id, format:literal_content->>format";
+
+type SchemaFormatProbeRow = {
+  source_local_id: string | null;
+  format: string | null;
+};
+
+export type SchemaFormatBackfill = {
+  nodeTypeIdsToBackfill: Set<string>;
+  withFormatCount: number;
+  orphanedCount: number;
+};
+
+export const buildSchemaFormatBackfill = ({
+  conceptRows,
+  nodeTypes,
+}: {
+  conceptRows: SchemaFormatProbeRow[];
+  nodeTypes: DiscourseNode[];
+}): SchemaFormatBackfill => {
+  const missingFormatIds = new Set<string>();
+  let withFormatCount = 0;
+  for (const row of conceptRows) {
+    if (row.source_local_id === null) continue;
+    if (row.format === null) {
+      missingFormatIds.add(row.source_local_id);
+    } else {
+      withFormatCount += 1;
+    }
+  }
+  const localTypeIds = new Set(nodeTypes.map((nodeType) => nodeType.type));
+  return {
+    nodeTypeIdsToBackfill: intersection(missingFormatIds, localTypeIds),
+    withFormatCount,
+    orphanedCount: difference(missingFormatIds, localTypeIds).size,
+  };
+};

--- a/apps/roam/src/utils/syncDgNodesToSupabase.ts
+++ b/apps/roam/src/utils/syncDgNodesToSupabase.ts
@@ -1129,19 +1129,19 @@ const probeSchemaFormatBackfill = async ({
   spaceId: number;
   nodeTypes: DiscourseNode[];
 }): Promise<SchemaFormatBackfill> => {
-  const probeRes = await supabaseClient
-    .from("my_concepts")
-    .select(SCHEMA_FORMAT_PROBE_SELECT)
-    .eq("space_id", spaceId)
-    .eq("is_schema", true)
-    .eq("is_relation", false);
-  if (probeRes.error) {
-    throw new Error(
-      `Schema format probe failed: ${JSON.stringify(probeRes.error, null, 2)}`,
-    );
-  }
+  const probeRows = await getAllPages(
+    supabaseClient
+      .from("my_concepts")
+      .select(SCHEMA_FORMAT_PROBE_SELECT)
+      .eq("space_id", spaceId)
+      .eq("is_schema", true)
+      .eq("is_relation", false)
+      .order("id"),
+    1000,
+  );
+  if (!Array.isArray(probeRows)) throw probeRows;
   return buildSchemaFormatBackfill({
-    conceptRows: probeRes.data,
+    conceptRows: probeRows,
     nodeTypes,
   });
 };

--- a/apps/roam/src/utils/syncDgNodesToSupabase.ts
+++ b/apps/roam/src/utils/syncDgNodesToSupabase.ts
@@ -25,6 +25,11 @@ import {
 } from "./convertRoamNodeToFullContent";
 import type { DGSupabaseClient } from "@repo/database/lib/client";
 import { intersection } from "@repo/utils/setOperations";
+import {
+  buildSchemaFormatBackfill,
+  SCHEMA_FORMAT_PROBE_SELECT,
+  type SchemaFormatBackfill,
+} from "./schemaFormatBackfill";
 import type { Json, Enums } from "@repo/database/dbTypes";
 import { render as renderToast } from "roamjs-components/components/Toast";
 import internalError from "~/utils/internalError";
@@ -634,6 +639,7 @@ export const convertDgToSupabaseConcepts = async ({
   since,
   allNodeTypes,
   sharedNodeTypeIds = new Set<string>(),
+  backfillNodeTypeIds = new Set<string>(),
   supabaseClient,
   context,
 }: {
@@ -641,6 +647,7 @@ export const convertDgToSupabaseConcepts = async ({
   since: number | undefined;
   allNodeTypes: DiscourseNode[];
   sharedNodeTypeIds?: ReadonlySet<string>;
+  backfillNodeTypeIds?: ReadonlySet<string>;
   supabaseClient: DGSupabaseClient;
   context: SupabaseContext;
 }) => {
@@ -650,7 +657,10 @@ export const convertDgToSupabaseConcepts = async ({
   );
 
   allNodeTypes.forEach((nodeType) => {
-    if (sharedNodeTypeIds.has(nodeType.type)) {
+    if (
+      sharedNodeTypeIds.has(nodeType.type) ||
+      backfillNodeTypeIds.has(nodeType.type)
+    ) {
       nodeTypesByUid.set(nodeType.type, nodeType);
     }
   });
@@ -1075,6 +1085,62 @@ const getSharedRoamNodesWithFullContentUpdatesSince = async ({
   });
 };
 
+const probeSchemaFormatBackfill = async ({
+  supabaseClient,
+  spaceId,
+  nodeTypes,
+}: {
+  supabaseClient: DGSupabaseClient;
+  spaceId: number;
+  nodeTypes: DiscourseNode[];
+}): Promise<SchemaFormatBackfill> => {
+  const probeRes = await supabaseClient
+    .from("my_concepts")
+    .select(SCHEMA_FORMAT_PROBE_SELECT)
+    .eq("space_id", spaceId)
+    .eq("is_schema", true)
+    .eq("is_relation", false);
+  if (probeRes.error) {
+    throw new Error(
+      `Schema format probe failed: ${JSON.stringify(probeRes.error, null, 2)}`,
+    );
+  }
+  return buildSchemaFormatBackfill({
+    conceptRows: probeRes.data,
+    nodeTypes,
+  });
+};
+
+const reportSchemaFormatBackfill = ({
+  backfilled,
+  skipped,
+  orphaned,
+}: {
+  backfilled: number;
+  skipped: number;
+  orphaned: number;
+}): void => {
+  posthog.capture("Sync schema format backfill", {
+    backfilled,
+    skipped,
+    orphaned,
+  });
+  if (backfilled === 0 && orphaned === 0) return;
+  const messages = [
+    `Backfilled format for ${backfilled} node type${backfilled === 1 ? "" : "s"}.`,
+    `${skipped} already had one.`,
+  ];
+  if (orphaned > 0) {
+    messages.push(`${orphaned} no longer match a node type in this graph.`);
+  }
+  renderToast({
+    id: "schema-format-backfill",
+    intent: orphaned > 0 ? "warning" : "success",
+    content: messages.join(" "),
+    timeout: 5000,
+  });
+};
+
 export const createOrUpdateDiscourseEmbedding = async (
   showToast = false,
   sendAll?: boolean,
@@ -1212,6 +1278,19 @@ export const createOrUpdateDiscourseEmbedding = async (
       (n) => n.backedBy === "user",
     );
 
+    const schemaFormatBackfill = isInitialSync
+      ? await measureSyncPhase({
+          phase: "probeSchemaFormatBackfill",
+          phases,
+          operation: () =>
+            probeSchemaFormatBackfill({
+              supabaseClient: activeSupabaseClient,
+              spaceId: activeContext.spaceId,
+              nodeTypes: allDgNodeTypes,
+            }),
+        })
+      : null;
+
     const changedNodeInstances = await measureSyncPhase({
       phase: isInitialSync
         ? "getAllMissingOrNewDiscourseNodes"
@@ -1323,10 +1402,18 @@ export const createOrUpdateDiscourseEmbedding = async (
           since: sinceTime,
           allNodeTypes: allDgNodeTypes,
           sharedNodeTypeIds,
+          backfillNodeTypeIds: schemaFormatBackfill?.nodeTypeIdsToBackfill,
           supabaseClient: activeSupabaseClient,
           context: activeContext,
         }),
     });
+    if (schemaFormatBackfill !== null) {
+      reportSchemaFormatBackfill({
+        backfilled: schemaFormatBackfill.nodeTypeIdsToBackfill.size,
+        skipped: schemaFormatBackfill.withFormatCount,
+        orphaned: schemaFormatBackfill.orphanedCount,
+      });
+    }
     await measureSyncPhase({
       phase: "cleanupOrphanedNodes",
       phases,

--- a/apps/roam/src/utils/syncDgNodesToSupabase.ts
+++ b/apps/roam/src/utils/syncDgNodesToSupabase.ts
@@ -1094,19 +1094,19 @@ const probeSchemaFormatBackfill = async ({
   spaceId: number;
   nodeTypes: DiscourseNode[];
 }): Promise<SchemaFormatBackfill> => {
-  const probeRes = await supabaseClient
-    .from("my_concepts")
-    .select(SCHEMA_FORMAT_PROBE_SELECT)
-    .eq("space_id", spaceId)
-    .eq("is_schema", true)
-    .eq("is_relation", false);
-  if (probeRes.error) {
-    throw new Error(
-      `Schema format probe failed: ${JSON.stringify(probeRes.error, null, 2)}`,
-    );
-  }
+  const probeRows = await getAllPages(
+    supabaseClient
+      .from("my_concepts")
+      .select(SCHEMA_FORMAT_PROBE_SELECT)
+      .eq("space_id", spaceId)
+      .eq("is_schema", true)
+      .eq("is_relation", false)
+      .order("id"),
+    1000,
+  );
+  if (!Array.isArray(probeRows)) throw probeRows;
   return buildSchemaFormatBackfill({
-    conceptRows: probeRes.data,
+    conceptRows: probeRows,
     nodeTypes,
   });
 };

--- a/apps/roam/src/utils/syncDgNodesToSupabase.ts
+++ b/apps/roam/src/utils/syncDgNodesToSupabase.ts
@@ -32,6 +32,11 @@ import {
   mergeNodesBySourceLocalId,
   type CoreTitleBackfill,
 } from "./coreTitleBackfill";
+import {
+  buildSchemaFormatBackfill,
+  SCHEMA_FORMAT_PROBE_SELECT,
+  type SchemaFormatBackfill,
+} from "./schemaFormatBackfill";
 import type { Json, Enums } from "@repo/database/dbTypes";
 import { render as renderToast } from "roamjs-components/components/Toast";
 import internalError from "~/utils/internalError";
@@ -641,6 +646,7 @@ export const convertDgToSupabaseConcepts = async ({
   since,
   allNodeTypes,
   sharedNodeTypeIds = new Set<string>(),
+  backfillNodeTypeIds = new Set<string>(),
   supabaseClient,
   context,
 }: {
@@ -648,6 +654,7 @@ export const convertDgToSupabaseConcepts = async ({
   since: number | undefined;
   allNodeTypes: DiscourseNode[];
   sharedNodeTypeIds?: ReadonlySet<string>;
+  backfillNodeTypeIds?: ReadonlySet<string>;
   supabaseClient: DGSupabaseClient;
   context: SupabaseContext;
 }) => {
@@ -657,7 +664,10 @@ export const convertDgToSupabaseConcepts = async ({
   );
 
   allNodeTypes.forEach((nodeType) => {
-    if (sharedNodeTypeIds.has(nodeType.type)) {
+    if (
+      sharedNodeTypeIds.has(nodeType.type) ||
+      backfillNodeTypeIds.has(nodeType.type)
+    ) {
       nodeTypesByUid.set(nodeType.type, nodeType);
     }
   });
@@ -1110,6 +1120,62 @@ const getSharedRoamNodesWithFullContentUpdatesSince = async ({
   });
 };
 
+const probeSchemaFormatBackfill = async ({
+  supabaseClient,
+  spaceId,
+  nodeTypes,
+}: {
+  supabaseClient: DGSupabaseClient;
+  spaceId: number;
+  nodeTypes: DiscourseNode[];
+}): Promise<SchemaFormatBackfill> => {
+  const probeRes = await supabaseClient
+    .from("my_concepts")
+    .select(SCHEMA_FORMAT_PROBE_SELECT)
+    .eq("space_id", spaceId)
+    .eq("is_schema", true)
+    .eq("is_relation", false);
+  if (probeRes.error) {
+    throw new Error(
+      `Schema format probe failed: ${JSON.stringify(probeRes.error, null, 2)}`,
+    );
+  }
+  return buildSchemaFormatBackfill({
+    conceptRows: probeRes.data,
+    nodeTypes,
+  });
+};
+
+const reportSchemaFormatBackfill = ({
+  backfilled,
+  skipped,
+  orphaned,
+}: {
+  backfilled: number;
+  skipped: number;
+  orphaned: number;
+}): void => {
+  posthog.capture("Sync schema format backfill", {
+    backfilled,
+    skipped,
+    orphaned,
+  });
+  if (backfilled === 0 && orphaned === 0) return;
+  const messages = [
+    `Backfilled format for ${backfilled} node type${backfilled === 1 ? "" : "s"}.`,
+    `${skipped} already had one.`,
+  ];
+  if (orphaned > 0) {
+    messages.push(`${orphaned} no longer match a node type in this graph.`);
+  }
+  renderToast({
+    id: "schema-format-backfill",
+    intent: orphaned > 0 ? "warning" : "success",
+    content: messages.join(" "),
+    timeout: 5000,
+  });
+};
+
 export const createOrUpdateDiscourseEmbedding = async (
   showToast = false,
   sendAll?: boolean,
@@ -1246,6 +1312,19 @@ export const createOrUpdateDiscourseEmbedding = async (
     const allDgNodeTypes = getDiscourseNodes().filter(
       (n) => n.backedBy === "user",
     );
+
+    const schemaFormatBackfill = isInitialSync
+      ? await measureSyncPhase({
+          phase: "probeSchemaFormatBackfill",
+          phases,
+          operation: () =>
+            probeSchemaFormatBackfill({
+              supabaseClient: activeSupabaseClient,
+              spaceId: activeContext.spaceId,
+              nodeTypes: allDgNodeTypes,
+            }),
+        })
+      : null;
 
     const { nodes: changedNodeInstances, coreTitleBackfill } =
       await measureSyncPhase({
@@ -1385,10 +1464,18 @@ export const createOrUpdateDiscourseEmbedding = async (
           since: sinceTime,
           allNodeTypes: allDgNodeTypes,
           sharedNodeTypeIds,
+          backfillNodeTypeIds: schemaFormatBackfill?.nodeTypeIdsToBackfill,
           supabaseClient: activeSupabaseClient,
           context: activeContext,
         }),
     });
+    if (schemaFormatBackfill !== null) {
+      reportSchemaFormatBackfill({
+        backfilled: schemaFormatBackfill.nodeTypeIdsToBackfill.size,
+        skipped: schemaFormatBackfill.withFormatCount,
+        orphaned: schemaFormatBackfill.orphanedCount,
+      });
+    }
     if (coreTitleBackfill !== null) {
       reportCoreTitleBackfill({
         backfilled: nodesToBackfillCoreTitle.length,


### PR DESCRIPTION


https://github.com/user-attachments/assets/551ab26c-73fe-4994-b4f5-5f9b538376bf

Schema rows synced before #1316 never get `literal_content.format`: publish skips schemas that already exist, and the periodic sync only re-selects types edited since the last watermark. This backfills them through the sync producer. #1316 has merged; this PR's diff is against `main`.

How it works:

- On the first sync cycle per session, probe own-space schema rows (`is_schema = true`, `is_relation = false`) for a missing `format`.
- Force the matching node types into the concept batch, so `discourseNodeSchemaToLocalConcept` recomputes the complete row.
- Report backfilled / already set / orphaned counts. Silent when there is nothing to do. Re-runs are no-ops.

Decisions, annotated inline on the diff:

- Sync producer, not publish path: `upsert_concepts` replaces `literal_content` wholesale, and the publish converter writes a different shape.
- No "waiting for sync" bucket, unlike the core_title backfill: the schema batch is not shared-gated today, and the probe result is intersected with rows that already exist, so nothing new can be published.
- The `getNodeExtraData` → `author_local_id` rider this backfill depends on landed in `main` via #1332; only the test asserting it (`conceptConversion.test.ts`) remains in this diff.

Known gaps, shared with the core_title backfill on #1332: the orphan toast repeats on each load, and the posthog event has no space attribution. Worth one joint fix later rather than forking the two reports now.

