### PR TITLE
ENG-2073 canvas node catch all

### DIFF
--- a/apps/roam/src/utils/__tests__/fixtures/legacyCanvasFalsePositiveRecords.json
+++ b/apps/roam/src/utils/__tests__/fixtures/legacyCanvasFalsePositiveRecords.json
@@ -1,0 +1,28 @@
+[
+  {
+    "id": "shape:sanitized-relation-1",
+    "typeName": "shape",
+    "type": "RELTYPE01",
+    "x": 0,
+    "y": 0,
+    "rotation": 0,
+    "index": "a3",
+    "parentId": "page:fixture-page",
+    "isLocked": false,
+    "opacity": 1,
+    "props": {
+      "uid": "REL_UID01",
+      "title": "Sanitized relation",
+      "bend": 0,
+      "start": {
+        "x": 0,
+        "y": 0
+      },
+      "end": {
+        "x": 1,
+        "y": 1
+      }
+    },
+    "meta": {}
+  }
+]

--- a/apps/roam/src/utils/__tests__/fixtures/legacyCanvasNodeRecords.json
+++ b/apps/roam/src/utils/__tests__/fixtures/legacyCanvasNodeRecords.json
@@ -1,0 +1,44 @@
+[
+  {
+    "id": "shape:fixture-node-1",
+    "typeName": "shape",
+    "type": "NODETYPE1",
+    "x": 128,
+    "y": 256,
+    "rotation": 0,
+    "index": "a1",
+    "parentId": "page:fixture-page",
+    "isLocked": false,
+    "opacity": 1,
+    "props": {
+      "uid": "NODEUID01",
+      "title": "[Sanitized node] Representative title",
+      "w": 320,
+      "h": 96,
+      "size": "m",
+      "fontFamily": "draw"
+    },
+    "meta": {}
+  },
+  {
+    "id": "shape:fixture-node-2",
+    "typeName": "shape",
+    "type": "NODE_TYP2",
+    "x": -64,
+    "y": 32,
+    "rotation": 0,
+    "index": "a2",
+    "parentId": "page:fixture-page",
+    "isLocked": false,
+    "opacity": 1,
+    "props": {
+      "uid": "NODE_UID2",
+      "title": "Sanitized block node",
+      "w": 240,
+      "h": 72,
+      "size": "s",
+      "fontFamily": "sans"
+    },
+    "meta": {}
+  }
+]

--- a/apps/roam/src/utils/__tests__/legacyCanvasNodeDetector.test.ts
+++ b/apps/roam/src/utils/__tests__/legacyCanvasNodeDetector.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import falsePositiveFixtures from "./fixtures/legacyCanvasFalsePositiveRecords.json";
+import fixtures from "./fixtures/legacyCanvasNodeRecords.json";
+import {
+  getLegacyCanvasNodeRecords,
+  isLegacyCanvasNodeCandidate,
+  isLegacyCanvasNodeRecord,
+} from "~/utils/legacyCanvasNodeDetector";
+
+describe("legacy canvas node detector", () => {
+  it("matches sanitized representative legacy node records", () => {
+    expect(fixtures.every(isLegacyCanvasNodeRecord)).toBe(true);
+    expect(getLegacyCanvasNodeRecords(fixtures)).toEqual(fixtures);
+  });
+
+  it("rejects relation-shaped candidates without node box dimensions", () => {
+    expect(falsePositiveFixtures.every(isLegacyCanvasNodeCandidate)).toBe(true);
+    expect(falsePositiveFixtures.every(isLegacyCanvasNodeRecord)).toBe(false);
+  });
+
+  it.each([
+    ["non-shape record", { ...fixtures[0], typeName: "asset" }],
+    ["long shape type", { ...fixtures[0], type: "discourse-node" }],
+    ["short shape type", { ...fixtures[0], type: "SHORTUID" }],
+    ["missing props", { ...fixtures[0], props: undefined }],
+    [
+      "long node uid",
+      { ...fixtures[0], props: { ...fixtures[0].props, uid: "TOO-LONG-UID" } },
+    ],
+    [
+      "invalid node uid character",
+      { ...fixtures[0], props: { ...fixtures[0].props, uid: "NODE.UID1" } },
+    ],
+    [
+      "missing width",
+      { ...fixtures[0], props: { ...fixtures[0].props, w: undefined } },
+    ],
+    [
+      "non-positive height",
+      { ...fixtures[0], props: { ...fixtures[0].props, h: 0 } },
+    ],
+    [
+      "non-finite width",
+      { ...fixtures[0], props: { ...fixtures[0].props, w: Number.NaN } },
+    ],
+  ])("rejects %s", (_, record) => {
+    expect(isLegacyCanvasNodeRecord(record)).toBe(false);
+  });
+});

--- a/apps/roam/src/utils/legacyCanvasNodeDetector.ts
+++ b/apps/roam/src/utils/legacyCanvasNodeDetector.ts
@@ -1,0 +1,38 @@
+export const ROAM_UID_PATTERN = /^[A-Za-z0-9_-]{9}$/;
+
+type UnknownRecord = Record<string, unknown>;
+
+const isRecord = (value: unknown): value is UnknownRecord =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+export const isLegacyCanvasNodeCandidate = (record: unknown): boolean => {
+  if (!isRecord(record) || record.typeName !== "shape") return false;
+  if (typeof record.type !== "string" || !ROAM_UID_PATTERN.test(record.type)) {
+    return false;
+  }
+  if (!isRecord(record.props) || typeof record.props.uid !== "string") {
+    return false;
+  }
+  return ROAM_UID_PATTERN.test(record.props.uid);
+};
+
+export const isLegacyCanvasNodeRecord = (record: unknown): boolean => {
+  if (!isLegacyCanvasNodeCandidate(record) || !isRecord(record)) return false;
+  if (!isRecord(record.props)) return false;
+  const { h, w } = record.props;
+  return (
+    typeof w === "number" &&
+    Number.isFinite(w) &&
+    w > 0 &&
+    typeof h === "number" &&
+    Number.isFinite(h) &&
+    h > 0
+  );
+};
+
+export const getLegacyCanvasNodeRecords = (
+  records: Iterable<unknown>,
+): UnknownRecord[] =>
+  Array.from(records).filter((record): record is UnknownRecord =>
+    isLegacyCanvasNodeRecord(record),
+  );


### PR DESCRIPTION
## Scope check

- [ ] Ran `$scope-check` against ENG-2073 and the final diff.
- Scope beyond `Done When`: The ticket's `Done When` criteria are unavailable in this environment.
- Linear issue: https://linear.app/discourse-graphs/issue/ENG-2073/canvas-node-catch-all

## Local delegated full review

- [x] Ran a comprehensive review of the entire final diff in a subagent with a fresh context. No findings.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/1370" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->