### PR TITLE
Reconcile engineering writing style with global preferences

### DIFF
--- a/.agents/skills/dg-engineering-writing-style/SKILL.md
+++ b/.agents/skills/dg-engineering-writing-style/SKILL.md
@@ -14,8 +14,9 @@ Write in a direct, concise, plainspoken style that preserves important context a
 - Identify wording or missing context that is ambiguous or could be misconstrued. Resolve it when the intended meaning is clear; otherwise, flag it and ask for clarification.
 - Use natural contractions and everyday wording. Avoid corporate jargon, inflated phrasing, and generic professional filler.
 - Avoid em dashes as sentence-level punctuation. Use a period, comma, colon, semicolon, or parentheses to separate thoughts instead. Preserve em dashes only when they appear in exact quotations, titles, source text, or technical content supplied by the requester.
+- Keep warmth light: use a brief greeting, thanks, or friendly closing when appropriate, without extended pleasantries.
 - When identifying a problem or disagreement, state it plainly and pivot toward clarification, resolution, criteria, or next steps.
-- Prefer bullets for distinct points. When prose reads more naturally, keep paragraphs and sentences short; avoid run-on sentences.
+- Use short paragraphs. Use bullets only when several distinct items genuinely scan better as a list. Keep sentences short and avoid run-on sentences.
 - Ask one clear question when one will do. Combine related questions only when separating them would add needless length.
 
 ## Adapt to the channel


### PR DESCRIPTION
## Reviewer brief

Bring the global engineering writing skill's light warmth and paragraph preferences into the repository-owned `dg-engineering-writing-style`. Preserve the existing ambiguity checks and technical-documentation guidance.

## Verification

- Skill metadata validation passed.
- `pnpm install --frozen-lockfile` and `pnpm ci:validate` passed in the isolated worktree containing both skill changes.
- Independent read-only review found no actionable introduced issues.

## Loom video

Not recorded. This draft contains a three-line documentation change.

## Scope check

- [ ] Ran `$scope-check` against the ENG ticket and final diff.
- Scope beyond `Done When`: No ENG ticket was supplied. Scope is the requested reconciliation of the global and repository writing skills.

## Local delegated full review

- [x] Ran a comprehensive review of the entire final diff in a subagent with a fresh context.
