### PR TITLE
ENG-2205 Use the correct Roam delete API for query pages

### DIFF
--- a/apps/roam/src/components/QueryBuilder.tsx
+++ b/apps/roam/src/components/QueryBuilder.tsx
@@ -26,9 +26,11 @@ import getPageUidByPageTitle from "roamjs-components/queries/getPageUidByPageTit
 import posthog from "posthog-js";
 import parseResultSettings from "~/utils/parseResultSettings";
 import { HIDE_METADATA_KEY } from "~/data/userSettings";
+import deleteQuery, { type QueryParentType } from "~/utils/deleteQuery";
 
 type QueryPageComponent = (props: {
   pageUid: string;
+  parentType?: QueryParentType;
   isEditBlock?: boolean;
   showAlias?: boolean;
   discourseNodeType?: string;
@@ -40,6 +42,7 @@ type Props = Parameters<QueryPageComponent>[0];
 
 const QueryBuilder = ({
   pageUid,
+  parentType = "block",
   isEditBlock,
   showAlias,
   discourseNodeType,
@@ -200,7 +203,7 @@ const QueryBuilder = ({
             results={results.map(({ id, ...a }) => a)}
             onRefresh={onRefresh}
             isEditBlock={isEditBlock}
-            onDeleteQuery={() => deleteBlock(pageUid)}
+            onDeleteQuery={() => deleteQuery({ uid: pageUid, parentType })}
           />
         ) : (
           <></>
@@ -246,7 +249,7 @@ export const renderQueryPage = ({
 
     ReactDOM.render(
       <ExtensionApiContextProvider {...onloadArgs}>
-        <QueryBuilder pageUid={uid} />
+        <QueryBuilder pageUid={uid} parentType="page" />
       </ExtensionApiContextProvider>,
       parent,
     );

--- a/apps/roam/src/components/QueryBuilder.tsx
+++ b/apps/roam/src/components/QueryBuilder.tsx
@@ -203,7 +203,9 @@ const QueryBuilder = ({
             results={results.map(({ id, ...a }) => a)}
             onRefresh={onRefresh}
             isEditBlock={isEditBlock}
-            onDeleteQuery={() => deleteQuery({ uid: pageUid, parentType })}
+            onDeleteQuery={() => {
+              void deleteQuery({ uid: pageUid, parentType });
+            }}
           />
         ) : (
           <></>

--- a/apps/roam/src/utils/__tests__/deleteQuery.test.ts
+++ b/apps/roam/src/utils/__tests__/deleteQuery.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import deleteBlock from "roamjs-components/writes/deleteBlock";
+import deleteQuery from "~/utils/deleteQuery";
+
+vi.mock("roamjs-components/writes/deleteBlock", () => ({ default: vi.fn() }));
+
+const mockedDeleteBlock = vi.mocked(deleteBlock);
+const deletePage = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedDeleteBlock.mockResolvedValue("query-uid");
+  deletePage.mockResolvedValue(undefined);
+  (globalThis as { window: unknown }).window = {
+    roamAlphaAPI: { deletePage },
+  };
+});
+
+describe("deleteQuery", () => {
+  it("deletes a block-backed query with deleteBlock", async () => {
+    await expect(
+      deleteQuery({ uid: "query-uid", parentType: "block" }),
+    ).resolves.toBe("query-uid");
+
+    expect(mockedDeleteBlock).toHaveBeenCalledWith("query-uid");
+    expect(deletePage).not.toHaveBeenCalled();
+  });
+
+  it("deletes a page-backed query with deletePage", async () => {
+    await expect(
+      deleteQuery({ uid: "query-uid", parentType: "page" }),
+    ).resolves.toBe("query-uid");
+
+    expect(deletePage).toHaveBeenCalledWith({ page: { uid: "query-uid" } });
+    expect(mockedDeleteBlock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/roam/src/utils/deleteQuery.ts
+++ b/apps/roam/src/utils/deleteQuery.ts
@@ -1,0 +1,19 @@
+import deleteBlock from "roamjs-components/writes/deleteBlock";
+
+export type QueryParentType = "block" | "page";
+
+const deleteQuery = ({
+  uid,
+  parentType,
+}: {
+  uid: string;
+  parentType: QueryParentType;
+}): Promise<string> => {
+  if (parentType === "page") {
+    return window.roamAlphaAPI.deletePage({ page: { uid } }).then(() => uid);
+  }
+
+  return deleteBlock(uid);
+};
+
+export default deleteQuery;


### PR DESCRIPTION
## Summary

- Route query-page deletion through Roam's deletePage API.
- Keep block-backed query deletion on deleteBlock.
- Cover both UID types with focused unit tests.

## Testing

- pnpm install --frozen-lockfile
- pnpm ci:validate
- pnpm --filter roam lint
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/1367" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->