### PR TITLE
ENG-2212 Port cross-platform Roam Playwright workflows to DiscourseGraphs

### DIFF
--- a/.agents/skills/dg-roam-load-extension/SKILL.md
+++ b/.agents/skills/dg-roam-load-extension/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: dg-roam-load-extension
-description: Build and load the local Discourse Graphs apps/roam extension into Roam Research through Roam Depot developer mode using a Playwright test account. Use when verifying local apps/roam changes in a real Roam graph, checking that DG commands/settings load, or capturing proof after loading apps/roam/dist.
+description: Build, register, activate, and verify the local Discourse Graphs Roam extension, then run an optional feature test in the same Playwright context. Use for live apps/roam proof on Windows or macOS without repeating browser, login, and folder-loading setup.
 ---
 
 # DG Roam Load Extension
 
-Use this skill to build `apps/roam`, load `apps/roam/dist` through Roam Depot developer mode, and verify that the Discourse Graphs extension is active.
+Use this skill for one complete lifecycle: build `apps/roam`, open an authenticated slot, register `apps/roam/dist`, activate it, verify DG runtime readiness, run an optional caller test, capture proof, and close.
 
 It composes with `dg-roam-playwright-session` for account/profile selection.
 
@@ -21,7 +21,31 @@ Use another slot for isolated work:
 pnpm --filter roam playwright:loadExtension -- --slot 2
 ```
 
-The script builds `apps/roam` by default, loads `apps/roam/dist`, verifies `window.roamjs.extension.queryBuilder`, and writes proof under `local/roam-playwright/artifacts`.
+The script builds by default, verifies `window.roamjs.extension.queryBuilder`, checks the DG settings UI, and writes proof under `local/roam-playwright/artifacts`.
+
+To add feature-specific assertions without copying the loader, pass an ESM test module:
+
+```sh
+pnpm --filter roam playwright:loadExtension -- --slot 1 --test-module ./local/roam-playwright/feature-proof.mjs
+```
+
+```js
+export default {
+  readySelector: "[data-testid='feature-ready']",
+  async ready({ page }) {
+    return page.evaluate(() => Boolean(window.myFeature?.ready));
+  },
+  async run({ page, outDir }) {
+    await page.getByText("Expected output").waitFor();
+    return { assertion: "passed" };
+  },
+  async cleanup({ page, state }) {
+    // Remove only fixtures created by run().
+  },
+};
+```
+
+`run()` starts only after the standard DG runtime proof and any caller readiness hook succeeds. `cleanup()` runs when `run()` started, including after a failed assertion. Return JSON-serializable proof values.
 
 ## Options
 
@@ -30,16 +54,23 @@ The script builds `apps/roam` by default, loads `apps/roam/dist`, verifies `wind
 - `--headed`: Run with a visible Chromium window.
 - `--keep-open`: Leave the browser open after loading.
 - `--dist <path>`: Load a different Roam extension folder. Use only when intentionally testing another build output.
+- `--registration-name <name>`: Developer Extensions row name. Defaults to the built folder name, usually `dist`.
+- `--test-module <path>`: Caller readiness, test, and cleanup hooks. Absolute Windows paths and paths containing spaces are supported.
+- `--out <path>` and `--screenshot-name <name>`: Proof artifact locations.
+- `--timeout <ms>`: UI and readiness timeout. Defaults to `45000`.
 
 ## Folder Loading
 
 Roam Depot's folder button calls `window.showDirectoryPicker()`, not an `<input type="file">`. The script installs a temporary in-page directory-picker shim backed by the files in `apps/roam/dist`.
 
-An IndexedDB clone warning for the fake directory handle is expected. Treat successful DG global verification and screenshot proof as the source of truth.
+The loader uses native Playwright clicks for developer mode and folder controls. It treats the extension row as registration only, then clicks the header or row refresh control when present and waits for DG runtime proof. Roam versions that activate automatically may expose no refresh control.
+
+An IndexedDB clone warning for the fake directory handle is expected and classified separately. Other page exceptions fail the run. `last-run.json` includes phase timings and bounded browser diagnostics; failures also capture a dedicated screenshot and compact DOM state.
 
 ## Safety Notes
 
 - Do not commit `.env`, browser profiles, or artifacts.
 - Do not commit real Roam test account emails, graph names, graph URLs, or proof screenshots.
+- Keep feature fixtures, command interactions, and assertions in the caller module. Do not add them to the generic loader.
 - Do not change Supabase local/branch/production config as part of this skill.
 - Do not run production-backend smoke tests in this workflow.

--- a/.agents/skills/dg-roam-playwright-session/SKILL.md
+++ b/.agents/skills/dg-roam-playwright-session/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: dg-roam-playwright-session
-description: Open Roam Research with a Discourse Graphs Playwright test account and persistent profile for apps/roam extension testing. Use when developing or verifying the Discourse Graphs Roam extension, rotating between the three local Playwright Roam accounts, capturing screenshot proof, or inspecting live Roam DOM behavior from this repository.
+description: Open one authenticated Roam Research Playwright context with a Discourse Graphs test slot on Windows or macOS. Use when testing apps/roam, capturing proof, inspecting live Roam behavior, or reusing the same page and profile across several checks.
 ---
 
 # DG Roam Playwright Session
 
-Use this skill to open a real Roam Research graph with one of the local Playwright test accounts.
+Use this skill to open a real Roam Research graph once, run all checks in the returned context, capture proof, and close it cleanly.
 
 Secrets must live only in the ignored `apps/roam/.env`. Do not print, inspect, or commit passwords, cookies, local storage, or Playwright profile contents.
 
@@ -26,6 +26,8 @@ pnpm --filter roam playwright:open -- --slot 3
 
 The script writes screenshots and JSON proof under `local/roam-playwright/artifacts`.
 
+For loading `apps/roam/dist` and running a feature test in the same context, use `dg-roam-load-extension` instead of creating a temporary browser harness.
+
 ## Environment
 
 The ignored `apps/roam/.env` should contain one set per slot:
@@ -43,9 +45,18 @@ Account emails and graph URLs are intentionally required from the ignored app `.
 
 Profile directories default to ignored local paths under `local/roam-playwright/profiles/`.
 
+The repo-relative `.env`, profile, and artifact paths work on Windows and macOS. Override them only when the slot needs a different local location:
+
+- `DG_ROAM_PLAYWRIGHT_ENV_PATH`: alternate ignored environment file.
+- `DG_ROAM_PLAYWRIGHT_PROFILE_DIR_<slot>` or `--profile-dir`: slot profile.
+- `--out`: proof output directory.
+
+When importing `openRoamSession`, keep the returned session and call `session.close()` in `finally`. A failed navigation or readiness check closes the context automatically.
+
 ## Safety Notes
 
 - Only one Chromium process can own a persistent profile at a time.
-- Use a different `--slot` for concurrent agents.
+- A profile-lock error identifies the occupied slot and path. Close that session or use another `--slot`; do not delete lock files.
 - Use `--headed --allow-login` if manual login recovery is needed.
+- Credential values never belong in result JSON or diagnostics.
 - Do not run Supabase smoke tests as part of this skill; this skill is only for Roam login/session proof.

--- a/apps/roam/scripts/__tests__/loadExtension.test.ts
+++ b/apps/roam/scripts/__tests__/loadExtension.test.ts
@@ -1,0 +1,82 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { BrowserContext, Locator, Page } from "playwright";
+import { describe, expect, it, vi } from "vitest";
+import {
+  activateDeveloperExtension,
+  classifyBrowserMessage,
+  loadTestDefinition,
+  waitForTestReady,
+} from "../playwright/loadExtension";
+
+const createInvisibleLocator = (): Locator =>
+  ({
+    first: vi.fn(() => ({ isVisible: vi.fn().mockResolvedValue(false) })),
+  }) as unknown as Locator;
+
+describe("loadExtension helpers", () => {
+  it("classifies only the fake directory-handle clone warning as expected", () => {
+    expect(
+      classifyBrowserMessage(
+        "Failed to execute 'put' on 'IDBObjectStore': object could not be cloned",
+      ),
+    ).toBe("expected-directory-handle-warning");
+    expect(classifyBrowserMessage("extension crashed")).toBe("error");
+  });
+
+  it("loads caller modules through file URLs when paths contain spaces", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "dg roam module "));
+    const moduleDir = path.join(root, "proof module");
+    const modulePath = path.join(moduleDir, "test.mjs");
+    await fs.mkdir(moduleDir, { recursive: true });
+    await fs.writeFile(
+      modulePath,
+      'export default { registrationName: "dist", async run() { return 42; } };\n',
+    );
+
+    try {
+      const definition = await loadTestDefinition(modulePath);
+      expect(definition?.modulePath).toBe(modulePath);
+      expect(definition?.registrationName).toBe("dist");
+      expect(await definition?.run?.({} as never)).toBe(42);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("allows automatic activation when no refresh control is visible", async () => {
+    const page = {
+      locator: vi.fn(() => createInvisibleLocator()),
+      waitForTimeout: vi.fn().mockResolvedValue(undefined),
+    } as unknown as Page;
+    const row = {
+      locator: vi.fn(() => createInvisibleLocator()),
+    } as unknown as Locator;
+
+    await expect(
+      activateDeveloperExtension({ page, row, timeout: 100 }),
+    ).resolves.toBe("automatic");
+  });
+
+  it("retries a caller readiness predicate in the existing context", async () => {
+    const ready = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("not registered yet"))
+      .mockResolvedValue(true);
+    const page = {
+      waitForTimeout: vi.fn().mockResolvedValue(undefined),
+    } as unknown as Page;
+    const context = {} as BrowserContext;
+
+    await expect(
+      waitForTestReady({
+        page,
+        context,
+        definition: { ready },
+        timeout: 1_000,
+      }),
+    ).resolves.toBeUndefined();
+    expect(ready).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/roam/scripts/__tests__/roamSession.test.ts
+++ b/apps/roam/scripts/__tests__/roamSession.test.ts
@@ -1,0 +1,135 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { BrowserContext, BrowserType, Page } from "playwright";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { openRoamSession } from "../playwright/roamSession";
+
+const ENV_KEYS = [
+  "DG_ROAM_PLAYWRIGHT_EMAIL_1",
+  "DG_ROAM_PLAYWRIGHT_PASSWORD_1",
+  "DG_ROAM_PLAYWRIGHT_GRAPH_URL_1",
+  "HEADLESS",
+] as const;
+
+const originalEnv = new Map<string, string | undefined>();
+const setEnv = (name: string, value: string): void => {
+  Reflect.set(process.env, name, value);
+};
+
+beforeEach(() => {
+  for (const key of ENV_KEYS) originalEnv.set(key, process.env[key]);
+  setEnv("DG_ROAM_PLAYWRIGHT_EMAIL_1", "person@example.com");
+  setEnv("DG_ROAM_PLAYWRIGHT_PASSWORD_1", "private");
+  setEnv(
+    "DG_ROAM_PLAYWRIGHT_GRAPH_URL_1",
+    "https://roamresearch.com/#/app/fixture",
+  );
+});
+
+afterEach(() => {
+  for (const [key, value] of originalEnv) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  originalEnv.clear();
+});
+
+const createPage = ({
+  goto = vi.fn().mockResolvedValue(undefined),
+}: {
+  goto?: ReturnType<typeof vi.fn>;
+} = {}): Page =>
+  ({
+    goto,
+    locator: vi.fn(() => ({ count: vi.fn().mockResolvedValue(0) })),
+    url: vi.fn(() => "https://roamresearch.com/#/app/fixture"),
+    waitForFunction: vi.fn().mockResolvedValue(undefined),
+    waitForTimeout: vi.fn().mockResolvedValue(undefined),
+  }) as unknown as Page;
+
+describe("openRoamSession", () => {
+  it("applies HEADLESS after environment resolution and exposes one close method", async () => {
+    setEnv("HEADLESS", "false");
+    const profileRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), "dg-roam-session-"),
+    );
+    const page = createPage();
+    const close = vi.fn().mockResolvedValue(undefined);
+    const context = {
+      close,
+      pages: vi.fn(() => [page]),
+    } as unknown as BrowserContext;
+    const launchPersistentContext = vi.fn().mockResolvedValue(context);
+    const chromium = {
+      launchPersistentContext,
+    } as unknown as BrowserType;
+
+    try {
+      const session = await openRoamSession({
+        chromium,
+        profileDir: path.join(profileRoot, "profile"),
+      });
+
+      expect(launchPersistentContext).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ headless: false }),
+      );
+      expect(session.headless).toBe(false);
+      await session.close();
+      expect(close).toHaveBeenCalledOnce();
+    } finally {
+      await fs.rm(profileRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("closes the context when navigation fails", async () => {
+    const profileRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), "dg-roam-navigation-"),
+    );
+    const page = createPage({
+      goto: vi.fn().mockRejectedValue(new Error("navigation failed")),
+    });
+    const close = vi.fn().mockResolvedValue(undefined);
+    const chromium = {
+      launchPersistentContext: vi.fn().mockResolvedValue({
+        close,
+        pages: vi.fn(() => [page]),
+      }),
+    } as unknown as BrowserType;
+
+    try {
+      await expect(
+        openRoamSession({
+          chromium,
+          profileDir: path.join(profileRoot, "profile"),
+        }),
+      ).rejects.toThrow("navigation failed");
+      expect(close).toHaveBeenCalledOnce();
+    } finally {
+      await fs.rm(profileRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("reports the locked slot and profile without exposing credentials", async () => {
+    const profileRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), "dg-roam-lock-"),
+    );
+    const profileDir = path.join(profileRoot, "profile");
+    const chromium = {
+      launchPersistentContext: vi
+        .fn()
+        .mockRejectedValue(new Error("ProcessSingleton profile in use")),
+    } as unknown as BrowserType;
+
+    try {
+      await expect(
+        openRoamSession({ chromium, profileDir, slot: "1" }),
+      ).rejects.toThrow(
+        `Could not open Playwright slot 1 because its profile is already in use: ${profileDir}`,
+      );
+    } finally {
+      await fs.rm(profileRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/roam/scripts/playwright/loadExtension.ts
+++ b/apps/roam/scripts/playwright/loadExtension.ts
@@ -1,7 +1,8 @@
 import { spawn } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { type Locator, type Page } from "playwright";
+import { pathToFileURL } from "node:url";
+import { type BrowserContext, type Locator, type Page } from "playwright";
 import {
   DEFAULT_ARTIFACT_DIR,
   REPO_ROOT,
@@ -45,6 +46,7 @@ type InstallDirectoryPickerShimOptions = {
 };
 
 type DeveloperMode = "already-enabled" | "enabled";
+type ExtensionActivation = "automatic" | "header-refresh" | "row-refresh";
 
 type DiscourseGraphGlobalProof = {
   hasRunQuery: boolean;
@@ -77,6 +79,7 @@ type LoadExtensionResult = {
   resultPath: string;
   headless: boolean;
   developerMode: DeveloperMode | null;
+  activation: ExtensionActivation | null;
   removedExisting: number;
   dgGlobal: DiscourseGraphGlobalProof | null;
   dgUi: DiscourseGraphUiProof | null;
@@ -84,8 +87,32 @@ type LoadExtensionResult = {
   consoleMessages: string[];
   failedRequests: string[];
   knownWarnings: string[];
+  phases: Record<string, { ok: boolean; durationMs: number; error?: string }>;
+  testModule: string | null;
+  test: { ok: boolean; value?: unknown; error?: string } | null;
+  cleanup: { ok: boolean; value?: unknown; error?: string } | null;
+  diagnostics: Record<string, unknown> | null;
+  failureScreenshotPath: string | null;
   error: string | null;
   capturedAt: string | null;
+};
+
+type ExtensionTestHookOptions = {
+  context: BrowserContext;
+  page: Page;
+  outDir: string;
+  distDir: string;
+  result: LoadExtensionResult;
+};
+
+export type ExtensionTestDefinition = {
+  registrationName?: string;
+  readySelector?: string;
+  ready?: (
+    options: Pick<ExtensionTestHookOptions, "context" | "page">,
+  ) => boolean | Promise<boolean>;
+  run?: (options: ExtensionTestHookOptions) => unknown;
+  cleanup?: (options: ExtensionTestHookOptions & { state: unknown }) => unknown;
 };
 
 type CommandPaletteCommand = {
@@ -120,7 +147,7 @@ type DgPlaywrightWindow = {
   showDirectoryPicker?: () => Promise<unknown>;
 };
 
-const ROOT_FILES: ExtensionRootFile[] = [
+export const ROOT_FILES: ExtensionRootFile[] = [
   { name: "extension.js", required: true, type: "text/javascript" },
   { name: "README.md", required: true, type: "text/markdown" },
   { name: "extension.css", required: false, type: "text/css" },
@@ -147,15 +174,39 @@ const runCommand = async ({
     });
   });
 
-const clickByDom = async (
+const clickNative = async (
   locator: Locator,
   timeout = 15_000,
 ): Promise<void> => {
-  await locator.first().waitFor({ timeout });
-  await locator.first().evaluate((element: HTMLElement) => {
-    element.scrollIntoView({ block: "center", inline: "nearest" });
-    element.click();
-  });
+  const target = locator.first();
+  await target.waitFor({ state: "visible", timeout });
+  await target.scrollIntoViewIfNeeded();
+  await target.click({ timeout });
+};
+
+export const classifyBrowserMessage = (
+  message: string,
+): "expected-directory-handle-warning" | "error" =>
+  message.includes("Failed to execute 'put' on 'IDBObjectStore'") &&
+  message.includes("could not be cloned")
+    ? "expected-directory-handle-warning"
+    : "error";
+
+export const loadTestDefinition = async (
+  testModulePath?: string,
+): Promise<(ExtensionTestDefinition & { modulePath: string }) | null> => {
+  if (!testModulePath) return null;
+  const modulePath = path.resolve(testModulePath);
+  const moduleUrl = pathToFileURL(modulePath);
+  moduleUrl.searchParams.set("run", Date.now().toString());
+  const imported = (await import(moduleUrl.href)) as {
+    default?: ExtensionTestDefinition;
+  } & ExtensionTestDefinition;
+  const definition = imported.default || imported;
+  if (!definition || typeof definition !== "object") {
+    throw new Error(`Test module must export an object: ${modulePath}`);
+  }
+  return { ...definition, modulePath };
 };
 
 const closeOpenModals = async (page: Page): Promise<void> => {
@@ -165,9 +216,10 @@ const closeOpenModals = async (page: Page): Promise<void> => {
     );
 
     if ((await closeButtons.count().catch(() => 0)) > 0) {
-      await closeButtons.last().evaluate((element: HTMLElement) => {
-        element.click();
-      });
+      await closeButtons
+        .last()
+        .click({ force: true })
+        .catch(() => undefined);
       await page.waitForTimeout(500);
       continue;
     }
@@ -357,14 +409,15 @@ const openRoamDepotSettings = async ({
   timeout,
 }: PageTimeoutOptions): Promise<void> => {
   await closeOpenModals(page);
-  await clickByDom(page.locator(".rm-topbar .bp3-icon-more"), timeout);
-  await page
-    .locator(".bp3-menu-item, .bp3-menu li, [role='menuitem']")
-    .filter({ hasText: /^Settings$/i })
-    .first()
-    .click({ force: true, timeout });
+  await clickNative(page.locator(".rm-topbar .bp3-icon-more"), timeout);
+  await clickNative(
+    page
+      .locator(".bp3-menu-item, .bp3-menu li, [role='menuitem']")
+      .filter({ hasText: /^Settings$/i }),
+    timeout,
+  );
   await page.locator(".rm-modal-dialog--settings").waitFor({ timeout });
-  await clickByDom(
+  await clickNative(
     page.locator("#bp3-tab-title_rm-settings-tabs_rm-depot-tab"),
     timeout,
   );
@@ -377,64 +430,75 @@ const ensureDeveloperMode = async ({
   page,
   timeout,
 }: PageTimeoutOptions): Promise<DeveloperMode> => {
-  await clickByDom(
+  await clickNative(
     page.locator(".rm-extensions-installed__header button.bp3-icon-cog"),
     timeout,
   );
   await page.waitForTimeout(500);
 
-  if ((await page.locator(".bp3-icon-folder-new").count()) > 0) {
+  const folderButton = page.locator(
+    ".rm-extensions-installed__header button.bp3-icon-folder-new",
+  );
+  if (
+    await folderButton
+      .first()
+      .isVisible()
+      .catch(() => false)
+  ) {
     return "already-enabled";
   }
 
-  await page
-    .locator(".bp3-menu-item, [role='menuitem']")
-    .filter({ hasText: /developer mode/i })
-    .first()
-    .click({ force: true, timeout });
-  await page.waitForFunction(
-    () => Boolean(document.querySelector(".bp3-icon-folder-new")),
-    undefined,
-    { timeout },
-  );
+  let enableDeveloperMode = page
+    .locator(".bp3-menu-item, .bp3-menu li, [role='menuitem'], button")
+    .filter({ hasText: /^Enable developer mode$/i });
+  if ((await enableDeveloperMode.count()) === 0) {
+    enableDeveloperMode = page
+      .locator(".bp3-menu-item, .bp3-menu li, [role='menuitem'], button")
+      .filter({ hasText: /enable.*developer mode|developer mode.*enable/i });
+  }
+  await clickNative(enableDeveloperMode, timeout);
+  await folderButton.first().waitFor({ state: "visible", timeout });
   return "enabled";
 };
 
 const removeExistingDeveloperExtensions = async ({
   page,
   extensionNames,
+  timeout,
 }: {
   page: Page;
   extensionNames: string[];
-}): Promise<number> =>
-  page.evaluate(async (names: string[]): Promise<number> => {
-    const pause = (ms: number): Promise<void> =>
-      new Promise((resolve) => window.setTimeout(resolve, ms));
-    const namesToRemove = new Set(names);
-    let removed = 0;
+  timeout: number;
+}): Promise<number> => {
+  let removed = 0;
 
+  for (const extensionName of new Set(extensionNames)) {
     for (let pass = 0; pass < 10; pass += 1) {
-      const row = Array.from(
-        document.querySelectorAll(".rm-extension-installed"),
-      ).find((element) =>
-        namesToRemove.has(
-          element
-            .querySelector(".rm-extension-installed__name")
-            ?.textContent?.trim() || "",
-        ),
+      const matchingName = page
+        .locator(".rm-extension-installed__name")
+        .filter({ hasText: new RegExp(`^${escapeRegExp(extensionName)}$`) })
+        .first();
+      if ((await matchingName.count()) === 0) break;
+
+      const row = matchingName.locator(
+        "xpath=ancestor::*[contains(concat(' ', normalize-space(@class), ' '), ' rm-extension-installed ')][1]",
       );
-
-      if (!row) break;
-
-      row.querySelector<HTMLButtonElement>("button.bp3-icon-cross")?.click();
+      await clickNative(row.locator("button.bp3-icon-cross"), timeout);
       removed += 1;
-      await pause(500);
+      await matchingName
+        .waitFor({ state: "detached", timeout })
+        .catch(() => undefined);
+      await page.waitForTimeout(250);
     }
+  }
 
-    return removed;
-  }, extensionNames);
+  return removed;
+};
 
-const reloadDeveloperExtension = async ({
+const escapeRegExp = (value: string): string =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+export const registerDeveloperExtension = async ({
   page,
   extensionName,
   timeout,
@@ -442,39 +506,59 @@ const reloadDeveloperExtension = async ({
   page: Page;
   extensionName: string;
   timeout: number;
-}): Promise<void> => {
-  await page.waitForFunction(
-    (name: string) =>
-      Array.from(document.querySelectorAll(".rm-extension-installed")).some(
-        (element) =>
-          element
-            .querySelector(".rm-extension-installed__name")
-            ?.textContent?.trim() === name,
-      ),
-    extensionName,
-    { timeout },
+}): Promise<Locator> => {
+  await clickNative(
+    page.locator(".rm-extensions-installed__header button.bp3-icon-folder-new"),
+    timeout,
   );
+  const extensionRowName = page
+    .locator(".rm-extension-installed__name")
+    .filter({ hasText: new RegExp(`^${escapeRegExp(extensionName)}$`) })
+    .last();
+  await extensionRowName.waitFor({ state: "visible", timeout });
+  return extensionRowName.locator(
+    "xpath=ancestor::*[contains(concat(' ', normalize-space(@class), ' '), ' rm-extension-installed ')][1]",
+  );
+};
 
-  await page.evaluate((name: string): void => {
-    const rows = Array.from(
-      document.querySelectorAll(".rm-extension-installed"),
-    );
-    const row = rows
-      .reverse()
-      .find(
-        (element) =>
-          element
-            .querySelector(".rm-extension-installed__name")
-            ?.textContent?.trim() === name,
-      );
-    const reloadButton = row
-      ?.querySelector(".bp3-icon-refresh")
-      ?.closest("button");
-    if (!(reloadButton instanceof HTMLElement)) {
-      throw new Error(`Could not find reload button for ${name}.`);
-    }
-    reloadButton.click();
-  }, extensionName);
+export const activateDeveloperExtension = async ({
+  page,
+  row,
+  timeout,
+}: {
+  page: Page;
+  row: Locator;
+  timeout: number;
+}): Promise<ExtensionActivation> => {
+  const headerRefresh = page.locator(
+    ".rm-extensions-installed__header button.bp3-icon-refresh, .rm-extensions-installed__header button[aria-label*='refresh' i], .rm-extensions-installed__header button[title*='refresh' i]",
+  );
+  if (
+    await headerRefresh
+      .first()
+      .isVisible()
+      .catch(() => false)
+  ) {
+    await clickNative(headerRefresh, timeout);
+    await page.waitForTimeout(500);
+    return "header-refresh";
+  }
+
+  const rowRefresh = row.locator(
+    "button.bp3-icon-refresh, button[aria-label*='refresh' i], button[title*='refresh' i]",
+  );
+  if (
+    await rowRefresh
+      .first()
+      .isVisible()
+      .catch(() => false)
+  ) {
+    await clickNative(rowRefresh, timeout);
+    await page.waitForTimeout(500);
+    return "row-refresh";
+  }
+
+  return "automatic";
 };
 
 const installCommandPaletteObserver = async (page: Page): Promise<void> => {
@@ -590,14 +674,14 @@ const verifyDiscourseGraphUi = async ({
       openSettings();
     });
   } else {
-    await clickByDom(
+    await clickNative(
       page
         .locator(".rm-modal-dialog--settings")
         .getByText(/^Discourse Graphs(?: \(dev\))?$/)
         .first(),
       timeout,
     );
-    await clickByDom(
+    await clickNative(
       page.locator(".rm-modal-dialog--settings button", {
         hasText: /^Open Settings$/i,
       }),
@@ -619,20 +703,127 @@ const verifyDiscourseGraphUi = async ({
   };
 };
 
+export const waitForTestReady = async ({
+  page,
+  context,
+  definition,
+  timeout,
+}: {
+  page: Page;
+  context: BrowserContext;
+  definition: ExtensionTestDefinition;
+  timeout: number;
+}): Promise<void> => {
+  if (!definition.ready && !definition.readySelector) return;
+
+  const deadline = Date.now() + timeout;
+  let lastError: string | null = null;
+  while (Date.now() < deadline) {
+    const selectorReady = definition.readySelector
+      ? await page
+          .locator(definition.readySelector)
+          .first()
+          .isVisible()
+          .catch(() => false)
+      : false;
+    let callerReady = false;
+    if (definition.ready) {
+      try {
+        callerReady = Boolean(await definition.ready({ page, context }));
+        lastError = null;
+      } catch (error) {
+        lastError = error instanceof Error ? error.message : String(error);
+      }
+    }
+    if (selectorReady || callerReady) return;
+    await page.waitForTimeout(250);
+  }
+
+  throw new Error(
+    `The caller test module did not become ready. Selector: ${definition.readySelector || "none"}; last predicate error: ${lastError || "none"}.`,
+  );
+};
+
+const captureDiagnostics = async (
+  page: Page,
+): Promise<Record<string, unknown> | null> =>
+  page
+    .evaluate(() => ({
+      url: location.href,
+      loadedExtensions: (() => {
+        const getLoadedName = (value: unknown): string => {
+          if (typeof value === "string") return value;
+          if (
+            value &&
+            typeof value === "object" &&
+            "name" in value &&
+            typeof value.name === "string"
+          ) {
+            return value.name;
+          }
+          return `[${typeof value}]`;
+        };
+        const loaded = (window as unknown as { roamjs?: { loaded?: unknown } })
+          .roamjs?.loaded;
+        if (!loaded) return [];
+        if (Array.isArray(loaded)) return loaded.map(getLoadedName);
+        if (loaded instanceof Set) return Array.from(loaded, getLoadedName);
+        if (typeof loaded === "object") return Object.keys(loaded);
+        return [getLoadedName(loaded)];
+      })(),
+      depotButtons: Array.from(
+        document.querySelectorAll(
+          "#bp3-tab-panel_rm-settings-tabs_rm-depot-tab button",
+        ),
+      )
+        .map((button) => ({
+          text: button.textContent?.trim() || "",
+          ariaLabel: button.getAttribute("aria-label"),
+          title: button.getAttribute("title"),
+          className: button.className,
+        }))
+        .slice(0, 50),
+      visibleText: document.body.innerText
+        .split("\n")
+        .map((line) => line.trim())
+        .filter(Boolean)
+        .slice(0, 200),
+    }))
+    .catch(() => null);
+
+const createPhaseRunner =
+  (result: LoadExtensionResult) =>
+  async <T>(name: string, callback: () => Promise<T>): Promise<T> => {
+    const startedAt = Date.now();
+    try {
+      const value = await callback();
+      result.phases[name] = {
+        ok: true,
+        durationMs: Date.now() - startedAt,
+      };
+      return value;
+    } catch (error) {
+      result.phases[name] = {
+        ok: false,
+        durationMs: Date.now() - startedAt,
+        error: error instanceof Error ? error.message : String(error),
+      };
+      throw error;
+    }
+  };
+
 const waitForTermination = async (): Promise<void> =>
   new Promise((resolve) => {
     process.once("SIGINT", resolve);
     process.once("SIGTERM", resolve);
   });
 
-const main = async (): Promise<void> => {
+export const main = async (): Promise<void> => {
   const args = parseArgs(process.argv.slice(2));
   const slot =
     getStringArg(args, "slot") || getEnvValue("DG_ROAM_PLAYWRIGHT_SLOT") || "1";
   const timeout = Number(getStringArg(args, "timeout") || 45_000);
-  const headless = getBooleanArg(args, "headed")
-    ? false
-    : getEnvValue("HEADLESS") !== "false";
+  const headless = getBooleanArg(args, "headed") ? false : undefined;
   const distDir = path.resolve(
     getStringArg(args, "dist") || path.join(ROAM_APP_ROOT, "dist"),
   );
@@ -643,6 +834,10 @@ const main = async (): Promise<void> => {
     getStringArg(args, "screenshot-name") ||
     `roam-load-extension-slot-${slot}-${timestamp()}.png`;
   const screenshotPath = path.join(outDir, screenshotName);
+  const failureScreenshotPath = path.join(
+    outDir,
+    `roam-load-extension-slot-${slot}-failure.png`,
+  );
   const resultPath = path.join(
     outDir,
     `load-extension-slot-${slot}-last-run.json`,
@@ -657,15 +852,22 @@ const main = async (): Promise<void> => {
   }
 
   const files = await readFolderFiles(distDir);
+  const testDefinition = await loadTestDefinition(
+    getStringArg(args, "test-module"),
+  );
   const extensionName =
     getStringArg(args, "extension-name") ||
     (await readPackageName(distDir)) ||
     "roam";
-  const developerExtensionName = path.basename(distDir);
+  const developerExtensionName =
+    getStringArg(args, "registration-name") ||
+    testDefinition?.registrationName ||
+    path.basename(distDir);
 
   await fs.mkdir(outDir, { recursive: true });
 
-  const { context, page, slotConfig } = await openRoamSession({
+  const sessionStartedAt = Date.now();
+  const session = await openRoamSession({
     slot,
     graphUrl: getStringArg(args, "url"),
     profileDir: getStringArg(args, "profile-dir"),
@@ -673,6 +875,7 @@ const main = async (): Promise<void> => {
     timeout,
     allowInteractiveLogin: getBooleanArg(args, "allow-login"),
   });
+  const { context, page, slotConfig } = session;
 
   const result: LoadExtensionResult = {
     ok: false,
@@ -689,8 +892,9 @@ const main = async (): Promise<void> => {
     })),
     screenshotPath,
     resultPath,
-    headless,
+    headless: session.headless,
     developerMode: null,
+    activation: null,
     removedExisting: 0,
     dgGlobal: null,
     dgUi: null,
@@ -698,6 +902,17 @@ const main = async (): Promise<void> => {
     consoleMessages: [],
     failedRequests: [],
     knownWarnings: [],
+    phases: {
+      session: {
+        ok: true,
+        durationMs: Date.now() - sessionStartedAt,
+      },
+    },
+    testModule: testDefinition?.modulePath || null,
+    test: null,
+    cleanup: null,
+    diagnostics: null,
+    failureScreenshotPath: null,
     error: null,
     capturedAt: null,
   };
@@ -707,8 +922,37 @@ const main = async (): Promise<void> => {
     if (messages.length > 50) messages.shift();
   };
 
+  const warningKeys = new Set<string>();
+  const recordBrowserMessage = ({
+    message,
+    source,
+  }: {
+    message: string;
+    source: "console" | "pageerror";
+  }): void => {
+    if (
+      classifyBrowserMessage(message) === "expected-directory-handle-warning"
+    ) {
+      if (!warningKeys.has(message)) result.knownWarnings.push(message);
+      warningKeys.add(message);
+      return;
+    }
+    if (source === "pageerror") result.pageErrors.push(message);
+  };
+
   page.on("console", (message) => {
-    pushBounded(result.consoleMessages, `${message.type()}: ${message.text()}`);
+    const text = `${message.type()}: ${message.text()}`;
+    if (message.type() === "error") {
+      if (
+        classifyBrowserMessage(message.text()) ===
+        "expected-directory-handle-warning"
+      ) {
+        recordBrowserMessage({ message: message.text(), source: "console" });
+        return;
+      }
+      recordBrowserMessage({ message: message.text(), source: "console" });
+    }
+    pushBounded(result.consoleMessages, text);
   });
 
   page.on("requestfailed", (request) => {
@@ -719,76 +963,190 @@ const main = async (): Promise<void> => {
   });
 
   page.on("pageerror", (error) => {
-    const message = error.message;
-    if (
-      message.includes("Failed to execute 'put' on 'IDBObjectStore'") &&
-      message.includes("could not be cloned")
-    ) {
-      result.knownWarnings.push(message);
-      return;
-    }
-    result.pageErrors.push(message);
+    recordBrowserMessage({ message: error.message, source: "pageerror" });
   });
 
   const persistResult = async (): Promise<void> => {
     result.configuredGraphLoaded = page.url().startsWith(slotConfig.graphUrl);
     result.pageTitleAvailable = Boolean(await page.title().catch(() => ""));
     result.capturedAt = new Date().toISOString();
+    if (!result.ok) {
+      result.diagnostics = await captureDiagnostics(page);
+      result.failureScreenshotPath = failureScreenshotPath;
+      await page
+        .screenshot({ path: failureScreenshotPath, fullPage: false })
+        .catch(() => undefined);
+    }
     await page
       .screenshot({ path: screenshotPath, fullPage: false })
       .catch(() => undefined);
     await fs.writeFile(resultPath, `${JSON.stringify(result, null, 2)}\n`);
   };
 
+  const phase = createPhaseRunner(result);
+  let testState: unknown;
+  let testStarted = false;
+  let primaryError: unknown = null;
+
   try {
-    await installSerializedFunctionShim(page);
-    await installDirectoryPickerShim({
-      page,
-      dirName: path.basename(distDir),
-      files,
+    await phase("picker-shim", async () => {
+      await installSerializedFunctionShim(page);
+      await installDirectoryPickerShim({
+        page,
+        dirName: path.basename(distDir),
+        files,
+      });
+      await installCommandPaletteObserver(page);
     });
-    await installCommandPaletteObserver(page);
-    await openRoamDepotSettings({ page, timeout });
-    result.developerMode = await ensureDeveloperMode({ page, timeout });
-    result.removedExisting = await removeExistingDeveloperExtensions({
-      page,
-      extensionNames: [extensionName, developerExtensionName],
-    });
+    await phase("open-depot", () => openRoamDepotSettings({ page, timeout }));
+    result.developerMode = await phase("developer-mode", () =>
+      ensureDeveloperMode({ page, timeout }),
+    );
+    result.removedExisting = await phase("remove-existing", () =>
+      removeExistingDeveloperExtensions({
+        page,
+        extensionNames: [extensionName, developerExtensionName],
+        timeout,
+      }),
+    );
+    const row = await phase("register", () =>
+      registerDeveloperExtension({
+        page,
+        extensionName: developerExtensionName,
+        timeout,
+      }),
+    );
+    result.activation = await phase("activate", () =>
+      activateDeveloperExtension({ page, row, timeout }),
+    );
 
-    await page
-      .locator(".rm-extensions-installed__header button.bp3-icon-folder-new")
-      .click({ force: true, timeout });
-    await reloadDeveloperExtension({
-      page,
-      extensionName: developerExtensionName,
-      timeout,
-    });
-
-    await waitForDiscourseGraphLoaded({ page, timeout });
-    result.dgGlobal = await getDiscourseGraphGlobalProof(page);
-    result.dgUi = await verifyDiscourseGraphUi({ page, timeout });
+    await phase("dg-ready", () =>
+      waitForDiscourseGraphLoaded({ page, timeout }),
+    );
+    result.dgGlobal = await phase("dg-global-proof", () =>
+      getDiscourseGraphGlobalProof(page),
+    );
+    result.dgUi = await phase("dg-ui-proof", () =>
+      verifyDiscourseGraphUi({ page, timeout }),
+    );
+    if (testDefinition) {
+      await phase("test-ready", () =>
+        waitForTestReady({
+          page,
+          context,
+          definition: testDefinition,
+          timeout,
+        }),
+      );
+    }
+    if (testDefinition?.run) {
+      testStarted = true;
+      testState = await phase("test", () =>
+        Promise.resolve(
+          testDefinition.run?.({
+            context,
+            page,
+            outDir,
+            distDir,
+            result,
+          }),
+        ),
+      );
+      result.test = { ok: true, value: testState };
+    }
     await page.waitForTimeout(1500);
+    if (result.pageErrors.length > 0) {
+      throw new Error(
+        `The extension produced ${result.pageErrors.length} page error(s).`,
+      );
+    }
 
     result.ok = true;
-    await persistResult();
-    console.log(JSON.stringify(result, null, 2));
   } catch (error: unknown) {
+    primaryError = error;
     result.error =
       error instanceof Error ? error.stack || error.message : String(error);
-    await persistResult();
-    console.error(JSON.stringify(result, null, 2));
-    throw error;
+    if (testStarted && !result.test) {
+      result.test = {
+        ok: false,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
   } finally {
+    if (testStarted && testDefinition?.cleanup) {
+      try {
+        const value = await phase("cleanup", () =>
+          Promise.resolve(
+            testDefinition.cleanup?.({
+              context,
+              page,
+              outDir,
+              distDir,
+              result,
+              state: testState,
+            }),
+          ),
+        );
+        result.cleanup = { ok: true, value };
+      } catch (error) {
+        result.cleanup = {
+          ok: false,
+          error: error instanceof Error ? error.message : String(error),
+        };
+        result.ok = false;
+        if (!primaryError) {
+          primaryError = error;
+          result.error =
+            error instanceof Error
+              ? error.stack || error.message
+              : String(error);
+        }
+      }
+    }
+    try {
+      await persistResult();
+    } catch (error) {
+      result.ok = false;
+      if (!primaryError) {
+        primaryError = error;
+        result.error =
+          error instanceof Error ? error.stack || error.message : String(error);
+      }
+    }
     if (getBooleanArg(args, "keep-open")) {
       console.log("Browser context left open. Press Ctrl+C to close it.");
       await waitForTermination();
     }
-    await context.close();
+    try {
+      await session.close();
+    } catch (error) {
+      result.ok = false;
+      if (!primaryError) {
+        primaryError = error;
+        result.error =
+          error instanceof Error ? error.stack || error.message : String(error);
+      }
+      await fs.writeFile(resultPath, `${JSON.stringify(result, null, 2)}\n`);
+    }
   }
+
+  if (primaryError) {
+    console.error(JSON.stringify(result, null, 2));
+    if (primaryError instanceof Error) throw primaryError;
+    throw new Error(
+      typeof primaryError === "string"
+        ? primaryError
+        : "The extension loader failed with a non-Error value.",
+    );
+  }
+  console.log(JSON.stringify(result, null, 2));
 };
 
-main().catch((error: unknown) => {
-  const message = error instanceof Error ? error.stack || error.message : error;
-  console.error(message);
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch((error: unknown) => {
+    const message =
+      error instanceof Error ? error.stack || error.message : error;
+    console.error(message);
+    process.exit(1);
+  });
+}

--- a/apps/roam/scripts/playwright/openRoam.ts
+++ b/apps/roam/scripts/playwright/openRoam.ts
@@ -33,9 +33,7 @@ const main = async (): Promise<void> => {
   const slot =
     getStringArg(args, "slot") || getEnvValue("DG_ROAM_PLAYWRIGHT_SLOT") || "1";
   const timeout = Number(getStringArg(args, "timeout") || 30_000);
-  const headless = getBooleanArg(args, "headed")
-    ? false
-    : getEnvValue("HEADLESS") !== "false";
+  const headless = getBooleanArg(args, "headed") ? false : undefined;
   const outDir = path.resolve(
     getStringArg(args, "out") || DEFAULT_ARTIFACT_DIR,
   );
@@ -47,7 +45,7 @@ const main = async (): Promise<void> => {
 
   await fs.mkdir(outDir, { recursive: true });
 
-  const { context, page, slotConfig } = await openRoamSession({
+  const session = await openRoamSession({
     slot,
     graphUrl: getStringArg(args, "url"),
     profileDir: getStringArg(args, "profile-dir"),
@@ -55,6 +53,7 @@ const main = async (): Promise<void> => {
     timeout,
     allowInteractiveLogin: getBooleanArg(args, "allow-login"),
   });
+  const { page, slotConfig } = session;
 
   try {
     await page.screenshot({ path: screenshotPath, fullPage: false });
@@ -67,7 +66,7 @@ const main = async (): Promise<void> => {
       profileDir: slotConfig.profileDir,
       screenshotPath,
       resultPath,
-      headless,
+      headless: session.headless,
       capturedAt: new Date().toISOString(),
     };
 
@@ -78,7 +77,7 @@ const main = async (): Promise<void> => {
       console.log("Browser context left open. Press Ctrl+C to close it.");
       await waitForTermination();
     }
-    await context.close();
+    await session.close();
   }
 };
 

--- a/apps/roam/scripts/playwright/roamSession.ts
+++ b/apps/roam/scripts/playwright/roamSession.ts
@@ -52,7 +52,7 @@ type WaitForRoamReadyOptions = {
   loginTimeout?: number;
 };
 
-type OpenRoamSessionOptions = {
+export type OpenRoamSessionOptions = {
   slot?: string | boolean;
   graphUrl?: string;
   profileDir?: string;
@@ -64,10 +64,12 @@ type OpenRoamSessionOptions = {
   chromium?: BrowserType<Browser>;
 };
 
-type OpenRoamSessionResult = {
+export type OpenRoamSessionResult = {
   context: BrowserContext;
   page: Page;
   slotConfig: SlotConfig;
+  headless: boolean;
+  close: () => Promise<void>;
 };
 
 const SCRIPT_DIR = __dirname;
@@ -321,19 +323,36 @@ export const waitForRoamReady = async ({
   await waitForReadySelector({ page, timeout });
 };
 
+const looksLikeProfileLock = (error: unknown): boolean =>
+  error instanceof Error &&
+  /processsingleton|profile.*(?:lock|in use)|singletonlock|already running/i.test(
+    error.message,
+  );
+
+export const closeRoamSession = async ({
+  context,
+}: {
+  context: BrowserContext;
+}): Promise<void> => {
+  await context.close();
+};
+
 export const openRoamSession = async ({
   slot = getEnvValue("DG_ROAM_PLAYWRIGHT_SLOT") || "1",
   graphUrl,
   profileDir,
-  headless = getEnvValue("HEADLESS") !== "false",
+  headless,
   viewport = { width: 1440, height: 1000 },
   timeout = 30_000,
   allowInteractiveLogin = false,
-  allowCredentialLogin = getEnvValue("DG_ROAM_PLAYWRIGHT_AUTO_LOGIN") !==
-    "false",
+  allowCredentialLogin,
   chromium = defaultChromium,
 }: OpenRoamSessionOptions = {}): Promise<OpenRoamSessionResult> => {
   const slotConfig = resolveSlotConfig({ slot, graphUrl, profileDir });
+  const resolvedHeadless = headless ?? getEnvValue("HEADLESS") !== "false";
+  const resolvedAllowCredentialLogin =
+    allowCredentialLogin ??
+    getEnvValue("DG_ROAM_PLAYWRIGHT_AUTO_LOGIN") !== "false";
   const resolvedConfig = {
     ...slotConfig,
     profileDir: path.resolve(slotConfig.profileDir),
@@ -341,24 +360,49 @@ export const openRoamSession = async ({
 
   fs.mkdirSync(resolvedConfig.profileDir, { recursive: true });
 
-  const context = await chromium.launchPersistentContext(
-    resolvedConfig.profileDir,
-    {
-      headless,
-      viewport,
-    },
-  );
+  let context: BrowserContext;
+  try {
+    context = await chromium.launchPersistentContext(
+      resolvedConfig.profileDir,
+      {
+        headless: resolvedHeadless,
+        viewport,
+      },
+    );
+  } catch (error) {
+    if (looksLikeProfileLock(error)) {
+      throw new Error(
+        `Could not open Playwright slot ${resolvedConfig.slot} because its profile is already in use: ${resolvedConfig.profileDir}. Close the other session or choose another --slot.`,
+        { cause: error },
+      );
+    }
+    throw error;
+  }
 
-  const page = context.pages()[0] || (await context.newPage());
-  await page.goto(resolvedConfig.graphUrl, { waitUntil: "domcontentloaded" });
-  await waitForRoamReady({
+  let page: Page;
+  try {
+    page = context.pages()[0] || (await context.newPage());
+    await page.goto(resolvedConfig.graphUrl, {
+      waitUntil: "domcontentloaded",
+    });
+    await waitForRoamReady({
+      page,
+      slotConfig: resolvedConfig,
+      headless: resolvedHeadless,
+      allowInteractiveLogin,
+      allowCredentialLogin: resolvedAllowCredentialLogin,
+      timeout,
+    });
+  } catch (error) {
+    await closeRoamSession({ context });
+    throw error;
+  }
+
+  return {
+    context,
     page,
     slotConfig: resolvedConfig,
-    headless,
-    allowInteractiveLogin,
-    allowCredentialLogin,
-    timeout,
-  });
-
-  return { context, page, slotConfig: resolvedConfig };
+    headless: resolvedHeadless,
+    close: () => closeRoamSession({ context }),
+  };
 };


### PR DESCRIPTION
## Reviewer brief

- Result: DiscourseGraphs can load and activate a local Roam extension once, run a caller test module in the same browser context, collect bounded proof and diagnostics, and close cleanly on Windows and macOS.
- Review focus: Session cleanup, activation/readiness fallbacks, and the same-context test-module contract.
- Risk or follow-up: No live macOS smoke test was available; platform-neutral paths and the automatic-activation fallback have focused coverage.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm ci:validate` — all typechecks and tests passed, including 130 Roam tests.
- Targeted ESLint, both skill validators, and `git diff --check` passed.

## Loom video

- Not recorded. This is a non-UI developer-tooling and skill change.

## Scope check

- [x] Ran `$scope-check` against ENG-2212 and the final diff.
- Scope beyond `Done When`: None.

## Local delegated full review

- [ ] Not run. This task did not authorize subagent delegation.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/1371" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->