### PR TITLE
FEE-88 standardize Roam & Obsidian doc titles to sentence case

### DIFF
--- a/apps/website/content/obsidian/use-cases/_meta.ts
+++ b/apps/website/content/obsidian/use-cases/_meta.ts
@@ -2,11 +2,11 @@ import type { MetaRecord } from "nextra";
 
 const meta: MetaRecord = {
   "build-utilize-personal-knowledge-base":
-    "Build and Utilize a Personal Knowledge Base",
+    "Build and utilize a personal knowledge base",
   "synthesize-insights-from-literature":
-    "Synthesize Insights from the Literature",
+    "Synthesize insights from the literature",
   "share-your-ideas-and-research": "Share your ideas & research",
-  "track-your-projects-and-experiments": "Track your Projects and Experiments",
+  "track-your-projects-and-experiments": "Track your projects and experiments",
 };
 
 export default meta;

--- a/apps/website/content/obsidian/use-cases/build-utilize-personal-knowledge-base.mdx
+++ b/apps/website/content/obsidian/use-cases/build-utilize-personal-knowledge-base.mdx
@@ -304,6 +304,6 @@ So when should you use Bases vs Datacore? The following table can help you devel
 
 ## What else would you like to do?
 
-- [Synthesize Insights from the Literature](/docs/obsidian/use-cases/synthesize-insights-from-literature)
-- [Track your Projects and Experiments](/docs/obsidian/use-cases/track-your-projects-and-experiments)
+- [Synthesize insights from the literature](/docs/obsidian/use-cases/synthesize-insights-from-literature)
+- [Track your projects and experiments](/docs/obsidian/use-cases/track-your-projects-and-experiments)
 - [Share your ideas & research](/docs/obsidian/use-cases/share-your-ideas-and-research)

--- a/apps/website/content/obsidian/use-cases/experiment-tracking.mdx
+++ b/apps/website/content/obsidian/use-cases/experiment-tracking.mdx
@@ -78,6 +78,6 @@ If you decide an Issue captures something worth doing, you can easily change it 
 
 ## What else would you like to do?
 
-- [Synthesize Insights from the Literature](/docs/obsidian/use-cases/synthesize-insights-from-literature)
-- [Build and Utilize a Personal Knowledge Base](/docs/obsidian/use-cases/build-utilize-personal-knowledge-base)
+- [Synthesize insights from the literature](/docs/obsidian/use-cases/synthesize-insights-from-literature)
+- [Build and utilize a personal knowledge base](/docs/obsidian/use-cases/build-utilize-personal-knowledge-base)
 - [Share your ideas & research](/docs/obsidian/use-cases/share-your-ideas-and-research)

--- a/apps/website/content/obsidian/use-cases/share-your-ideas-and-research.mdx
+++ b/apps/website/content/obsidian/use-cases/share-your-ideas-and-research.mdx
@@ -188,6 +188,6 @@ While the **Discourse Node Sync** feature mentioned above is the only fully-supp
 
 ## What else would you like to do?
 
-- [Build and Utilize a Personal Knowledge Base](/docs/obsidian/use-cases/build-utilize-personal-knowledge-base)
-- [Synthesize Insights from the Literature](/docs/obsidian/use-cases/synthesize-insights-from-literature)
-- [Track your Projects and Experiments](/docs/obsidian/use-cases/track-your-projects-and-experiments)
+- [Build and utilize a personal knowledge base](/docs/obsidian/use-cases/build-utilize-personal-knowledge-base)
+- [Synthesize insights from the literature](/docs/obsidian/use-cases/synthesize-insights-from-literature)
+- [Track your projects and experiments](/docs/obsidian/use-cases/track-your-projects-and-experiments)

--- a/apps/website/content/obsidian/use-cases/synthesize-insights-from-literature.mdx
+++ b/apps/website/content/obsidian/use-cases/synthesize-insights-from-literature.mdx
@@ -278,6 +278,6 @@ In the discourse graph workflow, these phases are largely simultaneous and mutua
 
 ## What else would you like to do?
 
-- [Build and Utilize a Personal Knowledge Base](/docs/obsidian/use-cases/build-utilize-personal-knowledge-base)
-- [Track your Projects and Experiments](/docs/obsidian/use-cases/track-your-projects-and-experiments)
+- [Build and utilize a personal knowledge base](/docs/obsidian/use-cases/build-utilize-personal-knowledge-base)
+- [Track your projects and experiments](/docs/obsidian/use-cases/track-your-projects-and-experiments)
 - [Share your ideas & research](/docs/obsidian/use-cases/share-your-ideas-and-research)

--- a/apps/website/content/obsidian/use-cases/track-your-projects-and-experiments.mdx
+++ b/apps/website/content/obsidian/use-cases/track-your-projects-and-experiments.mdx
@@ -166,6 +166,6 @@ If you decide an Issue captures something worth doing, you can easily change it 
 
 ## What else would you like to do?
 
-- [Build and Utilize a Personal Knowledge Base](/docs/obsidian/use-cases/build-utilize-personal-knowledge-base)
-- [Synthesize Insights from the Literature](/docs/obsidian/use-cases/synthesize-insights-from-literature)
+- [Build and utilize a personal knowledge base](/docs/obsidian/use-cases/build-utilize-personal-knowledge-base)
+- [Synthesize insights from the literature](/docs/obsidian/use-cases/synthesize-insights-from-literature)
 - [Share your ideas & research](/docs/obsidian/use-cases/share-your-ideas-and-research)

--- a/apps/website/content/obsidian/welcome/getting-started.md
+++ b/apps/website/content/obsidian/welcome/getting-started.md
@@ -9,7 +9,7 @@ The Discourse Graph plugin enables [Obsidian](https://obsidian.md/) users to sea
 
 For more information about Discourse Graphs, check out our website at [https://discoursegraphs.com](https://discoursegraphs.com)
 
-## Quick Start Guide
+## Quick start guide
 
 1. [Install the plugin](/docs/obsidian/welcome/installation)
 2. [Configure node and relationship types](/docs/obsidian/configuration/node-types-templates)
@@ -17,26 +17,35 @@ For more information about Discourse Graphs, check out our website at [https://d
 4. [Create relationships between nodes](/docs/obsidian/core-features/creating-discourse-relationships)
 5. [Explore your discourse graph](/docs/obsidian/core-features/canvas)
 
-## What's Next?
+## What's next?
 
 - Learn about [what makes a discourse graph](/docs/obsidian/fundamentals/what-is-a-discourse-graph)
 - Explore [use cases](/docs/obsidian/use-cases/synthesize-insights-from-literature) for discourse graphs
 - Join our community to share your experience and get help
 
-## Guides: Jump right in
+## Guides: jump right in
 
 Follow our handy guides to get started on the basics as quickly as possible:
 
 - [Creating discourse nodes](/docs/obsidian/core-features/creating-discourse-nodes)
 - [Creating discourse relationships](/docs/obsidian/core-features/creating-discourse-relationships)
-- [Exploring your Discourse Graph](/docs/obsidian/core-features/canvas)
+- [Exploring your discourse graph](/docs/obsidian/core-features/canvas)
 - [Running advanced commands](/docs/obsidian/advanced-features/command-palette)
-- [Extending and personalizing your Discourse Graph](/docs/obsidian/configuration/general-settings)
+- [Extending and personalizing your discourse graph](/docs/obsidian/configuration/general-settings)
 
-## Fundamentals: Dive a little deeper
+## Fundamentals: dive a little deeper
 
 Learn the fundamentals of the Discourse Graph plugin to get a deeper understanding of our main features:
 
-- [What is a Discourse Graph?](/docs/obsidian/fundamentals/what-is-a-discourse-graph)
+- [What is a discourse graph?](/docs/obsidian/fundamentals/what-is-a-discourse-graph)
 - [Relationship types](/docs/obsidian/configuration/relationship-types)
-- [The Base Grammar: questions, claims, and evidence](/docs/obsidian/fundamentals/base-grammar)
+- [The base grammar: questions, claims, and evidence](/docs/obsidian/fundamentals/base-grammar)
+
+## Use cases: popular discourse graph workflows
+
+See how others are putting discourse graphs to work:
+
+- [Build and utilize a personal knowledge base](/docs/obsidian/use-cases/build-utilize-personal-knowledge-base)
+- [Synthesize insights from the literature](/docs/obsidian/use-cases/synthesize-insights-from-literature)
+- [Share your ideas & research](/docs/obsidian/use-cases/share-your-ideas-and-research)
+- [Track your projects and experiments](/docs/obsidian/use-cases/track-your-projects-and-experiments)

--- a/apps/website/content/roam/use-cases/_meta.ts
+++ b/apps/website/content/roam/use-cases/_meta.ts
@@ -2,11 +2,11 @@ import type { MetaRecord } from "nextra";
 
 const meta: MetaRecord = {
   "build-utilize-personal-knowledge-base":
-    "Build and Utilize a Personal Knowledge Base",
+    "Build and utilize a personal knowledge base",
   "synthesize-insights-from-literature":
-    "Synthesize Insights from the Literature",
+    "Synthesize insights from the literature",
   "share-your-ideas-and-research": "Share your ideas & research",
-  "track-your-projects-and-experiments": "Track your Projects and Experiments",
+  "track-your-projects-and-experiments": "Track your projects and experiments",
 };
 
 export default meta;

--- a/apps/website/content/roam/use-cases/build-utilize-personal-knowledge-base.md
+++ b/apps/website/content/roam/use-cases/build-utilize-personal-knowledge-base.md
@@ -9,6 +9,6 @@ Description coming soon!
 
 ## What else would you like to do?
 
-- [Synthesize Insights from the Literature](/docs/roam/use-cases/synthesize-insights-from-literature)
-- [Track your Projects and Experiments](/docs/roam/use-cases/track-your-projects-and-experiments)
+- [Synthesize insights from the literature](/docs/roam/use-cases/synthesize-insights-from-literature)
+- [Track your projects and experiments](/docs/roam/use-cases/track-your-projects-and-experiments)
 - [Share your ideas & research](/docs/roam/use-cases/share-your-ideas-and-research)

--- a/apps/website/content/roam/use-cases/share-your-ideas-and-research.md
+++ b/apps/website/content/roam/use-cases/share-your-ideas-and-research.md
@@ -9,6 +9,6 @@ Description coming soon!
 
 ## What else would you like to do?
 
-- [Build and Utilize a Personal Knowledge Base](/docs/roam/use-cases/build-utilize-personal-knowledge-base)
-- [Synthesize Insights from the Literature](/docs/roam/use-cases/synthesize-insights-from-literature)
-- [Track your Projects and Experiments](/docs/roam/use-cases/track-your-projects-and-experiments)
+- [Build and utilize a personal knowledge base](/docs/roam/use-cases/build-utilize-personal-knowledge-base)
+- [Synthesize insights from the literature](/docs/roam/use-cases/synthesize-insights-from-literature)
+- [Track your projects and experiments](/docs/roam/use-cases/track-your-projects-and-experiments)

--- a/apps/website/content/roam/use-cases/synthesize-insights-from-literature.md
+++ b/apps/website/content/roam/use-cases/synthesize-insights-from-literature.md
@@ -9,6 +9,6 @@ Description coming soon!
 
 ## What else would you like to do?
 
-- [Build and Utilize a Personal Knowledge Base](/docs/roam/use-cases/build-utilize-personal-knowledge-base)
-- [Track your Projects and Experiments](/docs/roam/use-cases/track-your-projects-and-experiments)
+- [Build and utilize a personal knowledge base](/docs/roam/use-cases/build-utilize-personal-knowledge-base)
+- [Track your projects and experiments](/docs/roam/use-cases/track-your-projects-and-experiments)
 - [Share your ideas & research](/docs/roam/use-cases/share-your-ideas-and-research)

--- a/apps/website/content/roam/use-cases/track-your-projects-and-experiments.mdx
+++ b/apps/website/content/roam/use-cases/track-your-projects-and-experiments.mdx
@@ -386,6 +386,6 @@ _Claiming an Issue and setting up the resulting Experiment_
 
 ## What else would you like to do?
 
-- [Build and Utilize a Personal Knowledge Base](/docs/roam/use-cases/build-utilize-personal-knowledge-base)
-- [Synthesize Insights from the Literature](/docs/roam/use-cases/synthesize-insights-from-literature)
+- [Build and utilize a personal knowledge base](/docs/roam/use-cases/build-utilize-personal-knowledge-base)
+- [Synthesize insights from the literature](/docs/roam/use-cases/synthesize-insights-from-literature)
 - [Share your ideas & research](/docs/roam/use-cases/share-your-ideas-and-research)

--- a/apps/website/content/roam/welcome/getting-started.md
+++ b/apps/website/content/roam/welcome/getting-started.md
@@ -13,20 +13,29 @@ Here is a relatively brief walkthrough of some of the main features of the exten
 
 [https://www.loom.com/share/2ec80422301c451b888b65ee1d283b40](https://www.loom.com/share/2ec80422301c451b888b65ee1d283b40)
 
-## Guides: Jump right in
+## Guides: jump right in
 
 Follow our handy guides to get started on the basics as quickly as possible:
 
 - [Creating discourse nodes](/docs/roam/guides/creating-discourse-nodes)
 - [Creating discourse relationships](/docs/roam/guides/creating-discourse-relationships)
-- [Exploring your Discourse Graph](/docs/roam/guides/exploring-discourse-graph)
-- [Querying your Discourse Graph](/docs/roam/guides/querying-discourse-graph)
-- [Extending and Personalizing your Discourse Graph](/docs/roam/guides/extending-personalizing-graph)
+- [Exploring your discourse graph](/docs/roam/guides/exploring-discourse-graph)
+- [Querying your discourse graph](/docs/roam/guides/querying-discourse-graph)
+- [Extending and personalizing your discourse graph](/docs/roam/guides/extending-personalizing-graph)
 
-## Fundamentals: Dive a little deeper
+## Fundamentals: dive a little deeper
 
 Learn the fundamentals of the Discourse Graph extension to get a deeper understanding of our main features:
 
-- [What is a Discourse Graph?](/docs/roam/fundamentals/what-is-a-discourse-graph)
-- [The Discourse Graph extension grammar](/docs/roam/fundamentals/grammar)
+- [What is a discourse graph?](/docs/roam/fundamentals/what-is-a-discourse-graph)
+- [The discourse graph extension grammar](/docs/roam/fundamentals/grammar)
 - [The base grammar: questions, claims, and evidence](/docs/roam/fundamentals/grammar/base-grammar)
+
+## Use cases: popular discourse graph workflows
+
+See how others are putting discourse graphs to work:
+
+- [Build and utilize a personal knowledge base](/docs/roam/use-cases/build-utilize-personal-knowledge-base)
+- [Synthesize insights from the literature](/docs/roam/use-cases/synthesize-insights-from-literature)
+- [Share your ideas & research](/docs/roam/use-cases/share-your-ideas-and-research)
+- [Track your projects and experiments](/docs/roam/use-cases/track-your-projects-and-experiments)


### PR DESCRIPTION
This PR updates the roam and obsidian docs to standardize all doc titles to sentence case (currently mixed) and add the "Use cases" section to the bottom of both Roam & Obsidian "Getting Started" pages (N.B. for Roam 3 of these are still stubs that will be updated in upcoming PRs) to parallel "Guides" and "Fundamentals".

N.B. Not all "Guide" docs are included in the Guides section on the "Getting Started" page, although they are listed in the sidebar: I limited it to the most essential functions.