### PR TITLE
eng-2201 Correct errors in getAssociatedSpace

### DIFF
--- a/packages/database/src/lib/sharedNodes.ts
+++ b/packages/database/src/lib/sharedNodes.ts
@@ -255,9 +255,12 @@ const getAssociatedSpaces = async ({
   currentSpaceId?: number;
 }): Promise<SharedSpace[]> => {
   const associatedSpaceIds = new Set(
-    concepts
-      .flatMap((cpt) => cpt.concepts_of_relation.map((cr) => cr.space_id))
-      .filter((id) => id !== null),
+    [
+      ...concepts.map((cpt) => cpt.space_id),
+      ...concepts.flatMap((cpt) =>
+        cpt.concepts_of_relation.map((cr) => cr.space_id),
+      ),
+    ].filter((id) => id !== null),
   );
   if (currentSpace !== undefined) {
     currentSpaceId = currentSpace.id ?? currentSpaceId;
@@ -272,7 +275,7 @@ const getAssociatedSpaces = async ({
     const { data, error } = await client
       .from("my_spaces")
       .select(SPACE_COLUMNS)
-      .in("space_id", [...associatedSpaceIds]);
+      .in("id", [...associatedSpaceIds]);
     if (error) throw error;
     spaces.push(...data);
   }


### PR DESCRIPTION
## Scope check

- [x] Ran `$scope-check` against the ENG ticket and final diff.
- Scope beyond `Done When`: None

Loom: https://www.loom.com/share/a0f3810836124ea79fb04366ceeec35b

I notice that the Devin code review template was not applied?
I ran the Claude code review, and no comments (except that maybe I should add a test there, but it's an integration test.)
