### PR TITLE
ENG-2188 Node type settings are spread across seven inner tabs; put them on one page

### DIFF
--- a/apps/roam/src/components/settings/DiscourseNodeSpecification.tsx
+++ b/apps/roam/src/components/settings/DiscourseNodeSpecification.tsx
@@ -155,7 +155,8 @@ const NodeSpecification = ({
       </style>
       <DiscourseNodeFlagPanel
         nodeType={node.type}
-        title="enabled"
+        title="Enabled"
+        blockKey="enabled"
         description=""
         settingKeys={[
           DISCOURSE_NODE_KEYS.specification,
@@ -170,18 +171,18 @@ const NodeSpecification = ({
           parentSetEnabled?.(checked);
         }}
       />
-      <div
-        className={`${enabled ? "" : "bg-gray-200 opacity-75"} overflow-auto`}
-      >
-        <QueryEditor
-          parentUid={parentUid}
-          key={Number(migrated)}
-          hideCustomSwitch
-          discourseNodeType={node.type}
-          settingKey="specification"
-          returnNode={node.text}
-        />
-      </div>
+      {enabled && (
+        <div className="overflow-auto">
+          <QueryEditor
+            parentUid={parentUid}
+            key={Number(migrated)}
+            hideCustomSwitch
+            discourseNodeType={node.type}
+            settingKey="specification"
+            returnNode={node.text}
+          />
+        </div>
+      )}
     </div>
   );
 };

--- a/apps/roam/src/components/settings/DiscourseNodeSuggestiveRules.tsx
+++ b/apps/roam/src/components/settings/DiscourseNodeSuggestiveRules.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo } from "react";
-import { Button, Intent } from "@blueprintjs/core";
+import { Button, Collapse, Intent } from "@blueprintjs/core";
 import DualWriteBlocksPanel from "./components/EphemeralBlocksPanel";
 import getSubTree from "roamjs-components/util/getSubTree";
 import { DiscourseNode } from "~/utils/getDiscourseNodes";
@@ -17,6 +17,7 @@ import {
   TEMPLATE_SETTING_KEYS,
 } from "~/components/settings/utils/settingKeys";
 import { RenderRoamBlock } from "~/utils/roamReactComponents";
+import Description from "~/components/settings/SettingsDescription";
 import { ROAM_DOCS, withDocsLink } from "./utils/docs";
 
 const DiscourseNodeSuggestiveRules = ({
@@ -42,6 +43,7 @@ const DiscourseNodeSuggestiveRules = ({
       }).uid || "",
     [nodeUid],
   );
+  const [isTemplateOpen, setIsTemplateOpen] = useState(false);
 
   const [isUpdating, setIsUpdating] = useState(false);
 
@@ -68,18 +70,39 @@ const DiscourseNodeSuggestiveRules = ({
   };
 
   return (
-    <div className="flex flex-col gap-4 p-4">
-      <DualWriteBlocksPanel
-        nodeType={node.type}
-        title="Template"
-        description={withDocsLink(
-          `The template that auto fills ${node.text} page when generated.`,
-          ROAM_DOCS.creatingNodes,
-        )}
-        settingKeys={TEMPLATE_SETTING_KEYS}
-        uid={templateUid}
-        defaultValue={node.template}
-      />
+    <div className="flex flex-col gap-4">
+      <div>
+        <div className="flex items-center">
+          <Button
+            minimal
+            small
+            icon={isTemplateOpen ? "chevron-down" : "chevron-right"}
+            text="Template"
+            onClick={() => setIsTemplateOpen((open) => !open)}
+          />
+          <Description
+            description={withDocsLink(
+              `The template that auto fills ${node.text} page when generated.`,
+              ROAM_DOCS.creatingNodes,
+            )}
+          />
+        </div>
+        {/* Collapse unmounts its children, so the buffer block only exists while open. */}
+        <Collapse isOpen={isTemplateOpen}>
+          <div className="pl-6 pt-2">
+            <DualWriteBlocksPanel
+              nodeType={node.type}
+              description={withDocsLink(
+                `The template that auto fills ${node.text} page when generated.`,
+                ROAM_DOCS.creatingNodes,
+              )}
+              settingKeys={TEMPLATE_SETTING_KEYS}
+              uid={templateUid}
+              defaultValue={node.template}
+            />
+          </div>
+        </Collapse>
+      </div>
 
       <DiscourseNodeTextPanel
         nodeType={nodeUid}

--- a/apps/roam/src/components/settings/GrammarNodesRoute.tsx
+++ b/apps/roam/src/components/settings/GrammarNodesRoute.tsx
@@ -3,12 +3,20 @@ import { OnloadArgs } from "roamjs-components/types";
 import getDiscourseNodes, {
   excludeDefaultNodes,
 } from "~/utils/getDiscourseNodes";
+import { nodeConfigSegmentIds } from "./utils/settingsNavigation";
 import { useSettingsNav } from "./navigation/SettingsNavContext";
 import SettingsPageHeader from "./navigation/SettingsPageHeader";
 import DiscourseNodeConfigPanel from "./DiscourseNodeConfigPanel";
 import NodeConfig from "./NodeConfig";
+import NodeIndexPage from "./NodeIndexPage";
+import NodeTemplatePage from "./NodeTemplatePage";
 
 const NODES_ANCESTOR_LABELS = ["Grammar"] as const;
+
+const SUB_PAGE_LABELS: Record<string, string | undefined> = {
+  [nodeConfigSegmentIds.index]: "Index",
+  [nodeConfigSegmentIds.template]: "Template",
+};
 
 const GrammarNodesRoute = ({
   onloadArgs,
@@ -18,7 +26,7 @@ const GrammarNodesRoute = ({
   const { segments, goToDepth } = useSettingsNav();
   const nodes = getDiscourseNodes().filter(excludeDefaultNodes);
 
-  const [nodeTypeUid] = segments;
+  const [nodeTypeUid, subPage] = segments;
   const node = nodeTypeUid
     ? nodes.find((n) => n.type === nodeTypeUid)
     : undefined;
@@ -29,8 +37,10 @@ const GrammarNodesRoute = ({
     if (isStalePath) goToDepth(0);
   }, [isStalePath, goToDepth]);
 
-  const resolveLabel = (segment: string): string =>
-    nodes.find((n) => n.type === segment)?.text ?? segment;
+  const resolveLabel = (segment: string, segmentIndex: number): string =>
+    segmentIndex === 0
+      ? (nodes.find((n) => n.type === segment)?.text ?? segment)
+      : (SUB_PAGE_LABELS[segment] ?? segment);
 
   return (
     <div className="dg-settings-route">
@@ -40,12 +50,16 @@ const GrammarNodesRoute = ({
         resolveLabel={resolveLabel}
       />
       <div className="dg-settings-route__body">
-        {node ? (
-          <NodeConfig node={node} onloadArgs={onloadArgs} />
-        ) : (
+        {!node ? (
           <div className="p-1">
             <DiscourseNodeConfigPanel />
           </div>
+        ) : subPage === nodeConfigSegmentIds.index ? (
+          <NodeIndexPage node={node} onloadArgs={onloadArgs} />
+        ) : subPage === nodeConfigSegmentIds.template ? (
+          <NodeTemplatePage node={node} />
+        ) : (
+          <NodeConfig node={node} />
         )}
       </div>
     </div>

--- a/apps/roam/src/components/settings/NodeConfig.tsx
+++ b/apps/roam/src/components/settings/NodeConfig.tsx
@@ -1,13 +1,9 @@
 import React, { useState, useCallback, useEffect, useRef } from "react";
 import getDiscourseNodes, { DiscourseNode } from "~/utils/getDiscourseNodes";
-import DualWriteBlocksPanel from "./components/EphemeralBlocksPanel";
 import { getSubTree } from "roamjs-components/util";
 import Description from "~/components/settings/SettingsDescription";
 import {
   Label,
-  Tabs,
-  Tab,
-  TabId,
   InputGroup,
   ControlGroup,
   Tooltip,
@@ -18,8 +14,6 @@ import DiscourseNodeAttributes from "./DiscourseNodeAttributes";
 import DiscourseNodeCanvasSettings, {
   formatHexColor,
 } from "./DiscourseNodeCanvasSettings";
-import DiscourseNodeIndex from "./DiscourseNodeIndex";
-import { OnloadArgs } from "roamjs-components/types";
 import setInputSetting from "roamjs-components/util/setInputSetting";
 import {
   getDiscourseNodeSetting,
@@ -30,7 +24,6 @@ import {
   CANVAS_KEYS,
   DISCOURSE_NODE_KEYS,
   SPECIFICATION_KEYS,
-  TEMPLATE_SETTING_KEYS,
 } from "~/components/settings/utils/settingKeys";
 import DiscourseNodeSuggestiveRules from "./DiscourseNodeSuggestiveRules";
 import { getNodeTagStyles } from "~/utils/getDiscourseNodeColors";
@@ -40,6 +33,10 @@ import {
   DiscourseNodeSelectPanel,
 } from "./components/BlockPropSettingPanels";
 import { ROAM_DOCS, withDocsLink } from "./utils/docs";
+import { SettingsGroup } from "./components/SettingsHeadings";
+import SettingsDrillDownRow from "./components/SettingsDrillDownRow";
+import { useSettingsNav } from "./navigation/SettingsNavContext";
+import { nodeConfigSegmentIds } from "./utils/settingsNavigation";
 
 export const getCleanTagText = (tag: string): string => {
   return tag.replace(/^#+/, "").trim().toUpperCase();
@@ -168,13 +165,7 @@ const generateTagPlaceholder = (node: DiscourseNode): string => {
   return `#${nodeTextPrefix}-candidate`; // Evidence = #evi-candidate
 };
 
-const NodeConfig = ({
-  node,
-  onloadArgs,
-}: {
-  node: DiscourseNode;
-  onloadArgs: OnloadArgs;
-}) => {
+const NodeConfig = ({ node }: { node: DiscourseNode }) => {
   const getUid = (key: string) =>
     getSubTree({
       parentUid: node.type,
@@ -184,19 +175,17 @@ const NodeConfig = ({
   const descriptionUid = getUid("Description");
   const shortcutUid = getUid("Shortcut");
   const tagUid = getUid("Tag");
-  const templateUid = getUid("Template");
   const overlayUid = getUid("Overlay");
   const canvasUid = getUid("Canvas");
   const graphOverviewUid = getUid("Graph Overview");
   const specificationUid = getUid("Specification");
-  const indexUid = getUid("Index");
   const suggestiveRulesUid = getUid("Suggestive Rules");
   const attributeNode = getSubTree({
     parentUid: node.type,
     key: "Attributes",
   });
 
-  const [selectedTabId, setSelectedTabId] = useState<TabId>("general");
+  const nav = useSettingsNav();
   const [tagError, setTagError] = useState("");
   const [formatError, setFormatError] = useState("");
   const [shortcutError, setShortcutError] = useState("");
@@ -302,220 +291,169 @@ const NodeConfig = ({
   );
 
   return (
-    <>
-      <Tabs
-        onChange={(id) => setSelectedTabId(id)}
-        selectedTabId={selectedTabId}
-        renderActiveTabPanelOnly={true}
-      >
-        <Tab
-          id="general"
-          title="General"
-          panel={
-            <div className="flex flex-col gap-4 p-1">
-              <DiscourseNodeTextPanel
-                nodeType={node.type}
-                title="Description"
-                description={withDocsLink(
-                  `Describing what the ${node.text} node represents in your graph.`,
-                  ROAM_DOCS.grammarNodes,
-                )}
-                settingKeys={[DISCOURSE_NODE_KEYS.description]}
-                initialValue={node.description}
-                multiline
-                order={1}
-                parentUid={node.type}
-                uid={descriptionUid}
-              />
-              <DiscourseNodeTextPanel
-                nodeType={node.type}
-                title="Shortcut"
-                description={withDocsLink(
-                  `The trigger to quickly create a ${node.text} page from the node menu.`,
-                  ROAM_DOCS.creatingNodes,
-                )}
-                settingKeys={[DISCOURSE_NODE_KEYS.shortcut]}
-                initialValue={node.shortcut}
-                error={shortcutError}
-                onChange={handleShortcutChange}
-                order={0}
-                parentUid={node.type}
-                uid={shortcutUid}
-              />
-              <div>
-                <DiscourseNodeTextPanel
-                  nodeType={node.type}
-                  title="Tag"
-                  description={withDocsLink(
-                    `Designate a hashtag for marking potential ${node.text}.`,
-                    ROAM_DOCS.taggingCandidateNodes,
-                  )}
-                  settingKeys={[DISCOURSE_NODE_KEYS.tag]}
-                  initialValue={node.tag}
-                  placeholder={generateTagPlaceholder(node)}
-                  error={tagError}
-                  onChange={setTagValue}
-                  order={2}
-                  parentUid={node.type}
-                  uid={tagUid}
-                />
-              </div>
-              <DiscourseNodeColorSetting
-                canvasUid={canvasUid}
-                nodeType={node.type}
-                initialColor={node.canvasSettings?.color}
-                tagValue={tagValue}
-              />
-            </div>
-          }
-        />
-        <Tab
-          id="index"
+    <div className="dg-settings-node-page">
+      <SettingsGroup title="Identity">
+        <SettingsDrillDownRow
           title="Index"
-          panel={
-            <div className="flex flex-col gap-4 p-1">
-              <DiscourseNodeIndex
-                node={node}
-                parentUid={indexUid}
-                onloadArgs={onloadArgs}
-              />
-            </div>
-          }
+          description={`The saved list of all ${node.text} pages \u2014 which pages appear and which columns show.`}
+          buttonText={`See all ${node.text} nodes`}
+          onClick={() => nav.push(nodeConfigSegmentIds.index)}
         />
-        <Tab
-          id="format"
+        <DiscourseNodeTextPanel
+          nodeType={node.type}
+          title="Description"
+          description={withDocsLink(
+            `Describing what the ${node.text} node represents in your graph.`,
+            ROAM_DOCS.grammarNodes,
+          )}
+          settingKeys={[DISCOURSE_NODE_KEYS.description]}
+          initialValue={node.description}
+          multiline
+          order={1}
+          parentUid={node.type}
+          uid={descriptionUid}
+        />
+        <DiscourseNodeTextPanel
+          nodeType={node.type}
+          title="Tag"
+          description={withDocsLink(
+            `Designate a hashtag for marking potential ${node.text}.`,
+            ROAM_DOCS.taggingCandidateNodes,
+          )}
+          settingKeys={[DISCOURSE_NODE_KEYS.tag]}
+          initialValue={node.tag}
+          placeholder={generateTagPlaceholder(node)}
+          error={tagError}
+          onChange={setTagValue}
+          order={2}
+          parentUid={node.type}
+          uid={tagUid}
+        />
+        <DiscourseNodeColorSetting
+          canvasUid={canvasUid}
+          nodeType={node.type}
+          initialColor={node.canvasSettings?.color}
+          tagValue={tagValue}
+        />
+        <DiscourseNodeTextPanel
+          nodeType={node.type}
           title="Format"
-          panel={
-            <div className="flex flex-col gap-4 p-1">
-              <DiscourseNodeTextPanel
-                nodeType={node.type}
-                title="Format"
-                description={withDocsLink(
-                  `DEPRECATED - Use specification instead. The format ${node.text} pages should have.`,
-                  ROAM_DOCS.grammarNodes,
-                )}
-                settingKeys={[DISCOURSE_NODE_KEYS.format]}
-                initialValue={node.format}
-                error={formatError}
-                onChange={setFormatValue}
-                order={3}
-                parentUid={node.type}
-                uid={formatUid}
-              />
-              <Label>
-                Specification
-                <Description
-                  description={withDocsLink(
-                    `The conditions specified to identify a ${node.text} node.`,
-                    ROAM_DOCS.grammarNodes,
-                  )}
-                />
-                <DiscourseNodeSpecification
-                  node={node}
-                  parentUid={specificationUid}
-                  parentSetEnabled={(isSpecificationEnabled) => {
-                    validate({
-                      tag: tagValue,
-                      format: formatValue,
-                      isSpecificationEnabled,
-                    });
-                  }}
-                />
-              </Label>
-            </div>
-          }
+          description={withDocsLink(
+            `The format ${node.text} pages should have.`,
+            ROAM_DOCS.grammarNodes,
+          )}
+          settingKeys={[DISCOURSE_NODE_KEYS.format]}
+          initialValue={node.format}
+          error={formatError}
+          onChange={setFormatValue}
+          order={3}
+          parentUid={node.type}
+          uid={formatUid}
         />
-        <Tab
-          id="template"
+      </SettingsGroup>
+
+      <SettingsGroup title="Creation">
+        <DiscourseNodeTextPanel
+          nodeType={node.type}
+          title="Shortcut"
+          description={withDocsLink(
+            `The trigger to quickly create a ${node.text} page from the node menu.`,
+            ROAM_DOCS.creatingNodes,
+          )}
+          settingKeys={[DISCOURSE_NODE_KEYS.shortcut]}
+          initialValue={node.shortcut}
+          error={shortcutError}
+          onChange={handleShortcutChange}
+          order={0}
+          parentUid={node.type}
+          uid={shortcutUid}
+        />
+        <SettingsDrillDownRow
           title="Template"
-          panel={
-            <div className="flex flex-col gap-4 p-1">
-              <DualWriteBlocksPanel
-                nodeType={node.type}
-                title="Template"
-                description={withDocsLink(
-                  `The template that auto fills ${node.text} page when generated.`,
-                  ROAM_DOCS.creatingNodes,
-                )}
-                settingKeys={TEMPLATE_SETTING_KEYS}
-                uid={templateUid}
-                defaultValue={node.template}
-              />
-            </div>
-          }
+          description={withDocsLink(
+            `The template that auto fills ${node.text} page when generated.`,
+            ROAM_DOCS.creatingNodes,
+          )}
+          buttonText="Edit template"
+          onClick={() => nav.push(nodeConfigSegmentIds.template)}
         />
-        <Tab
-          id="attributes"
-          title="Attributes"
-          panel={
-            <div className="flex flex-col gap-4 p-1">
-              <DiscourseNodeAttributes
-                uid={attributeNode.uid}
-                nodeType={node.type}
-                defaultValue={getDiscourseNodeSetting<Record<string, string>>(
-                  node.type,
-                  [DISCOURSE_NODE_KEYS.attributes],
-                )}
-              />
-              <DiscourseNodeSelectPanel
-                nodeType={node.type}
-                title="Overlay"
-                description={withDocsLink(
-                  "Select which attribute is used for the discourse overlay",
-                  ROAM_DOCS.discourseAttributes,
-                )}
-                settingKeys={[DISCOURSE_NODE_KEYS.overlay]}
-                options={attributeNode.children.map((c) => c.text)}
-                initialValue={
-                  getDiscourseNodeSetting<string>(node.type, [
-                    DISCOURSE_NODE_KEYS.overlay,
-                  ]) ?? ""
-                }
-                order={0}
-                parentUid={node.type}
-                uid={overlayUid}
-              />
-            </div>
-          }
+      </SettingsGroup>
+
+      <SettingsGroup title="Canvas">
+        <DiscourseNodeCanvasSettings nodeType={node.type} uid={canvasUid} />
+        <DiscourseNodeFlagPanel
+          nodeType={node.type}
+          title="Graph Overview"
+          description="Whether to color the node in the graph overview based on canvas color.  This is based on the node's plain title as described by a \`has title\` condition in its specification."
+          settingKeys={[DISCOURSE_NODE_KEYS.graphOverview]}
+          initialValue={node.graphOverview}
+          order={0}
+          parentUid={node.type}
+          uid={graphOverviewUid}
         />
-        <Tab
-          id="canvas"
-          title="Canvas"
-          panel={
-            <div className="flex flex-col gap-4 p-1">
-              <DiscourseNodeCanvasSettings
-                nodeType={node.type}
-                uid={canvasUid}
-              />
-              <DiscourseNodeFlagPanel
-                nodeType={node.type}
-                title="Graph Overview"
-                description="Whether to color the node in the graph overview based on canvas color.  This is based on the node's plain title as described by a \`has title\` condition in its specification."
-                settingKeys={[DISCOURSE_NODE_KEYS.graphOverview]}
-                initialValue={node.graphOverview}
-                order={0}
-                parentUid={node.type}
-                uid={graphOverviewUid}
-              />
-            </div>
-          }
-        />
-        {isSyncEnabled() && (
-          <Tab
-            id="suggestive-mode"
-            title="Suggestive mode"
-            panel={
-              <div className="flex flex-col gap-4 p-1">
-                <DiscourseNodeSuggestiveRules
-                  node={node}
-                  parentUid={suggestiveRulesUid}
-                />
-              </div>
-            }
+      </SettingsGroup>
+
+      <SettingsGroup title="Legacy">
+        <Label>
+          Specification
+          <Description
+            description={withDocsLink(
+              `The conditions specified to identify a ${node.text} node.`,
+              ROAM_DOCS.grammarNodes,
+            )}
           />
-        )}
-      </Tabs>
-    </>
+          <DiscourseNodeSpecification
+            node={node}
+            parentUid={specificationUid}
+            parentSetEnabled={(isSpecificationEnabled) => {
+              validate({
+                tag: tagValue,
+                format: formatValue,
+                isSpecificationEnabled,
+              });
+            }}
+          />
+        </Label>
+      </SettingsGroup>
+
+      {isSyncEnabled() && (
+        <SettingsGroup title="Suggestive mode">
+          <DiscourseNodeSuggestiveRules
+            node={node}
+            parentUid={suggestiveRulesUid}
+          />
+        </SettingsGroup>
+      )}
+
+      <SettingsGroup title="Attributes">
+        <DiscourseNodeAttributes
+          uid={attributeNode.uid}
+          nodeType={node.type}
+          defaultValue={getDiscourseNodeSetting<Record<string, string>>(
+            node.type,
+            [DISCOURSE_NODE_KEYS.attributes],
+          )}
+        />
+        <DiscourseNodeSelectPanel
+          nodeType={node.type}
+          title="Overlay"
+          description={withDocsLink(
+            "Select which attribute is used for the discourse overlay",
+            ROAM_DOCS.discourseAttributes,
+          )}
+          settingKeys={[DISCOURSE_NODE_KEYS.overlay]}
+          options={attributeNode.children.map((c) => c.text)}
+          initialValue={
+            getDiscourseNodeSetting<string>(node.type, [
+              DISCOURSE_NODE_KEYS.overlay,
+            ]) ?? ""
+          }
+          order={0}
+          parentUid={node.type}
+          uid={overlayUid}
+        />
+      </SettingsGroup>
+    </div>
   );
 };
 

--- a/apps/roam/src/components/settings/NodeIndexPage.tsx
+++ b/apps/roam/src/components/settings/NodeIndexPage.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { getSubTree } from "roamjs-components/util";
+import { OnloadArgs } from "roamjs-components/types";
+import { DiscourseNode } from "~/utils/getDiscourseNodes";
+import DiscourseNodeIndex from "./DiscourseNodeIndex";
+
+const NodeIndexPage = ({
+  node,
+  onloadArgs,
+}: {
+  node: DiscourseNode;
+  onloadArgs: OnloadArgs;
+}): JSX.Element => {
+  const indexUid = getSubTree({ parentUid: node.type, key: "Index" }).uid;
+  return (
+    <div className="flex flex-col gap-4 p-1">
+      <DiscourseNodeIndex
+        node={node}
+        parentUid={indexUid}
+        onloadArgs={onloadArgs}
+      />
+    </div>
+  );
+};
+
+export default NodeIndexPage;

--- a/apps/roam/src/components/settings/NodeTemplatePage.tsx
+++ b/apps/roam/src/components/settings/NodeTemplatePage.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { getSubTree } from "roamjs-components/util";
+import { DiscourseNode } from "~/utils/getDiscourseNodes";
+import DualWriteBlocksPanel from "./components/EphemeralBlocksPanel";
+import { TEMPLATE_SETTING_KEYS } from "~/components/settings/utils/settingKeys";
+import { ROAM_DOCS, withDocsLink } from "./utils/docs";
+
+const NodeTemplatePage = ({ node }: { node: DiscourseNode }): JSX.Element => {
+  const templateUid = getSubTree({ parentUid: node.type, key: "Template" }).uid;
+  return (
+    <div className="flex flex-col gap-4 p-1">
+      <DualWriteBlocksPanel
+        nodeType={node.type}
+        title="Template"
+        description={withDocsLink(
+          `The template that auto fills ${node.text} page when generated.`,
+          ROAM_DOCS.creatingNodes,
+        )}
+        settingKeys={TEMPLATE_SETTING_KEYS}
+        uid={templateUid}
+        defaultValue={node.template}
+      />
+    </div>
+  );
+};
+
+export default NodeTemplatePage;

--- a/apps/roam/src/components/settings/components/SettingsDrillDownRow.tsx
+++ b/apps/roam/src/components/settings/components/SettingsDrillDownRow.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { Button, Intent, Label } from "@blueprintjs/core";
+import Description from "~/components/settings/SettingsDescription";
+
+const SettingsDrillDownRow = ({
+  title,
+  description,
+  buttonText,
+  onClick,
+}: {
+  title: string;
+  description: React.ReactNode;
+  buttonText: string;
+  onClick: () => void;
+}): JSX.Element => (
+  <Label>
+    {title}
+    <Description description={description} />
+    <div>
+      <Button
+        outlined
+        intent={Intent.PRIMARY}
+        rightIcon="chevron-right"
+        text={buttonText}
+        onClick={onClick}
+      />
+    </div>
+  </Label>
+);
+
+export default SettingsDrillDownRow;

--- a/apps/roam/src/components/settings/utils/settingsNavigation.ts
+++ b/apps/roam/src/components/settings/utils/settingsNavigation.ts
@@ -14,6 +14,11 @@ export type SettingsNavAction =
   | { type: "pop" }
   | { type: "truncate"; depth: number };
 
+export const nodeConfigSegmentIds = {
+  index: "index",
+  template: "template",
+} as const;
+
 export const rootPath = (tabId: string): SettingsPath => [tabId];
 
 export const tabIdOf = (path: SettingsPath): string => path[0] ?? "";

--- a/apps/roam/src/styles/settingsStyles.css
+++ b/apps/roam/src/styles/settingsStyles.css
@@ -81,3 +81,10 @@
 .dg-settings-page-header__crumb {
   cursor: pointer;
 }
+
+.dg-settings-node-page {
+  display: flex;
+  flex-direction: column;
+  gap: 44px;
+  padding: 2px;
+}


### PR DESCRIPTION
## Reviewer brief

- **Result:** a node type's settings are one vertical page instead of seven inner tabs. Groups, in order: Identity (Index, Description, Tag, Color, Format), Creation (Shortcut, Template), Canvas, Legacy (Specification), Suggestive mode (shown only when sync is on), Attributes. Index and Template are drill-down rows. Each opens its own sub-page with a `Grammar › Nodes › <node> › Index` breadcrumb.
- **Review focus: `NodeConfig.tsx` is a re-layout.** No setting changes its key, default, or write path. `SettingsDrillDownRow` renders a row that pushes a segment on the ENG-2186 route. `NodeIndexPage` and `NodeTemplatePage` wrap the existing panels for the two sub-pages.
- **Review focus: the Specification row.** The toggle now reads `Enabled`. Its block text stays lowercase `enabled` through `blockKey`, so storage is unchanged. The query builder renders only while the toggle is on.
- **Review focus: group order differs from the ticket.** The ticket lists Identity / Recognition / Creation / Index. Review dropped Recognition, moved Index and Format into Identity, moved Specification into a `Legacy` group for settings mid-migration, and moved Attributes last. Format's `DEPRECATED — use Specification` note went with it, because Specification is now the setting in flux.
- **Follow-up:** Suggestive mode stays on the node page. The ticket's Solution suggests moving it to the Admin panel, but it needs its own node selector there, so that move needs its own ticket. The Index row's description is proposed copy and needs sign-off.

## Verification

- `tsc --noEmit` and eslint report no errors or warnings for `apps/roam`. The production build completes with 0 errors.
- Checked in Roam: Grammar › Nodes → node type → Index and Template. Back and the breadcrumb work at each depth. Toggling `Enabled` shows and hides the query builder. Legacy and Attributes are the last two groups.

## Loom video

https://www.loom.com/share/f76e4399d7784cf2a85613fd91301e78

## Scope check

- [x] Ran `$scope-check` against the ENG ticket and final diff.
- Scope beyond `Done When`: group names and order follow the manager's review instead of the ticket text (see the review focus above). The ticket needs updating to match.

## Local delegated full review

- [x] Ran a comprehensive review of the entire final diff in a subagent with a fresh context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/discoursegraphs/discourse-graph/pull/1420" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
