### PR TITLE
Fix documented Roam loader command

### DIFF
--- a/.agents/skills/dg-roam-load-extension/SKILL.md
+++ b/.agents/skills/dg-roam-load-extension/SKILL.md
@@ -12,13 +12,13 @@ It composes with `dg-roam-playwright-session` for account/profile selection.
 ## Quick Start
 
 ```sh
-pnpm --filter roam playwright:loadExtension -- --slot 1
+pnpm --filter roam playwright:load-extension -- --slot 1
 ```
 
 Use another slot for isolated work:
 
 ```sh
-pnpm --filter roam playwright:loadExtension -- --slot 2
+pnpm --filter roam playwright:load-extension -- --slot 2
 ```
 
 The script builds by default, verifies `window.roamjs.extension.queryBuilder`, checks the DG settings UI, and writes proof under `local/roam-playwright/artifacts`.
@@ -26,7 +26,7 @@ The script builds by default, verifies `window.roamjs.extension.queryBuilder`, c
 To add feature-specific assertions without copying the loader, pass an ESM test module:
 
 ```sh
-pnpm --filter roam playwright:loadExtension -- --slot 1 --test-module ./local/roam-playwright/feature-proof.mjs
+pnpm --filter roam playwright:load-extension -- --slot 1 --test-module ./local/roam-playwright/feature-proof.mjs
 ```
 
 ```js


### PR DESCRIPTION
## Reviewer brief

The Roam loader skill invokes `playwright:loadExtension`, which is not defined in the app package. Correct all three examples to the existing `playwright:load-extension` command.

## Verification

- Confirmed examples match `apps/roam/package.json`; skill metadata validation and diff checks pass.
- Locked dependency installation passed. Full `pnpm ci:validate` stopped on React JSX type errors in unchanged `packages/ui` code; validation remains incomplete.

## Loom video

Not recorded; documentation-only command correction.

## Scope check

- [ ] Ran `$scope-check` against the ENG ticket and final diff.
- No ENG ticket supplied; scope is the requested command documentation correction.

## Local delegated full review

- [x] Ran a comprehensive review of the entire final diff in a subagent with a fresh context. No findings.
