### PR TITLE
ENG-2234 Standardize website unit test configuration

### DIFF
--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "check-types": "tsc --noEmit --skipLibCheck",
-    "test:unit": "vitest run --config vitest.unit.config.mts",
+    "test:unit": "node --test scripts/build-docs-search-index.test.mjs && vitest run --config vitest.unit.config.mts",
     "test:integration": "vitest run --config vitest.integration.config.ts",
     "test:integration:nodb": "vitest run --config vitest.integration.config.ts --tags-filter '!database'"
   },

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -12,6 +12,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "check-types": "tsc --noEmit --skipLibCheck",
+    "test:unit": "vitest run --config vitest.unit.config.mts",
     "test:integration": "vitest run --config vitest.integration.config.ts",
     "test:integration:nodb": "vitest run --config vitest.integration.config.ts --tags-filter '!database'"
   },

--- a/apps/website/vitest.unit.config.mts
+++ b/apps/website/vitest.unit.config.mts
@@ -1,0 +1,15 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["app/**/*.test.{ts,tsx}", "test/unit/**/*.test.{ts,tsx}"],
+    passWithNoTests: true,
+  },
+  resolve: {
+    alias: {
+      "~": fileURLToPath(new URL("./app", import.meta.url)),
+    },
+  },
+});


### PR DESCRIPTION
The five SEO PRs introduce competing website unit-test commands and include patterns, which can cause merge conflicts or silently omit tests.

Adds one website unit-test command and configuration covering TypeScript and TSX tests in `app` and `test/unit`, with the existing app alias and Node environment. Database integration tests retain their separate configuration. Empty suites are allowed so this foundation can land before the feature tests.

Validation: `pnpm install --frozen-lockfile` and `pnpm ci:validate`.

Foundation for #1385, #1386, #1387, #1388, and #1389. No dependency or lockfile changes.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/1406" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->