### PR TITLE
ENG-1249 Implement Discourse context overlay in Reading view

### DIFF
--- a/apps/obsidian/src/index.ts
+++ b/apps/obsidian/src/index.ts
@@ -21,6 +21,7 @@ import {
 import { createImageEmbedHoverExtension } from "~/utils/imageEmbedHoverIcon";
 import { createWikilinkDragExtension } from "~/utils/wikilinkDragHandler";
 import { createDiscourseContextOverlayExtension } from "~/utils/discourseContextOverlayExtension";
+import { createDiscourseContextOverlayPostProcessor } from "~/utils/discourseContextOverlayPostProcessor";
 import {
   registerDiscourseContextOverlayRefresh,
   refreshDiscourseContextOverlaySurfaces,
@@ -108,6 +109,9 @@ export default class DiscourseGraphPlugin extends Plugin {
     }
 
     this.relationsIndex.initialize();
+    this.registerMarkdownPostProcessor(
+      createDiscourseContextOverlayPostProcessor(this),
+    );
     registerDiscourseContextOverlayRefresh(this);
 
     registerCommands(this);
@@ -291,7 +295,10 @@ export default class DiscourseGraphPlugin extends Plugin {
     this.setupNodeTagHotkey();
   }
 
-  /** Applies the overlay setting immediately, without a reload. */
+  /**
+   * Re-renders both markdown surfaces so the discourse context overlay appears
+   * or disappears immediately when its setting is toggled, without a reload.
+   */
   refreshDiscourseContextOverlay(): void {
     refreshDiscourseContextOverlaySurfaces(this);
   }

--- a/apps/obsidian/src/utils/discourseContextOverlayPostProcessor.ts
+++ b/apps/obsidian/src/utils/discourseContextOverlayPostProcessor.ts
@@ -9,10 +9,7 @@ import {
 import { openDiscourseContextPopover } from "~/components/DiscourseContextPopover";
 import { resolveDiscourseLinkTarget } from "./discourseLinkUtils";
 
-/**
- * Adds, updates or removes the badge on every discourse-node link in `el`.
- * Idempotent: Obsidian reuses rendered sections and re-runs post processors.
- */
+/** Idempotent: Obsidian reuses rendered sections and re-runs post processors. */
 export const applyDiscourseContextBadges = ({
   plugin,
   el,
@@ -79,7 +76,6 @@ export const applyDiscourseContextBadges = ({
   }
 };
 
-/** Strips every badge under `el`, for when the setting is switched off. */
 export const removeDiscourseContextBadges = (el: HTMLElement): void => {
   el.querySelectorAll(`.${DISCOURSE_CONTEXT_BADGE_CLASS}`).forEach((badge) =>
     badge.remove(),

--- a/apps/obsidian/src/utils/discourseContextOverlayPostProcessor.ts
+++ b/apps/obsidian/src/utils/discourseContextOverlayPostProcessor.ts
@@ -1,0 +1,79 @@
+import type { MarkdownPostProcessorContext } from "obsidian";
+import type DiscourseGraphPlugin from "~/index";
+import {
+  createDiscourseContextBadge,
+  DISCOURSE_CONTEXT_BADGE_CLASS,
+} from "~/components/discourseContextBadge";
+import { openDiscourseContextPopover } from "~/components/DiscourseContextPopover";
+import { resolveDiscourseLinkTarget } from "./discourseLinkUtils";
+
+/**
+ * Adds, updates or removes the badge on every discourse-node link in `el`.
+ * Idempotent: Obsidian reuses rendered sections and re-runs post processors.
+ */
+export const applyDiscourseContextBadges = ({
+  plugin,
+  el,
+  sourcePath,
+}: {
+  plugin: DiscourseGraphPlugin;
+  el: HTMLElement;
+  sourcePath: string;
+}): void => {
+  const links = el.querySelectorAll<HTMLAnchorElement>("a.internal-link");
+
+  for (const link of Array.from(links)) {
+    const existing = link.nextElementSibling?.hasClass(
+      DISCOURSE_CONTEXT_BADGE_CLASS,
+    )
+      ? link.nextElementSibling
+      : null;
+
+    // data-href holds the link as written; href is resolved and URL-encoded.
+    const linktext =
+      link.getAttribute("data-href") ?? link.getAttribute("href");
+    if (!linktext) continue;
+
+    const target = resolveDiscourseLinkTarget({
+      plugin,
+      linktext,
+      sourcePath,
+    });
+    if (!target) {
+      existing?.remove();
+      continue;
+    }
+
+    const badge = createDiscourseContextBadge({
+      file: target.file,
+      nodeType: target.nodeType,
+      relationCount: target.relationCount,
+      onActivate: ({ file, anchor }) =>
+        openDiscourseContextPopover({
+          plugin,
+          file,
+          anchor,
+          relationCount: target.relationCount,
+        }),
+    });
+
+    // Replaced, not skipped, or it keeps a count from before the last change.
+    existing?.remove();
+    link.insertAdjacentElement("afterend", badge);
+  }
+};
+
+/** Strips every badge under `el`, for when the setting is switched off. */
+export const removeDiscourseContextBadges = (el: HTMLElement): void => {
+  el.querySelectorAll(`.${DISCOURSE_CONTEXT_BADGE_CLASS}`).forEach((badge) =>
+    badge.remove(),
+  );
+};
+
+export const createDiscourseContextOverlayPostProcessor =
+  (plugin: DiscourseGraphPlugin) =>
+  (el: HTMLElement, ctx: MarkdownPostProcessorContext): void => {
+    if (!plugin.settings.showDiscourseContextOverlay) return;
+    if (!ctx.sourcePath) return;
+    applyDiscourseContextBadges({ plugin, el, sourcePath: ctx.sourcePath });
+  };

--- a/apps/obsidian/src/utils/discourseContextOverlayPostProcessor.ts
+++ b/apps/obsidian/src/utils/discourseContextOverlayPostProcessor.ts
@@ -1,7 +1,9 @@
 import type { MarkdownPostProcessorContext } from "obsidian";
 import type DiscourseGraphPlugin from "~/index";
 import {
+  badgeTargetPath,
   createDiscourseContextBadge,
+  updateDiscourseContextBadge,
   DISCOURSE_CONTEXT_BADGE_CLASS,
 } from "~/components/discourseContextBadge";
 import { openDiscourseContextPopover } from "~/components/DiscourseContextPopover";
@@ -15,18 +17,22 @@ export const applyDiscourseContextBadges = ({
   plugin,
   el,
   sourcePath,
+  skipEmbedded = false,
 }: {
   plugin: DiscourseGraphPlugin;
   el: HTMLElement;
   sourcePath: string;
+  /** Links inside a transclusion resolve against the embedded file, not `sourcePath`. */
+  skipEmbedded?: boolean;
 }): void => {
   const links = el.querySelectorAll<HTMLAnchorElement>("a.internal-link");
 
   for (const link of Array.from(links)) {
+    if (skipEmbedded && link.closest(".internal-embed")) continue;
     const existing = link.nextElementSibling?.hasClass(
       DISCOURSE_CONTEXT_BADGE_CLASS,
     )
-      ? link.nextElementSibling
+      ? (link.nextElementSibling as HTMLElement)
       : null;
 
     // data-href holds the link as written; href is resolved and URL-encoded.
@@ -44,6 +50,17 @@ export const applyDiscourseContextBadges = ({
       continue;
     }
 
+    // Updated rather than replaced when the target is unchanged: an open
+    // popover anchored to this badge would otherwise hold a detached element.
+    if (existing && badgeTargetPath(existing) === target.file.path) {
+      updateDiscourseContextBadge({
+        badge: existing,
+        nodeType: target.nodeType,
+        relationCount: target.relationCount,
+      });
+      continue;
+    }
+
     const badge = createDiscourseContextBadge({
       file: target.file,
       nodeType: target.nodeType,
@@ -57,7 +74,6 @@ export const applyDiscourseContextBadges = ({
         }),
     });
 
-    // Replaced, not skipped, or it keeps a count from before the last change.
     existing?.remove();
     link.insertAdjacentElement("afterend", badge);
   }

--- a/apps/obsidian/src/utils/discourseContextOverlayRefresh.ts
+++ b/apps/obsidian/src/utils/discourseContextOverlayRefresh.ts
@@ -19,8 +19,8 @@ const isDiscourseNodeFile = (
   );
 
 /**
- * Redraws both surfaces when relations or frontmatter change. Reading view is
- * refreshed in place: rerender() blanks a pane that is not currently painting.
+ * Reading view is refreshed in place: rerender() blanks a pane that is not
+ * currently painting.
  */
 export const refreshDiscourseContextOverlaySurfaces = (
   plugin: DiscourseGraphPlugin,

--- a/apps/obsidian/src/utils/discourseContextOverlayRefresh.ts
+++ b/apps/obsidian/src/utils/discourseContextOverlayRefresh.ts
@@ -1,7 +1,11 @@
-import { debounce, type TFile } from "obsidian";
+import { debounce, MarkdownView, type TFile } from "obsidian";
 import type DiscourseGraphPlugin from "~/index";
 import { getNodeTypeIdFromFrontmatter } from "./discourseLinkFrontmatter";
 import { refreshMarkdownEditors } from "./markdownViewRefresh";
+import {
+  applyDiscourseContextBadges,
+  removeDiscourseContextBadges,
+} from "./discourseContextOverlayPostProcessor";
 
 const REFRESH_DEBOUNCE_MS = 300;
 
@@ -14,11 +18,26 @@ const isDiscourseNodeFile = (
     plugin.app.metadataCache.getFileCache(file)?.frontmatter,
   );
 
-/** Redraws the overlay when relations or a node's frontmatter change. */
+/**
+ * Redraws both surfaces when relations or frontmatter change. Reading view is
+ * refreshed in place: rerender() blanks a pane that is not currently painting.
+ */
 export const refreshDiscourseContextOverlaySurfaces = (
   plugin: DiscourseGraphPlugin,
 ): void => {
   refreshMarkdownEditors(plugin.app);
+  plugin.app.workspace.iterateAllLeaves((leaf) => {
+    if (!(leaf.view instanceof MarkdownView)) return;
+    const el = leaf.view.previewMode?.containerEl;
+    if (!el) return;
+    if (!plugin.settings.showDiscourseContextOverlay) {
+      removeDiscourseContextBadges(el);
+      return;
+    }
+    const sourcePath = leaf.view.file?.path;
+    if (!sourcePath) return;
+    applyDiscourseContextBadges({ plugin, el, sourcePath });
+  });
 };
 
 export const registerDiscourseContextOverlayRefresh = (

--- a/apps/obsidian/src/utils/discourseContextOverlayRefresh.ts
+++ b/apps/obsidian/src/utils/discourseContextOverlayRefresh.ts
@@ -36,7 +36,7 @@ export const refreshDiscourseContextOverlaySurfaces = (
     }
     const sourcePath = leaf.view.file?.path;
     if (!sourcePath) return;
-    applyDiscourseContextBadges({ plugin, el, sourcePath });
+    applyDiscourseContextBadges({ plugin, el, sourcePath, skipEmbedded: true });
   });
 };
 

--- a/apps/website/content/obsidian/configuration/general-settings.md
+++ b/apps/website/content/obsidian/configuration/general-settings.md
@@ -19,7 +19,7 @@ This setting controls the visibility of identifiers in your note's frontmatter s
 
 This setting controls whether links to discourse nodes carry an inline badge showing how many relations the linked node has.
 
-- When enabled, a badge appears after each link to a discourse node in Live Preview
+- When enabled, a badge appears after each link to a discourse node, in both Live Preview and Reading view
 - Selecting a badge opens that node's discourse context in a popover, where you can review its relationships and add a new one
 - A node with no relations shows a badge reading `0`, and its popover says "No discourse relation found"
 - Links to notes that are not discourse nodes never show a badge

--- a/apps/website/content/obsidian/core-features/discourse-context.md
+++ b/apps/website/content/obsidian/core-features/discourse-context.md
@@ -30,7 +30,7 @@ You can configure a custom hotkey in the Obsidian settings to quickly toggle the
 
 Links to a discourse node show a small badge with the number of relations that node has. Select the badge to open its discourse context in place, without leaving the note you are reading.
 
-The badge appears in Live Preview, on every link to a discourse node. A node with no relations yet shows a badge reading `0`, and opening it says "No discourse relation found" alongside the option to add one. You can turn the badge off in [General settings](/docs/obsidian/configuration/general-settings).
+The badge appears in both Live Preview and Reading view, on every link to a discourse node. A node with no relations yet shows a badge reading `0`, and opening it says "No discourse relation found" alongside the option to add one. You can turn the badge off in [General settings](/docs/obsidian/configuration/general-settings).
 
 ## Using the discourse context
 


### PR DESCRIPTION
Third of three stacked PRs for ENG-1249. Stack: #1413 → #1414 → **this**. **Based on #1414** — this diff is against it.

https://www.loom.com/share/c5c50f3fa8684bfc8fed6f14ed461b4e


## Reviewer brief

**Result:** The badge from #1414 now also renders in Reading view, with the same counts and the same popover. Completes the ticket.

**Review focus:** why this is a second implementation rather than a shared one, and why the refresh does not call `rerender()`. Both expanded below.

<details>
<summary><b>Why Reading view needs its own implementation</b></summary>

<br>

Live Preview and Reading view are not two skins over one renderer. They are two engines:

| | Live Preview | Reading view |
|---|---|---|
| What it is | a CodeMirror 6 editor | Markdown compiled to static HTML |
| Decorated via | a CM6 `ViewPlugin` | a markdown post processor |
| A link looks like | the characters `[[Note]]` in a buffer | `<a class="internal-link" data-href="Note">` |
| Redraw triggered by | a CM6 transaction | nothing, once rendered |

```mermaid
flowchart TD
  LP["Live Preview<br>scans raw [[...]] text"] --> B["shared badge element"]
  RV["Reading view<br>finds a.internal-link"] --> B
```

They meet at the badge element, which is why the two surfaces look identical. This plugin had **no** markdown post processor before this PR, so there was no precedent to copy.

> [!IMPORTANT]
> Obsidian reuses rendered sections and runs post processors over them again — and the same path serves hover previews and exports. The pass therefore has to be idempotent per link rather than one-shot: it updates or replaces an existing badge instead of assuming there is none.

</details>

<details>
<summary><b>Why the refresh does not call previewMode.rerender()</b></summary>

<br>

Reading view has no equivalent of CM6's update cycle, so something has to re-run the pass when a count changes. The obvious call is `previewMode.rerender()` — and it is a trap.

```mermaid
flowchart TD
  A["relation changes"] --> B{"how to refresh?"}
  B -->|"rerender()"| C["preview torn down"]
  C --> D["pane not painting<br>never rebuilds"]
  D --> E["Reading view blank, permanently"]
  B -->|"re-apply in place"| F["badges updated"]
  F --> G["content untouched"]
```

Re-applying badges over already-rendered content is both non-destructive and far cheaper than re-rendering a document to change one integer.

Embedded content is deliberately skipped on refresh: links inside a transclusion resolve against the *embedded* file, and only the post processor is handed that file's `sourcePath`. Resolving them against the outer note could drop a badge or show another node's count. The cost is that a count inside an embed updates on the next render rather than immediately.

</details>

## Verification

- `pnpm ci:validate`: 8/8 check-types, 5/5 test:unit.
- Full CDP suite against a real vault, **19 assertions**, stable across repeated runs: badges in both surfaces with matching counts, badge count equal to the rows the popover lists, popover open/scroll/dismiss, the empty state, the setting toggling both surfaces, counts following a relation added and removed outside the app, and the popover surviving a relation change with a connected anchor.

> [!TIP]
> Re-running that suite: Obsidian only renders Reading view while its window is frontmost, so a backgrounded app reads as "no badges" regardless of the code. The harness activates the window first.

## Scope check

- [x] Ran `$scope-check` against the ENG ticket and final diff.
- Scope beyond `Done When`: **None.**

## Local delegated full review

- [x] Ran a comprehensive review of the entire final diff in a subagent with a fresh context.

Review findings addressed here: embedded links are left to the post processor on refresh, and an existing badge is updated in place rather than replaced when its target is unchanged.

> [!WARNING]
> Known limitation: badges are emitted into Export to PDF/HTML output, since post processors run there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
