### PR TITLE
ENG-2206 Make the PR template reviewer-focused

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,20 @@
+## Reviewer brief
+
+<!-- Optional. Remove this section when it adds no value.
+Include only the fields that help the reviewer:
+- Result: The final behavior or outcome.
+- Review focus: A decision, risk, or part of the diff that needs careful review.
+- Risk or follow-up: Unresolved, unverified, or deferred work that affects approval.
+-->
+
+## Verification
+
+<!-- Optional checks and their results. Remove this section when it adds no value. -->
+
+## Loom video for verification
+
+<!-- Add a Loom video link when it is useful for verification. -->
+
 ## Scope check
 
 - [ ] Ran `$scope-check` against the ENG ticket and final diff.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,9 +11,16 @@ Include only the fields that help the reviewer:
 
 <!-- Optional checks and their results. Remove this section when it adds no value. -->
 
-## Loom video for verification
+## Loom video
 
-<!-- Add a Loom video link when it is useful for verification. -->
+<!-- Include a short Loom video for every PR (any change—UI, backend, refactors, infra, etc.). 
+This helps reviewers understand intent quickly and catches issues earlier
+- Keep it under 2–3 minutes
+- Show before/after for bug fixes
+- Narrate key design or dev decisions
+- Paste the Loom link in the PR body
+-->
+
 
 ## Scope check
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,17 @@ PR titles for Linear-backed work should follow this format:
 - Follow the ticket ID with the exact Linear ticket title
 - Example: `ENG-1912 Scaffold @repo/content-model`
 
+### Pull Request Bodies
+
+When creating or updating a pull request body:
+
+- Start with `.github/pull_request_template.md`. Preserve its headings and guidance instead of adding substitute sections.
+- Treat the Linear ticket as the source of truth. Do not restate it in the pull request body.
+- Do not add a file-by-file summary, implementation diary, investigation log, full command output, or unrelated pre-existing issues.
+- Put line-specific implementation context in inline GitHub comments.
+- Put any non-obvious rules that future changes must preserve in code comments, tests, or documentation, not only in the pull request.
+- Remove empty optional sections and anything that does not help review the diff.
+
 ## Style Guide
 
 ### UI Guidelines


### PR DESCRIPTION
## Reviewer brief

- Result: The PR template now keeps reviewer context optional, and root agent guidance prevents bots from expanding it into implementation logs.
- Review focus: Confirm the optional prompts work for both people and bots without becoming required fields.

## Verification

- `pnpm install --frozen-lockfile` completed with an unchanged lockfile.
- `pnpm ci:validate` passed all type checks and 161 unit tests.

## Scope check

- [x] Ran `$scope-check` against ENG-2206 and the final diff.
- Scope beyond `Done When`: Added root `AGENTS.md` instructions for bot-created PR bodies.
- Required now: Bots can replace GitHub's default template, so the template change alone would not constrain generated bodies.
- Anyone affected or consulted: Michael requested the addition.
- Decision: Not documented in Linear.

## Local delegated full review

- [ ] Ran a comprehensive review of the entire final diff in a subagent with a fresh context. Use `$dg-delegated-full-review` when no other full-review workflow is available.
- Not run: `$dg-delegated-full-review` was not explicitly invoked.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/1368" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->