### PR TITLE
ENG-1249 Add a cached relations index and link resolution

### DIFF
--- a/apps/obsidian/src/index.ts
+++ b/apps/obsidian/src/index.ts
@@ -35,6 +35,7 @@ import { NodeTagSuggestPopover } from "~/components/NodeTagSuggestModal";
 import { InlineNodeTypePicker } from "~/components/InlineNodeTypePicker";
 import { initializeSupabaseSync } from "~/utils/syncDgNodesToSupabase";
 import { FileChangeListener } from "~/utils/fileChangeListener";
+import { RelationsIndex } from "~/utils/relationsIndex";
 import generateUid from "~/utils/generateUid";
 import {
   migrateFrontmatterRelationsToRelationsJson,
@@ -51,6 +52,7 @@ import {
 
 export default class DiscourseGraphPlugin extends Plugin {
   settings: Settings = { ...DEFAULT_SETTINGS };
+  relationsIndex: RelationsIndex = new RelationsIndex(this);
   private tagNodeHandler: TagNodeHandler | null = null;
   private fileChangeListener: FileChangeListener | null = null;
   private activeNodePopover:
@@ -97,6 +99,8 @@ export default class DiscourseGraphPlugin extends Plugin {
         this.fileChangeListener = null;
       }
     }
+
+    this.relationsIndex.initialize();
 
     registerCommands(this);
     this.addSettingTab(new SettingsTab(this.app, this));
@@ -488,5 +492,7 @@ export default class DiscourseGraphPlugin extends Plugin {
       this.fileChangeListener.cleanup();
       this.fileChangeListener = null;
     }
+
+    this.relationsIndex.unload();
   }
 }

--- a/apps/obsidian/src/utils/discourseLinkFrontmatter.ts
+++ b/apps/obsidian/src/utils/discourseLinkFrontmatter.ts
@@ -1,0 +1,40 @@
+import type { RelationInstance } from "~/types";
+
+const asString = (value: unknown): string | undefined =>
+  typeof value === "string" && value.length > 0 ? value : undefined;
+
+export const getNodeTypeIdFromFrontmatter = (
+  frontmatter: Record<string, unknown> | undefined,
+): string | undefined => asString(frontmatter?.nodeTypeId);
+
+/** An imported node is referenced by both its nodeInstanceId and its importedFromRid. */
+export const getEndpointIdsFromFrontmatter = (
+  frontmatter: Record<string, unknown> | undefined,
+): string[] => {
+  const endpointIds: string[] = [];
+  const nodeInstanceId = asString(frontmatter?.nodeInstanceId);
+  const importedFromRid = asString(frontmatter?.importedFromRid);
+
+  if (nodeInstanceId) endpointIds.push(nodeInstanceId);
+  if (importedFromRid && importedFromRid !== nodeInstanceId) {
+    endpointIds.push(importedFromRid);
+  }
+
+  return endpointIds;
+};
+
+/**
+ * Counts what the panel would list. Excludes unaccepted imports and relations
+ * orphaned by a deleted relation type, both of which the panel hides.
+ */
+export const countDisplayableRelations = ({
+  relations,
+  isConfiguredType,
+}: {
+  relations: RelationInstance[];
+  isConfiguredType: (relationTypeId: string) => boolean;
+}): number =>
+  relations.filter(
+    (relation) =>
+      relation.tentative !== false && isConfiguredType(relation.type),
+  ).length;

--- a/apps/obsidian/src/utils/discourseLinkUtils.ts
+++ b/apps/obsidian/src/utils/discourseLinkUtils.ts
@@ -15,8 +15,8 @@ export type DiscourseLinkTarget = {
 };
 
 /**
- * Resolves a link to a discourse node and its relation count from in-memory
- * caches only; avoids getNodeTypeIdForFile, which polls 500ms for frontmatter.
+ * In-memory caches only, so this can run per link on a render path. Avoids
+ * getNodeTypeIdForFile, which polls 500ms waiting on frontmatter.
  */
 export const resolveDiscourseLinkTarget = ({
   plugin,

--- a/apps/obsidian/src/utils/discourseLinkUtils.ts
+++ b/apps/obsidian/src/utils/discourseLinkUtils.ts
@@ -1,0 +1,58 @@
+import { parseLinktext, TFile } from "obsidian";
+import type DiscourseGraphPlugin from "~/index";
+import type { DiscourseNode } from "~/types";
+import { getNodeTypeById, getRelationTypeById } from "./typeUtils";
+import {
+  countDisplayableRelations,
+  getEndpointIdsFromFrontmatter,
+  getNodeTypeIdFromFrontmatter,
+} from "./discourseLinkFrontmatter";
+
+export type DiscourseLinkTarget = {
+  file: TFile;
+  nodeType: DiscourseNode;
+  relationCount: number;
+};
+
+/**
+ * Resolves a link to a discourse node and its relation count from in-memory
+ * caches only; avoids getNodeTypeIdForFile, which polls 500ms for frontmatter.
+ */
+export const resolveDiscourseLinkTarget = ({
+  plugin,
+  linktext,
+  sourcePath,
+}: {
+  plugin: DiscourseGraphPlugin;
+  linktext: string;
+  sourcePath: string;
+}): DiscourseLinkTarget | null => {
+  // Strips any #heading or #^block subpath.
+  const { path } = parseLinktext(linktext);
+  if (!path) return null;
+
+  const file = plugin.app.metadataCache.getFirstLinkpathDest(path, sourcePath);
+  if (!file) return null;
+
+  const frontmatter = plugin.app.metadataCache.getFileCache(file)?.frontmatter;
+
+  const nodeTypeId = getNodeTypeIdFromFrontmatter(frontmatter);
+  if (!nodeTypeId) return null;
+
+  const nodeType = getNodeTypeById(plugin, nodeTypeId);
+  if (!nodeType) return null;
+
+  const endpointIds = getEndpointIdsFromFrontmatter(frontmatter);
+  if (endpointIds.length === 0) return { file, nodeType, relationCount: 0 };
+
+  const relations =
+    plugin.relationsIndex.getRelationsForEndpointIds(endpointIds);
+
+  const relationCount = countDisplayableRelations({
+    relations,
+    isConfiguredType: (relationTypeId) =>
+      !!getRelationTypeById(plugin, relationTypeId),
+  });
+
+  return { file, nodeType, relationCount };
+};

--- a/apps/obsidian/src/utils/internalLinkParsing.ts
+++ b/apps/obsidian/src/utils/internalLinkParsing.ts
@@ -1,0 +1,21 @@
+// Shared by the CM6 extensions that scan raw markdown for internal links.
+
+/** Embeds are not matched: the leading `!` sits outside, so callers check it. */
+export const INTERNAL_LINK_RE = /\[\[([^\]]+)\]\]|\[([^\]]+)\]\(([^)]+\.md)\)/g;
+
+/** Target of a wikilink or markdown link; any `#subpath` is left for parseLinktext. */
+export const extractLinktext = (match: string): string => {
+  if (match.startsWith("[[")) {
+    const inner = match.slice(2, -2);
+    const pipeIndex = inner.indexOf("|");
+    return pipeIndex >= 0 ? inner.slice(0, pipeIndex) : inner;
+  }
+
+  const parenOpen = match.lastIndexOf("(");
+  const rawPath = match.slice(parenOpen + 1, -1);
+  try {
+    return decodeURIComponent(rawPath);
+  } catch {
+    return rawPath;
+  }
+};

--- a/apps/obsidian/src/utils/internalLinkParsing.ts
+++ b/apps/obsidian/src/utils/internalLinkParsing.ts
@@ -1,7 +1,8 @@
 // Shared by the CM6 extensions that scan raw markdown for internal links.
 
 /** Embeds are not matched: the leading `!` sits outside, so callers check it. */
-export const INTERNAL_LINK_RE = /\[\[([^\]]+)\]\]|\[([^\]]+)\]\(([^)]+\.md)\)/g;
+export const INTERNAL_LINK_RE =
+  /\[\[([^\]]+)\]\]|\[([^\]]+)\]\(([^)]+\.md(?:#[^)]*)?)\)/g;
 
 /** Target of a wikilink or markdown link; any `#subpath` is left for parseLinktext. */
 export const extractLinktext = (match: string): string => {

--- a/apps/obsidian/src/utils/relationsEndpointIndex.ts
+++ b/apps/obsidian/src/utils/relationsEndpointIndex.ts
@@ -1,0 +1,54 @@
+import type { RelationInstance } from "~/types";
+
+/**
+ * Groups relations by the ids at either end, so a lookup is a Map hit rather
+ * than a scan. Self-relations are filed once, not twice.
+ */
+export const buildEndpointIndex = (
+  relations: Record<string, RelationInstance>,
+): Map<string, RelationInstance[]> => {
+  const index = new Map<string, RelationInstance[]>();
+
+  const fileUnder = (endpointId: string, relation: RelationInstance): void => {
+    const existing = index.get(endpointId);
+    if (existing) {
+      existing.push(relation);
+      return;
+    }
+    index.set(endpointId, [relation]);
+  };
+
+  for (const relation of Object.values(relations)) {
+    if (!relation) continue;
+    if (relation.source) fileUnder(relation.source, relation);
+    if (relation.destination && relation.destination !== relation.source) {
+      fileUnder(relation.destination, relation);
+    }
+  }
+
+  return index;
+};
+
+/** Relations touching any of `endpointIds`, deduped: an imported node matches on two ids. */
+export const collectRelations = ({
+  index,
+  endpointIds,
+}: {
+  index: Map<string, RelationInstance[]>;
+  endpointIds: Iterable<string>;
+}): RelationInstance[] => {
+  const seen = new Set<string>();
+  const collected: RelationInstance[] = [];
+
+  for (const endpointId of endpointIds) {
+    const relations = index.get(endpointId);
+    if (!relations) continue;
+    for (const relation of relations) {
+      if (seen.has(relation.id)) continue;
+      seen.add(relation.id);
+      collected.push(relation);
+    }
+  }
+
+  return collected;
+};

--- a/apps/obsidian/src/utils/relationsIndex.ts
+++ b/apps/obsidian/src/utils/relationsIndex.ts
@@ -35,6 +35,13 @@ export class RelationsIndex {
     this.plugin.registerEvent(vault.on("modify", invalidateIfRelationsFile));
     this.plugin.registerEvent(vault.on("create", invalidateIfRelationsFile));
     this.plugin.registerEvent(vault.on("delete", invalidateIfRelationsFile));
+    // Both directions: the file moving out of the root, and one moving in.
+    this.plugin.registerEvent(
+      vault.on("rename", (file, oldPath) => {
+        if (oldPath === getRelationsFilePath()) this.invalidate();
+        else invalidateIfRelationsFile(file);
+      }),
+    );
 
     void this.ensureLoaded();
   }

--- a/apps/obsidian/src/utils/relationsIndex.ts
+++ b/apps/obsidian/src/utils/relationsIndex.ts
@@ -1,0 +1,112 @@
+import { TAbstractFile, TFile } from "obsidian";
+import type DiscourseGraphPlugin from "~/index";
+import type { RelationInstance } from "~/types";
+import { getRelationsFilePath, loadRelations } from "./relationsStore";
+import { buildEndpointIndex, collectRelations } from "./relationsEndpointIndex";
+
+/**
+ * Parsed snapshot of relations.json so a render path can ask synchronously,
+ * rebuilt from vault events (which covers our own writes and sync alike).
+ */
+export class RelationsIndex {
+  private plugin: DiscourseGraphPlugin;
+  private index: Map<string, RelationInstance[]> | null = null;
+  private inFlight: Promise<void> | null = null;
+  private stale = false;
+  private unloaded = false;
+  /** Lets a ViewPlugin, which only sees transactions, detect a changed snapshot. */
+  private version = 0;
+  private subscribers = new Set<() => void>();
+  /** Guards against a load that started before an invalidation overwriting a newer one. */
+  private generation = 0;
+
+  constructor(plugin: DiscourseGraphPlugin) {
+    this.plugin = plugin;
+  }
+
+  initialize(): void {
+    const invalidateIfRelationsFile = (file: TAbstractFile): void => {
+      if (!(file instanceof TFile)) return;
+      if (file.path !== getRelationsFilePath()) return;
+      this.invalidate();
+    };
+
+    const { vault } = this.plugin.app;
+    this.plugin.registerEvent(vault.on("modify", invalidateIfRelationsFile));
+    this.plugin.registerEvent(vault.on("create", invalidateIfRelationsFile));
+    this.plugin.registerEvent(vault.on("delete", invalidateIfRelationsFile));
+
+    void this.ensureLoaded();
+  }
+
+  unload(): void {
+    this.unloaded = true;
+    this.subscribers.clear();
+    this.index = null;
+    this.inFlight = null;
+    this.generation += 1;
+  }
+
+  /** Changes whenever the snapshot is replaced; see the field comment. */
+  getVersion(): number {
+    return this.version;
+  }
+
+  /** Fires when the snapshot changes. Returns an unsubscribe function. */
+  onChange(subscriber: () => void): () => void {
+    this.subscribers.add(subscriber);
+    return () => this.subscribers.delete(subscriber);
+  }
+
+  async ensureLoaded(): Promise<void> {
+    if (this.unloaded) return;
+    if (this.index !== null && !this.stale) return;
+    if (this.inFlight) return this.inFlight;
+
+    const generation = this.generation;
+    this.inFlight = (async () => {
+      try {
+        const relationsFile = await loadRelations(this.plugin);
+        // Superseded mid-read; the invalidation already scheduled a reload.
+        if (generation !== this.generation || this.unloaded) return;
+        this.index = buildEndpointIndex(relationsFile.relations ?? {});
+        this.stale = false;
+        this.version += 1;
+      } finally {
+        // Every path, or ensureLoaded hands out a settled promise forever.
+        this.inFlight = null;
+      }
+      // The skipped invalidation above still needs a load of its own.
+      if (this.stale && !this.unloaded) {
+        void this.ensureLoaded();
+        return;
+      }
+      this.notify();
+    })();
+
+    return this.inFlight;
+  }
+
+  /**
+   * Empty while cold, so treat that as "not loaded yet", not "no relations".
+   * Never schedules a load: that would make notify -> re-render -> read loop.
+   */
+  getRelationsForEndpointIds(
+    endpointIds: Iterable<string>,
+  ): RelationInstance[] {
+    if (this.index === null) return [];
+    return collectRelations({ index: this.index, endpointIds });
+  }
+
+  /** Keeps the old snapshot while reloading, so badges do not flash to 0. */
+  private invalidate(): void {
+    this.generation += 1;
+    this.inFlight = null;
+    this.stale = true;
+    void this.ensureLoaded();
+  }
+
+  private notify(): void {
+    for (const subscriber of this.subscribers) subscriber();
+  }
+}

--- a/apps/obsidian/src/utils/relationsIndex.ts
+++ b/apps/obsidian/src/utils/relationsIndex.ts
@@ -80,8 +80,9 @@ export class RelationsIndex {
         this.stale = false;
         this.version += 1;
       } finally {
-        // Every path, or ensureLoaded hands out a settled promise forever.
-        this.inFlight = null;
+        // Only if still the current load: an invalidation mid-read starts a
+        // newer one, and clearing unconditionally would discard its tracking.
+        if (generation === this.generation) this.inFlight = null;
       }
       // The skipped invalidation above still needs a load of its own.
       if (this.stale && !this.unloaded) {

--- a/apps/obsidian/src/utils/wikilinkDragHandler.ts
+++ b/apps/obsidian/src/utils/wikilinkDragHandler.ts
@@ -10,6 +10,7 @@ import {
 import { TFile, WorkspaceLeaf } from "obsidian";
 import { VIEW_TYPE_TLDRAW_DG_PREVIEW } from "~/constants";
 import type DiscourseGraphPlugin from "~/index";
+import { extractLinktext, INTERNAL_LINK_RE } from "./internalLinkParsing";
 
 const buildObsidianUrl = (vaultName: string, filePath: string): string => {
   return `obsidian://open?vault=${encodeURIComponent(vaultName)}&file=${encodeURIComponent(filePath)}`;
@@ -41,29 +42,6 @@ const setDragData = (
 };
 
 // --- Live Preview ---
-
-/**
- * Extract the file path from a link match.
- * Handles wikilinks (`[[path]]`, `[[path|alias]]`) and
- * markdown links (`[text](path.md)`), decoding URL-encoded paths.
- */
-const extractLinkPath = (match: string): string => {
-  // Wikilink: [[path]] or [[path|alias]]
-  if (match.startsWith("[[")) {
-    const inner = match.slice(2, -2);
-    const pipeIndex = inner.indexOf("|");
-    return pipeIndex >= 0 ? inner.slice(0, pipeIndex) : inner;
-  }
-
-  // Markdown link: [text](path)
-  const parenOpen = match.lastIndexOf("(");
-  const rawPath = match.slice(parenOpen + 1, -1);
-  try {
-    return decodeURIComponent(rawPath);
-  } catch (error) {
-    return rawPath;
-  }
-};
 
 /**
  * Widget that renders a small drag handle next to an internal link.
@@ -103,10 +81,6 @@ class WikilinkDragHandleWidget extends WidgetType {
   }
 }
 
-// Matches wikilinks [[...]] and markdown links [text](path.md).
-// Embed exclusion (![[...]] and ![text](...)) is handled in the loop.
-const INTERNAL_LINK_RE = /\[\[([^\]]+)\]\]|\[([^\]]+)\]\(([^)]+\.md)\)/g;
-
 const hasVisibleCanvasLeaf = (plugin: DiscourseGraphPlugin): boolean =>
   plugin.app.workspace
     .getLeavesOfType(VIEW_TYPE_TLDRAW_DG_PREVIEW)
@@ -133,7 +107,7 @@ const buildWidgetDecorations = (
         view.state.doc.sliceString(checkPos, checkPos + 1) === "!";
       if (isEmbed) continue;
       const matchEnd = from + match.index + match[0].length;
-      const linkPath = extractLinkPath(match[0]);
+      const linkPath = extractLinktext(match[0]);
       const widget = new WikilinkDragHandleWidget(linkPath, plugin);
       widgets.push(Decoration.widget({ widget, side: 1 }).range(matchEnd));
     }


### PR DESCRIPTION
https://www.loom.com/share/ead877cbf304493bbfc087dfc09b10a2

https://www.loom.com/share/2f5badd2168546dba687e2844ebc2d46


First of three stacked PRs for ENG-1249. Stack: **this** → #1414 → #1415.

## Reviewer brief

**Result:** No user-visible change. This adds the data layer the overlay needs; nothing consumes it yet.

**Review focus:** the concurrency rules in `RelationsIndex`, and what the relation count deliberately excludes. Both are expanded below.

<details>
<summary><b>Why an index exists at all</b> — the cost argument</summary>

<br>

`getRelationsForFile` reads and parses the whole of `relations.json`, then scans every relation in it:

```mermaid
flowchart LR
  A["vault.read relations.json"] --> B["JSON.parse — 50 relations"]
  B --> C["Object.values .filter"]
```

That is fine for the Discourse Context panel, which asks once per file open. The overlay asks **once per discourse-node link on screen, per viewport update**. On a note with 40 such links that is 40 file reads and 40 parses to answer 40 questions about one document — on every keystroke.

`RelationsIndex` keeps a parsed snapshot grouped by endpoint id, so a lookup is a `Map` hit and answers **synchronously** — which matters as much as speed, because a CodeMirror `ViewPlugin` cannot await anything while building decorations.

```mermaid
flowchart LR
  subgraph store["relations.json"]
    R1["r1: a to b"]
    R2["r2: c to a"]
    R3["r3: a to a"]
  end
  store --> IDX["endpoint index<br>a → r1, r2, r3<br>b → r1<br>c → r2"]
  IDX --> Q["get('a') → 3<br>O(1), no await"]
```

Each relation is filed under **both** endpoints, so "relations touching X" is one lookup regardless of direction. A self-relation like `r3` is filed once, not twice, so one endpoint never yields it twice.

</details>

<details>
<summary><b>The concurrency rules</b> — each one is load-bearing</summary>

<br>

| Rule | Why it exists |
|---|---|
| Generation counter | A load that began before an invalidation is stale when it resolves and must not overwrite a newer snapshot. Not exotic: writing a relation modifies the file *while* a read may be in flight. |
| `inFlight` cleared in a `finally` | If a superseded load returns early without clearing it, `ensureLoaded` hands out an already-settled promise forever — the snapshot stays stale and every later read requests a load that never runs. |
| Reads never schedule loads | A read that triggers a load triggers a notify → re-render → read. Loading belongs to `initialize()` and `invalidate()` only. |
| Invalidation keeps the old snapshot | Dropping it would flash every badge to `0` until the reload lands — on the very action that triggered it, since saving a relation writes `relations.json`. |
| A version counter | So a `ViewPlugin`, which can only observe transactions, can detect that counts changed. Used by #1414. |

</details>

<details>
<summary><b>What the count excludes, and why it must</b></summary>

<br>

"How many relations does this node have?" is ambiguous. A node in the test vault has **6** relations in `relations.json`; the panel lists **4**.

| Relations | Type still configured? | Panel lists it? |
|---|---|---|
| r1, r2 | no — the type was deleted | no |
| r3–r6 | yes | yes |

Deleting a relation type does not delete its relations; they stay as orphans and the panel drops them while grouping by type. Imported relations awaiting acceptance (`tentative === false`) are likewise listed separately.

> [!IMPORTANT]
> The badge counts **what the panel would list**, not what the store holds. A badge reading 6 above a popover listing 4 advertises context the next click refuses to show. An earlier revision had exactly that bug.

</details>

## Verification

- `pnpm install --frozen-lockfile` + `pnpm ci:validate`: 8/8 check-types, 5/5 test:unit.
- Loaded in a real vault over CDP: the index initializes, reports the expected relation count for a known node, and renders no UI.

## Scope check

- [x] Ran `$scope-check` against the ENG ticket and final diff.
- Scope beyond `Done When`: **None.** Groundwork for the ticket's overlay requirement.

## Local delegated full review

- [x] Ran a comprehensive review of the entire final diff in a subagent with a fresh context.

Review findings addressed here: `relations.json` renames now invalidate the snapshot, and markdown links with a `#heading` subpath now match. One finding is open by design — see the thread on `discourseLinkFrontmatter.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
