### PR TITLE
[ENG-2181] Advanced node search filters menu UX update

### DIFF
--- a/apps/obsidian/src/components/NodeTypeFilterMenu.tsx
+++ b/apps/obsidian/src/components/NodeTypeFilterMenu.tsx
@@ -6,25 +6,21 @@ import { getAllDiscourseNodeColors } from "~/utils/colorUtils";
 import {
   NODE_TYPE_FILTER_SEARCH_THRESHOLD,
   filterNodeTypesByQuery,
-  fromPanelSelectedIds,
   hasActiveTypeFilter,
-  toPanelSelectedIds,
 } from "~/utils/discourseNodeTypeFilter";
 
 const NodeTypeFilterRow = ({
   color,
   isChecked,
   nodeType,
-  onSelectOnly,
   onToggle,
 }: {
   color: string | undefined;
   isChecked: boolean;
   nodeType: DiscourseNode;
-  onSelectOnly: () => void;
   onToggle: () => void;
 }): ReactElement => (
-  <div className="hover:bg-modifier-hover group flex items-center gap-2 px-3 py-1.5">
+  <div className="hover:bg-modifier-hover flex items-center gap-2 px-3 py-1.5">
     <label className="flex min-w-0 flex-1 cursor-pointer items-center gap-2">
       <input
         type="checkbox"
@@ -40,19 +36,6 @@ const NodeTypeFilterRow = ({
       )}
       <span className="text-normal truncate text-sm">{nodeType.name}</span>
     </label>
-    <button
-      type="button"
-      // Hidden until the row is hovered or focused so the list stays scannable,
-      // but focusable by keyboard rather than pointer-only.
-      className="text-muted hover:text-normal shrink-0 opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100"
-      onClick={(event) => {
-        event.stopPropagation();
-        onSelectOnly();
-      }}
-      onMouseDown={(event) => event.preventDefault()}
-    >
-      Only
-    </button>
   </div>
 );
 
@@ -102,9 +85,7 @@ const NodeTypeFilterPanel = ({
   return (
     <>
       {/* Clearing is the only thing this control ever does, so it says so and
-          appears only when there is a filter to clear. A "select all" checkbox
-          would sit checked-and-inert whenever no filter is active, since an empty
-          selection and a full one are the same state. */}
+          appears only when there is a filter to clear. */}
       {isFilterActive && (
         <div className="border-modifier-border border-b p-2">
           <button
@@ -141,7 +122,6 @@ const NodeTypeFilterPanel = ({
               color={colorsById.get(nodeType.id)}
               isChecked={selectedIdSet.has(nodeType.id)}
               nodeType={nodeType}
-              onSelectOnly={() => onSelectedIdsChange([nodeType.id])}
               onToggle={() => toggleType(nodeType.id)}
             />
           ))
@@ -166,23 +146,9 @@ export const NodeTypeFilterMenu = ({
   onSelectedNodeTypeIdsChange: (ids: string[]) => void;
   selectedNodeTypeIds: string[];
 }): ReactElement => {
-  const allTypeIds = useMemo(
-    () => nodeTypes.map((nodeType) => nodeType.id),
-    [nodeTypes],
-  );
+  const isFilterActive = hasActiveTypeFilter(selectedNodeTypeIds);
 
-  const isFilterActive = hasActiveTypeFilter({
-    selectedTypeIds: selectedNodeTypeIds,
-    allTypeIds,
-  });
-
-  const panelSelectedIds = useMemo(
-    () =>
-      toPanelSelectedIds({ selectedTypeIds: selectedNodeTypeIds, allTypeIds }),
-    [allTypeIds, selectedNodeTypeIds],
-  );
-
-  const activeFilterCount = isFilterActive ? selectedNodeTypeIds.length : 0;
+  const activeFilterCount = selectedNodeTypeIds.length;
 
   return (
     <SearchDropdown
@@ -208,12 +174,8 @@ export const NodeTypeFilterMenu = ({
       <NodeTypeFilterPanel
         isFilterActive={isFilterActive}
         nodeTypes={nodeTypes}
-        onSelectedIdsChange={(panelIds) =>
-          onSelectedNodeTypeIdsChange(
-            fromPanelSelectedIds({ panelSelectedIds: panelIds, allTypeIds }),
-          )
-        }
-        selectedIds={panelSelectedIds}
+        onSelectedIdsChange={onSelectedNodeTypeIdsChange}
+        selectedIds={selectedNodeTypeIds}
       />
     </SearchDropdown>
   );

--- a/apps/obsidian/src/utils/discourseNodeTypeFilter.ts
+++ b/apps/obsidian/src/utils/discourseNodeTypeFilter.ts
@@ -2,48 +2,16 @@ import { DiscourseNode } from "~/types";
 
 /**
  * Node type filtering for the search modal. An empty `selectedTypeIds` means no
- * filter, matching `filterCandidatesByNodeTypeIds` in QueryEngine — so "nothing
- * selected" and "every type selected" are the same state and both show all nodes.
+ * filter, matching `filterCandidatesByNodeTypeIds` in QueryEngine — so nothing
+ * checked shows every node, and checking a type narrows results to it.
  * Ported from Roam's advanced search so both apps filter alike.
  */
 
 /** Type count above which the panel adds a search box; the modal is desktop-only. */
 export const NODE_TYPE_FILTER_SEARCH_THRESHOLD = 7;
 
-export const hasActiveTypeFilter = ({
-  selectedTypeIds,
-  allTypeIds,
-}: {
-  selectedTypeIds: string[];
-  allTypeIds: string[];
-}): boolean =>
-  selectedTypeIds.length > 0 && selectedTypeIds.length < allTypeIds.length;
-
-/** Shows no-filter as every row checked, so the panel is never an empty checklist. */
-export const toPanelSelectedIds = ({
-  selectedTypeIds,
-  allTypeIds,
-}: {
-  selectedTypeIds: string[];
-  allTypeIds: string[];
-}): string[] => (selectedTypeIds.length === 0 ? allTypeIds : selectedTypeIds);
-
-/** Collapses both "all checked" and "none checked" back to no filter. */
-export const fromPanelSelectedIds = ({
-  panelSelectedIds,
-  allTypeIds,
-}: {
-  panelSelectedIds: string[];
-  allTypeIds: string[];
-}): string[] => {
-  if (
-    panelSelectedIds.length === 0 ||
-    panelSelectedIds.length === allTypeIds.length
-  ) {
-    return [];
-  }
-  return panelSelectedIds;
-};
+export const hasActiveTypeFilter = (selectedTypeIds: string[]): boolean =>
+  selectedTypeIds.length > 0;
 
 export const filterNodeTypesByQuery = (
   nodeTypes: DiscourseNode[],


### PR DESCRIPTION
## Summary

- Node type filter checkboxes in the Obsidian node search now start **unchecked** instead of all-checked-by-default; checking one filters results to it directly.
- Removed the per-row **Only** button (and its hover-reveal styling) — checking a single box now does the same thing.
- Simplified `discourseNodeTypeFilter.ts`: `hasActiveTypeFilter` is now a plain `selectedTypeIds.length > 0`, and `toPanelSelectedIds` / `fromPanelSelectedIds` are deleted — they existed only to translate an empty selection into an "all checked" display, which no longer applies.

Linear: https://linear.app/discourse-graphs/issue/ENG-2181/advanced-node-search-filters-menu-ux-update

## Video

https://www.loom.com/share/8d0c7af989684c49b5c44d7003b66efe

## Test plan

- [x] `pnpm run check-types` — no new errors (pre-existing unrelated tldraw/canvas type errors only)
- [x] `pnpm exec eslint` on both changed files — clean
- [x] Manually tested in dev vault via Open node search → filter by type menu
- [ ] Before/after screenshots attached
- [x] Loom walkthrough linked

## Self-review

Checked against `STYLE_GUIDE.md`:
- Explicit return types, named-object params where >2 args, no `any` — all hold.
- No stray comments left from the removed "Only" button; top-of-file doc comment updated to describe the new checkbox semantics.
- One gap: `discourseNodeTypeFilter.ts` has no unit tests (none existed before this change either). Flagging rather than adding tests unasked, since that'd be scope beyond this ticket — happy to add a follow-up if wanted.

## Scope check

- [ ] Ran `$scope-check` against ENG-2181 and the final diff.
- Scope beyond `Done When`: Not documented — ENG-2181 has no written `Done When` section, only a linked Loom video (from DES-286) I don't have the ability to watch. The diff matches the plain-language request this PR was built from: default-unchecked filter checkboxes, direct per-type filtering on check, and removal of the "Only" button. No other behavior was changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Simplified node-type filtering: selecting any node types now activates the filter, while clearing all selections removes it.
  - Filter counts and activity indicators now directly reflect the selected node types.
  - Removed the “Only” action from individual node-type filter options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->