### PR TITLE
ENG-1963 Standardize Roam error text on text-red-700

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,7 @@ When creating or updating a pull request body:
 - Use platform-native UI components (see below) first with shadcn/ui as a fallback
 - Maintain visual consistency with the host application's design system
 - Follow responsive design principles
+- Use `text-red-700` for Roam error message text. Obsidian keeps `text-error`; website and shared UI keep `text-destructive`. This convention does not change danger buttons, borders, backgrounds, or diagram colors.
 
 ### TypeScript Guidelines
 

--- a/apps/roam/AGENTS.md
+++ b/apps/roam/AGENTS.md
@@ -7,6 +7,7 @@ Prefer existing dependencies from package.json.
 ## Roam Style Guide
 
 Platform-native UI - use BlueprintJS 3 components and Tailwind CSS.
+Use `text-red-700` for error message text so errors have a consistent visual treatment. Keep danger buttons, borders, backgrounds, and diagram colors separate from this text convention. Obsidian keeps `text-error`; website and shared UI keep `text-destructive`.
 Do not introduce arbitrary visual styling, new shading colors, background palettes, gradients, accent colors, border colors, or text colors unless the user explicitly asks for them.
 When styling Roam UI, use this priority order:
 

--- a/apps/roam/src/components/FuzzySelectInput.tsx
+++ b/apps/roam/src/components/FuzzySelectInput.tsx
@@ -173,7 +173,7 @@ const FuzzySelectInput = <T extends Result = Result>({
           maxLength={MAX_CONTENT_LENGTH}
         />
         {editText.length >= MAX_CONTENT_LENGTH && (
-          <p className="mt-1 text-xs text-red-500">
+          <p className="mt-1 text-xs text-red-700">
             Character limit reached ({MAX_CONTENT_LENGTH})
           </p>
         )}
@@ -257,7 +257,7 @@ const FuzzySelectInput = <T extends Result = Result>({
             }}
           />
           {query.length >= MAX_CONTENT_LENGTH && (
-            <p className="mt-1 text-xs text-red-500">
+            <p className="mt-1 text-xs text-red-700">
               Character limit reached ({MAX_CONTENT_LENGTH})
             </p>
           )}

--- a/apps/roam/src/components/LeftSidebarView.tsx
+++ b/apps/roam/src/components/LeftSidebarView.tsx
@@ -450,7 +450,7 @@ const QuerySectionItem = ({
   if (isLoading) {
     body = <div className="pl-8 pr-2.5 text-sm text-gray-500">Loading…</div>;
   } else if (error) {
-    body = <div className="pl-8 pr-2.5 text-sm text-red-500">{error}</div>;
+    body = <div className="pl-8 pr-2.5 text-sm text-red-700">{error}</div>;
   } else if (limitedResults.length > 0) {
     body = limitedResults.map((child) => (
       <ChildRow

--- a/apps/roam/src/components/ModifyNodeDialog.tsx
+++ b/apps/roam/src/components/ModifyNodeDialog.tsx
@@ -628,7 +628,7 @@ const ModifyNodeDialog = ({
               disabled={loading}
               className="flex-shrink-0"
             />
-            <span className="flex-grow text-red-800">{error}</span>
+            <span className="flex-grow text-red-700">{error}</span>
             {loading && <Spinner size={SpinnerSize.SMALL} />}
           </div>
         </div>

--- a/apps/roam/src/components/canvas/Clipboard.tsx
+++ b/apps/roam/src/components/canvas/Clipboard.tsx
@@ -381,7 +381,7 @@ const AddPageModal = ({ isOpen, onClose, onConfirm }: AddPageModalProps) => {
               disabled={isLoading}
               className="flex-shrink-0"
             />
-            <span className={"flex-grow text-red-800"}>{error}</span>
+            <span className={"flex-grow text-red-700"}>{error}</span>
             {isLoading && <Spinner size={SpinnerSize.SMALL} />}
           </div>
         </div>

--- a/apps/roam/src/components/settings/DiscourseRelationConfigPanel.tsx
+++ b/apps/roam/src/components/settings/DiscourseRelationConfigPanel.tsx
@@ -453,7 +453,7 @@ export const RelationEditPanel = ({
     cyRef.current.nodes().forEach(nodeCallback);
     cyRef.current.edges().forEach(edgeCallback);
     cyRef.current.nodes(`#source`).style("background-color", "darkblue");
-    cyRef.current.nodes(`#destination`).style("background-color", "darkred");
+    cyRef.current.nodes(`#destination`).style("background-color", "#8b0000");
   }, [
     cyRef,
     containerRef,

--- a/apps/roam/src/components/settings/SearchTestTab.tsx
+++ b/apps/roam/src/components/settings/SearchTestTab.tsx
@@ -197,7 +197,7 @@ const ProviderResultCard = ({
 
       <div className="space-y-2 p-3">
         {result.error ? (
-          <div className="rounded border border-red-200 bg-red-50 px-2 py-2 text-sm text-red-800">
+          <div className="rounded border border-red-200 bg-red-50 px-2 py-2 text-sm text-red-700">
             {result.error}
           </div>
         ) : isRawVisible ? (

--- a/apps/roam/src/components/settings/components/BlockPropSettingPanels.tsx
+++ b/apps/roam/src/components/settings/components/BlockPropSettingPanels.tsx
@@ -177,7 +177,7 @@ const BaseTextPanel = ({
         )}
       </Label>
       {error && (
-        <div className="mt-1 text-sm font-medium text-red-600">{error}</div>
+        <div className="mt-1 text-sm font-medium text-red-700">{error}</div>
       )}
     </div>
   );


### PR DESCRIPTION


https://github.com/user-attachments/assets/ba0148cf-06f7-4b8b-832c-8afd4ea4ef9a


## Verification

- `pnpm install --frozen-lockfile`, `pnpm ci:validate`, and the Roam build passed.
- Windows Playwright: all eight affected surfaces passed before/after color checks. Controlled component fixtures cover query/provider failures; the settings check uses native validation. Both runs completed cleanup without unexpected page errors.

## Loom video

2:31 before/after recording with readable pauses. Controlled error fixtures are labeled.



## Scope check

- [x] Ran `$scope-check` against ENG-1963 and the final diff.
- Scope beyond `Done When`: None.

## Local delegated full review

- [x] Ran a comprehensive review of the entire final diff in a subagent with a fresh context. No findings.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/1403" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->