### PR TITLE
ENG-2246 Document data loss risks with multiple canvas instances

### DIFF
--- a/apps/website/content/obsidian/core-features/canvas.mdx
+++ b/apps/website/content/obsidian/core-features/canvas.mdx
@@ -34,9 +34,9 @@ Or click on the canvas icon at the top right corner
 ![Canvas icon button](/docs/obsidian/canvas-icon-button.png)
 
 <Callout type="warning">
-  Do not edit the markdown content of a canvas file by hand. The canvas data is
-  stored as a generated block inside the file, and hand edits to it can make the
-  canvas unreadable. See [Avoiding data loss](#avoiding-data-loss).
+  Do not hand-edit the generated canvas data block inside a canvas file. Hand
+  edits to that block can make the canvas unreadable. Text outside the block is
+  safe to edit. See [Avoiding data loss](#avoiding-data-loss).
 </Callout>
 
 ## Discourse nodes
@@ -155,20 +155,21 @@ Then you will see the image show up if any is present in the file.
 
 An open canvas holds its own copy of the canvas in memory and writes the whole canvas back to the markdown file shortly after each change. It also watches that file, so a change written by another tab, another device, or a hand edit is merged into your open canvas as it arrives.
 
-That merge works shape by shape, and it is not full conflict resolution. If the same shape is changed in two places at once, the change that arrives last wins and the other one is lost. Only that shape is affected — the rest of the canvas is kept.
+That merge works item by item — each shape, and each relation between nodes — and each item is merged as a whole rather than field by field. It is not full conflict resolution. If the same item is changed in two places at once, the version that reached the file first wins, and the later change to it is discarded. The rest of the canvas is kept.
 
 <Callout type="warning">
   Editing the same canvas on two devices that are offline or out of sync is the
-  riskiest case. Your sync service resolves that conflict at the file level, so
-  one whole version of the canvas replaces the other and the shape-by-shape
-  merge never runs. Changes made on the losing device are gone.
+  riskiest case. The two versions diverge across many items at once, so a large
+  part of one device's work is dropped — either your sync service picks a winner
+  at the file level, or the merge replaces your items wholesale. Changes made on
+  the losing device may be unrecoverable.
 </Callout>
 
 To keep your work safe:
 
 - Edit a canvas in one place at a time. Close duplicate tabs, splits, and popout windows showing the same canvas.
 - Let sync finish before you start editing on a second device, and check that the canvas shows your latest work before you change anything.
-- Do not edit the markdown of a canvas file directly while the canvas is open.
+- Do not hand-edit the canvas data block, whether or not the canvas is open.
 
 ### Use only one sync service
 
@@ -196,8 +197,9 @@ If your vault sits inside a cloud storage folder, move it out or turn off the ot
 
 - Check whether the same canvas is open in another tab, split, or window, and close the duplicates
 - On a synced vault, confirm sync has finished on every device
-- Check your sync service for a conflicted copy of the file, which may still hold the missing work
+- Check your sync service for a conflicted copy or version history of the file, which may still hold the missing work
 - Confirm only one sync service is running over the vault (see [Use only one sync service](#use-only-one-sync-service))
+- If you saw the notice "Canvas file contains invalid data; your latest changes were not saved.", the data block could not be read — check the file for a damaged or hand-edited data block
 
 **Performance Issues**:
 

--- a/apps/website/content/obsidian/core-features/canvas.mdx
+++ b/apps/website/content/obsidian/core-features/canvas.mdx
@@ -5,6 +5,8 @@ author: ""
 published: true
 ---
 
+import { Callout } from "nextra/components";
+
 The canvas feature in Discourse Graph provides an interactive visual workspace for creating and connecting discourse nodes and relations. Built on top of tldraw, it allows you to visually map out discourse structures with drag-and-drop functionality, adding other visual elements like texts, scribbles, embeddings, and images.
 
 ## Creating a new canvas
@@ -31,7 +33,11 @@ Using the command palette
 Or click on the canvas icon at the top right corner
 ![Canvas icon button](/docs/obsidian/canvas-icon-button.png)
 
-**WARNING: DO NOT MODIFY MARKDOWN CONTENT OF FILE**
+<Callout type="warning">
+  Do not edit the markdown content of a canvas file by hand. The canvas data is
+  stored as a generated block inside the file, and hand edits to it can make the
+  canvas unreadable. See [Avoiding data loss](#avoiding-data-loss).
+</Callout>
 
 ## Discourse nodes
 
@@ -133,6 +139,7 @@ Then you will see the image show up if any is present in the file.
 - Changes are automatically saved to the markdown file
 - No manual save required
 - File updates preserve the markdown structure and block references
+- An open canvas also watches its file, so changes written by another tab, another device, or a sync service are merged in as they arrive. See [Avoiding data loss](#avoiding-data-loss) for the cases this cannot cover.
 
 ### Export Options
 
@@ -141,6 +148,33 @@ Then you will see the image show up if any is present in the file.
 - **PNG Export**: Export canvas as PNG image (via tldraw)
 
 ![Export options](/docs/obsidian/export-options.png)
+
+## Avoiding data loss
+
+### Editing in more than one place
+
+An open canvas holds its own copy of the canvas in memory and writes the whole canvas back to the markdown file shortly after each change. It also watches that file, so a change written by another tab, another device, or a hand edit is merged into your open canvas as it arrives.
+
+That merge works shape by shape, and it is not full conflict resolution. If the same shape is changed in two places at once, the change that arrives last wins and the other one is lost. Only that shape is affected — the rest of the canvas is kept.
+
+<Callout type="warning">
+  Editing the same canvas on two devices that are offline or out of sync is the
+  riskiest case. Your sync service resolves that conflict at the file level, so
+  one whole version of the canvas replaces the other and the shape-by-shape
+  merge never runs. Changes made on the losing device are gone.
+</Callout>
+
+To keep your work safe:
+
+- Edit a canvas in one place at a time. Close duplicate tabs, splits, and popout windows showing the same canvas.
+- Let sync finish before you start editing on a second device, and check that the canvas shows your latest work before you change anything.
+- Do not edit the markdown of a canvas file directly while the canvas is open.
+
+### Use only one sync service
+
+Running more than one sync service over the same vault — for example Obsidian Sync alongside iCloud Drive, Dropbox, or Google Drive — can duplicate, corrupt, or delete files, and canvases are no exception. Obsidian calls this double-syncing and does not support it.
+
+If your vault sits inside a cloud storage folder, move it out or turn off the other service. See [Troubleshoot Obsidian Sync](https://obsidian.md/help/sync/troubleshoot) for Obsidian's own guidance.
 
 ## Troubleshooting
 
@@ -157,6 +191,13 @@ Then you will see the image show up if any is present in the file.
 - Ensure the node types allow the relation type you're trying to create
 - Check your discourse relation configuration in settings
 - Verify both nodes are valid discourse nodes
+
+**Canvas Is Missing Recent Changes**:
+
+- Check whether the same canvas is open in another tab, split, or window, and close the duplicates
+- On a synced vault, confirm sync has finished on every device
+- Check your sync service for a conflicted copy of the file, which may still hold the missing work
+- Confirm only one sync service is running over the vault (see [Use only one sync service](#use-only-one-sync-service))
 
 **Performance Issues**:
 


### PR DESCRIPTION
## Reviewer brief

- **Result**: the Obsidian canvas docs page now has an `Avoiding data loss` section covering both failure modes, plus a matching troubleshooting entry. Renamed `canvas.md` → `canvas.mdx` so the warnings use Nextra's `Callout`.
- **Risk or follow-up**: merging this before ENG-2107 leaves a window where the page describes behaviour the released plugin does not have — the Auto-save line about changes being "merged in as they arrive" is the overstatement. Fine if ENG-2107 lands soon; say the word if you would rather hold it.

The existing all-caps warning about hand-editing the markdown is folded into the same rewrite and scoped correctly: `Vault.process` preserves markdown *outside* the data block, so only the block itself is off limits.

## Verification

- `pnpm ci:validate` — 5/5 tasks, 0 cached, 226 tests pass
- `pnpm -C apps/website build` — clean, docs route prerenders
- `turbo lint --filter=website` passes; Prettier clean. (`@repo/database#lint` fails on pre-existing SQL capitalisation warnings, untouched by this diff.)
- Rendered locally from this worktree: both callouts render, all 25 in-page anchors resolve, no console errors. Screenshots came back blank from the preview pane, so visual confirmation is DOM assertions rather than an image.
- `obsidian.md/help/sync/troubleshoot` confirmed live and it does use the term "double-syncing".

## Loom video

Not recorded — @doantrang982 to add if wanted.

## Scope check

- [x] Ran `$scope-check` against the ENG ticket and final diff.
- Scope beyond `Done When`: the all-caps hand-edit warning was rewritten rather than left alone. It is the same data-loss surface and directly contradicted the new section, so leaving it would have shipped two conflicting instructions on one page.

## Local delegated full review

- [x] Ran a comprehensive review of the entire final diff in a subagent with a fresh context.

It caught the inverted conflict-winner claim, the overstated "the merge never runs" in the offline callout, a contradiction between "changes are gone" and "look for a conflicted copy", and that relations merge the same way as shapes. All fixed in `f65061a06`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
