### PR TITLE
ENG-2139 Map the Obsidian source relation to `source` on push

### DIFF
--- a/apps/obsidian/src/utils/conceptConversion.ts
+++ b/apps/obsidian/src/utils/conceptConversion.ts
@@ -11,6 +11,7 @@ import type { LocalConceptDataInput } from "@repo/database/inputTypes";
 import type { ObsidianDiscourseNodeData } from "./syncDgNodesToSupabase";
 import type { Json } from "@repo/database/dbTypes";
 import { extractContentFromTitle } from "./extractContentFromTitle";
+import { SOURCE_SLOT } from "./sourceSlot";
 
 /**
  * Get extra data (author, timestamps) from file metadata
@@ -162,10 +163,12 @@ export const discourseNodeInstanceToLocalConcept = ({
   context,
   nodeData,
   nodeTypesById,
+  sourceSlotByNodeId,
 }: {
   context: SupabaseContext;
   nodeData: ObsidianDiscourseNodeData;
   nodeTypesById: Record<string, DiscourseNode>;
+  sourceSlotByNodeId: Record<string, string>;
 }): LocalConceptDataInput => {
   const extraData = getNodeExtraData(nodeData.file, context.userId);
   const { nodeInstanceId, nodeTypeId, importedFromRid, ...otherData } =
@@ -180,6 +183,7 @@ export const discourseNodeInstanceToLocalConcept = ({
   };
   if (importedFromRid && typeof importedFromRid === "string")
     literal_content.importedFromRid = importedFromRid;
+  const sourceDocumentId = sourceSlotByNodeId[nodeData.nodeInstanceId];
   return {
     space_id: context.spaceId,
     name: nodeData.file.path,
@@ -187,6 +191,10 @@ export const discourseNodeInstanceToLocalConcept = ({
     schema_represented_by_local_id: nodeTypeId as string,
     is_schema: false,
     literal_content,
+    // A value the database cannot resolve to a concept fails this row's upsert (-2).
+    ...(sourceDocumentId
+      ? { local_reference_content: { [SOURCE_SLOT]: sourceDocumentId } }
+      : {}),
     ...extraData,
   };
 };

--- a/apps/obsidian/src/utils/sourceSlot.ts
+++ b/apps/obsidian/src/utils/sourceSlot.ts
@@ -1,4 +1,9 @@
-import { spaceUriAndLocalIdToRid } from "@repo/database/lib/rid";
+import {
+  isRid,
+  ridToSpaceUriAndLocalId,
+  spaceUriAndLocalIdToRid,
+} from "@repo/database/lib/rid";
+import type { Json } from "@repo/database/dbTypes";
 import type { DiscourseNode, RelationInstance } from "~/types";
 import type { DiscourseNodeInVault } from "./getDiscourseNodes";
 
@@ -78,4 +83,56 @@ export const indexSourceSlotValues = ({
       sourceDocumentIdOf(candidate.sourceDocumentNode),
     ]),
   );
+};
+
+export const SOURCE_SLOT_PROBE_SELECT =
+  "reference_content, concepts_of_relation(id, source_local_id)";
+
+export type SourceSlotProbeRow = {
+  source_local_id: string | null;
+  reference_content: Json | null;
+  concepts_of_relation: {
+    id: number | null;
+    source_local_id: string | null;
+  }[];
+};
+
+const storedSourceDocumentLocalId = (
+  row: SourceSlotProbeRow,
+): string | undefined => {
+  const content = row.reference_content;
+  if (typeof content !== "object" || content === null || Array.isArray(content))
+    return undefined;
+  const conceptId = content[SOURCE_SLOT];
+  if (typeof conceptId !== "number") return undefined;
+  return (
+    row.concepts_of_relation.find((concept) => concept.id === conceptId)
+      ?.source_local_id ?? undefined
+  );
+};
+
+const localIdOf = (sourceDocumentId: string): string =>
+  isRid(sourceDocumentId)
+    ? ridToSpaceUriAndLocalId(sourceDocumentId).sourceLocalId
+    : sourceDocumentId;
+
+// A relation added, accepted, or removed changes no note, so the stored slot is compared
+// with the wanted one on full sync. The comparison is by local id: the database stores
+// the Source's concept id, and an imported Source is wanted by its origin RID.
+export const findStaleSourceSlotNodeIds = ({
+  rows,
+  sourceSlotByNodeId,
+}: {
+  rows: SourceSlotProbeRow[];
+  sourceSlotByNodeId: Record<string, string>;
+}): Set<string> => {
+  const stale = new Set<string>();
+  for (const row of rows) {
+    if (row.source_local_id === null) continue;
+    const wanted = sourceSlotByNodeId[row.source_local_id];
+    const wantedLocalId = wanted === undefined ? undefined : localIdOf(wanted);
+    if (wantedLocalId !== storedSourceDocumentLocalId(row))
+      stale.add(row.source_local_id);
+  }
+  return stale;
 };

--- a/apps/obsidian/src/utils/sourceSlot.ts
+++ b/apps/obsidian/src/utils/sourceSlot.ts
@@ -1,0 +1,81 @@
+import { spaceUriAndLocalIdToRid } from "@repo/database/lib/rid";
+import type { DiscourseNode, RelationInstance } from "~/types";
+import type { DiscourseNodeInVault } from "./getDiscourseNodes";
+
+// Temporary hack, the Obsidian twin of apps/roam/src/utils/sourceSlot.ts: until slots
+// are a first-class node type setting, the Source type is the node type named "Source",
+// and a node's sourceDocument is the destination of its earliest relation to a node of
+// that type. Relation endpoints are stored as a nodeInstanceId, as this vault's RID for
+// it, or as an imported node's origin RID, so lookups go through an index of all three.
+
+export const SOURCE_SLOT = "sourceDocument";
+
+type NodesByEndpoint = Record<string, DiscourseNodeInVault>;
+
+const indexNodesByEndpoint = ({
+  nodes,
+  localSpaceUri,
+}: {
+  nodes: DiscourseNodeInVault[];
+  localSpaceUri: string;
+}): NodesByEndpoint => {
+  const index: NodesByEndpoint = {};
+  for (const node of nodes) {
+    index[node.nodeInstanceId] = node;
+    index[spaceUriAndLocalIdToRid(localSpaceUri, node.nodeInstanceId, "note")] =
+      node;
+    const importedFromRid = node.frontmatter.importedFromRid;
+    if (typeof importedFromRid === "string") index[importedFromRid] = node;
+  }
+  return index;
+};
+
+const isSourceNodeType = (nodeType: DiscourseNode | undefined): boolean =>
+  nodeType?.name.toLowerCase() === "source";
+
+const byCreatedThenId = (a: RelationInstance, b: RelationInstance): number =>
+  a.created - b.created || a.id.localeCompare(b.id);
+
+const sourceDocumentIdOf = (node: DiscourseNodeInVault): string => {
+  const importedFromRid = node.frontmatter.importedFromRid;
+  return typeof importedFromRid === "string"
+    ? importedFromRid
+    : node.nodeInstanceId;
+};
+
+type SourceCandidate = {
+  relation: RelationInstance;
+  sourceDocumentNode: DiscourseNodeInVault;
+};
+
+export const indexSourceSlotValues = ({
+  relations,
+  nodes,
+  localSpaceUri,
+  nodeTypesById,
+}: {
+  relations: RelationInstance[];
+  nodes: DiscourseNodeInVault[];
+  localSpaceUri: string;
+  nodeTypesById: Record<string, DiscourseNode>;
+}): Record<string, string> => {
+  const nodesByEndpoint = indexNodesByEndpoint({ nodes, localSpaceUri });
+  const earliestByNodeId: Record<string, SourceCandidate> = {};
+  for (const relation of relations) {
+    if (relation.tentative === false) continue;
+    const node = nodesByEndpoint[relation.source];
+    const sourceDocumentNode = nodesByEndpoint[relation.destination];
+    if (!node || !sourceDocumentNode) continue;
+    if (!isSourceNodeType(nodeTypesById[sourceDocumentNode.nodeTypeId]))
+      continue;
+    const current = earliestByNodeId[node.nodeInstanceId];
+    if (!current || byCreatedThenId(relation, current.relation) < 0)
+      earliestByNodeId[node.nodeInstanceId] = { relation, sourceDocumentNode };
+  }
+  return Object.fromEntries(
+    Object.entries(earliestByNodeId).map(([nodeInstanceId, candidate]) => [
+      nodeInstanceId,
+      sourceDocumentIdOf(candidate.sourceDocumentNode),
+    ]),
+  );
+};

--- a/apps/obsidian/src/utils/sourceSlot.ts
+++ b/apps/obsidian/src/utils/sourceSlot.ts
@@ -85,54 +85,80 @@ export const indexSourceSlotValues = ({
   );
 };
 
+// Appended to a my_concepts select that already carries source_local_id.
 export const SOURCE_SLOT_PROBE_SELECT =
-  "reference_content, concepts_of_relation(id, source_local_id)";
+  "reference_content, concepts_of_relation(id, space_id, source_local_id)";
 
 export type SourceSlotProbeRow = {
-  source_local_id: string | null;
   reference_content: Json | null;
   concepts_of_relation: {
     id: number | null;
+    space_id: number | null;
     source_local_id: string | null;
   }[];
 };
 
-const storedSourceDocumentLocalId = (
+type StoredSourceDocument = {
+  spaceId: number | null;
+  localId: string | null;
+};
+
+const storedSourceDocumentOf = (
   row: SourceSlotProbeRow,
-): string | undefined => {
+): StoredSourceDocument | undefined => {
   const content = row.reference_content;
   if (typeof content !== "object" || content === null || Array.isArray(content))
     return undefined;
   const conceptId = content[SOURCE_SLOT];
   if (typeof conceptId !== "number") return undefined;
-  return (
-    row.concepts_of_relation.find((concept) => concept.id === conceptId)
-      ?.source_local_id ?? undefined
+  const concept = row.concepts_of_relation.find(
+    (candidate) => candidate.id === conceptId,
   );
+  if (!concept) return undefined;
+  return { spaceId: concept.space_id, localId: concept.source_local_id };
 };
 
-const localIdOf = (sourceDocumentId: string): string =>
-  isRid(sourceDocumentId)
-    ? ridToSpaceUriAndLocalId(sourceDocumentId).sourceLocalId
-    : sourceDocumentId;
+const storedMatchesWanted = ({
+  stored,
+  wanted,
+  spaceId,
+}: {
+  stored: StoredSourceDocument | undefined;
+  wanted: string | undefined;
+  spaceId: number;
+}): boolean => {
+  if (wanted === undefined) return stored === undefined;
+  if (stored === undefined) return false;
+  if (isRid(wanted))
+    return (
+      stored.spaceId !== spaceId &&
+      stored.localId === ridToSpaceUriAndLocalId(wanted).sourceLocalId
+    );
+  return stored.spaceId === spaceId && stored.localId === wanted;
+};
 
-// A relation added, accepted, or removed changes no note, so the stored slot is compared
-// with the wanted one on full sync. The comparison is by local id: the database stores
-// the Source's concept id, and an imported Source is wanted by its origin RID.
+// A relation added, accepted, or removed changes no file, so the mtime check never
+// fires; full sync compares the stored slot with the wanted one instead. The database
+// stores the Source's concept id: a local Source must resolve to a concept in this
+// space, an imported Source (wanted by its origin RID) to one in another space.
 export const findStaleSourceSlotNodeIds = ({
   rows,
   sourceSlotByNodeId,
+  spaceId,
 }: {
-  rows: SourceSlotProbeRow[];
+  rows: (SourceSlotProbeRow & { source_local_id: string | null })[];
   sourceSlotByNodeId: Record<string, string>;
+  spaceId: number;
 }): Set<string> => {
   const stale = new Set<string>();
   for (const row of rows) {
     if (row.source_local_id === null) continue;
-    const wanted = sourceSlotByNodeId[row.source_local_id];
-    const wantedLocalId = wanted === undefined ? undefined : localIdOf(wanted);
-    if (wantedLocalId !== storedSourceDocumentLocalId(row))
-      stale.add(row.source_local_id);
+    const matches = storedMatchesWanted({
+      stored: storedSourceDocumentOf(row),
+      wanted: sourceSlotByNodeId[row.source_local_id],
+      spaceId,
+    });
+    if (!matches) stale.add(row.source_local_id);
   }
   return stale;
 };

--- a/apps/obsidian/src/utils/syncDgNodesToSupabase.ts
+++ b/apps/obsidian/src/utils/syncDgNodesToSupabase.ts
@@ -7,6 +7,7 @@ import type { Json } from "@repo/database/dbTypes";
 import {
   getSupabaseContext,
   getLoggedInClient,
+  getLocalSpaceUri,
   type SupabaseContext,
 } from "./supabaseContext";
 import { default as DiscourseGraphPlugin } from "~/index";
@@ -21,6 +22,7 @@ import {
   relationInstanceToLocalConcept,
 } from "./conceptConversion";
 import { loadRelations } from "~/utils/relationsStore";
+import { indexSourceSlotValues } from "./sourceSlot";
 import type { LocalConceptDataInput } from "@repo/database/inputTypes";
 import {
   type DiscourseNodeInVault,
@@ -605,18 +607,24 @@ const convertDgToSupabaseConcepts = async ({
     )
     .filter((n) => !!n);
 
+  const relationInstancesData = await loadRelations(plugin);
+  const relationInstances = Object.values(relationInstancesData.relations);
+  const sourceSlotByNodeId = indexSourceSlotValues({
+    relations: relationInstances,
+    nodes: allNodes,
+    localSpaceUri: getLocalSpaceUri(plugin.app),
+    nodeTypesById,
+  });
   const nodeInstanceToLocalConcepts = nodesSince.map((node) => {
     return discourseNodeInstanceToLocalConcept({
       context,
       nodeData: node,
       nodeTypesById,
+      sourceSlotByNodeId,
     });
   });
 
-  const relationInstancesData = await loadRelations(plugin);
-  const relationInstanceToLocalConcepts = Object.values(
-    relationInstancesData.relations,
-  )
+  const relationInstanceToLocalConcepts = relationInstances
     .filter(
       (relationInstanceData) =>
         !relationInstanceData.importedFromRid &&

--- a/apps/obsidian/src/utils/syncDgNodesToSupabase.ts
+++ b/apps/obsidian/src/utils/syncDgNodesToSupabase.ts
@@ -22,7 +22,11 @@ import {
   relationInstanceToLocalConcept,
 } from "./conceptConversion";
 import { loadRelations } from "~/utils/relationsStore";
-import { indexSourceSlotValues } from "./sourceSlot";
+import {
+  findStaleSourceSlotNodeIds,
+  indexSourceSlotValues,
+  SOURCE_SLOT_PROBE_SELECT,
+} from "./sourceSlot";
 import type { LocalConceptDataInput } from "@repo/database/inputTypes";
 import {
   type DiscourseNodeInVault,
@@ -235,6 +239,7 @@ type BuildChangedNodesOptions = {
   context: SupabaseContext;
   changeTypesByPath?: Map<string, ChangeType[]>;
   fullSync?: boolean;
+  sourceSlotByNodeId?: Record<string, string>;
 };
 
 type BuildChangedNodesResult = {
@@ -336,6 +341,7 @@ const buildChangedNodesFromNodes = async ({
   context,
   changeTypesByPath,
   fullSync = false,
+  sourceSlotByNodeId,
 }: BuildChangedNodesOptions): Promise<BuildChangedNodesResult> => {
   if (nodes.length === 0) {
     return { changedNodes: [] };
@@ -355,11 +361,12 @@ const buildChangedNodesFromNodes = async ({
   const changedNodes: ObsidianDiscourseNodeData[] = [];
   let missingConcepts: Set<string> | undefined;
   let missingCoreTitleIds: Set<string> | undefined;
+  let staleSourceSlotIds: Set<string> | undefined;
   if (fullSync) {
     const existingConceptIds = await getAllPages(
       supabaseClient
         .from("my_concepts")
-        .select(CORE_TITLE_PROBE_SELECT)
+        .select(`${CORE_TITLE_PROBE_SELECT}, ${SOURCE_SLOT_PROBE_SELECT}`)
         .eq("space_id", context.spaceId)
         .eq("is_relation", false)
         .eq("is_schema", false)
@@ -382,6 +389,11 @@ const buildChangedNodesFromNodes = async ({
       missingConcepts = difference(nodeIds, dbConceptIds);
       missingCoreTitleIds =
         partitionByCoreTitle(existingConceptIds).missingCoreTitleIds;
+      if (sourceSlotByNodeId)
+        staleSourceSlotIds = findStaleSourceSlotNodeIds({
+          rows: existingConceptIds,
+          sourceSlotByNodeId,
+        });
     }
   }
 
@@ -403,7 +415,8 @@ const buildChangedNodesFromNodes = async ({
     if (
       finalChangeTypes.length === 0 &&
       !missingConcepts?.has(node.nodeInstanceId) &&
-      !missingCoreTitleIds?.has(node.nodeInstanceId)
+      !missingCoreTitleIds?.has(node.nodeInstanceId) &&
+      !staleSourceSlotIds?.has(node.nodeInstanceId)
     ) {
       continue;
     }
@@ -420,6 +433,27 @@ const buildChangedNodesFromNodes = async ({
   }
 
   return { changedNodes };
+};
+
+const indexSourceSlots = async ({
+  plugin,
+  nodes,
+}: {
+  plugin: DiscourseGraphPlugin;
+  nodes: DiscourseNodeInVault[];
+}): Promise<Record<string, string>> => {
+  const relationInstancesData = await loadRelations(plugin);
+  return indexSourceSlotValues({
+    relations: Object.values(relationInstancesData.relations),
+    nodes,
+    localSpaceUri: getLocalSpaceUri(plugin.app),
+    nodeTypesById: Object.fromEntries(
+      (plugin.settings.nodeTypes ?? []).map((nodeType) => [
+        nodeType.id,
+        nodeType,
+      ]),
+    ),
+  });
 };
 
 export const syncAllNodesAndRelations = async (
@@ -439,6 +473,10 @@ export const syncAllNodesAndRelations = async (
     }
 
     const allNodes = await collectDiscourseNodesFromVault(plugin, true);
+    const sourceSlotByNodeId = await indexSourceSlots({
+      plugin,
+      nodes: allNodes,
+    });
 
     const { changedNodes: changedNodeInstances } = relationsOnly
       ? { changedNodes: [] }
@@ -447,6 +485,7 @@ export const syncAllNodesAndRelations = async (
           supabaseClient,
           context,
           fullSync: true,
+          sourceSlotByNodeId,
         });
 
     const accountLocalId = plugin.settings.accountLocalId;
@@ -469,6 +508,7 @@ export const syncAllNodesAndRelations = async (
       plugin,
       allNodes,
       fullSync: true,
+      sourceSlotByNodeId,
     });
 
     // When synced nodes are already published, ensure non-text assets are in storage.
@@ -489,6 +529,7 @@ const convertDgToSupabaseConcepts = async ({
   plugin,
   allNodes,
   fullSync,
+  sourceSlotByNodeId,
 }: {
   nodesSince: ObsidianDiscourseNodeData[];
   supabaseClient: DGSupabaseClient;
@@ -496,6 +537,7 @@ const convertDgToSupabaseConcepts = async ({
   plugin: DiscourseGraphPlugin;
   allNodes?: DiscourseNodeInVault[];
   fullSync?: boolean;
+  sourceSlotByNodeId?: Record<string, string>;
 }): Promise<void> => {
   const lastNodeSchemaSync = (
     await getLastNodeSchemaSyncTime(supabaseClient, context.spaceId)
@@ -609,18 +651,20 @@ const convertDgToSupabaseConcepts = async ({
 
   const relationInstancesData = await loadRelations(plugin);
   const relationInstances = Object.values(relationInstancesData.relations);
-  const sourceSlotByNodeId = indexSourceSlotValues({
-    relations: relationInstances,
-    nodes: allNodes,
-    localSpaceUri: getLocalSpaceUri(plugin.app),
-    nodeTypesById,
-  });
+  const sourceSlots =
+    sourceSlotByNodeId ??
+    indexSourceSlotValues({
+      relations: relationInstances,
+      nodes: allNodes,
+      localSpaceUri: getLocalSpaceUri(plugin.app),
+      nodeTypesById,
+    });
   const nodeInstanceToLocalConcepts = nodesSince.map((node) => {
     return discourseNodeInstanceToLocalConcept({
       context,
       nodeData: node,
       nodeTypesById,
-      sourceSlotByNodeId,
+      sourceSlotByNodeId: sourceSlots,
     });
   });
 

--- a/apps/obsidian/src/utils/syncDgNodesToSupabase.ts
+++ b/apps/obsidian/src/utils/syncDgNodesToSupabase.ts
@@ -21,7 +21,8 @@ import {
   discourseRelationTypeToLocalConcept,
   relationInstanceToLocalConcept,
 } from "./conceptConversion";
-import { loadRelations } from "~/utils/relationsStore";
+import { loadRelations, type RelationsFile } from "~/utils/relationsStore";
+import type { RelationInstance } from "~/types";
 import {
   findStaleSourceSlotNodeIds,
   indexSourceSlotValues,
@@ -393,6 +394,7 @@ const buildChangedNodesFromNodes = async ({
         staleSourceSlotIds = findStaleSourceSlotNodeIds({
           rows: existingConceptIds,
           sourceSlotByNodeId,
+          spaceId: context.spaceId,
         });
     }
   }
@@ -435,16 +437,17 @@ const buildChangedNodesFromNodes = async ({
   return { changedNodes };
 };
 
-const indexSourceSlots = async ({
+const indexSourceSlots = ({
   plugin,
   nodes,
+  relations,
 }: {
   plugin: DiscourseGraphPlugin;
   nodes: DiscourseNodeInVault[];
-}): Promise<Record<string, string>> => {
-  const relationInstancesData = await loadRelations(plugin);
-  return indexSourceSlotValues({
-    relations: Object.values(relationInstancesData.relations),
+  relations: RelationInstance[];
+}): Record<string, string> =>
+  indexSourceSlotValues({
+    relations,
     nodes,
     localSpaceUri: getLocalSpaceUri(plugin.app),
     nodeTypesById: Object.fromEntries(
@@ -454,7 +457,6 @@ const indexSourceSlots = async ({
       ]),
     ),
   });
-};
 
 export const syncAllNodesAndRelations = async (
   plugin: DiscourseGraphPlugin,
@@ -473,10 +475,14 @@ export const syncAllNodesAndRelations = async (
     }
 
     const allNodes = await collectDiscourseNodesFromVault(plugin, true);
-    const sourceSlotByNodeId = await indexSourceSlots({
-      plugin,
-      nodes: allNodes,
-    });
+    const relationInstancesData = await loadRelations(plugin);
+    const sourceSlotByNodeId = relationsOnly
+      ? undefined
+      : indexSourceSlots({
+          plugin,
+          nodes: allNodes,
+          relations: Object.values(relationInstancesData.relations),
+        });
 
     const { changedNodes: changedNodeInstances } = relationsOnly
       ? { changedNodes: [] }
@@ -508,6 +514,7 @@ export const syncAllNodesAndRelations = async (
       plugin,
       allNodes,
       fullSync: true,
+      relationInstancesData,
       sourceSlotByNodeId,
     });
 
@@ -529,6 +536,7 @@ const convertDgToSupabaseConcepts = async ({
   plugin,
   allNodes,
   fullSync,
+  relationInstancesData,
   sourceSlotByNodeId,
 }: {
   nodesSince: ObsidianDiscourseNodeData[];
@@ -537,6 +545,7 @@ const convertDgToSupabaseConcepts = async ({
   plugin: DiscourseGraphPlugin;
   allNodes?: DiscourseNodeInVault[];
   fullSync?: boolean;
+  relationInstancesData?: RelationsFile;
   sourceSlotByNodeId?: Record<string, string>;
 }): Promise<void> => {
   const lastNodeSchemaSync = (
@@ -649,22 +658,18 @@ const convertDgToSupabaseConcepts = async ({
     )
     .filter((n) => !!n);
 
-  const relationInstancesData = await loadRelations(plugin);
+  relationInstancesData =
+    relationInstancesData ?? (await loadRelations(plugin));
   const relationInstances = Object.values(relationInstancesData.relations);
-  const sourceSlots =
+  sourceSlotByNodeId =
     sourceSlotByNodeId ??
-    indexSourceSlotValues({
-      relations: relationInstances,
-      nodes: allNodes,
-      localSpaceUri: getLocalSpaceUri(plugin.app),
-      nodeTypesById,
-    });
+    indexSourceSlots({ plugin, nodes: allNodes, relations: relationInstances });
   const nodeInstanceToLocalConcepts = nodesSince.map((node) => {
     return discourseNodeInstanceToLocalConcept({
       context,
       nodeData: node,
       nodeTypesById,
-      sourceSlotByNodeId: sourceSlots,
+      sourceSlotByNodeId,
     });
   });
 


### PR DESCRIPTION
## Reviewer brief

- Result: an Obsidian node pushed to Supabase now carries `local_reference_content.sourceDocument` when it has a relation to a node of the Source type. The value is the Source's `importedFromRid` when it was imported, else its `nodeInstanceId`. With several such relations, the earliest by `created` (then `id`) wins. With none, or when the database cannot resolve the Source to a concept, the key is omitted. Full sync re-upserts every node whose stored slot differs from the one its relations call for, so a relation added, accepted, or removed reaches the database at the next full sync or publish, and existing vaults backfill on their first full sync.
- Review focus: `apps/obsidian/src/utils/sourceSlot.ts`. `indexSourceSlotValues` does one pass over `relations.json` and returns `Record<nodeInstanceId, sourceDocumentId>`; `filterAvailableSourceSlotValues` drops, for the nodes being pushed, every value `rid_or_local_id_to_concept_db_id` cannot resolve; the node converter reads `nodeData.sourceDocument`. `findStaleSourceSlotNodeIds` compares that map with the stored slot, read through the full-sync probe that already backfills `core_title` (`buildChangedNodesFromNodes`), by local id. The Source type is matched by name, as Roam does in `apps/roam/src/utils/sourceSlot.ts` (#1329). Both group decisions are settled: `SOURCE_SLOT` lives in `apps/obsidian/src/constants.ts`, and an unresolvable value is omitted with a console warning (see the Decision comment).
- Risk or follow-up:
  - `publishNewRelation` syncs relations only, so a relation added between two published nodes reaches the slot at the next full sync or publish, not at creation.
  - A Source whose concept the database cannot resolve (created while sync was off, or imported and later unshared) is omitted from the slot and a console warning names it, so the node's row succeeds. The full-sync comparison still wants that value, so the node's concept row re-upserts on every full sync (no content or embeddings) until the Source resolves; then the slot lands. The check is one RPC per distinct Source among the pushed nodes, run in parallel. Relation instances still carry the `-2` failure for a missing endpoint; unchanged here.
  - No tests. `apps/obsidian` has no unit-test runner; #1258 and #1366 each add one. The Done When line "Tests cover zero, one, and multiple matching relations" is not met here and goes with the harness question to ENG-2143.
  - Read side is out of scope: `dbToCrossAppConverters.ts` emits no instance `slots`, and `sharedNodes.ts:208` builds the cross-space slot RID without the `note` subtype Obsidian stores in `importedFromRid`. ENG-2140 and ENG-2142.
  - Obsidian schemas write no `roles`, so Obsidian Evidence keeps `arity 0` while Roam Evidence declares `roles: ["sourceDocument"]`. Slot-schema work is out of scope per the ticket.

## Verification

- `eslint --max-warnings 0`, `prettier --check`, `tsc --noEmit --skipLibCheck` on the four files: clean for this change. The two eslint warnings in `apps/obsidian` are present on main at untouched lines; the 20 tsc errors seen on main come from that checkout's local type resolution and do not appear in a fresh install.
- `turbo run test:unit`: 32 files pass (roam 25, database 5, content-model 2).
- `pnpm ci:validate` is red locally on main as well (obsidian, ui, website type errors from local type resolution). CI on main is green at ef37b20d.
- Runtime: not yet driven. See the Loom section.

## Loom video


https://github.com/user-attachments/assets/17f9eb38-721e-45ca-bbcd-6466fe7d948f


## Scope check

- [x] Ran `$scope-check` against ENG-2139 and the final diff.
- Scope beyond `Done When`: a node whose Source is not a concept the database can resolve pushes without `sourceDocument` and logs a warning naming the Source. The full-sync comparison itself is what makes "a node with no matching source relation omits the source value" and "repeated pushes produce the same single source value" hold after a relation changes.
- Required now: this PR writes the slot for the first time, and its full-sync comparison re-queues an unresolvable value on every full sync, which failed that node's concept row and its title sync with `-2`. Same behavior as ENG-2141 (#1380).
- Anyone affected or consulted: Yes, maparent.
- Decision: https://github.com/DiscourseGraphs/discourse-graph/pull/1381#pullrequestreview-5182196750 and https://github.com/DiscourseGraphs/discourse-graph/pull/1381#issuecomment-5660701219

## Local delegated full review

- [x] Ran a comprehensive review of the entire final diff in a subagent with a fresh context. Use `$dg-delegated-full-review` when no other full-review workflow is available.

