### PR TITLE
ENG-1356 Implement image to node conversion flow via icon button in tldraw Roam

### DIFF
--- a/apps/roam/src/components/ModifyNodeDialog.tsx
+++ b/apps/roam/src/components/ModifyNodeDialog.tsx
@@ -539,14 +539,14 @@ const ModifyNodeDialog = ({
           </div>
 
           {imageUrl && (
-            <div className="flex w-full flex-col gap-1">
-              <span>Image</span>
+            <Label className="w-full">
+              Image
               <img
                 src={imageUrl}
                 alt=""
-                className="max-h-40 w-full rounded object-contain"
+                className="mt-1 block max-h-40 max-w-full rounded"
               />
-            </div>
+            </Label>
           )}
 
           {/* Referenced Node Input */}

--- a/apps/roam/src/components/ModifyNodeDialog.tsx
+++ b/apps/roam/src/components/ModifyNodeDialog.tsx
@@ -597,14 +597,14 @@ const ModifyNodeDialog = ({
           </div>
 
           {imageUrl && (
-            <Label className="w-full">
-              Image
+            <div className="flex w-full flex-col gap-1">
+              <span>Image</span>
               <img
                 src={imageUrl}
                 alt=""
-                className="mt-1 max-h-40 w-full rounded object-contain"
+                className="max-h-40 w-full rounded object-contain"
               />
-            </Label>
+            </div>
           )}
 
           {/* Referenced Node Input */}

--- a/apps/roam/src/components/ModifyNodeDialog.tsx
+++ b/apps/roam/src/components/ModifyNodeDialog.tsx
@@ -58,6 +58,7 @@ export type ModifyNodeDialogProps = {
     text: string;
     uid: string;
     action: string;
+    nodeType?: string;
   }) => Promise<void>;
   onClose: () => void;
 };
@@ -371,6 +372,7 @@ const ModifyNodeDialog = ({
             text: content.text,
             uid: content.uid,
             action: "create",
+            nodeType: selectedNodeType?.type,
           });
 
           onClose();
@@ -480,6 +482,7 @@ const ModifyNodeDialog = ({
           text: formattedTitle,
           uid: newPageUid,
           action: "create",
+          nodeType: selectedNodeType?.type,
         });
       } else {
         // Edit mode: update the existing block
@@ -515,6 +518,7 @@ const ModifyNodeDialog = ({
           text: updatedContent,
           uid: sourceBlockUid || content.uid,
           action: "edit",
+          nodeType: selectedNodeType?.type,
         });
       }
       onClose();
@@ -591,6 +595,17 @@ const ModifyNodeDialog = ({
               />
             </Label>
           </div>
+
+          {imageUrl && (
+            <Label className="w-full">
+              Image
+              <img
+                src={imageUrl}
+                alt=""
+                className="mt-1 max-h-40 w-full rounded object-contain"
+              />
+            </Label>
+          )}
 
           {/* Referenced Node Input */}
           {referencedNode && !isContentLocked && mode === "create" && (

--- a/apps/roam/src/components/ModifyNodeDialog.tsx
+++ b/apps/roam/src/components/ModifyNodeDialog.tsx
@@ -31,12 +31,12 @@ import {
   getNewDiscourseNodeText,
   getReferencedNodeInFormat,
 } from "~/utils/formatUtils";
-import createDiscourseNode from "~/utils/createDiscourseNode";
+import createDiscourseNode, {
+  handleImageCreation,
+} from "~/utils/createDiscourseNode";
 import { OnloadArgs } from "roamjs-components/types";
 import { render as renderToast } from "roamjs-components/components/Toast";
 import getPageUidByPageTitle from "roamjs-components/queries/getPageUidByPageTitle";
-import resolveQueryBuilderRef from "~/utils/resolveQueryBuilderRef";
-import runQuery from "~/utils/runQuery";
 import posthog from "posthog-js";
 
 export type ModifyNodeDialogMode = "create" | "edit";
@@ -274,66 +274,6 @@ const ModifyNodeDialog = ({
     onClose();
   }, [onClose]);
 
-  const addImageToPage = useCallback(
-    async ({
-      pageUid,
-      imageUrl,
-      configPageUid,
-      extensionAPI,
-    }: {
-      pageUid: string;
-      imageUrl: string;
-      configPageUid: string;
-      extensionAPI?: OnloadArgs["extensionAPI"];
-    }) => {
-      const discourseNodes = getDiscourseNodes();
-      const canvasSettings = Object.fromEntries(
-        discourseNodes.map((n) => [n.type, { ...n.canvasSettings }]),
-      );
-      const {
-        "query-builder-alias": qbAlias = "",
-        "key-image": isKeyImage = "",
-        "key-image-option": keyImageOption = "",
-      } = canvasSettings[configPageUid] || {};
-
-      const createOrUpdateImageBlock = async (imagePlaceholderUid?: string) => {
-        const imageMarkdown = `![](${imageUrl})`;
-        if (imagePlaceholderUid) {
-          await updateBlock({
-            uid: imagePlaceholderUid,
-            text: imageMarkdown,
-          });
-        } else {
-          await createBlock({
-            node: { text: imageMarkdown },
-            order: 0,
-            parentUid: pageUid,
-          });
-        }
-      };
-
-      if (!isKeyImage || !extensionAPI) {
-        await createOrUpdateImageBlock();
-        return;
-      }
-
-      if (keyImageOption === "query-builder") {
-        const parentUid = resolveQueryBuilderRef({ queryRef: qbAlias });
-        const results = await runQuery({
-          extensionAPI,
-          parentUid,
-          // due to query format
-          inputs: { NODETEXT: content.text, NODEUID: pageUid },
-        });
-        const imagePlaceholderUid = results.allProcessedResults[0]?.uid;
-        await createOrUpdateImageBlock(imagePlaceholderUid);
-      } else {
-        await createOrUpdateImageBlock();
-      }
-    },
-    [content.text],
-  );
-
   const onSubmit = async () => {
     if (!content.text.trim()) return;
     if (!selectedNodeType && !isContentLocked) {
@@ -359,11 +299,13 @@ const ModifyNodeDialog = ({
           if (imageUrl) {
             const pageUid = content.uid || getPageUidByPageTitle(content.text);
             if (pageUid) {
-              await addImageToPage({
+              await handleImageCreation({
                 pageUid,
-                imageUrl,
+                discourseNodes: getDiscourseNodes(),
                 configPageUid: selectedNodeType?.type || "",
+                imageUrl,
                 extensionAPI,
+                text: content.text,
               });
             }
           }

--- a/apps/roam/src/components/canvas/Tldraw.tsx
+++ b/apps/roam/src/components/canvas/Tldraw.tsx
@@ -53,7 +53,7 @@ import {
 } from "tldraw";
 import "tldraw/tldraw.css";
 import tldrawStyles from "./tldrawStyles";
-import { DragHandleOverlay } from "./overlays/DragHandleOverlay";
+import { CanvasOverlays } from "./overlays/CanvasOverlays";
 import { isDiscourseNodeShape } from "./canvasUtils";
 import getDiscourseNodes, { DiscourseNode } from "~/utils/getDiscourseNodes";
 import getDiscourseRelations, {
@@ -995,7 +995,7 @@ const TldrawCanvasShared = ({
   const editorComponents: TLEditorComponents = {
     ...defaultEditorComponents,
     OnTheCanvas: ToastListener,
-    InFrontOfTheCanvas: DragHandleOverlay,
+    InFrontOfTheCanvas: CanvasOverlays,
   };
   const customUiComponents: TLUiComponents = createUiComponents({
     allNodes,

--- a/apps/roam/src/components/canvas/convertShapeToDiscourseNode.ts
+++ b/apps/roam/src/components/canvas/convertShapeToDiscourseNode.ts
@@ -1,0 +1,64 @@
+import { createShapeId, Editor, TLImageShape, TLShape } from "tldraw";
+import type { OnloadArgs } from "roamjs-components/types";
+import calcCanvasNodeSizeAndImg from "~/utils/calcCanvasNodeSizeAndImg";
+import { DISCOURSE_NODE_SHAPE_TYPE } from "./DiscourseNodeUtil";
+
+export const uploadImageShapeToRoam = async ({
+  editor,
+  shape,
+}: {
+  editor: Editor;
+  shape: TLImageShape;
+}): Promise<string | undefined> => {
+  const { assetId } = shape.props;
+  if (!assetId) return undefined;
+  const asset = editor.getAsset(assetId);
+  if (!asset || !asset.props.src) return undefined;
+  const file = await fetch(asset.props.src)
+    .then((r) => r.arrayBuffer())
+    .then((buf) => new File([buf], shape.id));
+  return window.roamAlphaAPI.util.uploadFile({ file });
+};
+
+export const replaceShapeWithDiscourseNode = async ({
+  editor,
+  extensionAPI,
+  shape,
+  nodeType,
+  text,
+  uid,
+}: {
+  editor: Editor;
+  extensionAPI: OnloadArgs["extensionAPI"];
+  shape: TLShape;
+  nodeType: string;
+  text: string;
+  uid: string;
+}): Promise<void> => {
+  const { x, y } = shape;
+  editor.deleteShapes([shape.id]);
+  const { h, w, imageUrl } = await calcCanvasNodeSizeAndImg({
+    nodeText: text,
+    extensionAPI,
+    nodeType,
+    uid,
+  });
+  editor.createShapes([
+    {
+      type: DISCOURSE_NODE_SHAPE_TYPE,
+      id: createShapeId(),
+      props: {
+        uid,
+        title: text,
+        h,
+        w,
+        imageUrl,
+        fontFamily: "sans",
+        size: "s",
+        nodeTypeId: nodeType,
+      },
+      x,
+      y,
+    },
+  ]);
+};

--- a/apps/roam/src/components/canvas/convertShapeToDiscourseNode.ts
+++ b/apps/roam/src/components/canvas/convertShapeToDiscourseNode.ts
@@ -14,6 +14,8 @@ export const uploadImageShapeToRoam = async ({
   if (!assetId) return undefined;
   const asset = editor.getAsset(assetId);
   if (!asset || !asset.props.src) return undefined;
+  // Dropped and pasted files are already uploaded to Roam by the canvas handlers
+  if (asset.props.src.startsWith("https:")) return asset.props.src;
   const file = await fetch(asset.props.src)
     .then((r) => r.arrayBuffer())
     .then((buf) => new File([buf], shape.id));

--- a/apps/roam/src/components/canvas/overlays/CanvasOverlays.tsx
+++ b/apps/roam/src/components/canvas/overlays/CanvasOverlays.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { DragHandleOverlay } from "./DragHandleOverlay";
 import { ImageConvertOverlay } from "./ImageConvertOverlay";
 
-export const CanvasOverlays = () => (
+export const CanvasOverlays = (): JSX.Element => (
   <>
     <DragHandleOverlay />
     <ImageConvertOverlay />

--- a/apps/roam/src/components/canvas/overlays/CanvasOverlays.tsx
+++ b/apps/roam/src/components/canvas/overlays/CanvasOverlays.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import { DragHandleOverlay } from "./DragHandleOverlay";
+import { ImageConvertOverlay } from "./ImageConvertOverlay";
+
+export const CanvasOverlays = () => (
+  <>
+    <DragHandleOverlay />
+    <ImageConvertOverlay />
+  </>
+);

--- a/apps/roam/src/components/canvas/overlays/ImageConvertOverlay.tsx
+++ b/apps/roam/src/components/canvas/overlays/ImageConvertOverlay.tsx
@@ -1,0 +1,108 @@
+import React, { useCallback, useState } from "react";
+import { Button, Icon } from "@blueprintjs/core";
+import { TLImageShape, useEditor, useValue } from "tldraw";
+import { useExtensionAPI } from "roamjs-components/components/ExtensionApiContext";
+import posthog from "posthog-js";
+import { renderModifyNodeDialog } from "~/components/ModifyNodeDialog";
+import { dispatchToastEvent } from "~/components/canvas/ToastListener";
+import {
+  replaceShapeWithDiscourseNode,
+  uploadImageShapeToRoam,
+} from "~/components/canvas/convertShapeToDiscourseNode";
+
+const BUTTON_INSET = 8;
+
+const isImageShape = (shape: unknown): shape is TLImageShape =>
+  !!shape && (shape as { type?: string }).type === "image";
+
+export const ImageConvertOverlay = () => {
+  const editor = useEditor();
+  const extensionAPI = useExtensionAPI();
+  const [uploading, setUploading] = useState(false);
+
+  const imageShape = useValue<TLImageShape | null>(
+    "imageConvertTarget",
+    () => {
+      if (!editor.isIn("select.idle")) return null;
+      const hovered = editor.getHoveredShape();
+      if (isImageShape(hovered)) return hovered;
+      const selected = editor.getOnlySelectedShape();
+      return isImageShape(selected) ? selected : null;
+    },
+    [editor],
+  );
+
+  const buttonPosition = useValue<{ left: number; top: number } | null>(
+    "imageConvertButtonPosition",
+    () => {
+      if (!imageShape) return null;
+      const bounds = editor.getShapePageBounds(imageShape.id);
+      if (!bounds) return null;
+      const vp = editor.pageToViewport({ x: bounds.minX, y: bounds.minY });
+      return { left: vp.x + BUTTON_INSET, top: vp.y + BUTTON_INSET };
+    },
+    [editor, imageShape?.id],
+  );
+
+  const openConvertDialog = useCallback(async () => {
+    if (!imageShape || !extensionAPI || uploading) return;
+    posthog.capture("Canvas: Image Convert Button Clicked");
+    setUploading(true);
+    try {
+      const src = await uploadImageShapeToRoam({ editor, shape: imageShape });
+      if (!src) {
+        dispatchToastEvent({
+          id: "tldraw-image-convert-no-asset",
+          title: "Could not read this image",
+          severity: "warning",
+        });
+        return;
+      }
+      renderModifyNodeDialog({
+        mode: "create",
+        initialValue: { text: "", uid: "" },
+        extensionAPI,
+        imageUrl: src,
+        onSuccess: async ({ text, uid, nodeType }) => {
+          const shape = editor.getShape(imageShape.id);
+          if (!shape || !nodeType) return;
+          await replaceShapeWithDiscourseNode({
+            editor,
+            extensionAPI,
+            shape,
+            nodeType,
+            text,
+            uid,
+          });
+        },
+        onClose: () => {},
+      });
+    } finally {
+      setUploading(false);
+    }
+  }, [editor, extensionAPI, imageShape, uploading]);
+
+  if (!buttonPosition) return null;
+
+  return (
+    <div style={{ position: "absolute", inset: 0, pointerEvents: "none" }}>
+      <Button
+        small
+        className="absolute z-20 rounded border border-gray-300 bg-white shadow"
+        style={{
+          left: `${buttonPosition.left}px`,
+          top: `${buttonPosition.top}px`,
+          pointerEvents: "all",
+        }}
+        icon={<Icon icon="new-object" />}
+        loading={uploading}
+        title="Convert to discourse node"
+        onPointerDown={(e) => e.stopPropagation()}
+        onClick={(e) => {
+          e.stopPropagation();
+          void openConvertDialog();
+        }}
+      />
+    </div>
+  );
+};

--- a/apps/roam/src/components/canvas/overlays/ImageConvertOverlay.tsx
+++ b/apps/roam/src/components/canvas/overlays/ImageConvertOverlay.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useState } from "react";
 import { Button, Icon } from "@blueprintjs/core";
-import { TLImageShape, useEditor, useValue } from "tldraw";
+import { TLImageShape, TLShape, useEditor, useValue } from "tldraw";
 import { useExtensionAPI } from "roamjs-components/components/ExtensionApiContext";
 import posthog from "posthog-js";
 import { renderModifyNodeDialog } from "~/components/ModifyNodeDialog";
@@ -12,10 +12,10 @@ import {
 
 const BUTTON_INSET = 8;
 
-const isImageShape = (shape: unknown): shape is TLImageShape =>
-  !!shape && (shape as { type?: string }).type === "image";
+const isConvertibleImage = (shape?: TLShape | null): shape is TLImageShape =>
+  shape?.type === "image" && !shape.isLocked;
 
-export const ImageConvertOverlay = () => {
+export const ImageConvertOverlay = (): JSX.Element | null => {
   const editor = useEditor();
   const extensionAPI = useExtensionAPI();
   const [uploading, setUploading] = useState(false);
@@ -25,9 +25,9 @@ export const ImageConvertOverlay = () => {
     () => {
       if (!editor.isIn("select.idle")) return null;
       const hovered = editor.getHoveredShape();
-      if (isImageShape(hovered)) return hovered;
+      if (isConvertibleImage(hovered)) return hovered;
       const selected = editor.getOnlySelectedShape();
-      return isImageShape(selected) ? selected : null;
+      return isConvertibleImage(selected) ? selected : null;
     },
     [editor],
   );
@@ -65,7 +65,14 @@ export const ImageConvertOverlay = () => {
         imageUrl: src,
         onSuccess: async ({ text, uid, nodeType }) => {
           const shape = editor.getShape(imageShape.id);
-          if (!shape || !nodeType) return;
+          if (!shape || !nodeType) {
+            dispatchToastEvent({
+              id: "tldraw-image-convert-not-replaced",
+              title: "Node created, but the image could not be replaced",
+              severity: "warning",
+            });
+            return;
+          }
           await replaceShapeWithDiscourseNode({
             editor,
             extensionAPI,
@@ -76,6 +83,12 @@ export const ImageConvertOverlay = () => {
           });
         },
         onClose: () => {},
+      });
+    } catch (error) {
+      dispatchToastEvent({
+        id: "tldraw-image-convert-failed",
+        title: `Could not upload this image: ${String(error)}`,
+        severity: "error",
       });
     } finally {
       setUploading(false);

--- a/apps/roam/src/components/canvas/uiOverrides.tsx
+++ b/apps/roam/src/components/canvas/uiOverrides.tsx
@@ -50,12 +50,14 @@ import { DiscourseContextType } from "./Tldraw";
 import { formatHexColor } from "~/components/settings/DiscourseNodeCanvasSettings";
 import {
   COLOR_ARRAY,
-  DISCOURSE_NODE_SHAPE_TYPE,
   getDiscourseNodeTypeId,
   isDiscourseNodeShape,
   type DiscourseNodeShape,
 } from "./DiscourseNodeUtil";
-import calcCanvasNodeSizeAndImg from "~/utils/calcCanvasNodeSizeAndImg";
+import {
+  replaceShapeWithDiscourseNode,
+  uploadImageShapeToRoam,
+} from "./convertShapeToDiscourseNode";
 import { AddReferencedNodeType } from "./DiscourseRelationShape/DiscourseRelationTool";
 import {
   DiscourseRelationShape,
@@ -171,8 +173,6 @@ export const getOnSelectForShape = ({
   editor: Editor;
   extensionAPI: OnloadArgs["extensionAPI"];
 }) => {
-  const { x, y } = shape;
-
   const openDialogAndCreateShape = ({
     initialText,
     imageUrl,
@@ -188,54 +188,26 @@ export const getOnSelectForShape = ({
       includeDefaultNodes: true,
       disableNodeTypeChange: true,
       imageUrl,
-      onSuccess: async ({ text, uid }) => {
-        editor.deleteShapes([shape.id]);
-
-        const {
-          h,
-          w,
-          imageUrl: nodeImageUrl,
-        } = await calcCanvasNodeSizeAndImg({
-          nodeText: text,
+      onSuccess: ({ text, uid }) =>
+        replaceShapeWithDiscourseNode({
+          editor,
           extensionAPI,
+          shape,
           nodeType,
+          text,
           uid,
-        });
-        editor.createShapes([
-          {
-            type: DISCOURSE_NODE_SHAPE_TYPE,
-            id: createShapeId(),
-            props: {
-              uid,
-              title: text,
-              h,
-              w,
-              imageUrl: nodeImageUrl,
-              fontFamily: "sans",
-              size: "s",
-              nodeTypeId: nodeType,
-            },
-            x,
-            y,
-          },
-        ]);
-      },
+        }),
       onClose: () => {},
     });
   };
 
   if (shape.type === "image") {
     return async () => {
-      const { assetId } = (shape as TLImageShape).props;
-      if (!assetId) return;
-      const asset = editor.getAsset(assetId);
-      if (!asset || !asset.props.src) return;
-      const file = await fetch(asset.props.src)
-        .then((r) => r.arrayBuffer())
-        .then((buf) => new File([buf], shape.id));
-      // this is a promise
-      // eslint-disable-next-line @typescript-eslint/await-thenable
-      const src = await window.roamAlphaAPI.util.uploadFile({ file });
+      const src = await uploadImageShapeToRoam({
+        editor,
+        shape: shape as TLImageShape,
+      });
+      if (!src) return;
       const initialText = nodeType === "blck-node" ? `![](${src})` : "";
 
       openDialogAndCreateShape({ initialText, imageUrl: src });

--- a/apps/roam/src/utils/createDiscourseNode.ts
+++ b/apps/roam/src/utils/createDiscourseNode.ts
@@ -40,7 +40,8 @@ const stripTemplateUids = (nodes: InputTextNode[]): InputTextNode[] =>
     };
   });
 
-const handleImageCreation = async ({
+// Key Image only decides where the image block goes, never whether it is added
+export const handleImageCreation = async ({
   pageUid,
   discourseNodes,
   configPageUid,
@@ -54,7 +55,8 @@ const handleImageCreation = async ({
   imageUrl?: string;
   extensionAPI?: OnloadArgs["extensionAPI"];
   text: string;
-}) => {
+}): Promise<void> => {
+  if (!imageUrl) return;
   const canvasSettings = Object.fromEntries(
     discourseNodes.map((n) => [n.type, { ...n.canvasSettings }]),
   );
@@ -64,38 +66,29 @@ const handleImageCreation = async ({
     "key-image-option": keyImageOption = "",
   } = canvasSettings[configPageUid] || {};
 
-  if (isKeyImage && imageUrl) {
-    const createOrUpdateImageBlock = async (imagePlaceholderUid?: string) => {
-      const imageMarkdown = `![](${imageUrl})`;
-      if (imagePlaceholderUid) {
-        await updateBlock({
-          uid: imagePlaceholderUid,
-          text: imageMarkdown,
-        });
-      } else {
-        await createBlock({
-          node: { text: imageMarkdown },
-          order: 0,
-          parentUid: pageUid,
-        });
-      }
-    };
+  const imageMarkdown = `![](${imageUrl})`;
+  const usesQueryBuilderPlaceholder =
+    !!isKeyImage && keyImageOption === "query-builder" && !!extensionAPI;
 
-    if (keyImageOption === "query-builder") {
-      if (!extensionAPI) return;
-
-      const parentUid = resolveQueryBuilderRef({ queryRef: qbAlias });
-      const results = await runQuery({
-        extensionAPI,
-        parentUid,
-        inputs: { NODETEXT: text, NODEUID: pageUid },
-      });
-      const imagePlaceholderUid = results.allProcessedResults[0]?.uid;
-      await createOrUpdateImageBlock(imagePlaceholderUid);
-    } else {
-      await createOrUpdateImageBlock();
+  if (usesQueryBuilderPlaceholder) {
+    const parentUid = resolveQueryBuilderRef({ queryRef: qbAlias });
+    const results = await runQuery({
+      extensionAPI,
+      parentUid,
+      inputs: { NODETEXT: text, NODEUID: pageUid },
+    });
+    const imagePlaceholderUid = results.allProcessedResults[0]?.uid;
+    if (imagePlaceholderUid) {
+      await updateBlock({ uid: imagePlaceholderUid, text: imageMarkdown });
+      return;
     }
   }
+
+  await createBlock({
+    node: { text: imageMarkdown },
+    order: 0,
+    parentUid: pageUid,
+  });
 };
 
 export const createBlocksFromTemplate = async ({

--- a/apps/website/content/roam/guides/using-the-canvas.mdx
+++ b/apps/website/content/roam/guides/using-the-canvas.mdx
@@ -217,7 +217,11 @@ _sending query results to your canvas_
 
 ### Converting images or text into discourse nodes
 
-You can select images or text from your graph, a document, a file, or a webpage, copy them to your canvas, and convert them into discourse nodes. Right-click the image, select "Convert to...", then modify the title as needed.
+You can select images or text from your graph, a document, a file, or a webpage, copy them to your canvas, and convert them into discourse nodes.
+
+To convert an image, hover over it and click the convert icon that appears in its top-left corner. In the create node dialog, pick the node type, enter a title, and confirm. The image is replaced on the canvas by the new node, and the image is added to the node's page.
+
+You can also right-click an image or text shape and select "Convert to...", pick the node type, then modify the title as needed. Use this path to convert text shapes or to turn an image into a block.
 
 <Callout type="info" emoji="💡">
   Remember to enable the **Key Image** feature in Settings if you want to

--- a/apps/website/content/roam/guides/using-the-canvas.mdx
+++ b/apps/website/content/roam/guides/using-the-canvas.mdx
@@ -219,9 +219,9 @@ _sending query results to your canvas_
 
 You can select images or text from your graph, a document, a file, or a webpage, copy them to your canvas, and convert them into discourse nodes.
 
-To convert an image, hover over it and click the convert icon that appears in its top-left corner. In the create node dialog, pick the node type, enter a title, and confirm. The image is replaced on the canvas by the new node, and the image is added to the node's page.
+To convert an image, hover over it and click the convert icon that appears in its top-left corner. In the create node dialog, pick the node type, enter a title, and confirm. The image is replaced on the canvas by the new node and, if **Key Image** is enabled for that node type, added to the node's page.
 
-You can also right-click an image or text shape and select "Convert to...", pick the node type, then modify the title as needed. Use this path to convert text shapes or to turn an image into a block.
+You can also right-click an image or text shape and select **Convert To**, pick the node type, then modify the title as needed. Use this path to convert text shapes or to turn an image into a block.
 
 <Callout type="info" emoji="💡">
   Remember to enable the **Key Image** feature in Settings if you want to

--- a/apps/website/content/roam/guides/using-the-canvas.mdx
+++ b/apps/website/content/roam/guides/using-the-canvas.mdx
@@ -219,13 +219,13 @@ _sending query results to your canvas_
 
 You can select images or text from your graph, a document, a file, or a webpage, copy them to your canvas, and convert them into discourse nodes.
 
-To convert an image, hover over it and click the convert icon that appears in its top-left corner. In the create node dialog, pick the node type, enter a title, and confirm. The image is replaced on the canvas by the new node and, if **Key Image** is enabled for that node type, added to the node's page.
+To convert an image, hover over it and click the convert icon that appears in its top-left corner. In the create node dialog, pick the node type, enter a title, and confirm. The image is replaced on the canvas by the new node and added to the node's page.
 
 You can also right-click an image or text shape and select **Convert To**, pick the node type, then modify the title as needed. Use this path to convert text shapes or to turn an image into a block.
 
 <Callout type="info" emoji="💡">
-  Remember to enable the **Key Image** feature in Settings if you want to
-  convert images to discourse nodes.
+  Enable the **Key Image** feature in Settings for a node type if you want its
+  canvas nodes to display the image.
 </Callout>
 
 <Image


### PR DESCRIPTION
https://www.loom.com/share/ba1a4a782b3c4ac6b0e713bd4561a8fb

Note: I updated the styling to match Figma design after recording this Loom. "Image" is now highlighted and embeded image is flushed to the left:
<img width="522" height="488" alt="image" src="https://github.com/user-attachments/assets/a1599897-27df-495d-8bbb-4a3cbd65361b" />


## Reviewer brief

- Result: hovering (or selecting) a tldraw image shape on the Roam canvas shows a convert button at its top-left. Clicking it opens the create node dialog with the type picker enabled, Page and Block hidden, and an image preview. Confirming replaces the image with a discourse node shape and adds the image to the node page. The right-click **Convert To** path is unchanged in UI and now shares the upload, image-insertion, and shape-replacement helpers.
- Review focus: `ImageConvertOverlay.tsx` hover tracking via `editor.getHoveredShape()` inside `useValue`; the additive `nodeType` field in the `ModifyNodeDialog.tsx` success payload; and `handleImageCreation` in `createDiscourseNode.ts`, which now always writes the image block for a canvas conversion and uses Key Image only to choose the query-builder placeholder (previously the image was dropped when Key Image was off).
- Optional commit, easy to drop: `72733d84a` "Reuse the canvas asset URL instead of re-uploading the image". Files dropped or pasted onto the canvas are already uploaded to Roam by the canvas handlers and stored as the asset `src`, so conversion now reuses that URL and only re-uploads when the `src` is a `data:` or `blob:` URL. This affects both flows. If we prefer every conversion to create its own copy of the file, revert or drop that single commit; nothing else depends on it.
- Risk or follow-up: the hover flow deliberately hides Block; images can still be turned into blocks through the context menu. Locked images do not show the button because tldraw skips locked shapes in `deleteShapes`. The canvas node shape still displays the image only for node types with Key Image on.

## Verification

- `pnpm install --frozen-lockfile` and `pnpm ci:validate` pass (226 Roam unit tests).
- Roam dev build succeeds with 0 errors; fresh-context subagent review of the full diff found nothing blocking, and its should-fix items are applied in the second commit.
- Manual check in a Roam graph (hover, dialog, replacement, image on the node page, context-menu regression) still to be done by the reviewer or author; Chrome automation was unavailable in this session.

## Scope check

- [x] Ran `$scope-check` against the ENG ticket and final diff.
- Scope beyond `Done When`: the always-add-image change and the URL reuse commit also apply to the existing right-click flow, because both flows share one implementation. Requested by Trang during review so both flows behave identically.

## Local delegated full review

- [x] Ran a comprehensive review of the entire final diff in a subagent with a fresh context. Use `$dg-delegated-full-review` when no other full-review workflow is available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)