### PR TITLE
ENG-1249 Implement Discourse context overlay in Live Preview

### DIFF
--- a/apps/obsidian/src/components/DiscourseContextPopover.tsx
+++ b/apps/obsidian/src/components/DiscourseContextPopover.tsx
@@ -1,0 +1,156 @@
+import { TFile } from "obsidian";
+import { createRoot, Root } from "react-dom/client";
+import type DiscourseGraphPlugin from "~/index";
+import { PluginProvider } from "~/components/PluginContext";
+import { RelationshipSection } from "~/components/RelationshipSection";
+
+const POPOVER_CLASS = "dg-discourse-context-popover";
+const VIEWPORT_MARGIN = 8;
+const EMPTY_MESSAGE = "No discourse relation found";
+
+/** Positions the popover under its badge, clamped inside the viewport. */
+const positionPopover = (popover: HTMLElement, anchor: HTMLElement): void => {
+  // The anchor's own window, or a popout gets clamped to the wrong viewport.
+  const win = anchor.ownerDocument.defaultView ?? window;
+  const anchorRect = anchor.getBoundingClientRect();
+  const { width, height } = popover.getBoundingClientRect();
+
+  const left = Math.min(
+    Math.max(VIEWPORT_MARGIN, anchorRect.left),
+    Math.max(VIEWPORT_MARGIN, win.innerWidth - width - VIEWPORT_MARGIN),
+  );
+
+  const spaceBelow = win.innerHeight - anchorRect.bottom;
+  const openUpward =
+    spaceBelow < height + VIEWPORT_MARGIN && anchorRect.top > height;
+  const top = openUpward
+    ? Math.max(VIEWPORT_MARGIN, anchorRect.top - height - 4)
+    : anchorRect.bottom + 4;
+
+  popover.style.left = `${left}px`;
+  popover.style.top = `${top}px`;
+};
+
+type PopoverOptions = {
+  plugin: DiscourseGraphPlugin;
+  file: TFile;
+  anchor: HTMLElement;
+  relationCount: number;
+};
+
+/**
+ * Discourse context shown when a badge is selected. Reuses RelationshipSection
+ * so it cannot disagree with the panel. Only one is open at a time.
+ */
+class DiscourseContextPopover {
+  private containerEl: HTMLElement;
+  private root: Root;
+  private plugin: DiscourseGraphPlugin;
+  private win: Window;
+  private reposition: () => void = () => {};
+  private resizeObserver: ResizeObserver | null = null;
+  private cleanupListeners: (() => void)[] = [];
+
+  constructor({ plugin, file, anchor, relationCount }: PopoverOptions) {
+    this.plugin = plugin;
+    const doc = anchor.ownerDocument;
+    this.win = doc.defaultView ?? window;
+    this.containerEl = doc.body.createDiv({ cls: POPOVER_CLASS });
+    this.containerEl.addClass(
+      "fixed",
+      "z-50",
+      "max-h-[60vh]",
+      "w-80",
+      "overflow-y-auto",
+      "rounded-md",
+      "border",
+      "border-solid",
+      "border-[var(--background-modifier-border)]",
+      "bg-[var(--background-primary)]",
+      "p-3",
+      "shadow-lg",
+    );
+
+    // CurrentRelationships renders nothing when empty, leaving a bare button.
+    if (relationCount === 0) {
+      this.containerEl.createDiv({
+        cls: "mb-2 text-sm text-[var(--text-muted)]",
+        text: EMPTY_MESSAGE,
+      });
+    }
+
+    const reactHost = this.containerEl.createDiv();
+    this.root = createRoot(reactHost);
+    this.root.render(
+      <PluginProvider plugin={this.plugin}>
+        <RelationshipSection activeFile={file} />
+      </PluginProvider>,
+    );
+
+    // A React 18 root commits async, so measure again after paint and on resize.
+    positionPopover(this.containerEl, anchor);
+    this.reposition = () => positionPopover(this.containerEl, anchor);
+    this.win.requestAnimationFrame(this.reposition);
+    this.resizeObserver = new ResizeObserver(this.reposition);
+    this.resizeObserver.observe(this.containerEl);
+
+    this.registerDismissListeners();
+  }
+
+  private registerDismissListeners(): void {
+    const doc = this.containerEl.ownerDocument;
+    const closeIfOutside = (event: MouseEvent): void => {
+      if (this.containerEl.contains(event.target as Node)) return;
+      this.close();
+    };
+    const closeOnEscape = (event: KeyboardEvent): void => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      this.close();
+    };
+    // Scrolling the note dismisses; scrolling the popover's own content must not.
+    const closeOnScroll = (event: Event): void => {
+      if (this.containerEl.contains(event.target as Node)) return;
+      this.close();
+    };
+
+    // Deferred so the opening click is not read as an outside click.
+    const attach = this.win.setTimeout(() => {
+      doc.addEventListener("click", closeIfOutside, true);
+    }, 0);
+
+    doc.addEventListener("keydown", closeOnEscape);
+    // Capture phase: scrolling happens inside panes, not on window.
+    doc.addEventListener("scroll", closeOnScroll, true);
+
+    this.cleanupListeners.push(() => {
+      this.win.clearTimeout(attach);
+      doc.removeEventListener("click", closeIfOutside, true);
+      doc.removeEventListener("keydown", closeOnEscape);
+      doc.removeEventListener("scroll", closeOnScroll, true);
+    });
+  }
+
+  close(): void {
+    for (const cleanup of this.cleanupListeners) cleanup();
+    this.cleanupListeners = [];
+    this.resizeObserver?.disconnect();
+    this.resizeObserver = null;
+    // Deferred: unmounting during React's event handling warns.
+    const root = this.root;
+    this.win.setTimeout(() => root.unmount(), 0);
+    this.containerEl.remove();
+    if (activePopover === this) activePopover = null;
+  }
+}
+
+let activePopover: DiscourseContextPopover | null = null;
+
+export const openDiscourseContextPopover = (options: PopoverOptions): void => {
+  activePopover?.close();
+  activePopover = new DiscourseContextPopover(options);
+};
+
+export const closeDiscourseContextPopover = (): void => {
+  activePopover?.close();
+};

--- a/apps/obsidian/src/components/DiscourseContextPopover.tsx
+++ b/apps/obsidian/src/components/DiscourseContextPopover.tsx
@@ -25,7 +25,6 @@ const POPOVER_CLASS = "dg-discourse-context-popover";
 const VIEWPORT_MARGIN = 8;
 const EMPTY_MESSAGE = "No discourse relation found";
 
-/** Positions the popover under its badge, clamped inside the viewport. */
 const positionPopover = (popover: HTMLElement, anchor: HTMLElement): void => {
   // The anchor's own window, or a popout gets clamped to the wrong viewport.
   const win = anchor.ownerDocument.defaultView ?? window;
@@ -58,8 +57,8 @@ type PopoverOptions = {
 };
 
 /**
- * Discourse context shown when a badge is selected. Reuses RelationshipSection
- * so it cannot disagree with the panel. Only one is open at a time.
+ * Reuses RelationshipSection so it cannot disagree with the sidebar panel.
+ * Only one is open at a time.
  */
 class DiscourseContextPopover {
   private containerEl: HTMLElement;

--- a/apps/obsidian/src/components/DiscourseContextPopover.tsx
+++ b/apps/obsidian/src/components/DiscourseContextPopover.tsx
@@ -3,6 +3,23 @@ import { createRoot, Root } from "react-dom/client";
 import type DiscourseGraphPlugin from "~/index";
 import { PluginProvider } from "~/components/PluginContext";
 import { RelationshipSection } from "~/components/RelationshipSection";
+import {
+  countDisplayableRelations,
+  getEndpointIdsFromFrontmatter,
+} from "~/utils/discourseLinkFrontmatter";
+import { getRelationTypeById } from "~/utils/typeUtils";
+
+const countRelationsForFile = (
+  plugin: DiscourseGraphPlugin,
+  file: TFile,
+): number => {
+  const frontmatter = plugin.app.metadataCache.getFileCache(file)?.frontmatter;
+  const endpointIds = getEndpointIdsFromFrontmatter(frontmatter);
+  return countDisplayableRelations({
+    relations: plugin.relationsIndex.getRelationsForEndpointIds(endpointIds),
+    isConfiguredType: (id) => !!getRelationTypeById(plugin, id),
+  });
+};
 
 const POPOVER_CLASS = "dg-discourse-context-popover";
 const VIEWPORT_MARGIN = 8;
@@ -21,8 +38,10 @@ const positionPopover = (popover: HTMLElement, anchor: HTMLElement): void => {
   );
 
   const spaceBelow = win.innerHeight - anchorRect.bottom;
+  // Open upward only when that genuinely has more room, so a popover taller
+  // than either side still lands on the roomier one instead of clipping.
   const openUpward =
-    spaceBelow < height + VIEWPORT_MARGIN && anchorRect.top > height;
+    spaceBelow < height + VIEWPORT_MARGIN && anchorRect.top > spaceBelow;
   const top = openUpward
     ? Math.max(VIEWPORT_MARGIN, anchorRect.top - height - 4)
     : anchorRect.bottom + 4;
@@ -49,6 +68,7 @@ class DiscourseContextPopover {
   private win: Window;
   private reposition: () => void = () => {};
   private resizeObserver: ResizeObserver | null = null;
+  private emptyEl: HTMLElement | null = null;
   private cleanupListeners: (() => void)[] = [];
 
   constructor({ plugin, file, anchor, relationCount }: PopoverOptions) {
@@ -73,10 +93,19 @@ class DiscourseContextPopover {
 
     // CurrentRelationships renders nothing when empty, leaving a bare button.
     if (relationCount === 0) {
-      this.containerEl.createDiv({
+      this.emptyEl = this.containerEl.createDiv({
         cls: "mb-2 text-sm text-[var(--text-muted)]",
         text: EMPTY_MESSAGE,
       });
+      // It lives outside React, so RelationshipSection cannot clear it when the
+      // first relation is added from this very popover.
+      this.cleanupListeners.push(
+        plugin.relationsIndex.onChange(() => {
+          if (countRelationsForFile(plugin, file) === 0) return;
+          this.emptyEl?.remove();
+          this.emptyEl = null;
+        }),
+      );
     }
 
     const reactHost = this.containerEl.createDiv();
@@ -101,6 +130,9 @@ class DiscourseContextPopover {
     const doc = this.containerEl.ownerDocument;
     const closeIfOutside = (event: MouseEvent): void => {
       if (this.containerEl.contains(event.target as Node)) return;
+      // AbstractInputSuggest mounts its list on body, so a click picking a node
+      // for a new relation would otherwise dismiss the popover behind it.
+      if ((event.target as Element)?.closest?.(".suggestion-container")) return;
       this.close();
     };
     const closeOnEscape = (event: KeyboardEvent): void => {

--- a/apps/obsidian/src/components/DiscourseContextView.tsx
+++ b/apps/obsidian/src/components/DiscourseContextView.tsx
@@ -10,6 +10,7 @@ import { createRoot, Root } from "react-dom/client";
 import DiscourseGraphPlugin from "~/index";
 import { getDiscourseNodeFormatExpression } from "~/utils/getDiscourseNodeFormatExpression";
 import { RelationshipSection } from "~/components/RelationshipSection";
+import { InfoTooltip } from "~/components/InfoTooltip";
 import { VIEW_TYPE_DISCOURSE_CONTEXT } from "~/types";
 import { PluginProvider, usePlugin } from "~/components/PluginContext";
 import {
@@ -25,21 +26,6 @@ import { useState } from "react";
 type DiscourseContextProps = {
   activeFile: TFile | null;
 };
-
-type InfoTooltipProps = {
-  content: string;
-};
-
-export const InfoTooltip = ({ content }: InfoTooltipProps) => (
-  <button
-    ref={(el) => {
-      if (el) setTooltip(el, content);
-    }}
-    className="clickable-icon text-muted hover:text-normal flex h-4 w-4 items-center justify-center"
-  >
-    <div ref={(el) => (el && setIcon(el, "info")) || undefined} />
-  </button>
-);
 
 const DiscourseContext = ({ activeFile }: DiscourseContextProps) => {
   const plugin = usePlugin();

--- a/apps/obsidian/src/components/GeneralSettings.tsx
+++ b/apps/obsidian/src/components/GeneralSettings.tsx
@@ -197,6 +197,8 @@ const GeneralSettings = () => {
   const [showHelpMenuStatusBarIcon, setShowHelpMenuStatusBarIcon] = useState(
     plugin.settings.showHelpMenuStatusBarIcon,
   );
+  const [showDiscourseContextOverlay, setShowDiscourseContextOverlay] =
+    useState(plugin.settings.showDiscourseContextOverlay);
 
   const handleToggleChange = (newValue: boolean) => {
     setShowIdsInFrontmatter(newValue);
@@ -208,6 +210,13 @@ const GeneralSettings = () => {
     setShowHelpMenuStatusBarIcon(newValue);
     plugin.settings.showHelpMenuStatusBarIcon = newValue;
     plugin.setHelpMenuStatusBarItemVisibility();
+    void plugin.saveSettings();
+  };
+
+  const handleDiscourseContextOverlayToggleChange = (newValue: boolean) => {
+    setShowDiscourseContextOverlay(newValue);
+    plugin.settings.showDiscourseContextOverlay = newValue;
+    plugin.refreshDiscourseContextOverlay();
     void plugin.saveSettings();
   };
 
@@ -342,6 +351,13 @@ const GeneralSettings = () => {
           />
         </div>
       </div>
+
+      <ToggleSetting
+        name="Show discourse context overlay"
+        description="Shows a badge next to links to discourse nodes with how many relations each one has. Select a badge to open its discourse context."
+        checked={showDiscourseContextOverlay}
+        onChange={handleDiscourseContextOverlayToggleChange}
+      />
 
       <ToggleSetting
         name="Show help menu icon in status bar"

--- a/apps/obsidian/src/components/InfoTooltip.tsx
+++ b/apps/obsidian/src/components/InfoTooltip.tsx
@@ -1,0 +1,16 @@
+import { setIcon, setTooltip } from "obsidian";
+
+type InfoTooltipProps = {
+  content: string;
+};
+
+export const InfoTooltip = ({ content }: InfoTooltipProps) => (
+  <button
+    ref={(el) => {
+      if (el) setTooltip(el, content);
+    }}
+    className="clickable-icon text-muted hover:text-normal flex h-4 w-4 items-center justify-center"
+  >
+    <div ref={(el) => (el && setIcon(el, "info")) || undefined} />
+  </button>
+);

--- a/apps/obsidian/src/components/RelationshipSection.tsx
+++ b/apps/obsidian/src/components/RelationshipSection.tsx
@@ -26,7 +26,7 @@ import {
   removeRelationBySourceDestinationType,
   updateRelation,
 } from "~/utils/relationsStore";
-import { InfoTooltip } from "./DiscourseContextView";
+import { InfoTooltip } from "./InfoTooltip";
 
 type RelationTypeOption = {
   id: string;

--- a/apps/obsidian/src/components/discourseContextBadge.ts
+++ b/apps/obsidian/src/components/discourseContextBadge.ts
@@ -22,8 +22,8 @@ const badgeTooltip = ({
 };
 
 /**
- * Inline badge next to a link to a discourse node. Plain DOM, not React, so both
- * render paths share it without mounting a React root per link.
+ * Plain DOM, not React, so both render paths share it without mounting a React
+ * root per link.
  */
 export const createDiscourseContextBadge = ({
   file,
@@ -72,10 +72,7 @@ export const createDiscourseContextBadge = ({
 export const badgeTargetPath = (badge: Element): string | null =>
   badge.getAttribute(BADGE_PATH_ATTR);
 
-/**
- * Updates a badge's count without replacing the element, so an open popover
- * anchored to it keeps a connected anchor to position against.
- */
+/** In place, so an open popover anchored to it keeps a connected anchor. */
 export const updateDiscourseContextBadge = ({
   badge,
   nodeType,

--- a/apps/obsidian/src/components/discourseContextBadge.ts
+++ b/apps/obsidian/src/components/discourseContextBadge.ts
@@ -1,0 +1,66 @@
+import { setIcon, setTooltip, TFile } from "obsidian";
+import type { DiscourseNode } from "~/types";
+
+/** Marks a badge so a re-run can find and replace it. */
+export const DISCOURSE_CONTEXT_BADGE_CLASS = "dg-discourse-context-badge";
+
+export type DiscourseContextBadgeProps = {
+  file: TFile;
+  nodeType: DiscourseNode;
+  relationCount: number;
+  onActivate: (args: { file: TFile; anchor: HTMLElement }) => void;
+};
+
+const badgeTooltip = ({
+  nodeType,
+  relationCount,
+}: Pick<DiscourseContextBadgeProps, "nodeType" | "relationCount">): string => {
+  const relations = relationCount === 1 ? "relation" : "relations";
+  return `${nodeType.name}: ${relationCount} ${relations} — open discourse context`;
+};
+
+/**
+ * Inline badge next to a link to a discourse node. Plain DOM, not React, so both
+ * render paths share it without mounting a React root per link.
+ */
+export const createDiscourseContextBadge = ({
+  file,
+  nodeType,
+  relationCount,
+  onActivate,
+}: DiscourseContextBadgeProps): HTMLElement => {
+  const badge = createSpan();
+  badge.className = `${DISCOURSE_CONTEXT_BADGE_CLASS} inline-flex items-center gap-0.5 align-middle ml-1 px-1 rounded cursor-pointer select-none text-[10px] leading-none text-[var(--text-muted)] hover:text-[var(--text-normal)] hover:bg-[var(--background-modifier-hover)] transition-colors duration-150`;
+
+  const icon = badge.createSpan({
+    cls: "inline-flex items-center [&>svg]:h-3 [&>svg]:w-3",
+  });
+  setIcon(icon, "network");
+
+  badge.createSpan({ text: String(relationCount) });
+
+  const label = badgeTooltip({ nodeType, relationCount });
+  setTooltip(badge, label);
+  badge.setAttribute("aria-label", label);
+  badge.setAttribute("role", "button");
+  badge.setAttribute("tabindex", "0");
+
+  const activate = (event: Event): void => {
+    // Do not follow the link the badge sits next to.
+    event.preventDefault();
+    event.stopPropagation();
+    onActivate({ file, anchor: badge });
+  };
+
+  // Otherwise the caret moves, expanding the raw [[...]] under the popover.
+  badge.addEventListener("mousedown", (event: MouseEvent) => {
+    event.preventDefault();
+  });
+  badge.addEventListener("click", activate);
+  badge.addEventListener("keydown", (event: KeyboardEvent) => {
+    if (event.key !== "Enter" && event.key !== " ") return;
+    activate(event);
+  });
+
+  return badge;
+};

--- a/apps/obsidian/src/components/discourseContextBadge.ts
+++ b/apps/obsidian/src/components/discourseContextBadge.ts
@@ -1,8 +1,10 @@
 import { setIcon, setTooltip, TFile } from "obsidian";
 import type { DiscourseNode } from "~/types";
 
-/** Marks a badge so a re-run can find and replace it. */
+/** Marks a badge so a re-run can find and update it. */
 export const DISCOURSE_CONTEXT_BADGE_CLASS = "dg-discourse-context-badge";
+const BADGE_COUNT_CLASS = "dg-discourse-context-badge-count";
+const BADGE_PATH_ATTR = "data-dg-path";
 
 export type DiscourseContextBadgeProps = {
   file: TFile;
@@ -37,13 +39,14 @@ export const createDiscourseContextBadge = ({
   });
   setIcon(icon, "network");
 
-  badge.createSpan({ text: String(relationCount) });
+  badge.createSpan({ cls: BADGE_COUNT_CLASS, text: String(relationCount) });
 
   const label = badgeTooltip({ nodeType, relationCount });
   setTooltip(badge, label);
   badge.setAttribute("aria-label", label);
   badge.setAttribute("role", "button");
   badge.setAttribute("tabindex", "0");
+  badge.setAttribute(BADGE_PATH_ATTR, file.path);
 
   const activate = (event: Event): void => {
     // Do not follow the link the badge sits next to.
@@ -63,4 +66,29 @@ export const createDiscourseContextBadge = ({
   });
 
   return badge;
+};
+
+/** The badge's target, so a refresh can tell an update from a replacement. */
+export const badgeTargetPath = (badge: Element): string | null =>
+  badge.getAttribute(BADGE_PATH_ATTR);
+
+/**
+ * Updates a badge's count without replacing the element, so an open popover
+ * anchored to it keeps a connected anchor to position against.
+ */
+export const updateDiscourseContextBadge = ({
+  badge,
+  nodeType,
+  relationCount,
+}: {
+  badge: HTMLElement;
+  nodeType: DiscourseNode;
+  relationCount: number;
+}): void => {
+  const count = badge.querySelector(`.${BADGE_COUNT_CLASS}`);
+  if (count) count.textContent = String(relationCount);
+
+  const label = badgeTooltip({ nodeType, relationCount });
+  setTooltip(badge, label);
+  badge.setAttribute("aria-label", label);
 };

--- a/apps/obsidian/src/constants.ts
+++ b/apps/obsidian/src/constants.ts
@@ -119,6 +119,7 @@ export const DEFAULT_SETTINGS: Settings = {
   canvasAttachmentsFolderPath: "attachments",
   nodeTagHotkey: "\\",
   showHelpMenuStatusBarIcon: false,
+  showDiscourseContextOverlay: true,
   spacePassword: undefined,
   accountLocalId: undefined,
   syncModeEnabled: false,

--- a/apps/obsidian/src/index.ts
+++ b/apps/obsidian/src/index.ts
@@ -20,6 +20,13 @@ import {
 } from "~/utils/editorMenuUtils";
 import { createImageEmbedHoverExtension } from "~/utils/imageEmbedHoverIcon";
 import { createWikilinkDragExtension } from "~/utils/wikilinkDragHandler";
+import { createDiscourseContextOverlayExtension } from "~/utils/discourseContextOverlayExtension";
+import {
+  registerDiscourseContextOverlayRefresh,
+  refreshDiscourseContextOverlaySurfaces,
+} from "~/utils/discourseContextOverlayRefresh";
+import { refreshMarkdownEditors } from "~/utils/markdownViewRefresh";
+import { closeDiscourseContextPopover } from "~/components/DiscourseContextPopover";
 import {
   registerCommands,
   createModifyNodeModalSubmitHandler,
@@ -101,6 +108,7 @@ export default class DiscourseGraphPlugin extends Plugin {
     }
 
     this.relationsIndex.initialize();
+    registerDiscourseContextOverlayRefresh(this);
 
     registerCommands(this);
     this.addSettingTab(new SettingsTab(this.app, this));
@@ -272,34 +280,20 @@ export default class DiscourseGraphPlugin extends Plugin {
       }),
     );
 
-    type EditorWithCm = { cm: EditorView };
-    const hasCodeMirrorView = (editor: unknown): editor is EditorWithCm => {
-      if (!editor || typeof editor !== "object") return false;
-      return "cm" in editor;
-    };
-
-    // Dispatch a no-op CM6 transaction to every markdown editor so their
-    // ViewPlugin re-evaluates hasVisibleCanvasLeaf and shows/hides widgets.
-    // layout-change covers splits/moves, active-leaf-change covers tab switches.
-    const refreshMarkdownEditors = (): void => {
-      this.app.workspace.iterateAllLeaves((leaf) => {
-        if (
-          leaf.view instanceof MarkdownView &&
-          hasCodeMirrorView(leaf.view.editor)
-        ) {
-          leaf.view.editor.cm.dispatch({});
-        }
-      });
-    };
+    // Re-evaluate ViewPlugins on splits/moves (layout-change) and tab switches.
+    const refreshEditors = (): void => refreshMarkdownEditors(this.app);
+    this.registerEvent(this.app.workspace.on("layout-change", refreshEditors));
     this.registerEvent(
-      this.app.workspace.on("layout-change", refreshMarkdownEditors),
-    );
-    this.registerEvent(
-      this.app.workspace.on("active-leaf-change", refreshMarkdownEditors),
+      this.app.workspace.on("active-leaf-change", refreshEditors),
     );
 
     // Register editor keydown listener for node tag hotkey
     this.setupNodeTagHotkey();
+  }
+
+  /** Applies the overlay setting immediately, without a reload. */
+  refreshDiscourseContextOverlay(): void {
+    refreshDiscourseContextOverlaySurfaces(this);
   }
 
   setHelpMenuStatusBarItemVisibility(): void {
@@ -373,6 +367,7 @@ export default class DiscourseGraphPlugin extends Plugin {
     this.registerEditorExtension(createImageEmbedHoverExtension(this));
 
     this.registerEditorExtension(createWikilinkDragExtension(this));
+    this.registerEditorExtension(createDiscourseContextOverlayExtension(this));
   }
 
   updateFrontmatterStyles(): void {
@@ -493,6 +488,8 @@ export default class DiscourseGraphPlugin extends Plugin {
       this.fileChangeListener = null;
     }
 
+    // Lives on document.body with its own listeners; would outlive the plugin.
+    closeDiscourseContextPopover();
     this.relationsIndex.unload();
   }
 }

--- a/apps/obsidian/src/types.ts
+++ b/apps/obsidian/src/types.ts
@@ -68,6 +68,7 @@ export type Settings = {
   canvasAttachmentsFolderPath: string;
   nodeTagHotkey: string;
   showHelpMenuStatusBarIcon: boolean;
+  showDiscourseContextOverlay: boolean;
   spacePassword?: string;
   accountLocalId?: string;
   syncModeEnabled?: boolean;

--- a/apps/obsidian/src/utils/discourseContextOverlayExtension.ts
+++ b/apps/obsidian/src/utils/discourseContextOverlayExtension.ts
@@ -1,0 +1,141 @@
+import {
+  type PluginValue,
+  ViewPlugin,
+  type ViewUpdate,
+  WidgetType,
+  Decoration,
+  type DecorationSet,
+  EditorView,
+} from "@codemirror/view";
+import { editorInfoField, editorLivePreviewField } from "obsidian";
+import type DiscourseGraphPlugin from "~/index";
+import { createDiscourseContextBadge } from "~/components/discourseContextBadge";
+import { openDiscourseContextPopover } from "~/components/DiscourseContextPopover";
+import {
+  resolveDiscourseLinkTarget,
+  type DiscourseLinkTarget,
+} from "./discourseLinkUtils";
+import { extractLinktext, INTERNAL_LINK_RE } from "./internalLinkParsing";
+
+class DiscourseContextBadgeWidget extends WidgetType {
+  constructor(
+    private target: DiscourseLinkTarget,
+    private plugin: DiscourseGraphPlugin,
+  ) {
+    super();
+  }
+
+  /** Keyed on what the badge displays, so keystrokes elsewhere do not rebuild it. */
+  eq(other: DiscourseContextBadgeWidget): boolean {
+    return (
+      this.target.file.path === other.target.file.path &&
+      this.target.relationCount === other.target.relationCount &&
+      this.target.nodeType.id === other.target.nodeType.id &&
+      this.target.nodeType.name === other.target.nodeType.name
+    );
+  }
+
+  toDOM(): HTMLElement {
+    return createDiscourseContextBadge({
+      file: this.target.file,
+      nodeType: this.target.nodeType,
+      relationCount: this.target.relationCount,
+      onActivate: ({ file, anchor }) =>
+        openDiscourseContextPopover({
+          plugin: this.plugin,
+          file,
+          anchor,
+          relationCount: this.target.relationCount,
+        }),
+    });
+  }
+
+  /** True (the CM6 default) means the editor ignores the event, so our click handler runs. */
+  ignoreEvent(): boolean {
+    return true;
+  }
+}
+
+const buildBadgeDecorations = (
+  view: EditorView,
+  plugin: DiscourseGraphPlugin,
+): DecorationSet => {
+  if (!plugin.settings.showDiscourseContextOverlay) return Decoration.none;
+  // Source mode shows raw markdown; a badge there is noise.
+  if (!view.state.field(editorLivePreviewField, false)) return Decoration.none;
+
+  const sourcePath = view.state.field(editorInfoField, false)?.file?.path;
+  if (!sourcePath) return Decoration.none;
+
+  const widgets = [];
+
+  for (const { from, to } of view.visibleRanges) {
+    const text = view.state.doc.sliceString(from, to);
+    let match: RegExpExecArray | null;
+    INTERNAL_LINK_RE.lastIndex = 0;
+
+    while ((match = INTERNAL_LINK_RE.exec(text)) !== null) {
+      const checkPos = from + match.index - 1;
+      const isEmbed =
+        checkPos >= 0 &&
+        view.state.doc.sliceString(checkPos, checkPos + 1) === "!";
+      if (isEmbed) continue;
+
+      const target = resolveDiscourseLinkTarget({
+        plugin,
+        linktext: extractLinktext(match[0]),
+        sourcePath,
+      });
+      if (!target) continue;
+
+      const matchEnd = from + match.index + match[0].length;
+      widgets.push(
+        Decoration.widget({
+          widget: new DiscourseContextBadgeWidget(target, plugin),
+          side: 1,
+        }).range(matchEnd),
+      );
+    }
+  }
+
+  return Decoration.set(widgets, true);
+};
+
+/** Renders the badge after each discourse-node link in Live Preview. */
+export const createDiscourseContextOverlayExtension = (
+  plugin: DiscourseGraphPlugin,
+): ViewPlugin<PluginValue> =>
+  ViewPlugin.fromClass(
+    class {
+      decorations: DecorationSet;
+      private enabled: boolean;
+      private indexVersion: number;
+
+      constructor(view: EditorView) {
+        this.enabled = plugin.settings.showDiscourseContextOverlay;
+        this.indexVersion = plugin.relationsIndex.getVersion();
+        this.decorations = buildBadgeDecorations(view, plugin);
+      }
+
+      update(update: ViewUpdate): void {
+        // Setting and relation changes arrive as an empty transaction, which
+        // changes neither doc nor viewport, so both need comparing explicitly.
+        const enabled = plugin.settings.showDiscourseContextOverlay;
+        const indexVersion = plugin.relationsIndex.getVersion();
+        if (
+          !update.docChanged &&
+          !update.viewportChanged &&
+          enabled === this.enabled &&
+          indexVersion === this.indexVersion
+        ) {
+          return;
+        }
+        this.enabled = enabled;
+        this.indexVersion = indexVersion;
+        this.decorations = buildBadgeDecorations(update.view, plugin);
+      }
+    },
+    {
+      decorations: (v) => v.decorations,
+    },
+  );

--- a/apps/obsidian/src/utils/discourseContextOverlayExtension.ts
+++ b/apps/obsidian/src/utils/discourseContextOverlayExtension.ts
@@ -117,7 +117,6 @@ const buildBadgeDecorations = (
   return Decoration.set(widgets, true);
 };
 
-/** Renders the badge after each discourse-node link in Live Preview. */
 export const createDiscourseContextOverlayExtension = (
   plugin: DiscourseGraphPlugin,
 ): ViewPlugin<PluginValue> =>

--- a/apps/obsidian/src/utils/discourseContextOverlayExtension.ts
+++ b/apps/obsidian/src/utils/discourseContextOverlayExtension.ts
@@ -9,7 +9,10 @@ import {
 } from "@codemirror/view";
 import { editorInfoField, editorLivePreviewField } from "obsidian";
 import type DiscourseGraphPlugin from "~/index";
-import { createDiscourseContextBadge } from "~/components/discourseContextBadge";
+import {
+  createDiscourseContextBadge,
+  updateDiscourseContextBadge,
+} from "~/components/discourseContextBadge";
 import { openDiscourseContextPopover } from "~/components/DiscourseContextPopover";
 import {
   resolveDiscourseLinkTarget,
@@ -48,6 +51,19 @@ class DiscourseContextBadgeWidget extends WidgetType {
           relationCount: this.target.relationCount,
         }),
     });
+  }
+
+  /**
+   * Updates in place so a popover anchored to this badge keeps a connected
+   * anchor; without this CM6 replaces the element on every count change.
+   */
+  updateDOM(dom: HTMLElement): boolean {
+    updateDiscourseContextBadge({
+      badge: dom,
+      nodeType: this.target.nodeType,
+      relationCount: this.target.relationCount,
+    });
+    return true;
   }
 
   /** True (the CM6 default) means the editor ignores the event, so our click handler runs. */

--- a/apps/obsidian/src/utils/discourseContextOverlayRefresh.ts
+++ b/apps/obsidian/src/utils/discourseContextOverlayRefresh.ts
@@ -31,10 +31,17 @@ export const registerDiscourseContextOverlayRefresh = (
   );
 
   plugin.register(plugin.relationsIndex.onChange(refresh));
+  // Files that were nodes must still trigger a refresh once they stop being
+  // one, or their existing badges never get removed.
+  const knownNodePaths = new Set<string>();
   // "changed", not "resolved": resolved also fires while a preview renders.
   plugin.registerEvent(
     plugin.app.metadataCache.on("changed", (file) => {
-      if (!isDiscourseNodeFile(plugin, file)) return;
+      if (isDiscourseNodeFile(plugin, file)) {
+        knownNodePaths.add(file.path);
+      } else if (!knownNodePaths.delete(file.path)) {
+        return;
+      }
       refresh();
     }),
   );

--- a/apps/obsidian/src/utils/discourseContextOverlayRefresh.ts
+++ b/apps/obsidian/src/utils/discourseContextOverlayRefresh.ts
@@ -1,0 +1,41 @@
+import { debounce, type TFile } from "obsidian";
+import type DiscourseGraphPlugin from "~/index";
+import { getNodeTypeIdFromFrontmatter } from "./discourseLinkFrontmatter";
+import { refreshMarkdownEditors } from "./markdownViewRefresh";
+
+const REFRESH_DEBOUNCE_MS = 300;
+
+/** Only a discourse node's own frontmatter can change what a badge shows. */
+const isDiscourseNodeFile = (
+  plugin: DiscourseGraphPlugin,
+  file: TFile,
+): boolean =>
+  !!getNodeTypeIdFromFrontmatter(
+    plugin.app.metadataCache.getFileCache(file)?.frontmatter,
+  );
+
+/** Redraws the overlay when relations or a node's frontmatter change. */
+export const refreshDiscourseContextOverlaySurfaces = (
+  plugin: DiscourseGraphPlugin,
+): void => {
+  refreshMarkdownEditors(plugin.app);
+};
+
+export const registerDiscourseContextOverlayRefresh = (
+  plugin: DiscourseGraphPlugin,
+): void => {
+  const refresh = debounce(
+    () => refreshDiscourseContextOverlaySurfaces(plugin),
+    REFRESH_DEBOUNCE_MS,
+    true,
+  );
+
+  plugin.register(plugin.relationsIndex.onChange(refresh));
+  // "changed", not "resolved": resolved also fires while a preview renders.
+  plugin.registerEvent(
+    plugin.app.metadataCache.on("changed", (file) => {
+      if (!isDiscourseNodeFile(plugin, file)) return;
+      refresh();
+    }),
+  );
+};

--- a/apps/obsidian/src/utils/markdownViewRefresh.ts
+++ b/apps/obsidian/src/utils/markdownViewRefresh.ts
@@ -1,0 +1,24 @@
+import { MarkdownView, type App } from "obsidian";
+import type { EditorView } from "@codemirror/view";
+
+type EditorWithCm = { cm: EditorView };
+
+export const hasCodeMirrorView = (editor: unknown): editor is EditorWithCm => {
+  if (!editor || typeof editor !== "object") return false;
+  return "cm" in editor;
+};
+
+/**
+ * Empty CM6 transaction to every open editor, forcing ViewPlugin.update() to
+ * run when something it reads changes outside the editor.
+ */
+export const refreshMarkdownEditors = (app: App): void => {
+  app.workspace.iterateAllLeaves((leaf) => {
+    if (
+      leaf.view instanceof MarkdownView &&
+      hasCodeMirrorView(leaf.view.editor)
+    ) {
+      leaf.view.editor.cm.dispatch({});
+    }
+  });
+};

--- a/apps/website/content/obsidian/configuration/general-settings.md
+++ b/apps/website/content/obsidian/configuration/general-settings.md
@@ -15,6 +15,16 @@ This setting controls the visibility of identifiers in your note's frontmatter s
 - When disabled, these IDs will be hidden from view
 - This can be useful if you prefer a cleaner frontmatter appearance while still maintaining the underlying structure
 
+## Show discourse context overlay
+
+This setting controls whether links to discourse nodes carry an inline badge showing how many relations the linked node has.
+
+- When enabled, a badge appears after each link to a discourse node in Live Preview
+- Selecting a badge opens that node's discourse context in a popover, where you can review its relationships and add a new one
+- A node with no relations shows a badge reading `0`, and its popover says "No discourse relation found"
+- Links to notes that are not discourse nodes never show a badge
+- When disabled, the badges are removed immediately; the [discourse context view](/docs/obsidian/core-features/discourse-context) remains available from the sidebar
+
 ## Discourse nodes folder path
 
 This setting determines where new discourse nodes will be created in your vault.

--- a/apps/website/content/obsidian/core-features/discourse-context.md
+++ b/apps/website/content/obsidian/core-features/discourse-context.md
@@ -26,6 +26,12 @@ You can configure a custom hotkey in the Obsidian settings to quickly toggle the
 
 3. Configure a custom hotkey in settings
 
+### Method 4: Using the discourse context overlay
+
+Links to a discourse node show a small badge with the number of relations that node has. Select the badge to open its discourse context in place, without leaving the note you are reading.
+
+The badge appears in Live Preview, on every link to a discourse node. A node with no relations yet shows a badge reading `0`, and opening it says "No discourse relation found" alongside the option to add one. You can turn the badge off in [General settings](/docs/obsidian/configuration/general-settings).
+
 ## Using the discourse context
 
 The discourse context view shows you:
@@ -41,3 +47,5 @@ You can use this view to:
 - Understand how nodes connect to each other
 - Add new relationships
 - Get a quick overview of your graph structure
+
+The overlay badge opens the same relationships in a popover, so it shows exactly what the sidebar view would show for that node. Relations that are still waiting to be accepted after an import are not counted in the badge; open the discourse context view to review those.


### PR DESCRIPTION
Second of three stacked PRs for ENG-1249. Stack: #1413 → **this** → #1415. **Based on #1413** — review that first; this diff is against it.

https://www.loom.com/share/a7a58ec7bfd54d34b702c395acffe819


## Reviewer brief

**Result:** In Live Preview, every link to a discourse node carries an inline badge with that node's relation count. Selecting it opens a popover listing those relations, with the option to add one. A node with no relations still badges, reading `0`, and its popover says "No discourse relation found". Toggled by **Show discourse context overlay** in General settings, applied without a reload. Reading view is unchanged and follows in #1415.

**Review focus:** how a badge learns its count changed, and the two CodeMirror flags whose meaning is easy to invert. Both expanded below.

<details>
<summary><b>How a badge gets on screen</b></summary>

<br>

```mermaid
flowchart LR
  DOC["editor text<br>see [[Claim A|this]]"] --> RE["extractLinktext<br>→ 'Claim A'"]
  RE --> RES["resolveDiscourseLinkTarget"]
  RES --> IDX[("RelationsIndex")]
  RES --> OUT["file, nodeType, count 4"]
  OUT --> W["CM6 widget decoration"]
  W --> BADGE["shared badge element"]
```

The badge is **plain DOM, not React**. Neither render surface has a React root where a badge is inserted, and mounting one per link — dozens per note — would be far heavier than the badge deserves. #1415 reuses this same element, which is what keeps the two surfaces from drifting apart visually.

React appears exactly once, in the popover, which renders `RelationshipSection` — the same component the sidebar panel uses, so the two cannot disagree about a node's relations.

</details>

<details>
<summary><b>How a badge learns its count changed</b> — the subtle part</summary>

<br>

Nothing about the *document* changes when a relation is added. The count lives entirely outside the text being rendered.

```mermaid
sequenceDiagram
  participant U as User
  participant F as relations.json
  participant I as RelationsIndex
  participant V as ViewPlugin
  U->>F: add a relation
  F->>I: vault "modify"
  I->>I: mark stale, reload<br>keep old snapshot
  I->>I: version 7 → 8
  I->>V: notify → empty transaction
  V->>V: update: version changed?
  V->>U: rebuild, badge now 5
```

The trap is in the last two steps. `update()` early-returns when nothing relevant changed, and an empty transaction changes **neither the document nor the viewport** — so the guard swallowed exactly the signal the refresh was sending:

```js
// before — the redraw ran and did nothing
if (!update.docChanged && !update.viewportChanged) return;
```

The fix gives `update()` something it can observe: the index exposes a monotonic version, compared alongside the setting.

> [!NOTE]
> This is why the index carries a version counter in #1413. A `ViewPlugin` can only see transactions, so state living outside the document has to be made visible to it explicitly.

</details>

<details>
<summary><b>Two flags whose meaning inverts easily</b></summary>

<br>

**`ignoreEvent()` returns `true`** — the CM6 default, and the one we want. The subject of "ignore" is the *editor*, not the widget: `true` keeps CM6 out of the way so the badge's own click listener fires. Returning `false` reads like "let the widget receive clicks" and does the opposite — an earlier revision had a badge that rendered perfectly and was completely inert.

**`updateDOM()` returns `true`** — meaning the element was updated in place and must not be replaced. CM6 rebuilds a widget's DOM whenever `eq()` is false, which a count change always is; replacing the element would detach the anchor an open popover is positioned against.

</details>

## Verification

- `pnpm ci:validate`: 8/8 check-types, 5/5 test:unit.
- Driven against a real vault over CDP **on this branch alone**: badges render with the correct count, the popover opens and lists the same relations, the setting adds and removes badges live, and Reading view correctly shows nothing yet.

## Scope check

- [x] Ran `$scope-check` against the ENG ticket and final diff.
- Scope beyond `Done When`: **None.** Covers the setting and the overlay for one surface; the second follows.

## Local delegated full review

- [x] Ran a comprehensive review of the entire final diff in a subagent with a fresh context.

Review findings addressed here: badges update in place so an open popover keeps a connected anchor; the outside-click guard no longer treats Obsidian's suggestion overlay as outside; the popover opens toward whichever side has more room; the empty-state message clears when the first relation is added; and a file that stops being a discourse node now triggers the refresh that removes its badges.

> [!WARNING]
> Known limitation: Live Preview skips a link straddling a viewport-range boundary. The badge also does not model `buildGroupedRelations` dropping relations whose endpoint no longer resolves to a file, so a relation pointing at a deleted note is still counted — that needs a file lookup per relation on a render path, so it is left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
