### PR TITLE
[ENG-2178] Add Search to filter nodes to Canvas drawer in tldraw (Roam)

### DIFF
--- a/apps/roam/src/components/canvas/CanvasDrawer.tsx
+++ b/apps/roam/src/components/canvas/CanvasDrawer.tsx
@@ -143,10 +143,34 @@ export const CanvasDrawerContent = ({
     [visibleGroups],
   );
 
-  const isFiltered =
-    filterType !== "All" ||
-    activeTabId === "duplicates" ||
-    !!trimmedSearchQuery;
+  const hasTypeOrTabFilter =
+    filterType !== "All" || activeTabId === "duplicates";
+  const hasSearch = !!trimmedSearchQuery;
+  const isFiltered = hasTypeOrTabFilter || hasSearch;
+
+  const emptyStateCopy = useMemo(() => {
+    if (!isFiltered) {
+      return {
+        icon: "search" as const,
+        title: `No nodes found for ${pageTitle}`,
+        description:
+          "Add discourse nodes to this canvas to populate the drawer.",
+        actionLabel: undefined,
+      };
+    }
+    const description =
+      hasSearch && hasTypeOrTabFilter
+        ? "Try a different search term or filter."
+        : hasSearch
+          ? "Try a different search term."
+          : "Try a different node type or switch tabs.";
+    return {
+      icon: "filter" as const,
+      title: "No nodes match your filters",
+      description,
+      actionLabel: hasTypeOrTabFilter ? "Clear filters" : "Clear search",
+    };
+  }, [isFiltered, hasSearch, hasTypeOrTabFilter, pageTitle]);
 
   const handleTabChange = useCallback((tabId: TabId) => {
     setActiveTab(tabId);
@@ -381,7 +405,7 @@ export const CanvasDrawerContent = ({
               />
             </span>
           </Tooltip>
-          {isFiltered && !trimmedSearchQuery && (
+          {hasTypeOrTabFilter && (
             <Tag minimal icon="eye-open">
               {visibleNodeCount} visible
             </Tag>
@@ -391,23 +415,13 @@ export const CanvasDrawerContent = ({
 
       {!visibleGroups.length ? (
         <NonIdealState
-          icon={isFiltered ? "filter" : "search"}
-          title={
-            isFiltered
-              ? "No nodes match your filters"
-              : `No nodes found for ${pageTitle}`
-          }
-          description={
-            trimmedSearchQuery
-              ? "Try a different search term."
-              : isFiltered
-                ? "Try a different node type or switch tabs."
-                : "Add discourse nodes to this canvas to populate the drawer."
-          }
+          icon={emptyStateCopy.icon}
+          title={emptyStateCopy.title}
+          description={emptyStateCopy.description}
           action={
-            isFiltered ? (
+            emptyStateCopy.actionLabel ? (
               <Button minimal icon="filter-remove" onClick={handleResetFilters}>
-                Clear filters
+                {emptyStateCopy.actionLabel}
               </Button>
             ) : undefined
           }

--- a/apps/roam/src/components/canvas/CanvasDrawer.tsx
+++ b/apps/roam/src/components/canvas/CanvasDrawer.tsx
@@ -3,6 +3,7 @@ import {
   Button,
   Collapse,
   Icon,
+  InputGroup,
   Menu,
   MenuItem,
   NonIdealState,
@@ -52,6 +53,7 @@ export const CanvasDrawerContent = ({
   const [activeShapeId, setActiveShapeId] = useState<string | null>(null);
   const [filterType, setFilterType] = useState("All");
   const [activeTab, setActiveTab] = useState<TabId>("all");
+  const [searchQuery, setSearchQuery] = useState("");
 
   const pageTitle = useMemo(() => getPageTitleByPageUid(pageUid), [pageUid]);
   const discourseNodes = useMemo(() => getDiscourseNodes(), []);
@@ -120,15 +122,20 @@ export const CanvasDrawerContent = ({
 
   const activeTabId = activeTab as "all" | "duplicates";
 
+  const trimmedSearchQuery = searchQuery.trim().toLowerCase();
+
   const visibleGroups = useMemo(
     () =>
       groups.filter((group) => {
         const matchesType =
           filterType === "All" || group.typeLabel === filterType;
         const matchesTab = activeTabId === "all" ? true : group.isDuplicate;
-        return matchesType && matchesTab;
+        const matchesSearch =
+          !trimmedSearchQuery ||
+          group.title.toLowerCase().includes(trimmedSearchQuery);
+        return matchesType && matchesTab && matchesSearch;
       }),
-    [groups, filterType, activeTabId],
+    [groups, filterType, activeTabId, trimmedSearchQuery],
   );
 
   const visibleNodeCount = useMemo(
@@ -136,7 +143,10 @@ export const CanvasDrawerContent = ({
     [visibleGroups],
   );
 
-  const isFiltered = filterType !== "All" || activeTabId === "duplicates";
+  const isFiltered =
+    filterType !== "All" ||
+    activeTabId === "duplicates" ||
+    !!trimmedSearchQuery;
 
   const handleTabChange = useCallback((tabId: TabId) => {
     setActiveTab(tabId);
@@ -174,6 +184,7 @@ export const CanvasDrawerContent = ({
   const handleResetFilters = useCallback(() => {
     setFilterType("All");
     setActiveTab("all");
+    setSearchQuery("");
   }, []);
 
   const renderNodeTypeItem = useCallback(
@@ -322,6 +333,22 @@ export const CanvasDrawerContent = ({
           <Tab id="all" title={`All Nodes (${totalNodeCount})`} />
           <Tab id="duplicates" title={`Duplicates (${duplicateNodeCount})`} />
         </Tabs>
+        <InputGroup
+          leftIcon="search"
+          placeholder="Search nodes"
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          rightElement={
+            searchQuery ? (
+              <Button
+                icon="cross"
+                minimal
+                small
+                onClick={() => setSearchQuery("")}
+              />
+            ) : undefined
+          }
+        />
         <div className="flex flex-wrap items-center gap-2">
           <Popover
             content={
@@ -354,7 +381,7 @@ export const CanvasDrawerContent = ({
               />
             </span>
           </Tooltip>
-          {isFiltered && (
+          {isFiltered && !trimmedSearchQuery && (
             <Tag minimal icon="eye-open">
               {visibleNodeCount} visible
             </Tag>
@@ -371,9 +398,11 @@ export const CanvasDrawerContent = ({
               : `No nodes found for ${pageTitle}`
           }
           description={
-            isFiltered
-              ? "Try a different node type or switch tabs."
-              : "Add discourse nodes to this canvas to populate the drawer."
+            trimmedSearchQuery
+              ? "Try a different search term."
+              : isFiltered
+                ? "Try a different node type or switch tabs."
+                : "Add discourse nodes to this canvas to populate the drawer."
           }
           action={
             isFiltered ? (

--- a/apps/roam/src/components/canvas/CanvasDrawer.tsx
+++ b/apps/roam/src/components/canvas/CanvasDrawer.tsx
@@ -360,6 +360,7 @@ export const CanvasDrawerContent = ({
         <InputGroup
           leftIcon="search"
           placeholder="Search nodes"
+          aria-label="Search nodes"
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
           rightElement={
@@ -368,6 +369,7 @@ export const CanvasDrawerContent = ({
                 icon="cross"
                 minimal
                 small
+                aria-label="Clear search"
                 onClick={() => setSearchQuery("")}
               />
             ) : undefined


### PR DESCRIPTION
## Summary
- Adds a search input to the Canvas Drawer that filters the node list by title, live as you type
- Combines with the existing type/tab filters; the "N visible" count badge is hidden while a search is active since it's redundant with the filtered list itself
- Empty-state copy now distinguishes a search-only miss ("Try a different search term.") from the type/tab-filter miss

Closes [ENG-2178](https://linear.app/discourse-graphs/issue/ENG-2178/add-search-to-filter-nodes-to-canvas-drawer-in-tldraw-roam)

## Video walkthrough
[Loom](https://www.loom.com/share/cc4502c0390c4724a10b5661262349df)

## Test plan
- [x] `pnpm check-types` passes
- [x] `pnpm lint` passes (no new warnings/errors)
- [x] `prettier --check` passes
- [x] Verified locally in a real Roam graph via Developer Extensions (loaded `apps/roam/dist`), confirmed branch build version, typed in the search box on a canvas with several discourse nodes and confirmed the list filters correctly
- [x] `/review` skill run against this PR
- [x] CodeRabbit full review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added node-title search to the canvas drawer.
  * Search results can be combined with node-type and duplicate-tab filters.
  * Added clear and reset controls for search and filtering.
  * Added dedicated messaging when no matching nodes are found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->